### PR TITLE
Unify boolean flag naming confention, getter spacing, and property attribute naming

### DIFF
--- a/AsyncDisplayKit/ASControlNode.h
+++ b/AsyncDisplayKit/ASControlNode.h
@@ -38,7 +38,7 @@ typedef NSUInteger ASControlNodeEvent;
  @abstract Indicates whether or not the receiver is enabled.
  @discussion Specify YES to make the control enabled; otherwise, specify NO to make it disabled. The default value is YES. If the enabled state is NO, the control ignores touch events and subclasses may draw differently.
  */
-@property (nonatomic, readwrite, assign, getter=isEnabled) BOOL enabled;
+@property (nonatomic, assign, getter=isEnabled) BOOL enabled;
 
 /**
  @abstract Indicates whether or not the receiver is highlighted.

--- a/AsyncDisplayKit/ASDisplayNode+Subclasses.h
+++ b/AsyncDisplayKit/ASDisplayNode+Subclasses.h
@@ -23,7 +23,7 @@
 + (Class)viewClass;
 
 // Returns YES if a cache node, defaults to NO
-@property (nonatomic, assign, readonly, getter = isCacheNode) BOOL cacheNode;
+@property (nonatomic, assign, readonly, getter=isCacheNode) BOOL cacheNode;
 
 // Returns array of cached strict descendants (excludes self). if this is not a cacheNode, returns nil
 @property (nonatomic, copy, readonly) NSArray *cachedNodes;
@@ -89,7 +89,7 @@
 @property (nonatomic, assign, readonly) CGFloat contentsScaleForDisplay;
 
 // Whether the view or layer of this display node is currently in a window
-@property (nonatomic, readonly, assign, getter = isInWindow) BOOL inWindow;
+@property (nonatomic, readonly, assign, getter=isInWindow) BOOL inWindow;
 
 // The function that gets called for each display node in -recursiveDescription
 - (NSString *)descriptionForRecursiveDescription;

--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -29,16 +29,16 @@
 - (id)initWithLayerClass:(Class)layerClass;
 
 // If this view is strictly synchronous (ie wraps a non _ASDisplayView view)
-@property (nonatomic, readonly) BOOL isSynchronous;
+@property (nonatomic, readonly, assign, getter=isSynchronous) BOOL synchronous;
 
 // The view property is lazily initialized, similar to UIViewController.
 // The first access to it must be on the main thread, and should only be used on the main thread thereafter as well.
 // To go the other direction, use ASViewToDisplayNode() in ASDisplayNodeExtras.h
 @property (nonatomic, readonly, retain) UIView *view;
-@property (atomic, readonly, assign) BOOL isViewLoaded;  // Also YES if isLayerBacked == YES && self.layer != nil.  Rename to isBackingLoaded?
+@property (atomic, readonly, assign, getter=isViewLoaded) BOOL viewLoaded;  // Also YES if isLayerBacked == YES && self.layer != nil.  Rename to isBackingLoaded?
 
 // If this node does not have an associated view, instead relying directly upon a layer
-@property (nonatomic, assign) BOOL isLayerBacked;
+@property (nonatomic, assign, getter=isLayerBacked) BOOL layerBacked;
 // The same restrictions apply as documented above about the view property. To go the other direction, use ASLayerToDisplayNode() in ASDisplayNodeExtras.h
 @property (nonatomic, readonly, retain) CALayer *layer;
 
@@ -131,7 +131,7 @@
 
  Note: this has nothing to do with CALayer@drawsAsynchronously
  */
