### PR TITLE
Override [ASCellNode supernode] to return its ASTableView's node wrapper

### DIFF
--- a/AsyncDisplayKit/ASCellNode.m
+++ b/AsyncDisplayKit/ASCellNode.m
@@ -40,7 +40,7 @@
 
 - (ASDisplayNode *)supernode
 {
-  // ASCellNode -> UITableViewCellContentView -> _ASTableViewCell -> UITableViewWrapperView -> ASTableView
+  // ASCellNode.view -> UITableViewCellContentView -> _ASTableViewCell -> UITableViewWrapperView -> ASTableView
   return self.nodeLoaded ? ASViewToDisplayNode(self.view.superview.superview.superview.superview) : nil;
 }
 


### PR DESCRIPTION
This may or may not be the best solution, but it is the simplest.

This fix allows `_ASDisplayNodeFindClosestCommonAncestor` to traverse `ASTableView` hierarchies without throwing an exception.

An alternative fix would be to add a check inside `_ASDisplayNodeFindClosestCommonAncestor` like `if ([supernode isKindOfClass:[ASCellNode class]])` and _then_ jump up to the `ASTableView` node wrapper instead of crashing.

Thoughts? :smile: 
