### PR TITLE
ASBridgeNode: wrapper around an existing UIView with ASDisplayNode semantics

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -12,6 +12,8 @@
 #import "ASBaseDefines.h"
 #import "ASDealloc2MainObject.h"
 
+typedef UIView *(^ASDisplayNodeViewBlock)();
+typedef CALayer *(^ASDisplayNodeLayerBlock)();
 
 /**
  * An `ASDisplayNode` is an abstraction over `UIView` and `CALayer` that allows you to perform calculations about a view
@@ -68,6 +70,22 @@
  * The layer instance will be created with alloc/init.
  */
 - (id)initWithLayerClass:(Class)layerClass;
+
+/**
+ * @abstract Alternative initializer with a block to create the backing view.
+ *
+ * @return An ASDisplayNode instance that loads its view with the given block that is guaranteed to run on the main
+ * queue. The view will render synchronously and -layout and touch handling methods on the node will not be called.
+ */
+- (id)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock;
+
+/**
+ * @abstract Alternative initializer with a block to create the backing layer.
+ *
+ * @return An ASDisplayNode instance that loads its layer with the given block that is guaranteed to run on the main
+ * queue. The layer will render synchronously and -layout and touch handling methods on the node will not be called.
+ */
+- (id)initWithLayerBlock:(ASDisplayNodeLayerBlock)viewBlock;
 
 
 /** @name Properties */

--- a/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
+++ b/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
@@ -56,6 +56,8 @@ typedef NS_OPTIONS(NSUInteger, ASDisplayNodeMethodOverrides) {
   UIEdgeInsets _hitTestSlop;
   NSMutableArray *_subnodes;
 
+  ASDisplayNodeViewBlock _viewBlock;
+  ASDisplayNodeLayerBlock _layerBlock;
   Class _viewClass;
   Class _layerClass;
   UIView *_view;


### PR DESCRIPTION
ASBridgeNode is a node that that wraps a UIView that you want to embed in a view hierarchy created by ASDK. Sometimes a view can't be constructed with `-[initWithViewClass:]` but you want to use it with ASDK.

The API is meant to preserve ASDisplayNode's behavior, so you can still construct and set properties on the node on a background queue before its view is loaded; even though the view was created a priori, it is not considered to be loaded until `node.view` is accessed.

Using ASBridgeNode looks like this:

    // Main queue:
    UIButton *button = [UIButton buttonWithType:UIButtonTypeSystem];
    [button sizeToFit];
    CGRect buttonFrame = button.frame;

    dispatch_async(backgroundQueue, ^{
        ASDisplayNode *node = [ASBridgeNode alloc] initWithView:button];
        // Use `node` as you normally would...
        node.frame = buttonFrame;
    });

ASBridgeNode takes care of managing the view hierarchy so you don't need to worry about it. The main thing it doesn't do (can't do?) is layout. Methods like `-[ASDisplayNode calculateSizeThatFits:]` and `-[ASDisplayNode layout]` cannot delegate to `[UIView sizeThatFits:]` and `[UIView layoutSubviews]` since the UIView methods must run on the main thread (well not always, but some views need it). If ASDK were internally asynchronous and could dispatch its layout calls to different threads (sort of like how ASTableView concurrently computes its cells' layouts) then we could mark ASBridgeNode as having "main-queue affinity" and delegate its layout to UIKit.

Test cases are included and all existing tests pass.