### PR TITLE
Fix text node positioning for non-left alignment

### DIFF
--- a/AsyncDisplayKit/ASTextNode.mm
+++ b/AsyncDisplayKit/ASTextNode.mm
@@ -234,6 +234,18 @@ ASDISPLAYNODE_INLINE CGFloat ceilPixelValue(CGFloat f)
   }
 }
 
+- (void)setBounds:(CGRect)bounds
+{
+  [super setBounds:bounds];
+  if (!CGSizeEqualToSize(bounds.size, _constrainedSize)) {
+    // Our bounds have changed to a size that is not identical to our constraining size,
+    // so our previous layout information is invalid, and TextKit may draw at the
+    // incorrect origin.
+    _constrainedSize = CGSizeMake(-INFINITY, -INFINITY);
+    [self _invalidateRenderer];
+  }
+}
+
 #pragma mark - Renderer Management
 
 - (ASTextNodeRenderer *)_renderer


### PR DESCRIPTION
We were using the cached renderer even if the bounds differed from the constraining size as a performance optimization, and suggesting people measure instead when they need to for performance reasons, but this leads to some pretty broken layouts using simple reproduction code, as reported in https://github.com/facebook/AsyncDisplayKit/issues/89.