### PR TITLE
Mehod -numberOfSectionsInTableView: is optional but not conditionally checked

### DIFF
--- a/AsyncDisplayKit/ASTableView.m
+++ b/AsyncDisplayKit/ASTableView.m
@@ -317,7 +317,11 @@ static BOOL _isInterceptedSelector(SEL sel)
 - (NSInteger)rangeControllerSections:(ASRangeController *)rangeController
 {
   ASDisplayNodeAssertMainThread();
-  return [_asyncDataSource numberOfSectionsInTableView:self];
+  if ([_asyncDataSource respondsToSelector:@selector(numberOfSectionsInTableView:)]) {
+    return [_asyncDataSource numberOfSectionsInTableView:self];
+  } else {
+    return 1;
+  }
 }
 
 - (NSInteger)rangeController:(ASRangeController *)rangeController rowsInSection:(NSInteger)section


### PR DESCRIPTION
The documentation for `UITableViewDataSource` specifies that the default value is 1, and that its implementation is optional. However, ASTableView's forwarding doesn't account for the unimplemented case. The desired behavior is to return 1 in the case that the method is not implemented.
