### PR TITLE
fix the crash when calling rebuildData

### DIFF
--- a/AsyncDisplayKit/Details/ASRangeController.mm
+++ b/AsyncDisplayKit/Details/ASRangeController.mm
@@ -117,6 +117,10 @@
 
 }
 
+- (void)cancelSizeNextBlock{
+    [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(sizeNextBlock) object:nil];
+}
+
 + (dispatch_queue_t)sizingQueue
 {
   static dispatch_queue_t sizingQueue = NULL;
@@ -296,6 +300,7 @@ static BOOL ASRangeIsValid(NSRange range)
    * teardown
    */
   [self teardownAllNodes];
+  [self cancelSizeNextBlock];
 
   /*
    * setup


### PR DESCRIPTION
When doing refresh, we should cancel perform requests previously registered with `performSelector:withObject:afterDelay:` first, or it will do the `sizeNextBlock` twice with the same indexPath and then it will crash.
