### PR TITLE
Use correct format identifiers for logs on 64 bit systems.

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -700,7 +700,10 @@ static bool disableNotificationsForMovingBetweenParents(ASDisplayNode *from, ASD
         if (canUseViewAPI && sublayerIndex != NSNotFound) {
           [_view insertSubview:subnode.view atIndex:sublayerIndex];
         } else if (sublayerIndex != NSNotFound) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wconversion"
           [_layer insertSublayer:subnode.layer atIndex:sublayerIndex];
+#pragma clang diagnostic pop
         }
       }
     }
@@ -840,7 +843,7 @@ static NSInteger incrementIfFound(NSInteger i) {
   ASDN::MutexLocker l(_propertyLock);
 
   if (idx > _subnodes.count || idx < 0) {
-    NSString *reason = [NSString stringWithFormat:@"Cannot insert a subnode at index %d. Count is %d", idx, _subnodes.count];
+    NSString *reason = [NSString stringWithFormat:@"Cannot insert a subnode at index %zd. Count is %zd", idx, _subnodes.count];
     @throw [NSException exceptionWithName:NSInvalidArgumentException reason:reason userInfo:nil];
   }
 

--- a/AsyncDisplayKit/ASImageNode.mm
+++ b/AsyncDisplayKit/ASImageNode.mm
@@ -59,7 +59,7 @@
 
 - (NSString *)description
 {
-  return [NSString stringWithFormat:@"<%@ : %p image:%@ cropEnabled:%@ opaque:%@ bounds:%@ contentsScale:%.2f backgroundColor:%@ tint:%u contentMode:%@ cropRect:%@>", [self class], self, self.image, @(self.cropEnabled), @(self.opaque), NSStringFromCGRect(self.bounds), self.contentsScale, self.backgroundColor, self.tint, ASDisplayNodeNSStringFromUIContentMode(self.contentMode), NSStringFromCGRect(self.cropRect)];
+  return [NSString stringWithFormat:@"<%@ : %p image:%@ cropEnabled:%@ opaque:%@ bounds:%@ contentsScale:%.2f backgroundColor:%@ tint:%zd contentMode:%@ cropRect:%@>", [self class], self, self.image, @(self.cropEnabled), @(self.opaque), NSStringFromCGRect(self.bounds), self.contentsScale, self.backgroundColor, self.tint, ASDisplayNodeNSStringFromUIContentMode(self.contentMode), NSStringFromCGRect(self.cropRect)];
 }
 
 @end

--- a/AsyncDisplayKit/Private/_ASCoreAnimationExtras.mm
+++ b/AsyncDisplayKit/Private/_ASCoreAnimationExtras.mm
@@ -119,7 +119,7 @@ NSString *const ASDisplayNodeCAContentsGravityFromUIContentMode(UIViewContentMod
       return UIContentModeCAGravityLUT[i].string;
     }
   }
-  ASDisplayNodeCAssert(contentMode == UIViewContentModeRedraw, @"Encountered an unknown contentMode %d. Is this a new version of iOS?", contentMode);
+  ASDisplayNodeCAssert(contentMode == UIViewContentModeRedraw, @"Encountered an unknown contentMode %ld. Is this a new version of iOS?", contentMode);
   // Redraw is ok to return nil.
   return nil;
 }

