### PR TITLE
Section UIEdgeInsets for ASCollectionView

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -424,11 +424,18 @@ static BOOL _isInterceptedSelector(SEL sel)
 - (CGSize)dataController:(ASDataController *)dataController constrainedSizeForNodeAtIndexPath:(NSIndexPath *)indexPath
 {
   CGSize restrainedSize = self.bounds.size;
+    
+  UIEdgeInsets sectionInsets = UIEdgeInsetsZero;
+    
+  if ([_asyncDelegate respondsToSelector: @selector(collectionView:layout:insetForSectionAtIndex:)])
+    sectionInsets = [_asyncDelegate collectionView: self layout: self.collectionViewLayout insetForSectionAtIndex: indexPath.section];
 
   if (_layoutController.layoutDirection == ASFlowLayoutDirectionHorizontal) {
     restrainedSize.width = FLT_MAX;
+    restrainedSize.height -= (sectionInsets.top + sectionInsets.bottom);
   } else {
     restrainedSize.height = FLT_MAX;
+    restrainedSize.height -= (sectionInsets.left + sectionInsets.right);
   }
 
   return restrainedSize;

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -435,7 +435,7 @@ static BOOL _isInterceptedSelector(SEL sel)
     restrainedSize.height -= (sectionInsets.top + sectionInsets.bottom);
   } else {
     restrainedSize.height = FLT_MAX;
-    restrainedSize.height -= (sectionInsets.left + sectionInsets.right);
+    restrainedSize.width -= (sectionInsets.left + sectionInsets.right);
   }
 
   return restrainedSize;

--- a/AsyncDisplayKit/ASCollectionViewProtocols.h
+++ b/AsyncDisplayKit/ASCollectionViewProtocols.h
@@ -53,4 +53,6 @@
 - (BOOL)collectionView:(UICollectionView *)collectionView canPerformAction:(SEL)action forItemAtIndexPath:(NSIndexPath *)indexPath withSender:(id)sender;
 - (void)collectionView:(UICollectionView *)collectionView performAction:(SEL)action forItemAtIndexPath:(NSIndexPath *)indexPath withSender:(id)sender;
 
+- (UIEdgeInsets)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout*)collectionViewLayout insetForSectionAtIndex:(NSInteger)section;
+
 @end


### PR DESCRIPTION
`ASCollectionView` uses `self.bounds.size` when providing constrained size for its node cells.

This pull request adds support for section `UIEdgeInsets`, which can be returned in corresponding `UICollectionViewDelegateFlowLayout` method:

```objc
- (UIEdgeInsets) collectionView: (UICollectionView*) collectionView
						 layout: (UICollectionViewLayout*) collectionViewLayout
		 insetForSectionAtIndex: (NSInteger) section
{
	return UIEdgeInsetsMake(30.0f, 15.0f, 30.0f, 15.0f);
}
```

As a result the one of the constrained size dimensions for cell nodes will be reduced by sum of:
- `bottom + top` for height when layout is horizontal
- `left + right` for width when layout is vertical