### PR TITLE
Recursive Set Prevent or Cancel for Rasterized SubNodes

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -1290,13 +1290,13 @@ static void _recursiveSetPreventOrCancelDisplay(ASDisplayNode *node, CALayer *la
   // Set the flag on the node.  If this is a pure layer (no node) then this has no effect (plain layers don't support preventing/cancelling display).
   node.preventOrCancelDisplay = flag;
 
-  if (layer) {
+  if (layer && !node.shouldRasterizeDescendants) {
     // If there is a layer, recurse down the layer hierarchy to set the flag on descendants.  This will cover both layer-based and node-based children.
     for (CALayer *sublayer in layer.sublayers) {
       _recursiveSetPreventOrCancelDisplay(nil, sublayer, flag);
     }
   } else {
-    // If there is no layer (view not loaded yet), recurse down the subnode hierarchy to set the flag on descendants.  This covers only node-based children, but for a node whose view is not loaded it can't possibly have nodeless children.
+    // If there is no layer (view not loaded yet) or this node rasterizes descendants (there won't be a layer tree to traverse), recurse down the subnode hierarchy to set the flag on descendants.  This covers only node-based children, but for a node whose view is not loaded it can't possibly have nodeless children.
     for (ASDisplayNode *subnode in node.subnodes) {
       _recursiveSetPreventOrCancelDisplay(subnode, nil, flag);
     }


### PR DESCRIPTION
Adds check for nodes who should rasterize descendants and opts to recurse down the subnode hierarchy in _recursiveSetPreventOrCancelDisplay.