-@property (nonatomic) BOOL displaysAsynchronously;
+@property (nonatomic, assign) BOOL displaysAsynchronously;
 
 /**
  @abstract

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -302,12 +302,12 @@ _OBJC_SUPPORTED_INLINE_REFCNT_WITH_DEALLOC2MAIN(_retainCount);
   return _flags.isSynchronous;
 }
 
-- (void)setIsSynchronous:(BOOL)flag
+- (void)setSynchronous:(BOOL)flag
 {
   _flags.isSynchronous = flag;
 }
 
-- (void)setIsLayerBacked:(BOOL)isLayerBacked
+- (void)setLayerBacked:(BOOL)isLayerBacked
 {
   if (![self.class layerBackedNodesEnabled]) return;
 

--- a/AsyncDisplayKit/ASImageNode.h
+++ b/AsyncDisplayKit/ASImageNode.h
@@ -23,7 +23,7 @@ typedef NS_ENUM(NSUInteger, ASImageNodeTint) {
 
 #pragma mark - Cropping
 //! @abstract Indicates whether efficient cropping of the receiver is enabled. Defaults to YES. See -setCropEnabled:recropImmediately:inBounds: for more information.
-@property (nonatomic, assign) BOOL cropEnabled;
+@property (nonatomic, assign, getter=isCropEnabled) BOOL cropEnabled;
 
 /**
  @abstract Enables or disables efficient cropping.

--- a/AsyncDisplayKit/ASImageNode.mm
+++ b/AsyncDisplayKit/ASImageNode.mm
@@ -302,7 +302,7 @@
 }
 
 #pragma mark - Cropping
-- (BOOL)cropEnabled
+- (BOOL)isCropEnabled
 {
   ASDisplayNodeAssertThreadAffinity(self);
   return _cropEnabled;

--- a/AsyncDisplayKit/ASTextNode.h
+++ b/AsyncDisplayKit/ASTextNode.h
@@ -52,12 +52,12 @@ typedef NS_ENUM(NSUInteger, ASTextNodeHighlightStyle) {
 /**
  @abstract If the text node is truncated. Text must have been sized first.
  */
-@property (nonatomic, assign, readonly, getter = isTruncated) BOOL truncated;
+@property (nonatomic, readonly, assign, getter=isTruncated) BOOL truncated;
 
 /**
  @abstract The number of lines in the text. Text must have been sized first.
  */
-@property (nonatomic, assign, readonly) NSUInteger lineCount;
+@property (nonatomic, readonly, assign) NSUInteger lineCount;
 
 #pragma mark - Shadow
 

--- a/AsyncDisplayKit/Details/ASHighlightOverlayLayer.h
+++ b/AsyncDisplayKit/Details/ASHighlightOverlayLayer.h
@@ -38,6 +38,6 @@
  @summary Set to YES to indicate to a sublayer that this is where highlight overlay layers (for pressed states) should
  be added so that the highlight won't be clipped by a neighboring layer.
  */
-@property (nonatomic, assign, setter = as_setAllowsHighlightDrawing:) BOOL as_allowsHighlightDrawing;
+@property (nonatomic, assign, setter=as_setAllowsHighlightDrawing:) BOOL as_allowsHighlightDrawing;
 
 @end

--- a/AsyncDisplayKit/Details/ASTextNodeShadower.h
+++ b/AsyncDisplayKit/Details/ASTextNodeShadower.h
@@ -37,16 +37,16 @@ static inline UIEdgeInsets ASDNEdgeInsetsInvert(UIEdgeInsets insets)
   * @discussion A positive width will move the shadow to the right.
   *             A positive height will move the shadow downwards.
   */
-@property (nonatomic, assign, readonly) CGSize shadowOffset;
+@property (nonatomic, readonly, assign) CGSize shadowOffset;
 
 //! CGColor in which the shadow is drawn
-@property (nonatomic, assign, readonly) CGColorRef shadowColor;
+@property (nonatomic, readonly, assign) CGColorRef shadowColor;
 
 //! Alpha of the shadow
-@property (nonatomic, assign, readonly) CGFloat shadowOpacity;
+@property (nonatomic, readonly, assign) CGFloat shadowOpacity;
 
 //! Radius, in pixels
-@property (nonatomic, assign, readonly) CGFloat shadowRadius;
+@property (nonatomic, readonly, assign) CGFloat shadowRadius;
 
 /**
   * @abstract The edge insets which represent shadow padding

--- a/AsyncDisplayKit/Details/Transactions/_ASAsyncTransaction.h
+++ b/AsyncDisplayKit/Details/Transactions/_ASAsyncTransaction.h
@@ -56,18 +56,18 @@ typedef NS_ENUM(NSUInteger, ASAsyncTransactionState) {
 /**
  The dispatch queue that the completion blocks will be called on.
  */
-@property (nonatomic, retain, readonly) dispatch_queue_t callbackQueue;
+@property (nonatomic, readonly, retain) dispatch_queue_t callbackQueue;
 
 /**
  A block that is called when the transaction is completed.
  */
-@property (nonatomic, copy, readonly) asyncdisplaykit_async_transaction_completion_block_t completionBlock;
+@property (nonatomic, readonly, copy) asyncdisplaykit_async_transaction_completion_block_t completionBlock;
 
 /**
  The state of the transaction.
  @see ASAsyncTransactionState
  */