--- a/AsyncDisplayKitTests/ASDisplayLayerTests.m
+++ b/AsyncDisplayKitTests/ASDisplayLayerTests.m
@@ -65,7 +65,7 @@ static UIImage *bogusImage() {
 
 - (NSString *)setContentsCounts
 {
-  return [NSString stringWithFormat:@"syncCount:%u, asyncCount:%u", _setContentsSyncCount, _setContentsAsyncCount];
+  return [NSString stringWithFormat:@"syncCount:%tu, asyncCount:%tu", _setContentsSyncCount, _setContentsAsyncCount];
 }
 
 - (BOOL)checkSetContentsCountsWithSyncCount:(NSUInteger)syncCount asyncCount:(NSUInteger)asyncCount

--- a/AsyncDisplayKitTests/ASDisplayNodeTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeTests.m
@@ -746,11 +746,11 @@ static inline BOOL _CGPointEqualToPointWithEpsilon(CGPoint point1, CGPoint point
   };
 
   // verify initial
-  XCTAssertTrue(1 == node.retainCount, @"unexpected retain count:%d", node.retainCount);
+  XCTAssertTrue(1 == node.retainCount, @"unexpected retain count:%tu", node.retainCount);
 
   // verify increment
   [node retain];
-  XCTAssertTrue(2 == node.retainCount, @"unexpected retain count:%d", node.retainCount);
+  XCTAssertTrue(2 == node.retainCount, @"unexpected retain count:%tu", node.retainCount);
 
   // verify dealloc
   [node release];
@@ -768,15 +768,15 @@ static inline BOOL _CGPointEqualToPointWithEpsilon(CGPoint point1, CGPoint point
   };
 
   // verify initial
-  XCTAssertTrue(1 == node.retainCount, @"unexpected retain count:%d", node.retainCount);
+  XCTAssertTrue(1 == node.retainCount, @"unexpected retain count:%tu", node.retainCount);
 
   UIView *v = [[UIView alloc] initWithFrame:CGRectZero];
   [v addSubview:node.view];
 
-  XCTAssertTrue(2 == node.retainCount, @"view should retain node when added. retain count:%d", node.retainCount);
+  XCTAssertTrue(2 == node.retainCount, @"view should retain node when added. retain count:%tu", node.retainCount);
 
   [node release];
-  XCTAssertTrue(1 == node.retainCount, @"unexpected retain count:%d", node.retainCount);
+  XCTAssertTrue(1 == node.retainCount, @"unexpected retain count:%tu", node.retainCount);
 
   [node.view removeFromSuperview];
   XCTAssertTrue(didDealloc, @"unexpected node lifetime:%@", node);

--- a/AsyncDisplayKitTests/ASTextNodeRendererTests.m
+++ b/AsyncDisplayKitTests/ASTextNodeRendererTests.m
@@ -93,10 +93,10 @@
   [_renderer size];
   NSRange stringRange = NSMakeRange(0, _attributedString.length);
   NSRange visibleRange = [_renderer visibleRange];
-  XCTAssertTrue(visibleRange.length < stringRange.length, @"Some truncation should occur if the constrained size is smaller than the previously calculated bounding size. String length %d, visible range %@", _attributedString.length, NSStringFromRange(visibleRange));
+  XCTAssertTrue(visibleRange.length < stringRange.length, @"Some truncation should occur if the constrained size is smaller than the previously calculated bounding size. String length %tu, visible range %@", _attributedString.length, NSStringFromRange(visibleRange));
   NSRange truncationRange = [_renderer truncationStringCharacterRange];
-  XCTAssertTrue(truncationRange.location == NSMaxRange(visibleRange), @"Truncation location (%d) should be after the end of the visible range (%d)", truncationRange.location, NSMaxRange(visibleRange));
-  XCTAssertTrue(truncationRange.length == _truncationString.length, @"Truncation string length (%d) should be the full length of the supplied truncation string (%@)", truncationRange.length, _truncationString.string);
+  XCTAssertTrue(truncationRange.location == NSMaxRange(visibleRange), @"Truncation location (%zd) should be after the end of the visible range (%zd)", truncationRange.location, NSMaxRange(visibleRange));
+  XCTAssertTrue(truncationRange.length == _truncationString.length, @"Truncation string length (%zd) should be the full length of the supplied truncation string (%@)", truncationRange.length, _truncationString.string);
 }
 
 /**


### PR DESCRIPTION
Incorrect format identifiers were being used for NS(U)Integer, and as such were generating warnings on 64 Bit Builds. Based on: https://twitter.com/gparker/status/377910611453046784

I've also silenced the insertSublayer:atIndex:  implicit conversion warning.
