### PR TITLE
ASBasicImageDownloader iOS 7 support

### DIFF
--- a/examples/Kittens/Sample.xcodeproj/project.pbxproj
+++ b/examples/Kittens/Sample.xcodeproj/project.pbxproj
@@ -311,6 +311,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = Sample/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -322,6 +323,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = Sample/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};


### PR DESCRIPTION
On iOS 7, NSURLSessionTask is actually a [__NSCFURLSessionTask](https://github.com/EthanArbuckle/IOS-7-Headers/blob/master/Frameworks/CFNetwork.framework/__NSCFURLSessionTask.h) (a private class) and our NSURLSessionTask category to add the associated object asyncdisplaykit_metadata was crashing on iOS 7 stating that there was no method. This commit changes the category to extend NSURLRequest as well as change NSURLSessionTask to NSURLSessionDownloadTask.
