### PR TITLE
Add -tableView:editActionsForRowAtIndexPath: to ASCommonTableViewDelegate

### DIFF
--- a/AsyncDisplayKit/ASTableViewProtocols.h
+++ b/AsyncDisplayKit/ASTableViewProtocols.h
@@ -71,6 +71,7 @@
 
 - (UITableViewCellEditingStyle)tableView:(UITableView *)tableView editingStyleForRowAtIndexPath:(NSIndexPath *)indexPath;
 - (NSString *)tableView:(UITableView *)tableView titleForDeleteConfirmationButtonForRowAtIndexPath:(NSIndexPath *)indexPath;
+- (NSArray *)tableView:(UITableView *)tableView editActionsForRowAtIndexPath:(NSIndexPath *)indexPath;
 
 - (BOOL)tableView:(UITableView *)tableView shouldIndentWhileEditingRowAtIndexPath:(NSIndexPath *)indexPath;
 


### PR DESCRIPTION
Might as well make ASTableView's support for this method explicit.

It was introduced in iOS 8 but I don't think there's a need to gate it with an `#ifdef`. It'll simply never get called on iOS 7.