### PR TITLE
Enable nodes entering the visible range to display

### DIFF
--- a/AsyncDisplayKit/Details/ASRangeController.mm
+++ b/AsyncDisplayKit/Details/ASRangeController.mm
@@ -54,6 +54,11 @@
   ASDisplayNodeAssert(node, @"Cannot move a nil node to a view");
   ASDisplayNodeAssert(view, @"Cannot move a node to a non-existent view");
 
+  // force any nodes that are about to come into view to have display enabled
+  if (node.displaySuspended) {
+    [node recursivelySetDisplaySuspended:NO];
+  }
+
   [view addSubview:node.view];
 }
 


### PR DESCRIPTION
In testing, I found that its possible for a node to skip the working range and go straight into the visible range. Typically this can happen if you scroll way to the bottom of a large collection and tap the status bar to go to the top. What happens is that the node was set to suspend display, but it was never enabled again. Thus the node is suspended until it enters the working range again.