-@property (nonatomic, readonly) ASAsyncTransactionState state;
+@property (nonatomic, readonly, assign) ASAsyncTransactionState state;
 
 /**
  @summary Adds a synchronous operation to the transaction.  The execution block will be executed immediately.

--- a/AsyncDisplayKit/Details/Transactions/_ASAsyncTransactionContainer+Private.h
+++ b/AsyncDisplayKit/Details/Transactions/_ASAsyncTransactionContainer+Private.h
@@ -9,8 +9,8 @@
 #import "_ASAsyncTransactionContainer.h"
 
 @interface CALayer (ASAsyncTransactionContainerTransactions)
-@property (nonatomic, retain, setter = asyncdisplaykit_setAsyncLayerTransactions:) NSHashTable *asyncdisplaykit_asyncLayerTransactions;
-@property (nonatomic, retain, setter = asyncdisplaykit_setCurrentAsyncLayerTransaction:) _ASAsyncTransaction *asyncdisplaykit_currentAsyncLayerTransaction;
+@property (nonatomic, retain, setter=asyncdisplaykit_setAsyncLayerTransactions:) NSHashTable *asyncdisplaykit_asyncLayerTransactions;
+@property (nonatomic, retain, setter=asyncdisplaykit_setCurrentAsyncLayerTransaction:) _ASAsyncTransaction *asyncdisplaykit_currentAsyncLayerTransaction;
 
 - (void)asyncdisplaykit_asyncTransactionContainerWillBeginTransaction:(_ASAsyncTransaction *)transaction;
 - (void)asyncdisplaykit_asyncTransactionContainerDidCompleteTransaction:(_ASAsyncTransaction *)transaction;

--- a/AsyncDisplayKit/Details/Transactions/_ASAsyncTransactionContainer.h
+++ b/AsyncDisplayKit/Details/Transactions/_ASAsyncTransactionContainer.h
@@ -32,12 +32,12 @@ typedef NS_ENUM(NSUInteger, ASAsyncTransactionContainerState) {
 
  @default NO
  */
-@property (nonatomic, assign, getter = asyncdisplaykit_isAsyncTransactionContainer, setter = asyncdisplaykit_setAsyncTransactionContainer:) BOOL asyncdisplaykit_asyncTransactionContainer;
+@property (nonatomic, assign, getter=asyncdisplaykit_isAsyncTransactionContainer, setter=asyncdisplaykit_setAsyncTransactionContainer:) BOOL asyncdisplaykit_asyncTransactionContainer;
 
 /**
  @summary The current state of the receiver; indicates if it is currently performing asynchronous operations or if all operations have finished/canceled.
  */
-@property (nonatomic, assign, readonly) ASAsyncTransactionContainerState asyncdisplaykit_asyncTransactionContainerState;
+@property (nonatomic, readonly, assign) ASAsyncTransactionContainerState asyncdisplaykit_asyncTransactionContainerState;
 
 /**
  @summary Cancels all async transactions on the receiver.
@@ -58,13 +58,13 @@ typedef NS_ENUM(NSUInteger, ASAsyncTransactionContainerState) {
  did not already exist. This method will always return an open, uncommitted transaction.
  @desc asyncdisplaykit_isAsyncTransactionContainer does not need to be YES for this to return a transaction.
  */
-@property (nonatomic, retain, readonly) _ASAsyncTransaction *asyncdisplaykit_asyncTransaction;
+@property (nonatomic, readonly, retain) _ASAsyncTransaction *asyncdisplaykit_asyncTransaction;
 
 /**
  @summary Goes up the superlayer chain until it finds the first layer with asyncdisplaykit_isAsyncTransactionContainer=YES (including the receiver) and returns it.
  Returns nil if no parent container is found.
  */
-@property (nonatomic, retain, readonly) CALayer *asyncdisplaykit_parentTransactionContainer;
+@property (nonatomic, readonly, retain) CALayer *asyncdisplaykit_parentTransactionContainer;
 @end
 
 @interface UIView (ASDisplayNodeAsyncTransactionContainer) <ASDisplayNodeAsyncTransactionContainer>

