### PR TITLE
Update manual display logic

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -294,24 +294,6 @@
  */
 @property (nonatomic, assign) BOOL shouldRasterizeDescendants;
 
-/**
- * @abstract Calls -setNeedsDisplay and -displayIfNeeded on the node's backing store.
- *
- * @note This method must be called on the main thread but there are plans to allow this on any thread.
- */
-- (void)display;
-
-/**
- * @abstract Call -display on the node and recursively on all subnodes, forcing the entire node hierarchy to be
- * displayed.
- */
-- (void)recursivelyDisplay;
-
-/** 
- * @abstract Display the node's view/layer immediately on the current thread, bypassing the background thread rendering.
- */
-- (void)displayImmediately;
-
 /** 
  * @abstract Prevent the node's layer from displaying.
  *

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -434,33 +434,6 @@ void ASDisplayNodePerformBlockOnMainThread(void (^block)())
   _contentsScaleForDisplay = contentsScaleForDisplay;
 }
 
-- (void)display
-{
-  ASDisplayNodeAssertMainThread();
-  ASDisplayNodeAssert(self.nodeLoaded, @"backing store must be loaded before calling -display");
-
-  // rendering a backing store requires a node be laid out
-  [self __layout];
-
-  CALayer *layer = [self isLayerBacked] ? self.layer : self.view.layer;
-
-  if (layer.contents) {
-    return;
-  }
-
-  [layer setNeedsDisplay];
-  [layer displayIfNeeded];
-}
-
-- (void)recursivelyDisplay
-{
-  for (ASDisplayNode *node in self.subnodes) {
-    [node recursivelyDisplay];
-  }
-
-  [self display];
-}
-
 - (void)displayImmediately
 {
   ASDisplayNodeAssertMainThread();

--- a/AsyncDisplayKit/Details/ASRangeController.mm
+++ b/AsyncDisplayKit/Details/ASRangeController.mm
@@ -13,6 +13,45 @@
 #import "ASDisplayNodeInternal.h"
 #import "ASRangeControllerInternal.h"
 
+@interface ASDisplayNode (ASRangeController)
+
+- (void)display;
+- (void)recursivelyDisplay;
+
+@end
+
+@implementation ASDisplayNode (ASRangeController)
+
+- (void)display
+{
+  ASDisplayNodeAssertMainThread();
+  ASDisplayNodeAssert(self.nodeLoaded, @"backing store must be loaded before calling -display");
+
+  CALayer *layer = self.layer;
+
+  // rendering a backing store requires a node be laid out
+  [layer setNeedsLayout];
+  [layer layoutIfNeeded];
+
+  if (layer.contents) {
+    return;
+  }
+
+  [layer setNeedsDisplay];
+  [layer displayIfNeeded];
+}
+
+- (void)recursivelyDisplay
+{
+  for (ASDisplayNode *node in self.subnodes) {
+    [node recursivelyDisplay];
+  }
+
+  [self display];
+}
+
+@end
+
 @interface ASRangeController () {
   // index path -> node mapping
   NSMutableDictionary *_nodes;

--- a/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
+++ b/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
@@ -115,6 +115,9 @@ void ASDisplayNodePerformBlockOnMainThread(void (^block)());
 // Call didExitHierarchy if necessary and set inHierarchy = NO if visibility notifications are enabled on all of its parents
 - (void)__exitHierarchy;
 
+// Display the node's view/layer immediately on the current thread, bypassing the background thread rendering. Will be deprecated.
+- (void)displayImmediately;
+
 // Returns the ancestor node that rasterizes descendants, or nil if none.
 - (ASDisplayNode *)__rasterizedContainerNode;
 


### PR DESCRIPTION
Postpone manual display until a future release when it can be called on any thread. Provide the current node manual display logic as a category on ASDisplayNode only available for ASRangeController. Prepare -displayImmediately for deprecation.
