### PR TITLE
Compile for extensions

### DIFF
--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -137,6 +137,7 @@
 		05A6D05B19D0EB64002DD95E /* ASDealloc2MainObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 05A6D05919D0EB64002DD95E /* ASDealloc2MainObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		05F20AA41A15733C00DCA68A /* ASImageProtocols.h in Headers */ = {isa = PBXBuildFile; fileRef = 05F20AA31A15733C00DCA68A /* ASImageProtocols.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1950C4491A3BB5C1005C8279 /* ASEqualityHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 1950C4481A3BB5C1005C8279 /* ASEqualityHelpers.h */; };
+		2911485C1A77147A005D0878 /* ASControlNodeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2911485B1A77147A005D0878 /* ASControlNodeTests.m */; };
 		3C9C128519E616EF00E942A0 /* ASTableViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C9C128419E616EF00E942A0 /* ASTableViewTests.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		464052201A3F83C40061C0BA /* ASDataController.h in Headers */ = {isa = PBXBuildFile; fileRef = 464052191A3F83C40061C0BA /* ASDataController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		464052211A3F83C40061C0BA /* ASDataController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4640521A1A3F83C40061C0BA /* ASDataController.mm */; };
@@ -281,6 +282,7 @@
 		05A6D05919D0EB64002DD95E /* ASDealloc2MainObject.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ASDealloc2MainObject.m; path = ../Details/ASDealloc2MainObject.m; sourceTree = "<group>"; };
 		05F20AA31A15733C00DCA68A /* ASImageProtocols.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASImageProtocols.h; sourceTree = "<group>"; };
 		1950C4481A3BB5C1005C8279 /* ASEqualityHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASEqualityHelpers.h; sourceTree = "<group>"; };
+		2911485B1A77147A005D0878 /* ASControlNodeTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASControlNodeTests.m; sourceTree = "<group>"; };
 		3C9C128419E616EF00E942A0 /* ASTableViewTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASTableViewTests.m; sourceTree = "<group>"; };
 		464052191A3F83C40061C0BA /* ASDataController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASDataController.h; sourceTree = "<group>"; };
 		4640521A1A3F83C40061C0BA /* ASDataController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASDataController.mm; sourceTree = "<group>"; };
@@ -423,6 +425,7 @@
 				058D0A37195D057000B7D73C /* ASTextNodeWordKernerTests.mm */,
 				052EE06A1A15A0D8002C6279 /* TestResources */,
 				058D09C6195D04C000B7D73C /* Supporting Files */,
+				2911485B1A77147A005D0878 /* ASControlNodeTests.m */,
 			);
 			path = AsyncDisplayKitTests;
 			sourceTree = "<group>";
@@ -795,6 +798,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2911485C1A77147A005D0878 /* ASControlNodeTests.m in Sources */,
 				058D0A3E195D057000B7D73C /* ASTextNodeRendererTests.m in Sources */,
 				058D0A3D195D057000B7D73C /* ASTextNodeCoreTextAdditionsTests.m in Sources */,
 				058D0A3C195D057000B7D73C /* ASMutableAttributedStringBuilderTests.m in Sources */,
@@ -903,6 +907,7 @@
 		058D09D0195D04C000B7D73C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				DSTROOT = /tmp/AsyncDisplayKit.dst;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "AsyncDisplayKit/AsyncDisplayKit-Prefix.pch";
@@ -918,6 +923,7 @@
 		058D09D1195D04C000B7D73C /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				DSTROOT = /tmp/AsyncDisplayKit.dst;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "AsyncDisplayKit/AsyncDisplayKit-Prefix.pch";

--- a/AsyncDisplayKit/ASControlNode.m
+++ b/AsyncDisplayKit/ASControlNode.m
@@ -347,13 +347,18 @@ void _ASEnumerateControlEventsIncludedInMaskWithBlock(ASControlNodeEvent mask, v
         for (NSString *actionMessage in targetActions)
         {
           SEL action = NSSelectorFromString(actionMessage);
+          id responder = target;
 
-          // Hand off to UIApplication to send the action message.
-          // This also handles sending to the first responder is target is nil.
-          if (target == [NSNull null])
-            [[UIApplication sharedApplication] sendAction:action to:nil from:self forEvent:event];
-          else
-            [[UIApplication sharedApplication] sendAction:action to:target from:self forEvent:event];
+          // NSNull means that a nil target was set, so start at self and travel the responder chain
+          if (responder == [NSNull null]) {
+            // if the target cannot perform the action, travel the responder chain to try to find something that does
+            responder = [self.view targetForAction:action withSender:self];
+          }
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+          [responder performSelector:action withObject:self withObject:event];
+#pragma clang diagnostic pop
         }
       }
     });

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -241,13 +241,6 @@ void ASDisplayNodePerformBlockOnMainThread(void (^block)())
   _pendingDisplayNodes = nil;
 }
 
-#pragma mark - UIResponder overrides
-
-- (UIResponder *)nextResponder
-{
-  return self.view.superview;
-}
-
 #pragma mark - Core
 
 - (ASDisplayNode *)__rasterizedContainerNode