--- a/AsyncDisplayKit/Details/UIView+ASConvenience.h
+++ b/AsyncDisplayKit/Details/UIView+ASConvenience.h
@@ -53,7 +53,7 @@
 @property (nonatomic, assign)                           UIViewContentMode contentMode;
 @property (nonatomic, assign, getter=isUserInteractionEnabled) BOOL userInteractionEnabled;
 @property (nonatomic, assign, getter=isExclusiveTouch) BOOL exclusiveTouch;
-@property (nonatomic, assign, getter = asyncdisplaykit_isAsyncTransactionContainer, setter = asyncdisplaykit_setAsyncTransactionContainer:) BOOL asyncdisplaykit_asyncTransactionContainer;
+@property (nonatomic, assign, getter=asyncdisplaykit_isAsyncTransactionContainer, setter = asyncdisplaykit_setAsyncTransactionContainer:) BOOL asyncdisplaykit_asyncTransactionContainer;
 
 /**
  Following properties of the UIAccessibility informal protocol are supported as well.

--- a/AsyncDisplayKit/Details/_ASDisplayLayer.h
+++ b/AsyncDisplayKit/Details/_ASDisplayLayer.h
@@ -55,7 +55,7 @@ typedef BOOL(^asdisplaynode_iscancelled_block_t)(void);
 
  @default NO
  */
