### PR TITLE
Working-range-driven image loading.

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode+Subclasses.h
+++ b/AsyncDisplayKit/ASDisplayNode+Subclasses.h
@@ -170,6 +170,14 @@
 - (NSObject *)drawParametersForAsyncLayer:(_ASDisplayLayer *)layer;
 
 /**
+ * @abstract Indicates that the receiver is about to display.
+ *
+ * @discussion Subclasses may override this method to be notified when display (asynchronous or synchronous) is
+ * about to begin.
+ */
+- (void)displayWillStart ASDISPLAYNODE_REQUIRES_SUPER;
+
+/**
  * @abstract Indicates that the receiver has finished displaying.
  *
  * @discussion Subclasses may override this method to be notified when display (asynchronous or synchronous) has

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -630,6 +630,8 @@ static inline CATransform3D _calculateTransformFromReferenceToTarget(ASDisplayNo
 
 - (void)willDisplayAsyncLayer:(_ASDisplayLayer *)layer
 {
+  // Subclass hook.
+  [self displayWillStart];
 }
 
 - (void)didDisplayAsyncLayer:(_ASDisplayLayer *)layer
@@ -1180,6 +1182,10 @@ static NSInteger incrementIfFound(NSInteger i) {
 - (void)layout
 {
   ASDisplayNodeAssertMainThread();
+}
+
+- (void)displayWillStart
+{
 }
 
 - (void)displayDidFinish

--- a/AsyncDisplayKit/ASMultiplexImageNode.mm
+++ b/AsyncDisplayKit/ASMultiplexImageNode.mm
@@ -172,9 +172,9 @@ static inline BOOL _shouldUpdateAfterChangedImageIdentifiers(id loadedIdentifier
 }
 
 #pragma mark - ASDisplayNode Overrides
-- (void)didExitHierarchy
+- (void)reclaimMemory
 {
-  [super didExitHierarchy]; // This actually clears the contents, so we need to do this first for our displayedImageIdentifier to be meaningful.
+  [super reclaimMemory]; // This actually clears the contents, so we need to do this first for our displayedImageIdentifier to be meaningful.
   [self _setDisplayedImageIdentifier:nil withImage:nil];
 
   if (_downloadIdentifier) {
@@ -184,9 +184,9 @@ static inline BOOL _shouldUpdateAfterChangedImageIdentifiers(id loadedIdentifier
   }
 }
 
-- (void)willEnterHierarchy
+- (void)displayWillStart
 {
-  [super willEnterHierarchy];
+  [super displayWillStart];
 
   if(_canceledImageDownload) {
     [self _updatedImageIdentifiers];

--- a/AsyncDisplayKit/ASNetworkImageNode.mm
+++ b/AsyncDisplayKit/ASNetworkImageNode.mm
@@ -122,9 +122,9 @@
   return _delegate;
 }
 
-- (void)didExitHierarchy
+- (void)reclaimMemory
 {
-  [super didExitHierarchy];
+  [super reclaimMemory];
 
   {
     ASDN::MutexLocker l(_lock);
@@ -135,9 +135,9 @@
   }
 }
 
-- (void)willEnterHierarchy
+- (void)displayWillStart
 {
-  [super willEnterHierarchy];
+  [super displayWillStart];
 
   {
     ASDN::MutexLocker l(_lock);


### PR DESCRIPTION
Adds a new Node subclass hook, `-displayWillStart`, paralleling `-displayDidFinish`.
