### PR TITLE
Revert "Let ASMultiplexImageNode skip failed image identifiers"

### DIFF
--- a/AsyncDisplayKit/ASMultiplexImageNode.h
+++ b/AsyncDisplayKit/ASMultiplexImageNode.h
@@ -69,11 +69,6 @@ typedef NS_ENUM(NSUInteger, ASMultiplexImageNodeErrorCode) {
 @property (nonatomic, readwrite, assign) BOOL downloadsIntermediateImages;
 
 /**
- * @abstract Indicates that the receiver should stop loading if it encounters an error while loading an intermediate image identifier. Defaults to NO.
- */
-@property (nonatomic, readwrite, assign) BOOL haltsLoadingOnError;
-
-/**
  * @abstract An array of identifiers representing various versions of an image for ASMultiplexImageNode to display.
  *
  * @discussion An identifier can be any object that conforms to NSObject and NSCopying.  The array should be in


### PR DESCRIPTION
Reverts facebook/AsyncDisplayKit#228 (cc @andyscott) — it introduced a bug where, if the best image identifier is unavailable (e.g., 404 error), ASMultiplexImageNode infinite-loops in an attempt to load it.