-@property (atomic, assign, getter = isDisplaySuspended) BOOL displaySuspended;
+@property (atomic, assign, getter=isDisplaySuspended) BOOL displaySuspended;
 
 /**
  @summary Bypasses asynchronous rendering and performs a blocking display immediately on the current thread.

--- a/AsyncDisplayKitTests/ASDisplayNodeAppearanceTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeAppearanceTests.m
@@ -132,7 +132,7 @@ static dispatch_block_t modifyMethodByAddingPrologueBlockAndReturnCleanupBlock(C
   DeclareNodeNamed(n);
   DeclareViewNamed(superview);
 
-  n.isLayerBacked = isLayerBacked;
+  n.layerBacked = isLayerBacked;
 
   if (isLayerBacked) {
     [superview.layer addSublayer:n.layer];
@@ -179,7 +179,7 @@ static dispatch_block_t modifyMethodByAddingPrologueBlockAndReturnCleanupBlock(C
   DeclareNodeNamed(ab);
 
   for (ASDisplayNode *n in @[parent, a, b, aa, ab]) {
-    n.isLayerBacked = isLayerBacked;
+    n.layerBacked = isLayerBacked;
     if (isViewLoaded)
       [n layer];
   }
@@ -273,7 +273,7 @@ static dispatch_block_t modifyMethodByAddingPrologueBlockAndReturnCleanupBlock(C
   DeclareNodeNamed(layerBackedNode);
   DeclareNodeNamed(viewBackedNode);
 
-  layerBackedNode.isLayerBacked = YES;
+  layerBackedNode.layerBacked = YES;
 
   UIWindow *window = [[UIWindow alloc] initWithFrame:CGRectZero];
   [parentSynchronousNode addSubnode:layerBackedNode];
@@ -326,7 +326,7 @@ static dispatch_block_t modifyMethodByAddingPrologueBlockAndReturnCleanupBlock(C
   DeclareNodeNamed(childSubnode);
 
   for (ASDisplayNode *n in @[parentA, parentB, child, childSubnode]) {
-    n.isLayerBacked = isLayerBacked;
+    n.layerBacked = isLayerBacked;
   }
 
   [parentA addSubnode:child];

--- a/AsyncDisplayKitTests/ASDisplayNodeTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeTests.m
@@ -183,7 +183,7 @@ for (ASDisplayNode *n in @[ nodes ]) {\
   ASDisplayNode *node = [[ASDisplayNode alloc] init];
 
   XCTAssertEqual(NO, node.isLayerBacked, @"default isLayerBacked broken without view");
-  node.isLayerBacked = isLayerBacked;
+  node.layerBacked = isLayerBacked;
   XCTAssertEqual(isLayerBacked, node.isLayerBacked, @"setIsLayerBacked: broken");
 
   // Assert that the values can be fetched from the node before the view is realized.
@@ -274,7 +274,7 @@ for (ASDisplayNode *n in @[ nodes ]) {\
 
   [self executeOffThread:^{
     node = [[ASDisplayNode alloc] init];
-    node.isLayerBacked = isLayerBacked;
+    node.layerBacked = isLayerBacked;
 
     node.contents = (id)[self bogusImage].CGImage;
     node.clipsToBounds = YES;
@@ -840,7 +840,7 @@ static inline BOOL _CGPointEqualToPointWithEpsilon(CGPoint point1, CGPoint point
   DeclareNodeNamed(c);
 
   for (ASDisplayNode *n in @[parent, a, b, c]) {
-    n.isLayerBacked = isLayerBacked;
+    n.layerBacked = isLayerBacked;
   }
 
   [parent addSubnode:a];
@@ -1103,7 +1103,7 @@ static inline BOOL _CGPointEqualToPointWithEpsilon(CGPoint point1, CGPoint point
   DeclareNodeNamed(c);
 
   for (ASDisplayNode *v in @[parent, a, b, c]) {
-    v.isLayerBacked = isLayerBacked;
+    v.layerBacked = isLayerBacked;
   }
 
   // Load parent
@@ -1113,7 +1113,7 @@ static inline BOOL _CGPointEqualToPointWithEpsilon(CGPoint point1, CGPoint point
 
   // Add another subnode to test creation after parent is loaded
   DeclareNodeNamed(d);
-  d.isLayerBacked = isLayerBacked;
+  d.layerBacked = isLayerBacked;
   if (loaded) {
     XCTAssertFalse(d.isViewLoaded, @"Should not yet be loaded");
   }
@@ -1358,7 +1358,7 @@ static inline BOOL _CGPointEqualToPointWithEpsilon(CGPoint point1, CGPoint point
   DeclareNodeNamed(c);
 
   for (ASDisplayNode *v in @[parent, a, b, c]) {
-    v.isLayerBacked = isLayerBacked;
+    v.layerBacked = isLayerBacked;
   }
 
   [parent addSubnode:b];
@@ -1438,7 +1438,7 @@ static inline BOOL _CGPointEqualToPointWithEpsilon(CGPoint point1, CGPoint point
   DeclareNodeNamed(c);
 
   for (ASDisplayNode *n in @[parent, a, b, c]) {
-    n.isLayerBacked = isLayerBacked;
+    n.layerBacked = isLayerBacked;
   }
 
   [parent addSubnode:a];
@@ -1493,7 +1493,7 @@ static inline BOOL _CGPointEqualToPointWithEpsilon(CGPoint point1, CGPoint point
 - (void)checkBackgroundColorOpaqueRelationshipWithViewLoaded:(BOOL)loaded layerBacked:(BOOL)isLayerBacked
 {
   ASDisplayNode *node = [[ASDisplayNode alloc] init];
-  node.isLayerBacked = isLayerBacked;
+  node.layerBacked = isLayerBacked;
 
   if (loaded) {
     // Force load
@@ -1577,9 +1577,9 @@ static bool stringContainsPointer(NSString *description, const void *p) {
   ASDisplayNode *parent = [[ASDisplayNode alloc] init];
 
   ASDisplayNode *a = [[[ASDisplayNode alloc] init] autorelease];
-  a.isLayerBacked = YES;
+  a.layerBacked = YES;
   ASDisplayNode *b = [[[ASDisplayNode alloc] init] autorelease];
-  b.isLayerBacked = YES;
+  b.layerBacked = YES;
   b.frame = CGRectMake(0, 0, 100, 123);
   ASDisplayNode *c = [[[ASDisplayNode alloc] init] autorelease];
 
@@ -1611,7 +1611,7 @@ static bool stringContainsPointer(NSString *description, const void *p) {
 - (void)checkNameInDescriptionIsLayerBacked:(BOOL)isLayerBacked
 {
   ASDisplayNode *node = [[ASDisplayNode alloc] init];
-  node.isLayerBacked = isLayerBacked;
+  node.layerBacked = isLayerBacked;
 
   XCTAssertFalse([node.description rangeOfString:@"name"].location != NSNotFound, @"Shouldn't reference 'name' in description");
   node.name = @"big troll eater name";


### PR DESCRIPTION
Summary:
- Fixes #3
- Ordering: atomicity, then [optional] readonly, then value semantics (retain/copy/assign)
- Removed redundant `readwrite`
- No spaces between "getter = name" ("getter=name" instead)
- Property method overrides renamed as well
- self.isBlah, while technically not entirely correct, still resolves to [self blah], so left alone (@kimon had advice on this sort of naming issue last summer), and largely inconsequential

Test Plan:
- Compile and run
