### PR TITLE
Fix ASImageNode -measure: / -setImage: deadlock.

### DIFF
--- a/AsyncDisplayKit/ASImageNode.mm
+++ b/AsyncDisplayKit/ASImageNode.mm
@@ -108,6 +108,8 @@
   ASDN::MutexLocker l(_imageLock);
   if (_image != image) {
     _image = image;
+
+    ASDN::MutexUnlocker u(_imageLock);
     ASDisplayNodePerformBlockOnMainThread(^{
       [self invalidateCalculatedSize];
       [self setNeedsDisplay];


### PR DESCRIPTION
Speculative fix for #380.  Calling `-[ASImageNode setImage:]` on a
background queue will take the image lock, then trampoline to the main
queue to invalidate calculatedSize and set needsDisplay without
releasing the lock.  Any other method call that takes the image lock on
the main queue can block on the trampoline completing -- deadlock.

Note that the trampoline is itself a clowny workaround for thread
affinity (#134) and should be removed.  With this patch applied,
ASImageNode's `-setImage:` and `-calculateSizeThatFits:` can still race:

1.  -setImage changes _image, then trampolines to main
2.  -calculateSizeThatFits measures _image
3.  trampoline completes, invalidates calculated size
4.  ???
5.  ~~profit!~~ :boom: