### PR TITLE
Make ASNetworkImageNode Just Work.

### DIFF
--- a/AsyncDisplayKit/ASNetworkImageNode.h
+++ b/AsyncDisplayKit/ASNetworkImageNode.h
@@ -29,10 +29,16 @@
  *
  * @discussion If `cache` is nil, the receiver will not attempt to retrieve images from a cache before downloading them.
  *
- * @result An initialized ASNetworkImageNode.
+ * @returns An initialized ASNetworkImageNode.
  */
 - (instancetype)initWithCache:(id<ASImageCacheProtocol>)cache downloader:(id<ASImageDownloaderProtocol>)downloader;
-- (instancetype)init NS_UNAVAILABLE;
+
+/**
+ * Convenience initialiser.
+ *
+ * @returns An ASNetworkImageNode configured to use the NSURLSession-powered ASBasicImageDownloader, and no extra cache.
+ */
+- (instancetype)init;
 
 /**
  * The delegate, which must conform to the <ASNetworkImageNodeDelegate> protocol.

--- a/AsyncDisplayKit/ASNetworkImageNode.mm
+++ b/AsyncDisplayKit/ASNetworkImageNode.mm
@@ -8,8 +8,9 @@
 
 #import "ASNetworkImageNode.h"
 
-#import <AsyncDisplayKit/ASDisplayNode+Subclasses.h>
-#import <AsyncDisplayKit/ASThread.h>
+#import "ASBasicImageDownloader.h"
+#import "ASDisplayNode+Subclasses.h"
+#import "ASThread.h"
 
 
 @interface ASNetworkImageNode ()
@@ -49,7 +50,7 @@
 
 - (instancetype)init
 {
-  ASDISPLAYNODE_NOT_DESIGNATED_INITIALIZER();
+  return [self initWithCache:nil downloader:[[ASBasicImageDownloader alloc] init]];
 }
 
 - (void)dealloc

--- a/examples/Kittens/Sample/KittenNode.m
+++ b/examples/Kittens/Sample/KittenNode.m
@@ -74,7 +74,7 @@ static const CGFloat kInnerPadding = 10.0f;
   _kittenSize = size;
 
   // kitten image, with a purple background colour serving as placeholder
-  _imageNode = [[ASNetworkImageNode alloc] initWithCache:nil downloader:[[ASBasicImageDownloader alloc] init]];
+  _imageNode = [[ASNetworkImageNode alloc] init];
   _imageNode.backgroundColor = [UIColor purpleColor];
   _imageNode.URL = [NSURL URLWithString:[NSString stringWithFormat:@"http://placekitten.com/%zd/%zd",
                                                                    (NSInteger)roundl(_kittenSize.width),


### PR DESCRIPTION
Use ASBasicImageDownloader by default -- you can now do...

``` objective-c
ASNetworkImageNode *imageNode = [[ASNetworkImageNode alloc] init];
imageNode.URL = [NSURL URLWithString:@"..."];
[self.view addSubview:imageNode.view];
```

...and it'll do the right thing.
