### PR TITLE
Let ASMultiplexImageNode skip failed image identifiers

### DIFF
--- a/AsyncDisplayKit/ASMultiplexImageNode.h
+++ b/AsyncDisplayKit/ASMultiplexImageNode.h
@@ -69,6 +69,11 @@ typedef NS_ENUM(NSUInteger, ASMultiplexImageNodeErrorCode) {
 @property (nonatomic, readwrite, assign) BOOL downloadsIntermediateImages;
 
 /**
+ * @abstract Indicates that the receiver should stop loading if it encounters an error while loading an intermediate image identifier. Defaults to NO.
+ */
+@property (nonatomic, readwrite, assign) BOOL haltLoadingOnError;
+
+/**
  * @abstract An array of identifiers representing various versions of an image for ASMultiplexImageNode to display.
  *
  * @discussion An identifier can be any object that conforms to NSObject and NSCopying.  The array should be in

--- a/AsyncDisplayKit/ASMultiplexImageNode.mm
+++ b/AsyncDisplayKit/ASMultiplexImageNode.mm
@@ -62,6 +62,7 @@ typedef void(^ASMultiplexImageLoadCompletionBlock)(UIImage *image, id imageIdent
 
   // Image flags.
   BOOL _downloadsIntermediateImages; // Defaults to NO.
+  BOOL _haltLoadingOnError;          // Defaults to NO.
   OSSpinLock _imageIdentifiersLock;
   NSArray *_imageIdentifiers;
   id _loadedImageIdentifier;
@@ -588,9 +589,9 @@ typedef void(^ASMultiplexImageLoadCompletionBlock)(UIImage *image, id imageIdent
 #pragma mark -
 - (void)_finishedLoadingImage:(UIImage *)image forIdentifier:(id)imageIdentifier error:(NSError *)error
 {
-  // If we failed to load, we stop the loading process.
+  // If we failed to load and _haltLoadingOnError is YES, we stop the loading process.
   // Note that if we bailed before we began downloading because the best identifier changed, we don't bail, but rather just begin loading the best image identifier.
-  if (error && error.code != ASMultiplexImageNodeErrorCodeBestImageIdentifierChanged)
+  if (_haltLoadingOnError && error && error.code != ASMultiplexImageNodeErrorCodeBestImageIdentifierChanged)
     return;
 
   OSSpinLockLock(&_imageIdentifiersLock);


### PR DESCRIPTION
This addressed #159.