### PR TITLE
Fix crash in Flow Controller

### DIFF
--- a/AsyncDisplayKit/Details/ASFlowLayoutController.mm
+++ b/AsyncDisplayKit/Details/ASFlowLayoutController.mm
@@ -155,7 +155,7 @@ static const std::pair<int, int> ASFindIndexForRange(const std::vector<std::vect
 
   if (range < 0.0 && cur.first >= 0 && cur.second >= 0) {
     // search backward
-    while (range < 0.0 && cur.second >= 0) {
+    while (range < 0.0 && cur.first >= 0 && cur.second >= 0) {
       pre = cur;
       CGSize size = nodes[cur.first][cur.second];
       range += layoutDirection == ASFlowLayoutDirectionHorizontal ? size.width : size.height;
@@ -170,7 +170,7 @@ static const std::pair<int, int> ASFindIndexForRange(const std::vector<std::vect
     }
   } else {
     // search forward
-    while (range > 0.0 && cur.second < nodes[cur.first].size()) {
+    while (range > 0.0 && cur.first < nodes.size() && cur.second < nodes[cur.first].size()) {
       pre = cur;
       CGSize size = nodes[cur.first][cur.second];
       range -= layoutDirection == ASFlowLayoutDirectionHorizontal ? size.width : size.height;


### PR DESCRIPTION
The cur.first may out of boundary in the case for all empty sections