### PR TITLE
Added tintColor convenience methods

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -474,6 +474,9 @@
 */
 @property (atomic, retain)           UIColor *backgroundColor;              // default=nil
 
+@property (atomic, retain)           UIColor *tintColor;                    // default=Blue
+- (void)tintColorDidChange;     // Notifies the node when the tintColor has changed.
+
 /**
  * @abstract A flag used to determine how a node lays out its content when its bounds change.
  *

--- a/AsyncDisplayKit/Details/UIView+ASConvenience.h
+++ b/AsyncDisplayKit/Details/UIView+ASConvenience.h
@@ -48,6 +48,7 @@
 @property (nonatomic, getter=isHidden)                  BOOL hidden;
 @property (nonatomic, assign)                           BOOL autoresizesSubviews;
 @property (nonatomic, assign)                           UIViewAutoresizing autoresizingMask;
+@property (nonatomic, retain)                           UIColor *tintColor;
 @property (nonatomic, assign)                           CGFloat alpha;
 @property (nonatomic, assign)                           CGRect bounds;
 @property (nonatomic, assign)                           UIViewContentMode contentMode;

--- a/AsyncDisplayKit/Details/_ASDisplayView.mm
+++ b/AsyncDisplayKit/Details/_ASDisplayView.mm
@@ -213,4 +213,11 @@
   [_node asyncdisplaykit_asyncTransactionContainerStateDidChange];
 }
 
+- (void)tintColorDidChange
+{
+    [super tintColorDidChange];
+    
+    [_node tintColorDidChange];
+}
+
 @end

--- a/AsyncDisplayKit/Private/ASDisplayNode+UIViewBridge.mm
+++ b/AsyncDisplayKit/Private/ASDisplayNode+UIViewBridge.mm
@@ -364,6 +364,25 @@
   _setToLayer(backgroundColor, backgroundColor.CGColor);
 }
 
+- (UIColor *)tintColor
+{
+    _bridge_prologue;
+    ASDisplayNodeAssert(!_flags.isLayerBacked, @"Danger: this property is undefined on layer-backed nodes.");
+    return _getFromViewOnly(tintColor);
+}
+
+- (void)setTintColor:(UIColor *)color
+{
+    _bridge_prologue;
+    ASDisplayNodeAssert(!_flags.isLayerBacked, @"Danger: this property is undefined on layer-backed nodes.");
+    _setToViewOnly(tintColor, color);
+}
+
+- (void)tintColorDidChange
+{
+    // ignore this, allow subclasses to be notified
+}
+
 - (CGColorRef)shadowColor
 {
   _bridge_prologue;

--- a/AsyncDisplayKit/Private/_ASPendingState.m
+++ b/AsyncDisplayKit/Private/_ASPendingState.m
@@ -61,6 +61,7 @@
     int setAutoresizingMask:1;
     int setBounds:1;
     int setBackgroundColor:1;
+    int setTintColor:1;
     int setContents:1;
     int setHidden:1;
     int setAlpha:1;
@@ -109,6 +110,7 @@
 @synthesize edgeAntialiasingMask=edgeAntialiasingMask;
 @synthesize autoresizesSubviews=autoresizesSubviews;
 @synthesize autoresizingMask=autoresizingMask;
+@synthesize tintColor=tintColor;
 @synthesize alpha=alpha;
 @synthesize contentMode=contentMode;
 @synthesize anchorPoint=anchorPoint;
@@ -148,6 +150,7 @@
   opaque = YES;
   bounds = CGRectZero;
   backgroundColor = nil;
+  tintColor = [UIColor colorWithRed:0.0 green:0.478 blue:1.0 alpha:1.0];
   contents = nil;
   isHidden = NO;
   needsDisplayOnBoundsChange = NO;
@@ -263,6 +266,12 @@
   CGColorRelease(backgroundColor);
   backgroundColor = CGColorRetain(color);
   _flags.setBackgroundColor = YES;
+}
+
+- (void)setTintColor:(UIColor *)newTintColor
+{
+  tintColor = newTintColor;
+  _flags.setTintColor = YES;
 }
 
 - (void)setContents:(id)newContents
@@ -651,6 +660,9 @@
 
   if (_flags.setBackgroundColor)
     layer.backgroundColor = backgroundColor;
+
+  if (_flags.setTintColor)
+    view.tintColor = self.tintColor;
 
   if (_flags.setOpaque)
     view.layer.opaque = opaque;


### PR DESCRIPTION
tintColor is now forwarded to the underlying view, and much more importantly, the node is notified when the tintColor changes on the view.
