### PR TITLE
Add property to quickly get the cell view for nodes in tables or collections.

### DIFF
--- a/AsyncDisplayKit/ASCellNode.h
+++ b/AsyncDisplayKit/ASCellNode.h
@@ -19,6 +19,12 @@
 //@property (atomic, retain) UIColor *backgroundColor;
 @property (nonatomic) UITableViewCellSelectionStyle selectionStyle;
 
+/**
+ * @abstract Returns the UICollectionViewCell or UITableViewCell if the node is currently
+ * visible in either a ASCollectionView or ASTableView, respectively.
+ */
+@property (nonatomic, readonly, retain) UIView *cellView;
+
 @end
 
 

--- a/AsyncDisplayKit/ASCellNode.h
+++ b/AsyncDisplayKit/ASCellNode.h
@@ -22,6 +22,8 @@
 /**
  * @abstract Returns the UICollectionViewCell or UITableViewCell if the node is currently
  * visible in either a ASCollectionView or ASTableView, respectively.
+ *
+ * @discussion Assumes the ASCellNode is being used with an ASCollectionView or ASTableView.
  */
 @property (nonatomic, readonly, retain) UIView *cellView;
 

--- a/AsyncDisplayKit/ASCellNode.m
+++ b/AsyncDisplayKit/ASCellNode.m
@@ -28,6 +28,15 @@
   return self;
 }
 
+- (UIView *)cellView
+{
+  UIView *contentView = self.view.superview;
+  if (contentView != nil) {
+    return contentView.superview;
+  }
+  return nil;
+}
+
 - (void)setLayerBacked:(BOOL)layerBacked
 {
   // ASRangeController expects ASCellNodes to be view-backed.  (Layer-backing is supported on ASCellNode subnodes.)


### PR DESCRIPTION
Sometimes it is useful to have access to the cell view that's being displayed in the table or collection view.