### PR TITLE
UIView hierarchy traversal when comparing ASDisplayNode ancestors

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -535,7 +535,6 @@ static inline ASDisplayNode *_ASDisplayNodeFindClosestCommonAncestor(ASDisplayNo
   UIView *ancestorView;
 
   do {
-    NSLog(@"ancestorNode: %@\nancestorView: %@", ancestorNode, ancestorView);
     if (ancestorNode) {
       if (_ASDisplayNodeIsAncestorOfDisplayNode(ancestorNode, node2)) {
         break;


### PR DESCRIPTION
This allows `[ASDisplayNode convertPoint:toNode:]` and friends to work as expected with UI hierarchies that have intermingling `UIView`s and `ASDisplayNode`s. A good example of this problem is a hierarchy that looks like this: `ASDisplayNode -> ASTableView -> ASDisplayNode`.

Cheers! :+1: 
