### PR TITLE
Fix ASControlNode Event Dispatch Table Memory Semantics

### DIFF
--- a/AsyncDisplayKit/ASControlNode.m
+++ b/AsyncDisplayKit/ASControlNode.m
@@ -226,7 +226,7 @@ void _ASEnumerateControlEventsIncludedInMaskWithBlock(ASControlNodeEvent mask, v
       if (!eventDispatchTable)
       {
         // Create the dispatch table for this event.
-        eventDispatchTable = [NSMapTable weakToStrongObjectsMapTable];
+        eventDispatchTable = [NSMapTable strongToStrongObjectsMapTable];
         [_controlEventDispatchTable setObject:eventDispatchTable forKey:eventKey];
       }
 


### PR DESCRIPTION
Summary: `weakToStrong` where the keys are NSNumbers that aren't strongly held by anyone means the events in the table get removed almost immediately. 

Test Plan: Confirm that events are not dropped from the table after they're added. 

Differential Revision: https://phabricator.fb.com/D1819759