### PR TITLE
Annotate -didLoad with an attribute (if supported) that will flag missing didLoad calls

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode+Subclasses.h
+++ b/AsyncDisplayKit/ASDisplayNode+Subclasses.h
@@ -74,7 +74,7 @@
  *
  * @discussion This is the best time to add gesture recognizers to the view.
  */
-- (void)didLoad;
+- (void)didLoad ASDISPLAYNODE_REQUIRES_SUPER;
 
 
 /** @name Layout */

--- a/Base/ASBaseDefines.h
+++ b/Base/ASBaseDefines.h
@@ -90,6 +90,10 @@
 #define __has_feature(x) 0 // Compatibility with non-clang compilers.
 #endif
 
+#ifndef __has_attribute      // Optional.
+#define __has_attribute(x) 0 // Compatibility with non-clang compilers.
+#endif
+
 #ifndef NS_CONSUMED
 #if __has_feature(attribute_ns_consumed)
 #define NS_CONSUMED __attribute__((ns_consumed))
@@ -129,3 +133,11 @@
 // http://gcc.gnu.org/onlinedocs/cpp/Stringification.html
 #define ASDISPLAYNODE_TO_STRING(str) #str
 #define ASDISPLAYNODE_TO_UNICODE_STRING(str) @ASDISPLAYNODE_TO_STRING(str)
+
+#ifndef ASDISPLAYNODE_REQUIRES_SUPER
+#if __has_attribute(objc_requires_super)
+#define ASDISPLAYNODE_REQUIRES_SUPER __attribute__((objc_requires_super))
+#else
+#define ASDISPLAYNODE_REQUIRES_SUPER
+#endif
+#endif


### PR DESCRIPTION
I was getting some bizarre memory deallocation calls on a trivial demo. In building a repro case, I realized it was because I didn't call [super didLoad] in my node subclass (there were no problems after I did this). It'd be nice to get a warning for this, so I added in `ASDISPLAYNODE_REQUIRES_SUPER` in `ASBaseDefines.h` and applied it to didLoad.