--- a/AsyncDisplayKitTests/ASControlNodeTests.m
+++ b/AsyncDisplayKitTests/ASControlNodeTests.m
@@ -1,0 +1,114 @@
+/* Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <AsyncDisplayKit/ASControlNode.h>
+
+#import <XCTest/XCTest.h>
+
+#define ACTION @selector(action)
+#define ACTION_SENDER @selector(action:)
+#define ACTION_SENDER_EVENT @selector(action:event:)
+#define EVENT ASControlNodeEventTouchUpInside
+
+@interface ReceiverController : UIViewController
+@property (nonatomic) NSInteger hits;
+@end
+@implementation ReceiverController
+@end
+
+@interface ASActionController : ReceiverController
+@property (nonatomic) NSInteger hits;
+@end
+@implementation ASActionController
+- (void)action { self.hits++; }
+@end
+
+@interface ASActionSenderController : ReceiverController
+@end
+@implementation ASActionSenderController
+- (void)action:(id)sender { self.hits++; }
+@end
+
+@interface ASActionSenderEventController : ReceiverController
+@end
+@implementation ASActionSenderEventController
+- (void)action:(id)sender event:(UIEvent *)event { self.hits++; }
+@end
+
+@interface ASControlNodeTests : XCTestCase
+
+@end
+
+@implementation ASControlNodeTests
+
+- (void)testActionWithoutParameters {
+  ASActionController *controller = [[ASActionController alloc] init];
+  ASControlNode *node = [[ASControlNode alloc] init];
+  [node addTarget:controller action:ACTION forControlEvents:EVENT];
+  [controller.view addSubview:node.view];
+  [node sendActionsForControlEvents:EVENT withEvent:nil];
+  XCTAssert(controller.hits == 1, @"Controller did not receive the action event");
+}
+
+- (void)testActionAndSender {
+  ASActionSenderController *controller = [[ASActionSenderController alloc] init];
+  ASControlNode *node = [[ASControlNode alloc] init];
+  [node addTarget:controller action:ACTION_SENDER forControlEvents:EVENT];
+  [controller.view addSubview:node.view];
+  [node sendActionsForControlEvents:EVENT withEvent:nil];
+  XCTAssert(controller.hits == 1, @"Controller did not receive the action event");
+}
+
+- (void)testActionAndSenderAndEvent {
+  ASActionSenderEventController *controller = [[ASActionSenderEventController alloc] init];
+  ASControlNode *node = [[ASControlNode alloc] init];
+  [node addTarget:controller action:ACTION_SENDER_EVENT forControlEvents:EVENT];
+  [controller.view addSubview:node.view];
+  [node sendActionsForControlEvents:EVENT withEvent:nil];
+  XCTAssert(controller.hits == 1, @"Controller did not receive the action event");
+}
+
+- (void)testActionWithoutTarget {
+  ASActionController *controller = [[ASActionController alloc] init];
+  ASControlNode *node = [[ASControlNode alloc] init];
+  [node addTarget:nil action:ACTION forControlEvents:EVENT];
+  [controller.view addSubview:node.view];
+  [node sendActionsForControlEvents:EVENT withEvent:nil];
+  XCTAssert(controller.hits == 1, @"Controller did not receive the action event");
+}
+
+- (void)testActionAndSenderWithoutTarget {
+  ASActionSenderController *controller = [[ASActionSenderController alloc] init];
+  ASControlNode *node = [[ASControlNode alloc] init];
+  [node addTarget:nil action:ACTION_SENDER forControlEvents:EVENT];
+  [controller.view addSubview:node.view];
+  [node sendActionsForControlEvents:EVENT withEvent:nil];
+  XCTAssert(controller.hits == 1, @"Controller did not receive the action event");
+}
+
+- (void)testActionAndSenderAndEventWithoutTarget {
+  ASActionSenderEventController *controller = [[ASActionSenderEventController alloc] init];
+  ASControlNode *node = [[ASControlNode alloc] init];
+  [node addTarget:nil action:ACTION_SENDER_EVENT forControlEvents:EVENT];
+  [controller.view addSubview:node.view];
+  [node sendActionsForControlEvents:EVENT withEvent:nil];
+  XCTAssert(controller.hits == 1, @"Controller did not receive the action event");
+}
+
+- (void)testDeeperHierarchyWithoutTarget {
+  ASActionController *controller = [[ASActionController alloc] init];
+  UIView *view = [[UIView alloc] init];
+  ASControlNode *node = [[ASControlNode alloc] init];
+  [node addTarget:nil action:ACTION forControlEvents:EVENT];
+  [view addSubview:node.view];
+  [controller.view addSubview:view];
+  [node sendActionsForControlEvents:EVENT withEvent:nil];
+  XCTAssert(controller.hits == 1, @"Controller did not receive the action event");
+}
+
+@end


### PR DESCRIPTION
Set a build setting so that ASDK compiles "extension-safe".

We've removed calls to `-[UIApplication sharedApplication]` which is banned in extensions. Instead, we fall back on the plain ol' responder chain to handle `ASControlNode` events.

This PR also includes some basic tests to account for event propagation for control nodes, as well as minor semantics with what the actual `-[ASDisplayNode nextResponder]` (a private method) is.

fixes #98