### PR TITLE
ASImageNode not opaque by default

### DIFF
--- a/AsyncDisplayKit/ASImageNode.mm
+++ b/AsyncDisplayKit/ASImageNode.mm
@@ -87,7 +87,7 @@
   // TODO can this be removed?
   self.contentsScale = ASDisplayNodeScreenScale();
   self.contentMode = UIViewContentModeScaleAspectFill;
-  self.opaque = YES;
+  self.opaque = NO;
 
   _cropEnabled = YES;
   _cropRect = CGRectMake(0.5, 0.5, 0, 0);


### PR DESCRIPTION
fixes #298

Side note: should we document this behavior somewhere? I get that the change broke some builds, but should we note anywhere that `ASImageNode` is **not** opaque by default?

I ask because we document that `ASDisplayNode` is opaque [here](https://github.com/facebook/AsyncDisplayKit/blob/master/AsyncDisplayKit/ASDisplayNode.h#L452).