### PR TITLE
Wraps transaction async dispatches with autorelease pools.

### DIFF
--- a/AsyncDisplayKit/Details/Transactions/_ASAsyncTransaction.m
+++ b/AsyncDisplayKit/Details/Transactions/_ASAsyncTransaction.m
@@ -87,12 +87,14 @@
   ASDisplayNodeAsyncTransactionOperation *operation = [[ASDisplayNodeAsyncTransactionOperation alloc] initWithOperationCompletionBlock:completion];
   [_operations addObject:operation];
   dispatch_group_async(_group, queue, ^{
-    if (_state != ASAsyncTransactionStateCanceled) {
-      dispatch_group_enter(_group);
-      block(^(id<NSObject> value){
-        operation.value = value;
-        dispatch_group_leave(_group);
-      });
+    @autoreleasepool {
+      if (_state != ASAsyncTransactionStateCanceled) {
+        dispatch_group_enter(_group);
+        block(^(id<NSObject> value){
+          operation.value = value;
+          dispatch_group_leave(_group);
+        });
+      }
     }
   });
 }
@@ -109,8 +111,10 @@
   ASDisplayNodeAsyncTransactionOperation *operation = [[ASDisplayNodeAsyncTransactionOperation alloc] initWithOperationCompletionBlock:completion];
   [_operations addObject:operation];
   dispatch_group_async(_group, queue, ^{
-    if (_state != ASAsyncTransactionStateCanceled) {
-      operation.value = block();
+    @autoreleasepool {
+      if (_state != ASAsyncTransactionStateCanceled) {
+        operation.value = block();
+      }
     }
   });
 }


### PR DESCRIPTION
This change helps relieve memory pressure when running memory intensive operations inside an async transaction. Grand central dispatch doesn't guarantee when it drains its autorelease pools. All unit tests ran green.
