### PR TITLE
Remove CATransaction hack.

### DIFF
--- a/AsyncDisplayKit/Details/ASRangeController.mm
+++ b/AsyncDisplayKit/Details/ASRangeController.mm
@@ -121,12 +121,7 @@
   ASDisplayNodeAssertMainThread();
   ASDisplayNodeAssert(node && view, @"invalid argument, did you mean -removeNodeFromWorkingRange:?");
 
-  // use an explicit transaction to force CoreAnimation to display nodes in the order they are added.
-  [CATransaction begin];
-
   [view addSubview:node.view];
-
-  [CATransaction commit];
 }
 
 #pragma mark -


### PR DESCRIPTION
ASRangeController previously enqueued display of individual nodes by
adding their views to the hierarchy, wrapping each `-addSubview:` call
in an explicit CATransaction to force displays to occur in order.  This
hack is no longer necessary -- kill it.
