### PR TITLE
Remove "working range" from flow layout

### DIFF
--- a/AsyncDisplayKit/Details/ASFlowLayoutController.mm
+++ b/AsyncDisplayKit/Details/ASFlowLayoutController.mm
@@ -16,8 +16,8 @@ static const CGFloat kASFlowLayoutControllerRefreshingThreshold = 0.3;
   std::pair<int, int> _visibleRangeStartPos;
   std::pair<int, int> _visibleRangeEndPos;
 
-  std::pair<int, int> _workingRangeStartPos;
-  std::pair<int, int> _workingRangeEndPos;
+  std::pair<int, int> _rangeStartPos;
+  std::pair<int, int> _rangeEndPos;
 }
 
 @end
@@ -74,7 +74,7 @@ static const CGFloat kASFlowLayoutControllerRefreshingThreshold = 0.3;
   }];
 }
 
-- (BOOL)shouldUpdateWorkingRangesForVisibleIndexPath:(NSArray *)indexPaths
+- (BOOL)shouldUpdateForVisibleIndexPath:(NSArray *)indexPaths
                                         viewportSize:(CGSize)viewportSize {
   if (!indexPaths.count) {
     return NO;
@@ -83,12 +83,12 @@ static const CGFloat kASFlowLayoutControllerRefreshingThreshold = 0.3;
   std::pair<int, int> startPos, endPos;
   ASFindIndexPathRange(indexPaths, startPos, endPos);
 
-  if (_workingRangeStartPos >= startPos || _workingRangeEndPos <= endPos) {
+  if (_rangeStartPos >= startPos || _rangeEndPos <= endPos) {
     return YES;
   }
 
-  return ASFlowLayoutDistance(startPos, _visibleRangeStartPos, _nodeSizes) > ASFlowLayoutDistance(_visibleRangeStartPos, _workingRangeStartPos, _nodeSizes) * kASFlowLayoutControllerRefreshingThreshold ||
-         ASFlowLayoutDistance(endPos, _visibleRangeEndPos, _nodeSizes) > ASFlowLayoutDistance(_visibleRangeEndPos, _workingRangeEndPos, _nodeSizes) * kASFlowLayoutControllerRefreshingThreshold;
+  return ASFlowLayoutDistance(startPos, _visibleRangeStartPos, _nodeSizes) > ASFlowLayoutDistance(_visibleRangeStartPos, _rangeStartPos, _nodeSizes) * kASFlowLayoutControllerRefreshingThreshold ||
+         ASFlowLayoutDistance(endPos, _visibleRangeEndPos, _nodeSizes) > ASFlowLayoutDistance(_visibleRangeEndPos, _rangeEndPos, _nodeSizes) * kASFlowLayoutControllerRefreshingThreshold;
 }
 
 - (void)setVisibleNodeIndexPaths:(NSArray *)indexPaths {
@@ -98,7 +98,7 @@ static const CGFloat kASFlowLayoutControllerRefreshingThreshold = 0.3;
 /**
  * IndexPath array for the element in the working range.
  */
-- (NSSet *)workingRangeIndexPathsForScrolling:(enum ASScrollDirection)scrollDirection
+- (NSSet *)indexPathsForScrolling:(enum ASScrollDirection)scrollDirection
                                  viewportSize:(CGSize)viewportSize {
   std::pair<int, int> startIter, endIter;
 

--- a/AsyncDisplayKit/Details/ASLayoutController.h
+++ b/AsyncDisplayKit/Details/ASLayoutController.h
@@ -18,7 +18,7 @@ typedef NS_ENUM(NSInteger, ASScrollDirection) {
 @protocol ASLayoutController <NSObject>
 
 /**
- * Tuning parameters for the working range.
+ * Tuning parameters for the range.
  *
  * Defaults to a trailing buffer of one screenful and a leading buffer of two screenfuls.
  */
@@ -34,9 +34,8 @@ typedef NS_ENUM(NSInteger, ASScrollDirection) {
 
 - (void)setVisibleNodeIndexPaths:(NSArray *)indexPaths;
 
-- (BOOL)shouldUpdateWorkingRangesForVisibleIndexPath:(NSArray *)indexPath
-                                        viewportSize:(CGSize)viewportSize;
+- (BOOL)shouldUpdateForVisibleIndexPath:(NSArray *)indexPath viewportSize:(CGSize)viewportSize;
 
-- (NSSet *)workingRangeIndexPathsForScrolling:(enum ASScrollDirection)scrollDirection
-                                 viewportSize:(CGSize)viewportSize;
+- (NSSet *)indexPathsForScrolling:(enum ASScrollDirection)scrollDirection viewportSize:(CGSize)viewportSize;
+
 @end

--- a/AsyncDisplayKit/Details/ASRangeController.mm
+++ b/AsyncDisplayKit/Details/ASRangeController.mm
@@ -162,9 +162,9 @@
   NSArray *indexPaths = [_delegate rangeControllerVisibleNodeIndexPaths:self];
   CGSize viewportSize = [_delegate rangeControllerViewportSize:self];
 
-  if ([_layoutController shouldUpdateWorkingRangesForVisibleIndexPath:indexPaths viewportSize:viewportSize]) {
+  if ([_layoutController shouldUpdateForVisibleIndexPath:indexPaths viewportSize:viewportSize]) {
     [_layoutController setVisibleNodeIndexPaths:indexPaths];
-    NSSet *workingRangeIndexPaths = [_layoutController workingRangeIndexPathsForScrolling:_scrollDirection viewportSize:viewportSize];
+    NSSet *workingRangeIndexPaths = [_layoutController indexPathsForScrolling:_scrollDirection viewportSize:viewportSize];
     NSSet *visibleRangeIndexPaths = [NSSet setWithArray:indexPaths];
 
     NSMutableSet *removedIndexPaths = _workingRangeIsValid ? [_workingRangeIndexPaths mutableCopy] : [NSMutableSet set];


### PR DESCRIPTION
This is a step towards a preloading range. We first want to migrate towards arbitrary ranges instead of being coupled to the notion of a single "working range".

This PR is one of several iterative, sequential PRs so that they are broken into smaller, consumable changes.