### PR TITLE
Fix text highlighting in UIScrollView

### DIFF
--- a/AsyncDisplayKit/ASTextNode.mm
+++ b/AsyncDisplayKit/ASTextNode.mm
@@ -554,6 +554,12 @@ ASDISPLAYNODE_INLINE CGFloat ceilPixelValue(CGFloat f)
         for (NSValue *rectValue in highlightRects) {
           CGRect rendererRect = [[self class] _adjustRendererRect:rectValue.CGRectValue forShadowPadding:_shadower.shadowPadding];
           CGRect highlightedRect = [self.layer convertRect:rendererRect toLayer:highlightTargetLayer];
+
+          // We set our overlay layer's frame to the bounds of the highlight target layer.
+          // Offset highlight rects to avoid double-counting target layer's bounds.origin.
+          highlightedRect.origin.x -= highlightTargetLayer.bounds.origin.x;
+          highlightedRect.origin.y -= highlightTargetLayer.bounds.origin.y;
+          
           [converted addObject:[NSValue valueWithCGRect:highlightedRect]];
         }
 


### PR DESCRIPTION
Highlight target layers with non-zero bounds.origin exhibited broken
text highlighting behavior. Highlights would appear offset by the
layer’s bounds.origin, and would not align with their target text. This
most often appeared in UIScrollView, where highlights would appear
incorrectly offset once the scroll view was scrolled. Fix by accounting
for bounds.origin in the calculations of the text overlay highlight
rects.
