### PR TITLE
userInteractionEnabled defaults to NO

### DIFF
--- a/AsyncDisplayKit/ASTextNode.mm
+++ b/AsyncDisplayKit/ASTextNode.mm
@@ -117,8 +117,8 @@ ASDISPLAYNODE_INLINE CGFloat ceilPixelValue(CGFloat f)
     _shadowOpacity = [super shadowOpacity];
     _shadowRadius = [super shadowRadius];
 
-    // Enable user interaction for text node, as ASControlNode disables it by default.
-    self.userInteractionEnabled = YES;
+    // Disable user interaction for text node by default.
+    self.userInteractionEnabled = NO;
     self.needsDisplayOnBoundsChange = YES;
 
     _truncationMode = NSLineBreakByWordWrapping;


### PR DESCRIPTION
Previously self.userInteractionEnabled defaulted to YES, and this
caused plenty of bugs for me when text nodes would silently steal
touches. It should default to NO, and callers who want tappability on
their text nodes should manually set .userInteractionEnabled to YES.
