### PR TITLE
Text node highlights fully fade in before fading out

### DIFF
--- a/AsyncDisplayKit/ASTextNode.mm
+++ b/AsyncDisplayKit/ASTextNode.mm
@@ -520,12 +520,24 @@ ASDISPLAYNODE_INLINE CGFloat ceilPixelValue(CGFloat f)
 
         weakHighlightLayer.opacity = 0.0;
 
+        CFTimeInterval beginTime = CACurrentMediaTime();
+        CABasicAnimation *possibleFadeIn = (CABasicAnimation *)[weakHighlightLayer animationForKey:@"opacity"];
+        if (possibleFadeIn) {
+          // Calculate when we should begin fading out based on the end of the fade in animation,
+          // Also check to make sure that the new begin time hasn't already passed
+          CGFloat newBeginTime = (possibleFadeIn.beginTime + possibleFadeIn.duration);
+          if (newBeginTime > beginTime) {
+            beginTime = newBeginTime;
+          }
+        }
+        
         CABasicAnimation *fadeOut = [CABasicAnimation animationWithKeyPath:@"opacity"];
         fadeOut.timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseInEaseOut];
-        fadeOut.fromValue = @(((CALayer *)weakHighlightLayer.presentationLayer).opacity);
+        fadeOut.fromValue = possibleFadeIn.toValue ?: @(((CALayer *)weakHighlightLayer.presentationLayer).opacity);
         fadeOut.toValue = @0.0;
         fadeOut.fillMode = kCAFillModeBoth;
         fadeOut.duration = ASTextNodeHighlightFadeOutDuration;
+        fadeOut.beginTime = beginTime;
 
         dispatch_block_t prev = [CATransaction completionBlock];
         [CATransaction setCompletionBlock:^{
@@ -562,7 +574,6 @@ ASDISPLAYNODE_INLINE CGFloat ceilPixelValue(CGFloat f)
           // Offset highlight rects to avoid double-counting target layer's bounds.origin.
           highlightedRect.origin.x -= highlightTargetLayer.bounds.origin.x;
           highlightedRect.origin.y -= highlightTargetLayer.bounds.origin.y;
-          
           [converted addObject:[NSValue valueWithCGRect:highlightedRect]];
         }
 
@@ -578,6 +589,7 @@ ASDISPLAYNODE_INLINE CGFloat ceilPixelValue(CGFloat f)
           fadeIn.fromValue = @0.0;
           fadeIn.toValue = @(overlayLayer.opacity);
           fadeIn.duration = ASTextNodeHighlightFadeInDuration;
+          fadeIn.beginTime = CACurrentMediaTime();
 
           [overlayLayer addAnimation:fadeIn forKey:fadeIn.keyPath];
         }


### PR DESCRIPTION
Similarly like a UIButton will fully highlight and unhighlight when you tap it regardless of if your touch-down duration is less than the duration of the fade.
