### PR TITLE
Give a change to ASTableView's delegate to configure each node's container cell before it is shown.

### DIFF
--- a/AsyncDisplayKit/ASTableView.h
+++ b/AsyncDisplayKit/ASTableView.h
@@ -108,6 +108,7 @@
 @optional
 
 - (void)tableView:(UITableView *)tableView willDisplayNode:(ASCellNode *)cellNode insideCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath;
+- (void)tableView:(UITableView *)tableView willDisplayNodeForRowAtIndexPath:(NSIndexPath *)indexPath;
 - (void)tableView:(UITableView *)tableView didEndDisplayingNodeForRowAtIndexPath:(NSIndexPath*)indexPath;
 
 @end

--- a/AsyncDisplayKit/ASTableView.m
+++ b/AsyncDisplayKit/ASTableView.m
@@ -288,6 +288,9 @@ static BOOL _isInterceptedSelector(SEL sel)
   if ([_asyncDelegate respondsToSelector:@selector(tableView:willDisplayNode:insideCell:forRowAtIndexPath:)]) {
     [_asyncDelegate tableView:self willDisplayNode:[_asyncDataSource tableView:self nodeForRowAtIndexPath:indexPath] insideCell:cell forRowAtIndexPath:indexPath];
   }
+  else if ([_asyncDelegate respondsToSelector:@selector(tableView:willDisplayNodeForRowAtIndexPath:)]) {
+    [_asyncDelegate tableView:self willDisplayNodeForRowAtIndexPath:indexPath];
+  }
 }
 
 - (void)tableView:(UITableView *)tableView didEndDisplayingCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath*)indexPath


### PR DESCRIPTION
In the current version, instances of _ASTableViewCell are reused / created with default values for all of its properties. They have a white background, default selectionstyle and many others.

Exposing the tableviewcell in the delegate method triggered just before the node is shown allows ASTableView's delegate to configure the container cell (background color, selection style, etc...)
