### PR TITLE
Track control node touches

### DIFF
--- a/AsyncDisplayKit/ASControlNode.m
+++ b/AsyncDisplayKit/ASControlNode.m
@@ -363,7 +363,7 @@ void _ASEnumerateControlEventsIncludedInMaskWithBlock(ASControlNodeEvent mask, v
 - (BOOL)_isInterestedInTouches
 {
   // We're only interested in touches if we're enabled and we've got targets to talk to.
-  return self.enabled && ([_controlEventDispatchTable count] > 0);
+  return self.enabled;
 }
 
 id<NSCopying> _ASControlNodeEventKeyForControlEvent(ASControlNodeEvent controlEvent)


### PR DESCRIPTION
Tested with custom `ASTextNode` subclass. No targets added, but tracking events are still received upon touches.

fixes #268