### PR TITLE
Add point parameter to ASTextNode delegate methods

### DIFF
--- a/AsyncDisplayKit/ASTextNode.h
+++ b/AsyncDisplayKit/ASTextNode.h
@@ -204,19 +204,21 @@ typedef NS_ENUM(NSUInteger, ASTextNodeHighlightStyle) {
  @param textNode The text node containing the entity attribute.
  @param attribute The attribute that was tapped. Will not be nil.
  @param value The value of the tapped attribute.
+ @param point The point within textNode, in textNode's coordinate system, that was touched to trigger a highlight.
  @discussion If not implemented, the default value is NO.
  @return YES if the entity attribute should be a link, NO otherwise.
  */
-- (BOOL)textNode:(ASTextNode *)textNode shouldHighlightLinkAttribute:(NSString *)attribute value:(id)value;
+- (BOOL)textNode:(ASTextNode *)textNode shouldHighlightLinkAttribute:(NSString *)attribute value:(id)value atPoint:(CGPoint)point;
 
 /**
  @abstract Indicates to the text node if an attribute is a valid long-press target
  @param textNode The text node containing the entity attribute.
  @param attribute The attribute that was tapped. Will not be nil.
  @param value The value of the tapped attribute.
+ @param point The point within textNode, in textNode's coordinate system, that was long-pressed.
  @discussion If not implemented, the default value is NO.
  @return YES if the entity attribute should be treated as a long-press target, NO otherwise.
  */
-- (BOOL)textNode:(ASTextNode *)textNode shouldLongPressLinkAttribute:(NSString *)attribute value:(id)value;
+- (BOOL)textNode:(ASTextNode *)textNode shouldLongPressLinkAttribute:(NSString *)attribute value:(id)value atPoint:(CGPoint)point;
 
 @end

--- a/AsyncDisplayKit/ASTextNode.mm
+++ b/AsyncDisplayKit/ASTextNode.mm
@@ -418,8 +418,8 @@ ASDISPLAYNODE_INLINE CGFloat ceilPixelValue(CGFloat f)
 
       // Check if delegate implements optional method, if not assume NO.
       // Should the text be highlightable/touchable?
-      if (![_delegate respondsToSelector:@selector(textNode:shouldHighlightLinkAttribute:value:)] ||
-          ![_delegate textNode:self shouldHighlightLinkAttribute:name value:value]) {
+      if (![_delegate respondsToSelector:@selector(textNode:shouldHighlightLinkAttribute:value:atPoint:)] ||
+          ![_delegate textNode:self shouldHighlightLinkAttribute:name value:value atPoint:point]) {
         value = nil;
         name = nil;
       }
@@ -465,8 +465,11 @@ ASDISPLAYNODE_INLINE CGFloat ceilPixelValue(CGFloat f)
     }
 
     // Ask our delegate if a long-press on an attribute is relevant
-    if ([self.delegate respondsToSelector:@selector(textNode:shouldLongPressLinkAttribute:value:)]) {
-      return [self.delegate textNode:self shouldLongPressLinkAttribute:_highlightedLinkAttributeName value:_highlightedLinkAttributeValue];
+    if ([self.delegate respondsToSelector:@selector(textNode:shouldLongPressLinkAttribute:value:atPoint:)]) {
+      return [self.delegate textNode:self
+        shouldLongPressLinkAttribute:_highlightedLinkAttributeName
+                               value:_highlightedLinkAttributeValue
+                             atPoint:[gestureRecognizer locationInView:self.view]];
     }
 
     // Otherwise we are good to go.

--- a/AsyncDisplayKitTests/ASTextNodeTests.m
+++ b/AsyncDisplayKitTests/ASTextNodeTests.m
@@ -30,7 +30,7 @@
   _tappedLinkValue = value;
 }
 
-- (BOOL)textNode:(ASTextNode *)textNode shouldHighlightLinkAttribute:(NSString *)attribute value:(id)value
+- (BOOL)textNode:(ASTextNode *)textNode shouldHighlightLinkAttribute:(NSString *)attribute value:(id)value atPoint:(CGPoint)point
 {
   return YES;
 }


### PR DESCRIPTION
Outfit ASTextNodeDelegate shouldHighlight and shouldLongPress methods
with a point parameter that describes the location of the relevant
touch.
