### PR TITLE
Allow all gestures through ASControlNode

### DIFF
--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -416,22 +416,22 @@
 		058D09C5195D04C000B7D73C /* AsyncDisplayKitTests */ = {
 			isa = PBXGroup;
 			children = (
+				2911485B1A77147A005D0878 /* ASControlNodeTests.m */,
 				058D0A2D195D057000B7D73C /* ASDisplayLayerTests.m */,
 				058D0A2E195D057000B7D73C /* ASDisplayNodeAppearanceTests.m */,
 				058D0A2F195D057000B7D73C /* ASDisplayNodeTests.m */,
 				058D0A30195D057000B7D73C /* ASDisplayNodeTestsHelper.h */,
 				058D0A31195D057000B7D73C /* ASDisplayNodeTestsHelper.m */,
-				058D0A32195D057000B7D73C /* ASMutableAttributedStringBuilderTests.m */,
 				052EE0651A159FEF002C6279 /* ASMultiplexImageNodeTests.m */,
+				058D0A32195D057000B7D73C /* ASMutableAttributedStringBuilderTests.m */,
 				3C9C128419E616EF00E942A0 /* ASTableViewTests.m */,
 				058D0A33195D057000B7D73C /* ASTextNodeCoreTextAdditionsTests.m */,
 				058D0A34195D057000B7D73C /* ASTextNodeRendererTests.m */,
 				058D0A35195D057000B7D73C /* ASTextNodeShadowerTests.m */,
 				058D0A36195D057000B7D73C /* ASTextNodeTests.m */,
 				058D0A37195D057000B7D73C /* ASTextNodeWordKernerTests.mm */,
-				052EE06A1A15A0D8002C6279 /* TestResources */,
 				058D09C6195D04C000B7D73C /* Supporting Files */,
-				2911485B1A77147A005D0878 /* ASControlNodeTests.m */,
+				052EE06A1A15A0D8002C6279 /* TestResources */,
 			);
 			path = AsyncDisplayKitTests;
 			sourceTree = "<group>";

--- a/AsyncDisplayKit/ASControlNode.m
+++ b/AsyncDisplayKit/ASControlNode.m
@@ -197,11 +197,7 @@ void _ASEnumerateControlEventsIncludedInMaskWithBlock(ASControlNodeEvent mask, v
 
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer
 {
-  // If we're interested in touches, this is a tap (the only gesture we care about) and passed -hitTest for us, then no, you may not begin. Sir.
-  if ([self _isInterestedInTouches] && [gestureRecognizer isKindOfClass:[UITapGestureRecognizer class]])
-    return NO;
-
-  // Otherwise, go ahead. :]
+  // similar to UIControl, gestures always win
   return YES;
 }
 
@@ -365,9 +361,10 @@ void _ASEnumerateControlEventsIncludedInMaskWithBlock(ASControlNodeEvent mask, v
 }
 
 #pragma mark - Convenience
+
 - (BOOL)_isInterestedInTouches
 {
-  // We're only interested in touches if we're enabled and we've got targets to talk to.
+  // We're only interested in touches if we're enabled
   return self.enabled;
 }
 

--- a/AsyncDisplayKitTests/ASControlNodeTests.m
+++ b/AsyncDisplayKitTests/ASControlNodeTests.m
@@ -40,6 +40,13 @@
 - (void)action:(id)sender event:(UIEvent *)event { self.hits++; }
 @end
 
+@interface ASGestureController : ReceiverController
+@end
+@implementation ASGestureController
+- (void)onGesture:(UIGestureRecognizer *)recognizer { self.hits++; }
+- (void)action:(id)sender { self.hits++; }
+@end
+
 @interface ASControlNodeTests : XCTestCase
 
 @end
@@ -109,6 +116,17 @@
   [controller.view addSubview:view];
   [node sendActionsForControlEvents:EVENT withEvent:nil];
   XCTAssert(controller.hits == 1, @"Controller did not receive the action event");
+}
+
+- (void)testTouchesWorkWithGestures {
+  ASGestureController *controller = [[ASGestureController alloc] init];
+  ASControlNode *node = [[ASControlNode alloc] init];
+  [node addTarget:controller action:@selector(action:) forControlEvents:ASControlNodeEventTouchUpInside];
+  [node.view addGestureRecognizer:[[UITapGestureRecognizer alloc] initWithTarget:controller action:@selector(onGesture:)]];
+  [controller.view addSubnode:node];
+
+  [node sendActionsForControlEvents:EVENT withEvent:nil];
+  XCTAssert(controller.hits == 1, @"Controller did not receive the tap event");
 }
 
 @end


### PR DESCRIPTION
Tested locally by adding a tap gesture to Kittens. Added unit tests to confirm that taps and gestures can work alongside each other. The unit test is limited to only testing that the target/action works since gestures are horribly un-unit-testable.

fixes #305 
