### PR TITLE
Let ASMultiplexImageNode skip failed image identifiers

### DIFF
--- a/AsyncDisplayKit/ASMultiplexImageNode.h
+++ b/AsyncDisplayKit/ASMultiplexImageNode.h
@@ -69,6 +69,11 @@ typedef NS_ENUM(NSUInteger, ASMultiplexImageNodeErrorCode) {
 @property (nonatomic, readwrite, assign) BOOL downloadsIntermediateImages;
 
 /**
+ * @abstract Indicates that the receiver should stop loading if it encounters an error while loading an intermediate image identifier. Defaults to NO.
+ */
+@property (nonatomic, readwrite, assign) BOOL haltLoadingOnError;
+
+/**
  * @abstract An array of identifiers representing various versions of an image for ASMultiplexImageNode to display.
  *
  * @discussion An identifier can be any object that conforms to NSObject and NSCopying.  The array should be in

--- a/AsyncDisplayKit/ASMultiplexImageNode.h
+++ b/AsyncDisplayKit/ASMultiplexImageNode.h
@@ -71,7 +71,7 @@ typedef NS_ENUM(NSUInteger, ASMultiplexImageNodeErrorCode) {
 /**
  * @abstract Indicates that the receiver should stop loading if it encounters an error while loading an intermediate image identifier. Defaults to NO.
  */
-@property (nonatomic, readwrite, assign) BOOL haltLoadingOnError;
+@property (nonatomic, readwrite, assign) BOOL haltsLoadingOnError;
 
 /**
  * @abstract An array of identifiers representing various versions of an image for ASMultiplexImageNode to display.

--- a/AsyncDisplayKit/ASMultiplexImageNode.mm
+++ b/AsyncDisplayKit/ASMultiplexImageNode.mm
@@ -62,11 +62,13 @@ typedef void(^ASMultiplexImageLoadCompletionBlock)(UIImage *image, id imageIdent
 
   // Image flags.
   BOOL _downloadsIntermediateImages; // Defaults to NO.
+  BOOL _haltLoadingOnError;          // Defaults to NO.
   OSSpinLock _imageIdentifiersLock;
   NSArray *_imageIdentifiers;
   id _loadedImageIdentifier;
   id _loadingImageIdentifier;
   id _displayedImageIdentifier;
+  id _failedImageIdentifier;         // Reset to nil whenever an image is successfully loaded
 
   // Networking.
   id _downloadIdentifier;
@@ -353,9 +355,11 @@ typedef void(^ASMultiplexImageLoadCompletionBlock)(UIImage *image, id imageIdent
 {
   OSSpinLockLock(&_imageIdentifiersLock);
 
+  id _currentImageIdentifier = _failedImageIdentifier != nil ? _failedImageIdentifier : _loadedImageIdentifier;
+    
   // If we've already loaded the best identifier, we've got nothing else to do.
   id bestImageIdentifier = ([_imageIdentifiers count] > 0) ? _imageIdentifiers[0] : nil;
-  if (!bestImageIdentifier || [_loadedImageIdentifier isEqual:bestImageIdentifier]) {
+  if (!bestImageIdentifier || [_currentImageIdentifier isEqual:bestImageIdentifier]) {
     OSSpinLockUnlock(&_imageIdentifiersLock);
     return nil;
   }
@@ -368,15 +372,15 @@ typedef void(^ASMultiplexImageLoadCompletionBlock)(UIImage *image, id imageIdent
   }
   // Otherwise, load progressively.
   else {
-    NSUInteger loadedIndex = [_imageIdentifiers indexOfObject:_loadedImageIdentifier];
+    NSUInteger currentIndex = [_imageIdentifiers indexOfObject:_currentImageIdentifier];
 
     // If nothing has loaded yet, load the worst identifier.
-    if (loadedIndex == NSNotFound) {
+    if (currentIndex == NSNotFound) {
       nextImageIdentifierToDownload = [_imageIdentifiers lastObject];
     }
     // Otherwise, load the next best identifier (if there is one)
-    else if (loadedIndex > 0) {
-      nextImageIdentifierToDownload = _imageIdentifiers[loadedIndex - 1];
+    else if (currentIndex > 0) {
+      nextImageIdentifierToDownload = _imageIdentifiers[currentIndex - 1];
     }
   }
 
@@ -588,10 +592,16 @@ typedef void(^ASMultiplexImageLoadCompletionBlock)(UIImage *image, id imageIdent
 #pragma mark -
 - (void)_finishedLoadingImage:(UIImage *)image forIdentifier:(id)imageIdentifier error:(NSError *)error
 {
-  // If we failed to load, we stop the loading process.
+  // If we failed to load and _haltLoadingOnError is YES, we stop the loading process.
   // Note that if we bailed before we began downloading because the best identifier changed, we don't bail, but rather just begin loading the best image identifier.
-  if (error && error.code != ASMultiplexImageNodeErrorCodeBestImageIdentifierChanged)
-    return;
+  if (error && error.code != ASMultiplexImageNodeErrorCodeBestImageIdentifierChanged) {
+    if (_haltLoadingOnError) {
+      return;
+    }
+    _failedImageIdentifier = imageIdentifier;
+  } else {
+      _failedImageIdentifier = nil;
+  }
 
   OSSpinLockLock(&_imageIdentifiersLock);
   NSUInteger imageIdentifierCount = [_imageIdentifiers count];

--- a/AsyncDisplayKit/ASMultiplexImageNode.mm
+++ b/AsyncDisplayKit/ASMultiplexImageNode.mm
@@ -62,7 +62,7 @@ typedef void(^ASMultiplexImageLoadCompletionBlock)(UIImage *image, id imageIdent
 
   // Image flags.
   BOOL _downloadsIntermediateImages; // Defaults to NO.
-  BOOL _haltLoadingOnError;          // Defaults to NO.
+  BOOL _haltsLoadingOnError;         // Defaults to NO.
   OSSpinLock _imageIdentifiersLock;
   NSArray *_imageIdentifiers;
   id _loadedImageIdentifier;
@@ -355,11 +355,11 @@ typedef void(^ASMultiplexImageLoadCompletionBlock)(UIImage *image, id imageIdent
 {
   OSSpinLockLock(&_imageIdentifiersLock);
 
-  id _currentImageIdentifier = _failedImageIdentifier != nil ? _failedImageIdentifier : _loadedImageIdentifier;
+  id currentImageIdentifier = _failedImageIdentifier != nil ? _failedImageIdentifier : _loadedImageIdentifier;
     
   // If we've already loaded the best identifier, we've got nothing else to do.
   id bestImageIdentifier = ([_imageIdentifiers count] > 0) ? _imageIdentifiers[0] : nil;
-  if (!bestImageIdentifier || [_currentImageIdentifier isEqual:bestImageIdentifier]) {
+  if (!bestImageIdentifier || [currentImageIdentifier isEqual:bestImageIdentifier]) {
     OSSpinLockUnlock(&_imageIdentifiersLock);
     return nil;
   }
@@ -372,7 +372,7 @@ typedef void(^ASMultiplexImageLoadCompletionBlock)(UIImage *image, id imageIdent
   }
   // Otherwise, load progressively.
   else {
-    NSUInteger currentIndex = [_imageIdentifiers indexOfObject:_currentImageIdentifier];
+    NSUInteger currentIndex = [_imageIdentifiers indexOfObject:currentImageIdentifier];
 
     // If nothing has loaded yet, load the worst identifier.
     if (currentIndex == NSNotFound) {
@@ -592,10 +592,10 @@ typedef void(^ASMultiplexImageLoadCompletionBlock)(UIImage *image, id imageIdent
 #pragma mark -
 - (void)_finishedLoadingImage:(UIImage *)image forIdentifier:(id)imageIdentifier error:(NSError *)error
 {
-  // If we failed to load and _haltLoadingOnError is YES, we stop the loading process.
+  // If we failed to load and _haltsLoadingOnError is YES, we stop the loading process.
   // Note that if we bailed before we began downloading because the best identifier changed, we don't bail, but rather just begin loading the best image identifier.
   if (error && error.code != ASMultiplexImageNodeErrorCodeBestImageIdentifierChanged) {
-    if (_haltLoadingOnError) {
+    if (_haltsLoadingOnError) {
       return;
     }
     _failedImageIdentifier = imageIdentifier;


### PR DESCRIPTION
A hopefully better attempt at #159.

I went for the easy route and just kept track of the failed image identifier. The logic that determines which image to load next was updated to consider the failed identifier before using the last loaded identifier.