### PR TITLE
Batch Fetching API

### DIFF
--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -138,7 +138,6 @@
 		05F20AA41A15733C00DCA68A /* ASImageProtocols.h in Headers */ = {isa = PBXBuildFile; fileRef = 05F20AA31A15733C00DCA68A /* ASImageProtocols.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1950C4491A3BB5C1005C8279 /* ASEqualityHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 1950C4481A3BB5C1005C8279 /* ASEqualityHelpers.h */; };
 		2911485C1A77147A005D0878 /* ASControlNodeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2911485B1A77147A005D0878 /* ASControlNodeTests.m */; };
-<<<<<<< HEAD
 		292C599F1A956527007E5DD6 /* ASLayoutRangeType.h in Headers */ = {isa = PBXBuildFile; fileRef = 292C59991A956527007E5DD6 /* ASLayoutRangeType.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		292C59A01A956527007E5DD6 /* ASRangeHandlerPreload.h in Headers */ = {isa = PBXBuildFile; fileRef = 292C599A1A956527007E5DD6 /* ASRangeHandlerPreload.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		292C59A11A956527007E5DD6 /* ASRangeHandlerPreload.mm in Sources */ = {isa = PBXBuildFile; fileRef = 292C599B1A956527007E5DD6 /* ASRangeHandlerPreload.mm */; };
@@ -146,6 +145,7 @@
 		292C59A31A956527007E5DD6 /* ASRangeHandlerRender.h in Headers */ = {isa = PBXBuildFile; fileRef = 292C599D1A956527007E5DD6 /* ASRangeHandlerRender.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		292C59A41A956527007E5DD6 /* ASRangeHandlerRender.mm in Sources */ = {isa = PBXBuildFile; fileRef = 292C599E1A956527007E5DD6 /* ASRangeHandlerRender.mm */; };
 		299DA1A91A828D2900162D41 /* ASBatchContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 299DA1A71A828D2900162D41 /* ASBatchContext.h */; };
+		299DA1A91A828D2900162D41 /* ASBatchContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 299DA1A71A828D2900162D41 /* ASBatchContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		299DA1AA1A828D2900162D41 /* ASBatchContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 299DA1A81A828D2900162D41 /* ASBatchContext.m */; };
 		3C9C128519E616EF00E942A0 /* ASTableViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C9C128419E616EF00E942A0 /* ASTableViewTests.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		464052201A3F83C40061C0BA /* ASDataController.h in Headers */ = {isa = PBXBuildFile; fileRef = 464052191A3F83C40061C0BA /* ASDataController.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -293,7 +293,6 @@
 		05F20AA31A15733C00DCA68A /* ASImageProtocols.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASImageProtocols.h; sourceTree = "<group>"; };
 		1950C4481A3BB5C1005C8279 /* ASEqualityHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASEqualityHelpers.h; sourceTree = "<group>"; };
 		2911485B1A77147A005D0878 /* ASControlNodeTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASControlNodeTests.m; sourceTree = "<group>"; };
-<<<<<<< HEAD
 		292C59991A956527007E5DD6 /* ASLayoutRangeType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASLayoutRangeType.h; sourceTree = "<group>"; };
 		292C599A1A956527007E5DD6 /* ASRangeHandlerPreload.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASRangeHandlerPreload.h; sourceTree = "<group>"; };
 		292C599B1A956527007E5DD6 /* ASRangeHandlerPreload.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASRangeHandlerPreload.mm; sourceTree = "<group>"; };

--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -144,12 +144,11 @@
 		292C59A21A956527007E5DD6 /* ASRangeHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 292C599C1A956527007E5DD6 /* ASRangeHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		292C59A31A956527007E5DD6 /* ASRangeHandlerRender.h in Headers */ = {isa = PBXBuildFile; fileRef = 292C599D1A956527007E5DD6 /* ASRangeHandlerRender.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		292C59A41A956527007E5DD6 /* ASRangeHandlerRender.mm in Sources */ = {isa = PBXBuildFile; fileRef = 292C599E1A956527007E5DD6 /* ASRangeHandlerRender.mm */; };
-		299DA1A91A828D2900162D41 /* ASBatchContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 299DA1A71A828D2900162D41 /* ASBatchContext.h */; };
-		296A0A2E1A9516B2005ACEAA /* ASBatchFetching.h in Headers */ = {isa = PBXBuildFile; fileRef = 296A0A2C1A9516B2005ACEAA /* ASBatchFetching.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		296A0A2E1A9516B2005ACEAA /* ASBatchFetching.h in Headers */ = {isa = PBXBuildFile; fileRef = 296A0A2C1A9516B2005ACEAA /* ASBatchFetching.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		296A0A2F1A9516B2005ACEAA /* ASBatchFetching.m in Sources */ = {isa = PBXBuildFile; fileRef = 296A0A2D1A9516B2005ACEAA /* ASBatchFetching.m */; };
 		296A0A351A951ABF005ACEAA /* ASBatchFetchingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 296A0A341A951ABF005ACEAA /* ASBatchFetchingTests.m */; };
 		299DA1A91A828D2900162D41 /* ASBatchContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 299DA1A71A828D2900162D41 /* ASBatchContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		299DA1AA1A828D2900162D41 /* ASBatchContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 299DA1A81A828D2900162D41 /* ASBatchContext.m */; };
+		299DA1AA1A828D2900162D41 /* ASBatchContext.mm in Sources */ = {isa = PBXBuildFile; fileRef = 299DA1A81A828D2900162D41 /* ASBatchContext.mm */; };
 		3C9C128519E616EF00E942A0 /* ASTableViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C9C128419E616EF00E942A0 /* ASTableViewTests.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		464052201A3F83C40061C0BA /* ASDataController.h in Headers */ = {isa = PBXBuildFile; fileRef = 464052191A3F83C40061C0BA /* ASDataController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		464052211A3F83C40061C0BA /* ASDataController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4640521A1A3F83C40061C0BA /* ASDataController.mm */; };
@@ -302,12 +301,12 @@
 		292C599C1A956527007E5DD6 /* ASRangeHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASRangeHandler.h; sourceTree = "<group>"; };
 		292C599D1A956527007E5DD6 /* ASRangeHandlerRender.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASRangeHandlerRender.h; sourceTree = "<group>"; };
 		292C599E1A956527007E5DD6 /* ASRangeHandlerRender.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASRangeHandlerRender.mm; sourceTree = "<group>"; };
-		296A0A2C1A9516B2005ACEAA /* ASBatchFetching.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASBatchFetching.h; sourceTree = "<group>"; };
-		296A0A2D1A9516B2005ACEAA /* ASBatchFetching.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASBatchFetching.m; sourceTree = "<group>"; };
+		296A0A2C1A9516B2005ACEAA /* ASBatchFetching.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASBatchFetching.h; path = ../Details/ASBatchFetching.h; sourceTree = "<group>"; };
+		296A0A2D1A9516B2005ACEAA /* ASBatchFetching.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ASBatchFetching.m; path = ../Details/ASBatchFetching.m; sourceTree = "<group>"; };
 		296A0A311A951715005ACEAA /* ASScrollDirection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASScrollDirection.h; path = AsyncDisplayKit/Details/ASScrollDirection.h; sourceTree = SOURCE_ROOT; };
 		296A0A341A951ABF005ACEAA /* ASBatchFetchingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASBatchFetchingTests.m; sourceTree = "<group>"; };
 		299DA1A71A828D2900162D41 /* ASBatchContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASBatchContext.h; sourceTree = "<group>"; };
-		299DA1A81A828D2900162D41 /* ASBatchContext.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASBatchContext.m; sourceTree = "<group>"; };
+		299DA1A81A828D2900162D41 /* ASBatchContext.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASBatchContext.mm; sourceTree = "<group>"; };
 		3C9C128419E616EF00E942A0 /* ASTableViewTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASTableViewTests.m; sourceTree = "<group>"; };
 		464052191A3F83C40061C0BA /* ASDataController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASDataController.h; sourceTree = "<group>"; };
 		4640521A1A3F83C40061C0BA /* ASDataController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASDataController.mm; sourceTree = "<group>"; };
@@ -479,9 +478,7 @@
 				054963471A1EA066000F8E56 /* ASBasicImageDownloader.h */,
 				054963481A1EA066000F8E56 /* ASBasicImageDownloader.mm */,
 				299DA1A71A828D2900162D41 /* ASBatchContext.h */,
-				299DA1A81A828D2900162D41 /* ASBatchContext.m */,
-				296A0A2C1A9516B2005ACEAA /* ASBatchFetching.h */,
-				296A0A2D1A9516B2005ACEAA /* ASBatchFetching.m */,
+				299DA1A81A828D2900162D41 /* ASBatchContext.mm */,
 				464052191A3F83C40061C0BA /* ASDataController.h */,
 				4640521A1A3F83C40061C0BA /* ASDataController.mm */,
 				05A6D05819D0EB64002DD95E /* ASDealloc2MainObject.h */,
@@ -546,6 +543,8 @@
 		058D0A01195D050800B7D73C /* Private */ = {
 			isa = PBXGroup;
 			children = (
+				296A0A2C1A9516B2005ACEAA /* ASBatchFetching.h */,
+				296A0A2D1A9516B2005ACEAA /* ASBatchFetching.m */,
 				058D0A02195D050800B7D73C /* _AS-objc-internal.h */,
 				058D0A03195D050800B7D73C /* _ASCoreAnimationExtras.h */,
 				058D0A04195D050800B7D73C /* _ASCoreAnimationExtras.mm */,
@@ -809,7 +808,7 @@
 				058D0A18195D050800B7D73C /* _ASDisplayLayer.mm in Sources */,
 				058D0A2C195D050800B7D73C /* ASSentinel.m in Sources */,
 				464052211A3F83C40061C0BA /* ASDataController.mm in Sources */,
-				299DA1AA1A828D2900162D41 /* ASBatchContext.m in Sources */,
+				299DA1AA1A828D2900162D41 /* ASBatchContext.mm in Sources */,
 				058D0A15195D050800B7D73C /* ASDisplayNodeExtras.mm in Sources */,
 				058D0A1F195D050800B7D73C /* ASTextNodeTextKitHelpers.mm in Sources */,
 				055F1A3519ABD3E3004DAFF1 /* ASTableView.mm in Sources */,
@@ -862,6 +861,7 @@
 				058D0A3B195D057000B7D73C /* ASDisplayNodeTestsHelper.m in Sources */,
 				058D0A3A195D057000B7D73C /* ASDisplayNodeTests.m in Sources */,
 				052EE0661A159FEF002C6279 /* ASMultiplexImageNodeTests.m in Sources */,
+				291D92411A9D537B008286B8 /* ASBatchFetching.m in Sources */,
 				058D0A39195D057000B7D73C /* ASDisplayNodeAppearanceTests.m in Sources */,
 				058D0A41195D057000B7D73C /* ASTextNodeWordKernerTests.mm in Sources */,
 				058D0A40195D057000B7D73C /* ASTextNodeTests.m in Sources */,

--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -138,12 +138,15 @@
 		05F20AA41A15733C00DCA68A /* ASImageProtocols.h in Headers */ = {isa = PBXBuildFile; fileRef = 05F20AA31A15733C00DCA68A /* ASImageProtocols.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1950C4491A3BB5C1005C8279 /* ASEqualityHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 1950C4481A3BB5C1005C8279 /* ASEqualityHelpers.h */; };
 		2911485C1A77147A005D0878 /* ASControlNodeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2911485B1A77147A005D0878 /* ASControlNodeTests.m */; };
+<<<<<<< HEAD
 		292C599F1A956527007E5DD6 /* ASLayoutRangeType.h in Headers */ = {isa = PBXBuildFile; fileRef = 292C59991A956527007E5DD6 /* ASLayoutRangeType.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		292C59A01A956527007E5DD6 /* ASRangeHandlerPreload.h in Headers */ = {isa = PBXBuildFile; fileRef = 292C599A1A956527007E5DD6 /* ASRangeHandlerPreload.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		292C59A11A956527007E5DD6 /* ASRangeHandlerPreload.mm in Sources */ = {isa = PBXBuildFile; fileRef = 292C599B1A956527007E5DD6 /* ASRangeHandlerPreload.mm */; };
 		292C59A21A956527007E5DD6 /* ASRangeHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 292C599C1A956527007E5DD6 /* ASRangeHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		292C59A31A956527007E5DD6 /* ASRangeHandlerRender.h in Headers */ = {isa = PBXBuildFile; fileRef = 292C599D1A956527007E5DD6 /* ASRangeHandlerRender.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		292C59A41A956527007E5DD6 /* ASRangeHandlerRender.mm in Sources */ = {isa = PBXBuildFile; fileRef = 292C599E1A956527007E5DD6 /* ASRangeHandlerRender.mm */; };
+		299DA1A91A828D2900162D41 /* ASBatchContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 299DA1A71A828D2900162D41 /* ASBatchContext.h */; };
+		299DA1AA1A828D2900162D41 /* ASBatchContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 299DA1A81A828D2900162D41 /* ASBatchContext.m */; };
 		3C9C128519E616EF00E942A0 /* ASTableViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C9C128419E616EF00E942A0 /* ASTableViewTests.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		464052201A3F83C40061C0BA /* ASDataController.h in Headers */ = {isa = PBXBuildFile; fileRef = 464052191A3F83C40061C0BA /* ASDataController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		464052211A3F83C40061C0BA /* ASDataController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4640521A1A3F83C40061C0BA /* ASDataController.mm */; };
@@ -290,12 +293,15 @@
 		05F20AA31A15733C00DCA68A /* ASImageProtocols.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASImageProtocols.h; sourceTree = "<group>"; };
 		1950C4481A3BB5C1005C8279 /* ASEqualityHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASEqualityHelpers.h; sourceTree = "<group>"; };
 		2911485B1A77147A005D0878 /* ASControlNodeTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASControlNodeTests.m; sourceTree = "<group>"; };
+<<<<<<< HEAD
 		292C59991A956527007E5DD6 /* ASLayoutRangeType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASLayoutRangeType.h; sourceTree = "<group>"; };
 		292C599A1A956527007E5DD6 /* ASRangeHandlerPreload.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASRangeHandlerPreload.h; sourceTree = "<group>"; };
 		292C599B1A956527007E5DD6 /* ASRangeHandlerPreload.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASRangeHandlerPreload.mm; sourceTree = "<group>"; };
 		292C599C1A956527007E5DD6 /* ASRangeHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASRangeHandler.h; sourceTree = "<group>"; };
 		292C599D1A956527007E5DD6 /* ASRangeHandlerRender.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASRangeHandlerRender.h; sourceTree = "<group>"; };
 		292C599E1A956527007E5DD6 /* ASRangeHandlerRender.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASRangeHandlerRender.mm; sourceTree = "<group>"; };
+		299DA1A71A828D2900162D41 /* ASBatchContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASBatchContext.h; sourceTree = "<group>"; };
+		299DA1A81A828D2900162D41 /* ASBatchContext.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASBatchContext.m; sourceTree = "<group>"; };
 		3C9C128419E616EF00E942A0 /* ASTableViewTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASTableViewTests.m; sourceTree = "<group>"; };
 		464052191A3F83C40061C0BA /* ASDataController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASDataController.h; sourceTree = "<group>"; };
 		4640521A1A3F83C40061C0BA /* ASDataController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASDataController.mm; sourceTree = "<group>"; };
@@ -465,6 +471,8 @@
 				058D09E5195D050800B7D73C /* _ASDisplayView.mm */,
 				054963471A1EA066000F8E56 /* ASBasicImageDownloader.h */,
 				054963481A1EA066000F8E56 /* ASBasicImageDownloader.mm */,
+				299DA1A71A828D2900162D41 /* ASBatchContext.h */,
+				299DA1A81A828D2900162D41 /* ASBatchContext.m */,
 				464052191A3F83C40061C0BA /* ASDataController.h */,
 				4640521A1A3F83C40061C0BA /* ASDataController.mm */,
 				05A6D05819D0EB64002DD95E /* ASDealloc2MainObject.h */,
@@ -619,6 +627,7 @@
 				292C599F1A956527007E5DD6 /* ASLayoutRangeType.h in Headers */,
 				464052251A3F83C40061C0BA /* ASMultidimensionalArrayUtils.h in Headers */,
 				058D0A64195D05DC00B7D73C /* ASTextNodeWordKerner.h in Headers */,
+				299DA1A91A828D2900162D41 /* ASBatchContext.h in Headers */,
 				058D0A65195D05DC00B7D73C /* ASTextNodeWordKerner.m in Headers */,
 				058D0A66195D05DC00B7D73C /* NSMutableAttributedString+TextKitAdditions.h in Headers */,
 				058D0A67195D05DC00B7D73C /* NSMutableAttributedString+TextKitAdditions.m in Headers */,
@@ -789,6 +798,7 @@
 				058D0A18195D050800B7D73C /* _ASDisplayLayer.mm in Sources */,
 				058D0A2C195D050800B7D73C /* ASSentinel.m in Sources */,
 				464052211A3F83C40061C0BA /* ASDataController.mm in Sources */,
+				299DA1AA1A828D2900162D41 /* ASBatchContext.m in Sources */,
 				058D0A15195D050800B7D73C /* ASDisplayNodeExtras.mm in Sources */,
 				058D0A1F195D050800B7D73C /* ASTextNodeTextKitHelpers.mm in Sources */,
 				055F1A3519ABD3E3004DAFF1 /* ASTableView.mm in Sources */,

--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -145,6 +145,9 @@
 		292C59A31A956527007E5DD6 /* ASRangeHandlerRender.h in Headers */ = {isa = PBXBuildFile; fileRef = 292C599D1A956527007E5DD6 /* ASRangeHandlerRender.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		292C59A41A956527007E5DD6 /* ASRangeHandlerRender.mm in Sources */ = {isa = PBXBuildFile; fileRef = 292C599E1A956527007E5DD6 /* ASRangeHandlerRender.mm */; };
 		299DA1A91A828D2900162D41 /* ASBatchContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 299DA1A71A828D2900162D41 /* ASBatchContext.h */; };
+		296A0A2E1A9516B2005ACEAA /* ASBatchFetching.h in Headers */ = {isa = PBXBuildFile; fileRef = 296A0A2C1A9516B2005ACEAA /* ASBatchFetching.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		296A0A2F1A9516B2005ACEAA /* ASBatchFetching.m in Sources */ = {isa = PBXBuildFile; fileRef = 296A0A2D1A9516B2005ACEAA /* ASBatchFetching.m */; };
+		296A0A351A951ABF005ACEAA /* ASBatchFetchingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 296A0A341A951ABF005ACEAA /* ASBatchFetchingTests.m */; };
 		299DA1A91A828D2900162D41 /* ASBatchContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 299DA1A71A828D2900162D41 /* ASBatchContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		299DA1AA1A828D2900162D41 /* ASBatchContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 299DA1A81A828D2900162D41 /* ASBatchContext.m */; };
 		3C9C128519E616EF00E942A0 /* ASTableViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C9C128419E616EF00E942A0 /* ASTableViewTests.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
@@ -299,6 +302,10 @@
 		292C599C1A956527007E5DD6 /* ASRangeHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASRangeHandler.h; sourceTree = "<group>"; };
 		292C599D1A956527007E5DD6 /* ASRangeHandlerRender.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASRangeHandlerRender.h; sourceTree = "<group>"; };
 		292C599E1A956527007E5DD6 /* ASRangeHandlerRender.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASRangeHandlerRender.mm; sourceTree = "<group>"; };
+		296A0A2C1A9516B2005ACEAA /* ASBatchFetching.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASBatchFetching.h; sourceTree = "<group>"; };
+		296A0A2D1A9516B2005ACEAA /* ASBatchFetching.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASBatchFetching.m; sourceTree = "<group>"; };
+		296A0A311A951715005ACEAA /* ASScrollDirection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASScrollDirection.h; path = AsyncDisplayKit/Details/ASScrollDirection.h; sourceTree = SOURCE_ROOT; };
+		296A0A341A951ABF005ACEAA /* ASBatchFetchingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASBatchFetchingTests.m; sourceTree = "<group>"; };
 		299DA1A71A828D2900162D41 /* ASBatchContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASBatchContext.h; sourceTree = "<group>"; };
 		299DA1A81A828D2900162D41 /* ASBatchContext.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASBatchContext.m; sourceTree = "<group>"; };
 		3C9C128419E616EF00E942A0 /* ASTableViewTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASTableViewTests.m; sourceTree = "<group>"; };
@@ -432,6 +439,7 @@
 		058D09C5195D04C000B7D73C /* AsyncDisplayKitTests */ = {
 			isa = PBXGroup;
 			children = (
+				296A0A341A951ABF005ACEAA /* ASBatchFetchingTests.m */,
 				2911485B1A77147A005D0878 /* ASControlNodeTests.m */,
 				058D0A2D195D057000B7D73C /* ASDisplayLayerTests.m */,
 				058D0A2E195D057000B7D73C /* ASDisplayNodeAppearanceTests.m */,
@@ -472,6 +480,8 @@
 				054963481A1EA066000F8E56 /* ASBasicImageDownloader.mm */,
 				299DA1A71A828D2900162D41 /* ASBatchContext.h */,
 				299DA1A81A828D2900162D41 /* ASBatchContext.m */,
+				296A0A2C1A9516B2005ACEAA /* ASBatchFetching.h */,
+				296A0A2D1A9516B2005ACEAA /* ASBatchFetching.m */,
 				464052191A3F83C40061C0BA /* ASDataController.h */,
 				4640521A1A3F83C40061C0BA /* ASDataController.mm */,
 				05A6D05819D0EB64002DD95E /* ASDealloc2MainObject.h */,
@@ -497,6 +507,7 @@
 				292C599C1A956527007E5DD6 /* ASRangeHandler.h */,
 				292C599D1A956527007E5DD6 /* ASRangeHandlerRender.h */,
 				292C599E1A956527007E5DD6 /* ASRangeHandlerRender.mm */,
+				296A0A311A951715005ACEAA /* ASScrollDirection.h */,
 				058D09EA195D050800B7D73C /* ASTextNodeCoreTextAdditions.h */,
 				058D09EB195D050800B7D73C /* ASTextNodeCoreTextAdditions.m */,
 				058D09EC195D050800B7D73C /* ASTextNodeRenderer.h */,
@@ -600,6 +611,7 @@
 				058D0A4F195D05CB00B7D73C /* ASImageNode.h in Headers */,
 				058D0A50195D05CB00B7D73C /* ASImageNode.mm in Headers */,
 				058D0A51195D05CB00B7D73C /* ASTextNode.h in Headers */,
+				296A0A2E1A9516B2005ACEAA /* ASBatchFetching.h in Headers */,
 				058D0A52195D05CB00B7D73C /* ASTextNode.mm in Headers */,
 				055F1A3819ABD413004DAFF1 /* ASRangeController.h in Headers */,
 				292C59A31A956527007E5DD6 /* ASRangeHandlerRender.h in Headers */,
@@ -832,6 +844,7 @@
 				058D0A29195D050800B7D73C /* ASDisplayNode+DebugTiming.mm in Sources */,
 				058D0A22195D050800B7D73C /* _ASAsyncTransaction.m in Sources */,
 				055F1A3919ABD413004DAFF1 /* ASRangeController.mm in Sources */,
+				296A0A2F1A9516B2005ACEAA /* ASBatchFetching.m in Sources */,
 				D785F6631A74327E00291744 /* ASScrollNode.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -841,6 +854,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2911485C1A77147A005D0878 /* ASControlNodeTests.m in Sources */,
+				296A0A351A951ABF005ACEAA /* ASBatchFetchingTests.m in Sources */,
 				058D0A3E195D057000B7D73C /* ASTextNodeRendererTests.m in Sources */,
 				058D0A3D195D057000B7D73C /* ASTextNodeCoreTextAdditionsTests.m in Sources */,
 				058D0A3C195D057000B7D73C /* ASMutableAttributedStringBuilderTests.m in Sources */,

--- a/AsyncDisplayKit/ASCollectionView.h
+++ b/AsyncDisplayKit/ASCollectionView.h
@@ -11,6 +11,7 @@
 #import <AsyncDisplayKit/ASRangeController.h>
 #import <AsyncDisplayKit/ASCollectionViewProtocols.h>
 #import <AsyncDisplayKit/ASBaseDefines.h>
+#import <AsyncDisplayKit/ASBatchContext.h>
 
 
 @class ASCellNode;
@@ -61,6 +62,13 @@
  * The application should not update the data source while the data source is locked, to keep data consistence.
  */
 - (instancetype)initWithFrame:(CGRect)frame collectionViewLayout:(UICollectionViewLayout *)layout asyncDataFetching:(BOOL)asyncDataFetchingEnabled;
+
+/**
+ * The number of screens left to scroll before the delegate -collectionView:beginBatchFetchingWithContext: is called.
+ *
+ * Defaults to one screenful.
+ */
+@property (nonatomic, assign) CGFloat leadingScreensForBatching;
 
 /**
  * Reload everything from scratch, destroying the working range and all cached nodes.
@@ -165,6 +173,34 @@
 
 - (void)collectionView:(ASCollectionView *)collectionView willDisplayNodeForItemAtIndexPath:(NSIndexPath *)indexPath;
 - (void)collectionView:(ASCollectionView *)collectionView didEndDisplayingNodeForItemAtIndexPath:(NSIndexPath*)indexPath;
+
+/**
+ * Tell the collectionView if batch fetching should begin.
+ *
+ * @param collectionView The sender.
+ *
+ * @discussion Use this method to conditionally fetch batches. Example use cases are: limiting the total number of
+ * objects that can be fetched or no network connection.
+ *
+ * If not implemented, the collectionView assumes that it should notify its asyncDelegate when batch fetching
+ * should occur.
+ */
+- (BOOL)shouldBatchFetchForCollectionView:(UICollectionView *)collectionView;
+
+/**
+ * Receive a message that the collectionView is near the end of its data set and more data should be fetched if 
+ * necessary.
+ *
+ * @param tableView The sender.
+ * @param context A context object that must be notified when the batch fetch is completed.
+ *
+ * @discussion You must eventually call -completeBatchFetching: with an argument of YES in order to receive future
+ * notifications to do batch fetches.
+ *
+ * UICollectionView currently only supports batch events for tail loads. If you require a head load, consider
+ * implementing a UIRefreshControl.
+ */
+- (void)collectionView:(UICollectionView *)collectionView beginBatchFetchingWithContext:(ASBatchContext *)context;
 
 @end
 

--- a/AsyncDisplayKit/ASCollectionView.h
+++ b/AsyncDisplayKit/ASCollectionView.h
@@ -185,7 +185,7 @@
  * If not implemented, the collectionView assumes that it should notify its asyncDelegate when batch fetching
  * should occur.
  */
-- (BOOL)shouldBatchFetchForCollectionView:(UICollectionView *)collectionView;
+- (BOOL)shouldBatchFetchForCollectionView:(ASCollectionView *)collectionView;
 
 /**
  * Receive a message that the collectionView is near the end of its data set and more data should be fetched if 
@@ -200,7 +200,7 @@
  * UICollectionView currently only supports batch events for tail loads. If you require a head load, consider
  * implementing a UIRefreshControl.
  */
-- (void)collectionView:(UICollectionView *)collectionView beginBatchFetchingWithContext:(ASBatchContext *)context;
+- (void)collectionView:(ASCollectionView *)collectionView beginBatchFetchingWithContext:(ASBatchContext *)context;
 
 @end
 

--- a/AsyncDisplayKit/ASCollectionView.h
+++ b/AsyncDisplayKit/ASCollectionView.h
@@ -175,6 +175,21 @@
 - (void)collectionView:(ASCollectionView *)collectionView didEndDisplayingNodeForItemAtIndexPath:(NSIndexPath*)indexPath;
 
 /**
+ * Receive a message that the collectionView is near the end of its data set and more data should be fetched if 
+ * necessary.
+ *
+ * @param tableView The sender.
+ * @param context A context object that must be notified when the batch fetch is completed.
+ *
+ * @discussion You must eventually call -completeBatchFetching: with an argument of YES in order to receive future
+ * notifications to do batch fetches. This method is called on a background queue.
+ *
+ * UICollectionView currently only supports batch events for tail loads. If you require a head load, consider
+ * implementing a UIRefreshControl.
+ */
+- (void)collectionView:(ASCollectionView *)collectionView willBeginBatchFetchWithContext:(ASBatchContext *)context;
+
+/**
  * Tell the collectionView if batch fetching should begin.
  *
  * @param collectionView The sender.
@@ -186,21 +201,6 @@
  * should occur.
  */
 - (BOOL)shouldBatchFetchForCollectionView:(ASCollectionView *)collectionView;
-
-/**
- * Receive a message that the collectionView is near the end of its data set and more data should be fetched if 
- * necessary.
- *
- * @param tableView The sender.
- * @param context A context object that must be notified when the batch fetch is completed.
- *
- * @discussion You must eventually call -completeBatchFetching: with an argument of YES in order to receive future
- * notifications to do batch fetches.
- *
- * UICollectionView currently only supports batch events for tail loads. If you require a head load, consider
- * implementing a UIRefreshControl.
- */
-- (void)collectionView:(ASCollectionView *)collectionView beginBatchFetchingWithContext:(ASBatchContext *)context;
 
 @end
 

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -386,11 +386,12 @@ static BOOL _isInterceptedSelector(SEL sel)
 
 - (BOOL)shouldBatchFetch
 {
-  if ([_asyncDelegate respondsToSelector:@selector(shouldBatchFetchForCollectionView:)]) {
+  // if the delegate does not respond to this method, there is no point in starting to fetch
+  BOOL canFetch = [_asyncDelegate respondsToSelector:@selector(collectionView:willBeginBatchFetchWithContext:)];
+  if (canFetch && [_asyncDelegate respondsToSelector:@selector(shouldBatchFetchForCollectionView:)]) {
     return [_asyncDelegate shouldBatchFetchForCollectionView:self];
   } else {
-    // if the delegate does not respond to this method, there is no point in starting to fetch
-    return [_asyncDelegate respondsToSelector:@selector(collectionView:willBeginBatchFetchWithContext:)];
+    return canFetch;
   }
 }
 

--- a/AsyncDisplayKit/ASTableView.h
+++ b/AsyncDisplayKit/ASTableView.h
@@ -190,7 +190,7 @@
  * If not implemented, the tableView assumes that it should notify its asyncDelegate when batch fetching
  * should occur.
  */
-- (BOOL)shouldBatchFetchForTableView:(UITableView *)tableView;
+- (BOOL)shouldBatchFetchForTableView:(ASTableView *)tableView;
 
 /**
  * Receive a message that the tableView is near the end of its data set and more data should be fetched if necessary.
@@ -204,7 +204,7 @@
  * ASTableView currently only supports batch events for tail loads. If you require a head load, consider implementing a
  * UIRefreshControl.
  */
-- (void)tableView:(UITableView *)tableView beginBatchFetchingWithContext:(ASBatchContext *)context;
+- (void)tableView:(ASTableView *)tableView beginBatchFetchingWithContext:(ASBatchContext *)context;
 
 @end
 

--- a/AsyncDisplayKit/ASTableView.h
+++ b/AsyncDisplayKit/ASTableView.h
@@ -64,7 +64,7 @@
 - (instancetype)initWithFrame:(CGRect)frame style:(UITableViewStyle)style asyncDataFetching:(BOOL)asyncDataFetchingEnabled;
 
 /**
- * The number of screens left to scroll before the delegate -tableView:shouldBeginBatchFetchingWithContext: is called.
+ * The number of screens left to scroll before the delegate -tableView:beginBatchFetchingWithContext: is called.
  *
  * Defaults to one screenful.
  */

--- a/AsyncDisplayKit/ASTableView.h
+++ b/AsyncDisplayKit/ASTableView.h
@@ -180,31 +180,31 @@
 - (void)tableView:(ASTableView *)tableView didEndDisplayingNodeForRowAtIndexPath:(NSIndexPath*)indexPath;
 
 /**
- * Tell the tableView if batch fetching should begin.
- *
- * @param tableView The sender.
- *
- * @discussion Use this method to conditionally fetch batches. Example use cases are: limiting the total number of
- * objects that can be fetched or no network connection.
- * 
- * If not implemented, the tableView assumes that it should notify its asyncDelegate when batch fetching
- * should occur.
- */
-- (BOOL)shouldBatchFetchForTableView:(ASTableView *)tableView;
-
-/**
  * Receive a message that the tableView is near the end of its data set and more data should be fetched if necessary.
  *
  * @param tableView The sender.
  * @param context A context object that must be notified when the batch fetch is completed.
  *
  * @discussion You must eventually call -completeBatchFetching: with an argument of YES in order to receive future
- * notifications to do batch fetches.
+ * notifications to do batch fetches. This method is called on a background queue.
  *
  * ASTableView currently only supports batch events for tail loads. If you require a head load, consider implementing a
  * UIRefreshControl.
  */
-- (void)tableView:(ASTableView *)tableView beginBatchFetchingWithContext:(ASBatchContext *)context;
+- (void)tableView:(ASTableView *)tableView willBeginBatchFetchWithContext:(ASBatchContext *)context;
+
+/**
+ * Tell the tableView if batch fetching should begin.
+ *
+ * @param tableView The sender.
+ *
+ * @discussion Use this method to conditionally fetch batches. Example use cases are: limiting the total number of
+ * objects that can be fetched or no network connection.
+ *
+ * If not implemented, the tableView assumes that it should notify its asyncDelegate when batch fetching
+ * should occur.
+ */
+- (BOOL)shouldBatchFetchForTableView:(ASTableView *)tableView;
 
 @end
 

--- a/AsyncDisplayKit/ASTableView.h
+++ b/AsyncDisplayKit/ASTableView.h
@@ -11,6 +11,7 @@
 #import <AsyncDisplayKit/ASRangeController.h>
 #import <AsyncDisplayKit/ASTableViewProtocols.h>
 #import <AsyncDisplayKit/ASBaseDefines.h>
+#import <AsyncDisplayKit/ASBatchContext.h>
 
 
 @class ASCellNode;
@@ -61,6 +62,13 @@
  * The application should not update the data source while the data source is locked, to keep data consistence.
  */
 - (instancetype)initWithFrame:(CGRect)frame style:(UITableViewStyle)style asyncDataFetching:(BOOL)asyncDataFetchingEnabled;
+
+/**
+ * The number of screens left to scroll before the delegate -tableView:shouldBeginBatchFetchingWithContext: is called.
+ *
+ * Defaults to one screenful.
+ */
+@property (nonatomic, assign) CGFloat leadingScreensForBatching;
 
 /**
  * Reload everything from scratch, destroying the working range and all cached nodes.
@@ -170,6 +178,33 @@
 
 - (void)tableView:(ASTableView *)tableView willDisplayNodeForRowAtIndexPath:(NSIndexPath *)indexPath;
 - (void)tableView:(ASTableView *)tableView didEndDisplayingNodeForRowAtIndexPath:(NSIndexPath*)indexPath;
+
+/**
+ * Tell the tableView if batch fetching should begin.
+ *
+ * @param tableView The sender.
+ *
+ * @discussion Use this method to conditionally fetch batches. Example use cases are: limiting the total number of
+ * objects that can be fetched or no network connection.
+ * 
+ * If not implemented, the tableView assumes that it should notify its asyncDelegate when batch fetching
+ * should occur.
+ */
+- (BOOL)shouldBatchFetchForTableView:(UITableView *)tableView;
+
+/**
+ * Receive a message that the tableView is near the end of its data set and more data should be fetched if necessary.
+ *
+ * @param tableView The sender.
+ * @param context A context object that must be notified when the batch fetch is completed.
+ *
+ * @discussion You must eventually call -completeBatchFetching: with an argument of YES in order to receive future
+ * notifications to do batch fetches.
+ *
+ * ASTableView currently only supports batch events for tail loads. If you require a head load, consider implementing a
+ * UIRefreshControl.
+ */
+- (void)tableView:(UITableView *)tableView beginBatchFetchingWithContext:(ASBatchContext *)context;
 
 @end
 

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -401,6 +401,8 @@ static BOOL _isInterceptedSelector(SEL sel)
 
 - (void)handleBatchFetchScrollingToOffset:(CGPoint)targetOffset
 {
+  ASDisplayNodeAssert(_batchContext != nil, @"Batch context should exist");
+
   // Bail if we are already fetching, the delegate doesn't care, or we're told not to fetch
   if ([_batchContext isFetching] ||
       ![self.asyncDelegate respondsToSelector:@selector(tableView:beginBatchFetchingWithContext:)] ||

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -392,11 +392,12 @@ static BOOL _isInterceptedSelector(SEL sel)
 
 - (BOOL)shouldBatchFetch
 {
-  if ([_asyncDelegate respondsToSelector:@selector(shouldBatchFetchForTableView:)]) {
+  // if the delegate does not respond to this method, there is no point in starting to fetch
+  BOOL canFetch = [_asyncDelegate respondsToSelector:@selector(tableView:willBeginBatchFetchWithContext:)];
+  if (canFetch && [_asyncDelegate respondsToSelector:@selector(shouldBatchFetchForTableView:)]) {
     return [_asyncDelegate shouldBatchFetchForTableView:self];
   } else {
-    // if the delegate does not respond to this method, there is no point in starting to fetch
-    return [_asyncDelegate respondsToSelector:@selector(tableView:willBeginBatchFetchWithContext:)];
+    return canFetch;
   }
 }
 

--- a/AsyncDisplayKit/Details/ASBatchContext.h
+++ b/AsyncDisplayKit/Details/ASBatchContext.h
@@ -6,6 +6,8 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#import <Foundation/Foundation.h>
+
 /**
  * @abstract A context object to notify when batch fetches are finished or cancelled.
  */
@@ -29,8 +31,6 @@
  */
 - (void)completeBatchFetching:(BOOL)didComplete;
 
-- (void)beginBatchFetching;
-
 /**
  * Ask the context object if the batch fetching process was cancelled by the context owner.
  *
@@ -48,5 +48,13 @@
  * be left to the owner of the batch process unless there is a specific purpose.
  */
 - (void)cancelBatchFetching;
+
+/**
+ * Notify the context object that fetching has started.
+ *
+ * @discussion Call this method only when you are beginning a fetch process. This should really only be called by the 
+ * context object's owner. Calling this method should be complimented with -completeBatchFetching:.
+ */
+- (void)beginBatchFetching;
 
 @end

--- a/AsyncDisplayKit/Details/ASBatchContext.h
+++ b/AsyncDisplayKit/Details/ASBatchContext.h
@@ -53,7 +53,7 @@
  * Notify the context object that fetching has started.
  *
  * @discussion Call this method only when you are beginning a fetch process. This should really only be called by the 
- * context object's owner. Calling this method should be complimented with -completeBatchFetching:.
+ * context object's owner. Calling this method should be paired with -completeBatchFetching:.
  */
 - (void)beginBatchFetching;
 

--- a/AsyncDisplayKit/Details/ASBatchContext.h
+++ b/AsyncDisplayKit/Details/ASBatchContext.h
@@ -1,0 +1,52 @@
+/* Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+/**
+ * @abstract A context object to notify when batch fetches are finished or cancelled.
+ */
+@interface ASBatchContext : NSObject
+
+/**
+ * Retreive the state of the current batch process.
+ *
+ * @returns A boolean reflecting if the owner of the context object is fetching another batch.
+ */
+- (BOOL)isFetching;
+
+/**
+ * Let the context object know that a batch fetch was completed.
+ *
+ * @param didComplete A boolean that states whether or not the batch fetch completed.
+ *
+ * @discussion Only by passing YES will the owner of the context know to attempt another batch update when necessary.
+ * For instance, when a table has reached the end of its data, a batch fetch will be attempted unless the context
+ * object thinks that it is still fetching.
+ */
+- (void)completeBatchFetching:(BOOL)didComplete;
+
+- (void)beginBatchFetching;
+
+/**
+ * Ask the context object if the batch fetching process was cancelled by the context owner.
+ *
+ * @discussion If an error occurs in the context owner, the batch fetching may become out of sync and need to be
+ * cancelled. For best practices, pass the return value of -batchWasCancelled to -completeBatchFetch:.
+ *
+ * @returns A boolean reflecting if the context object owner had to cancel the batch process.
+ */
+- (BOOL)batchFetchingWasCancelled;
+
+/**
+ * Notify the context object that something has interupted the batch fetching process.
+ *
+ * @discussion Call this method only when something has corrupted the batch fetching process. Calling this method should
+ * be left to the owner of the batch process unless there is a specific purpose.
+ */
+- (void)cancelBatchFetching;
+
+@end

--- a/AsyncDisplayKit/Details/ASBatchContext.m
+++ b/AsyncDisplayKit/Details/ASBatchContext.m
@@ -1,0 +1,60 @@
+/* Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "ASBatchContext.h"
+
+typedef NS_ENUM(NSInteger, ASBatchContextState) {
+  ASBatchContextStateFetching,
+  ASBatchContextStateCancelled,
+  ASBatchContextStateCompleted
+};
+
+@interface ASBatchContext ()
+{
+  ASBatchContextState _state;
+}
+@end
+
+@implementation ASBatchContext
+
+- (instancetype)init
+{
+  if (self = [super init]) {
+    _state = ASBatchContextStateCompleted;
+  }
+  return self;
+}
+
+- (BOOL)isFetching
+{
+  return _state == ASBatchContextStateFetching;
+}
+
+- (BOOL)batchFetchingWasCancelled
+{
+  return _state == ASBatchContextStateCancelled;
+}
+
+- (void)completeBatchFetching:(BOOL)didComplete
+{
+  if (didComplete) {
+    _state = ASBatchContextStateCompleted;
+  }
+}
+
+- (void)beginBatchFetching
+{
+  _state = ASBatchContextStateFetching;
+}
+
+- (void)cancelBatchFetching
+{
+  _state = ASBatchContextStateCancelled;
+}
+
+@end

--- a/AsyncDisplayKit/Details/ASBatchContext.mm
+++ b/AsyncDisplayKit/Details/ASBatchContext.mm
@@ -8,6 +8,8 @@
 
 #import "ASBatchContext.h"
 
+#import "ASThread.h"
+
 typedef NS_ENUM(NSInteger, ASBatchContextState) {
   ASBatchContextStateFetching,
   ASBatchContextStateCancelled,
@@ -17,6 +19,7 @@ typedef NS_ENUM(NSInteger, ASBatchContextState) {
 @interface ASBatchContext ()
 {
   ASBatchContextState _state;
+  ASDN::RecursiveMutex _propertyLock;
 }
 @end
 
@@ -32,28 +35,33 @@ typedef NS_ENUM(NSInteger, ASBatchContextState) {
 
 - (BOOL)isFetching
 {
+  ASDN::MutexLocker l(_propertyLock);
   return _state == ASBatchContextStateFetching;
 }
 
 - (BOOL)batchFetchingWasCancelled
 {
+  ASDN::MutexLocker l(_propertyLock);
   return _state == ASBatchContextStateCancelled;
 }
 
 - (void)completeBatchFetching:(BOOL)didComplete
 {
   if (didComplete) {
+    ASDN::MutexLocker l(_propertyLock);
     _state = ASBatchContextStateCompleted;
   }
 }
 
 - (void)beginBatchFetching
 {
+  ASDN::MutexLocker l(_propertyLock);
   _state = ASBatchContextStateFetching;
 }
 
 - (void)cancelBatchFetching
 {
+  ASDN::MutexLocker l(_propertyLock);
   _state = ASBatchContextStateCancelled;
 }
 

--- a/AsyncDisplayKit/Details/ASBatchFetching.h
+++ b/AsyncDisplayKit/Details/ASBatchFetching.h
@@ -1,0 +1,36 @@
+/* Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <UIKit/UIKit.h>
+
+#import "ASBatchContext.h"
+#import "ASScrollDirection.h"
+#import "ASBaseDefines.h"
+
+ASDISPLAYNODE_EXTERN_C_BEGIN
+
+/**
+ @abstract Determine if batch fetching should begin based on the state of the parameters.
+ @param context The batch fetching context that contains knowledge about in-flight fetches.
+ @param scrollDirection The current scrolling direction of the scroll view.
+ @param bounds The bounds of the scrollview.
+ @param contentSize The content size of the scrollview.
+ @param targetOffset The offset that the scrollview will scroll to.
+ @param leadingScreens How many screens in the remaining distance will trigger batch fetching.
+ @return Whether or not the current state should proceed with batch fetching.
+ @discussion This method is broken into a category for unit testing purposes and should be used with the ASTableView and
+ * ASCollectionView batch fetching API.
+ */
+extern BOOL ASDisplayShouldFetchBatchForContext(ASBatchContext *context,
+                                                ASScrollDirection scrollDirection,
+                                                CGRect bounds,
+                                                CGSize contentSize,
+                                                CGPoint targetOffset,
+                                                CGFloat leadingScreens);
+
+ASDISPLAYNODE_EXTERN_C_END

--- a/AsyncDisplayKit/Details/ASBatchFetching.m
+++ b/AsyncDisplayKit/Details/ASBatchFetching.m
@@ -1,0 +1,51 @@
+/* Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "ASBatchFetching.h"
+
+BOOL ASDisplayShouldFetchBatchForContext(ASBatchContext *context,
+                                    ASScrollDirection scrollDirection,
+                                    CGRect bounds,
+                                    CGSize contentSize,
+                                    CGPoint targetOffset,
+                                    CGFloat leadingScreens) {
+  // do not allow fetching if a batch is already in-flight and hasn't been completed or cancelled
+  if ([context isFetching]) {
+    return NO;
+  }
+
+  // no fetching for null states
+  if (leadingScreens <= 0.0 ||
+      CGPointEqualToPoint(targetOffset, CGPointZero) ||
+      CGSizeEqualToSize(contentSize, CGSizeZero) ||
+      CGRectEqualToRect(bounds, CGRectZero)) {
+    return NO;
+  }
+
+  // only Up and Left scrolls are currently supported (tail loading)
+  if (scrollDirection != ASScrollDirectionUp && scrollDirection != ASScrollDirectionLeft) {
+    return NO;
+  }
+
+  CGFloat viewLength, offset, contentLength;
+
+  if (scrollDirection == ASScrollDirectionUp) {
+    viewLength = bounds.size.height;
+    offset = targetOffset.y;
+    contentLength = contentSize.height;
+  } else { // horizontal
+    viewLength = bounds.size.width;
+    offset = targetOffset.x;
+    contentLength = contentSize.width;
+  }
+
+  CGFloat triggerDistance = viewLength * leadingScreens;
+  CGFloat remainingDistance = contentLength - viewLength - offset;
+
+  return remainingDistance <= triggerDistance;
+}

--- a/AsyncDisplayKit/Details/ASBatchFetching.m
+++ b/AsyncDisplayKit/Details/ASBatchFetching.m
@@ -19,16 +19,14 @@ BOOL ASDisplayShouldFetchBatchForContext(ASBatchContext *context,
     return NO;
   }
 
-  // no fetching for null states
-  if (leadingScreens <= 0.0 ||
-      CGPointEqualToPoint(targetOffset, CGPointZero) ||
-      CGSizeEqualToSize(contentSize, CGSizeZero) ||
-      CGRectEqualToRect(bounds, CGRectZero)) {
+  // only Up and Left scrolls are currently supported (tail loading)
+  if (scrollDirection != ASScrollDirectionUp && scrollDirection != ASScrollDirectionLeft) {
     return NO;
   }
 
-  // only Up and Left scrolls are currently supported (tail loading)
-  if (scrollDirection != ASScrollDirectionUp && scrollDirection != ASScrollDirectionLeft) {
+  // no fetching for null states
+  if (leadingScreens <= 0.0 ||
+      CGRectEqualToRect(bounds, CGRectZero)) {
     return NO;
   }
 
@@ -44,8 +42,11 @@ BOOL ASDisplayShouldFetchBatchForContext(ASBatchContext *context,
     contentLength = contentSize.width;
   }
 
+  // target offset will always be 0 if the content size is smaller than the viewport
+  BOOL hasSmallContent = offset == 0.0 && contentLength < viewLength;
+
   CGFloat triggerDistance = viewLength * leadingScreens;
   CGFloat remainingDistance = contentLength - viewLength - offset;
 
-  return remainingDistance <= triggerDistance;
+  return hasSmallContent || remainingDistance <= triggerDistance;
 }

--- a/AsyncDisplayKit/Details/ASLayoutController.h
+++ b/AsyncDisplayKit/Details/ASLayoutController.h
@@ -10,19 +10,13 @@
 
 #import <AsyncDisplayKit/ASBaseDefines.h>
 #import <AsyncDisplayKit/ASLayoutRangeType.h>
+#import "ASScrollDirection.h"
+
 
 typedef struct {
   CGFloat leadingBufferScreenfuls;
   CGFloat trailingBufferScreenfuls;
 } ASRangeTuningParameters;
-
-typedef NS_ENUM(NSInteger, ASScrollDirection) {
-  ASScrollDirectionNone,
-  ASScrollDirectionRight,
-  ASScrollDirectionLeft,
-  ASScrollDirectionUp,
-  ASScrollDirectionDown,
-};
 
 @protocol ASLayoutController <NSObject>
 

--- a/AsyncDisplayKit/Details/ASScrollDirection.h
+++ b/AsyncDisplayKit/Details/ASScrollDirection.h
@@ -1,0 +1,17 @@
+/* Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Foundation/Foundation.h>
+
+typedef NS_ENUM(NSInteger, ASScrollDirection) {
+  ASScrollDirectionNone,
+  ASScrollDirectionRight,
+  ASScrollDirectionLeft,
+  ASScrollDirectionUp,
+  ASScrollDirectionDown,
+};

--- a/AsyncDisplayKitTests/ASBatchFetchingTests.m
+++ b/AsyncDisplayKitTests/ASBatchFetchingTests.m
@@ -1,0 +1,102 @@
+/* Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "ASBatchFetching.h"
+
+@interface ASBatchFetchingTests : XCTestCase
+
+@end
+
+@implementation ASBatchFetchingTests
+
+#define PASSING_RECT (CGRect){0,0,1,1}
+#define PASSING_SIZE (CGSize){1,1}
+#define PASSING_POINT (CGPoint){1,1}
+#define VERTICAL_RECT(h) (CGRect){0,0,0,h}
+#define VERTICAL_SIZE(h) (CGSize){0,h}
+#define VERTICAL_OFFSET(y) (CGPoint){0,y}
+#define HORIZONTAL_RECT(w) (CGRect){0,0,w,0}
+#define HORIZONTAL_SIZE(w) (CGSize){w,0}
+#define HORIZONTAL_OFFSET(x) (CGPoint){x,0}
+
+- (void)testBatchNullState {
+  ASBatchContext *context = [[ASBatchContext alloc] init];
+  BOOL shouldFetch = ASDisplayShouldFetchBatchForContext(context, ASScrollDirectionUp, CGRectZero, CGSizeZero, CGPointZero, 0.0);
+  XCTAssert(shouldFetch == NO, @"Should not fetch in the null state");
+}
+
+- (void)testBatchAlreadyFetching {
+  ASBatchContext *context = [[ASBatchContext alloc] init];
+  [context beginBatchFetching];
+  BOOL shouldFetch = ASDisplayShouldFetchBatchForContext(context, ASScrollDirectionUp, PASSING_RECT, PASSING_SIZE, PASSING_POINT, 1.0);
+  XCTAssert(shouldFetch == NO, @"Should not fetch when context is already fetching");
+}
+
+- (void)testUnsupportedScrollDirections {
+  ASBatchContext *context = [[ASBatchContext alloc] init];
+  BOOL fetchRight = ASDisplayShouldFetchBatchForContext(context, ASScrollDirectionRight, PASSING_RECT, PASSING_SIZE, PASSING_POINT, 1.0);
+  XCTAssert(fetchRight == NO, @"Should not fetch for scrolling right");
+  BOOL fetchDown = ASDisplayShouldFetchBatchForContext(context, ASScrollDirectionDown, PASSING_RECT, PASSING_SIZE, PASSING_POINT, 1.0);
+  XCTAssert(fetchDown == NO, @"Should not fetch for scrolling down");
+  BOOL fetchUp = ASDisplayShouldFetchBatchForContext(context, ASScrollDirectionUp, PASSING_RECT, PASSING_SIZE, PASSING_POINT, 1.0);
+  XCTAssert(fetchUp == YES, @"Should fetch for scrolling up");
+  BOOL fetchLeft = ASDisplayShouldFetchBatchForContext(context, ASScrollDirectionLeft, PASSING_RECT, PASSING_SIZE, PASSING_POINT, 1.0);
+  XCTAssert(fetchLeft == YES, @"Should fetch for scrolling left");
+}
+
+- (void)testVerticalScrollToExactLeading {
+  CGFloat screen = 1.0;
+  ASBatchContext *context = [[ASBatchContext alloc] init];
+  // scroll to 1-screen top offset, height is 1 screen, so bottom is 1 screen away from end of content
+  BOOL shouldFetch = ASDisplayShouldFetchBatchForContext(context, ASScrollDirectionUp, VERTICAL_RECT(screen), VERTICAL_SIZE(screen * 3.0), VERTICAL_OFFSET(screen * 1.0), 1.0);
+  XCTAssert(shouldFetch == YES, @"Fetch should begin when vertically scrolling to exactly 1 leading screen away");
+}
+
+- (void)testVerticalScrollToLessThanLeading {
+  CGFloat screen = 1.0;
+  ASBatchContext *context = [[ASBatchContext alloc] init];
+  // 3 screens of content, scroll only 1/2 of one screen
+  BOOL shouldFetch = ASDisplayShouldFetchBatchForContext(context, ASScrollDirectionUp, VERTICAL_RECT(screen), VERTICAL_SIZE(screen * 3.0), VERTICAL_OFFSET(screen * 0.5), 1.0);
+  XCTAssert(shouldFetch == NO, @"Fetch should not begin when vertically scrolling less than the leading distance away");
+}
+
+- (void)testVerticalScrollingPastContentSize {
+  CGFloat screen = 1.0;
+  ASBatchContext *context = [[ASBatchContext alloc] init];
+  // 3 screens of content, top offset to 3-screens, height 1 screen, so its 1 screen past the leading
+  BOOL shouldFetch = ASDisplayShouldFetchBatchForContext(context, ASScrollDirectionUp, VERTICAL_RECT(screen), VERTICAL_SIZE(screen * 3.0), VERTICAL_OFFSET(screen * 3.0), 1.0);
+  XCTAssert(shouldFetch == YES, @"Fetch should begin when vertically scrolling past the content size");
+}
+
+- (void)testHorizontalScrollToExactLeading {
+  CGFloat screen = 1.0;
+  ASBatchContext *context = [[ASBatchContext alloc] init];
+  // scroll to 1-screen left offset, width is 1 screen, so right is 1 screen away from end of content
+  BOOL shouldFetch = ASDisplayShouldFetchBatchForContext(context, ASScrollDirectionLeft, HORIZONTAL_RECT(screen), HORIZONTAL_SIZE(screen * 3.0), HORIZONTAL_OFFSET(screen * 1.0), 1.0);
+  XCTAssert(shouldFetch == YES, @"Fetch should begin when horizontally scrolling to exactly 1 leading screen away");
+}
+
+- (void)testHorizontalScrollToLessThanLeading {
+  CGFloat screen = 1.0;
+  ASBatchContext *context = [[ASBatchContext alloc] init];
+  // 3 screens of content, scroll only 1/2 of one screen
+  BOOL shouldFetch = ASDisplayShouldFetchBatchForContext(context, ASScrollDirectionRight, HORIZONTAL_RECT(screen), HORIZONTAL_SIZE(screen * 3.0), HORIZONTAL_OFFSET(screen * 0.5), 1.0);
+  XCTAssert(shouldFetch == NO, @"Fetch should not begin when horizontally scrolling less than the leading distance away");
+}
+
+- (void)testHorizontalScrollingPastContentSize {
+  CGFloat screen = 1.0;
+  ASBatchContext *context = [[ASBatchContext alloc] init];
+  // 3 screens of content, left offset to 3-screens, width 1 screen, so its 1 screen past the leading
+  BOOL shouldFetch = ASDisplayShouldFetchBatchForContext(context, ASScrollDirectionUp, HORIZONTAL_RECT(screen), HORIZONTAL_SIZE(screen * 3.0), HORIZONTAL_OFFSET(screen * 3.0), 1.0);
+  XCTAssert(shouldFetch == YES, @"Fetch should begin when vertically scrolling past the content size");
+}
+
+@end

--- a/AsyncDisplayKitTests/ASBatchFetchingTests.m
+++ b/AsyncDisplayKitTests/ASBatchFetchingTests.m
@@ -99,4 +99,20 @@
   XCTAssert(shouldFetch == YES, @"Fetch should begin when vertically scrolling past the content size");
 }
 
+- (void)testVerticalScrollingSmallContentSize {
+  CGFloat screen = 1.0;
+  ASBatchContext *context = [[ASBatchContext alloc] init];
+  // when the content size is < screen size, the target offset will always be 0
+  BOOL shouldFetch = ASDisplayShouldFetchBatchForContext(context, ASScrollDirectionUp, VERTICAL_RECT(screen), VERTICAL_SIZE(screen * 0.5), VERTICAL_OFFSET(0.0), 1.0);
+  XCTAssert(shouldFetch == YES, @"Fetch should begin when the target is 0 and the content size is smaller than the scree");
+}
+
+- (void)testHorizontalScrollingSmallContentSize {
+  CGFloat screen = 1.0;
+  ASBatchContext *context = [[ASBatchContext alloc] init];
+  // when the content size is < screen size, the target offset will always be 0
+  BOOL shouldFetch = ASDisplayShouldFetchBatchForContext(context, ASScrollDirectionLeft, HORIZONTAL_RECT(screen), HORIZONTAL_SIZE(screen * 0.5), HORIZONTAL_OFFSET(0.0), 1.0);
+  XCTAssert(shouldFetch == YES, @"Fetch should begin when the target is 0 and the content size is smaller than the scree");
+}
+
 @end

--- a/examples/ASCollectionView/Sample/ViewController.m
+++ b/examples/ASCollectionView/Sample/ViewController.m
@@ -65,7 +65,7 @@
 
 - (ASCellNode *)collectionView:(ASCollectionView *)collectionView nodeForItemAtIndexPath:(NSIndexPath *)indexPath
 {
-  NSString *text = [NSString stringWithFormat:@"[%ld.%ld] says hi", indexPath.section, indexPath.item];
+  NSString *text = [NSString stringWithFormat:@"[%zd.%zd] says hi", indexPath.section, indexPath.item];
   ASTextCellNode *node = [[ASTextCellNode alloc] init];
   node.text = text;
   node.backgroundColor = [UIColor lightGrayColor];
@@ -78,13 +78,21 @@
   return 300;
 }
 
-- (void)collectionViewLockDataSource:(ASCollectionView *)collectionView {
+- (void)collectionViewLockDataSource:(ASCollectionView *)collectionView
+{
   // lock the data source
   // The data source should not be change until it is unlocked.
 }
 
-- (void)collectionViewUnlockDataSource:(ASCollectionView *)collectionView {
+- (void)collectionViewUnlockDataSource:(ASCollectionView *)collectionView
+{
   // unlock the data source to enable data source updating.
+}
+
+- (void)collectionView:(UICollectionView *)collectionView beginBatchFetchingWithContext:(ASBatchContext *)context
+{
+  NSLog(@"fetch additional content");
+  [context completeBatchFetching:YES];
 }
 
 @end

--- a/examples/ASCollectionView/Sample/ViewController.m
+++ b/examples/ASCollectionView/Sample/ViewController.m
@@ -89,7 +89,7 @@
   // unlock the data source to enable data source updating.
 }
 
-- (void)collectionView:(UICollectionView *)collectionView beginBatchFetchingWithContext:(ASBatchContext *)context
+- (void)collectionView:(UICollectionView *)collectionView willBeginBatchFetchWithContext:(ASBatchContext *)context
 {
   NSLog(@"fetch additional content");
   [context completeBatchFetching:YES];

--- a/examples/Kittens/Sample/ViewController.m
+++ b/examples/Kittens/Sample/ViewController.m
@@ -17,8 +17,10 @@
 #import "BlurbNode.h"
 #import "KittenNode.h"
 
-static const NSInteger kLitterSize = 200;
 
+static const NSInteger kLitterSize = 20;
+static const NSInteger kLitterBatchSize = 10;
+static const NSInteger kMaxLitterSize = 100;
 
 @interface ViewController () <ASTableViewDataSource, ASTableViewDelegate>
 {
@@ -52,17 +54,23 @@ static const NSInteger kLitterSize = 200;
   _tableView.asyncDelegate = self;
 
   // populate our "data source" with some random kittens
-  NSMutableArray *kittenDataSource = [NSMutableArray arrayWithCapacity:kLitterSize];
+
+  _kittenDataSource = [self createLitterWithSize:kLitterSize];;
+
+  return self;
+}
+
+- (NSArray *)createLitterWithSize:(NSInteger)litterSize
+{
+  NSMutableArray *kittens = [NSMutableArray arrayWithCapacity:litterSize];
   for (NSInteger i = 0; i < kLitterSize; i++) {
     u_int32_t deltaX = arc4random_uniform(10) - 5;
     u_int32_t deltaY = arc4random_uniform(10) - 5;
     CGSize size = CGSizeMake(350 + 2 * deltaX, 350 + 4 * deltaY);
 
-    [kittenDataSource addObject:[NSValue valueWithCGSize:size]];
+    [kittens addObject:[NSValue valueWithCGSize:size]];
   }
-  _kittenDataSource = kittenDataSource;
-
-  return self;
+  return kittens;
 }
 
 - (void)setKittenDataSource:(NSArray *)kittenDataSource {
@@ -117,12 +125,43 @@ static const NSInteger kLitterSize = 200;
   return NO;
 }
 
-- (void)tableViewLockDataSource:(ASTableView *)tableView {
+- (void)tableViewLockDataSource:(ASTableView *)tableView
+{
   self.dataSourceLocked = YES;
 }
 
-- (void)tableViewUnlockDataSource:(ASTableView *)tableView {
+- (void)tableViewUnlockDataSource:(ASTableView *)tableView
+{
   self.dataSourceLocked = NO;
+}
+
+- (BOOL)shouldBatchFetchForTableView:(UITableView *)tableView
+{
+  return _kittenDataSource.count < kMaxLitterSize;
+}
+
+- (void)tableView:(UITableView *)tableView beginBatchFetchingWithContext:(ASBatchContext *)context
+{
+  NSLog(@"adding kitties");
+  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+    sleep(1);
+    dispatch_async(dispatch_get_main_queue(), ^{
+      NSArray *moarKittens = [self createLitterWithSize:kLitterBatchSize];
+
+      NSMutableArray *indexPaths = [[NSMutableArray alloc] init];
+      NSInteger existingKittens = _kittenDataSource.count;
+      for (NSInteger i = 0; i < moarKittens.count; i++) {
+        [indexPaths addObject:[NSIndexPath indexPathForRow:existingKittens + i inSection:0]];
+      }
+
+      _kittenDataSource = [_kittenDataSource arrayByAddingObjectsFromArray:moarKittens];
+      [tableView insertRowsAtIndexPaths:indexPaths withRowAnimation:UITableViewRowAnimationFade];
+
+      [context completeBatchFetching:YES];
+
+      NSLog(@"kittens added");
+    });
+  });
 }
 
 @end

--- a/examples/Kittens/Sample/ViewController.m
+++ b/examples/Kittens/Sample/ViewController.m
@@ -55,7 +55,7 @@ static const NSInteger kMaxLitterSize = 100;
 
   // populate our "data source" with some random kittens
 
-  _kittenDataSource = [self createLitterWithSize:kLitterSize];;
+  _kittenDataSource = [self createLitterWithSize:kLitterSize];
 
   return self;
 }
@@ -63,7 +63,7 @@ static const NSInteger kMaxLitterSize = 100;
 - (NSArray *)createLitterWithSize:(NSInteger)litterSize
 {
   NSMutableArray *kittens = [NSMutableArray arrayWithCapacity:litterSize];
-  for (NSInteger i = 0; i < kLitterSize; i++) {
+  for (NSInteger i = 0; i < litterSize; i++) {
     u_int32_t deltaX = arc4random_uniform(10) - 5;
     u_int32_t deltaY = arc4random_uniform(10) - 5;
     CGSize size = CGSizeMake(350 + 2 * deltaX, 350 + 4 * deltaY);
@@ -140,7 +140,7 @@ static const NSInteger kMaxLitterSize = 100;
   return _kittenDataSource.count < kMaxLitterSize;
 }
 
-- (void)tableView:(UITableView *)tableView beginBatchFetchingWithContext:(ASBatchContext *)context
+- (void)tableView:(UITableView *)tableView willBeginBatchFetchWithContext:(ASBatchContext *)context
 {
   NSLog(@"adding kitties");
   dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{


### PR DESCRIPTION
This PR introduces a new API for `ASTableView` and `ASCollectionView` to be notified when scrolling near the tail end of the available content. Notifications are limited to vertically scrolling near the bottom of `ASTableView`, and vertical and horizontal scrolling to the bottom and right, respectively, for `ASCollectionView`.

There are 2 new delegate methods for `ASTableView` and `ASCollectionView`:

- `-shouldBatchFetchForCollectionView:` returns a boolean to determine if a collection view should initiate the fetching process.
- `-collectionView:beginBatchFetchingWithContext:` is called when near the end of content.

`ASTableView`'s APIs are identical and differ only by classes and naming conventions.

The `ASBatchContext` object passed to `-collectionView:beginBatchFetchingWithContext:` has the method `-completeBatchFetching:` which **must** be called when finished fetching and processing your content. You can call this method synchronously, or after an asynchronous process such as fetching content from the network. 

If you fail to call `-completeBatchFetching:`, you will never be notified to fetch batch content again. This mechanism exists to prevent over-notifying and over-fetching.

The API adds `@property (assign) CGFloat leadingScreensForBatching` to both `ASTableView` and `ASCollectionView`, which defaults to 1.0. Changing this value will adjust the distance from the end of content that batch notifications will fire.

The Kittens project has been updated with an example of how to batch load content. The ASCollectionView project has been updated to simply demonstrate batch notifications with horizontal scrolling.

Unit tests are included, but this is the first iteration, so YMMV :smile: 