### PR TITLE
Add (optional) completion handler for ASTableView and AsCollectionView reloadData

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.h
+++ b/AsyncDisplayKit/ASCollectionView.h
@@ -73,6 +73,14 @@
 /**
  * Reload everything from scratch, destroying the working range and all cached nodes.
  *
+ * @param completion Block to run on completion or nil.
+ * @warning This method is substantially more expensive than UICollectionView's version.
+ */
+- (void)reloadDataWithCompletion:(void (^)())completion;
+
+/**
+ * Reload everything from scratch, destroying the working range and all cached nodes.
+ *
  * @warning This method is substantially more expensive than UICollectionView's version.
  */
 - (void)reloadData;

--- a/AsyncDisplayKit/ASCollectionView.h
+++ b/AsyncDisplayKit/ASCollectionView.h
@@ -73,7 +73,8 @@
 /**
  * Reload everything from scratch, destroying the working range and all cached nodes.
  *
- * @param completion Block to run on completion or nil.
+ * @param completion block to run on completion of asynchronous loading or nil. If supplied, the block is run on
+ * the main thread.
  * @warning This method is substantially more expensive than UICollectionView's version.
  */
 - (void)reloadDataWithCompletion:(void (^)())completion;

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -162,13 +162,18 @@ static BOOL _isInterceptedSelector(SEL sel)
 #pragma mark -
 #pragma mark Overrides.
 
-- (void)reloadData
+- (void)reloadDataWithCompletion:(void (^)())completion
 {
   ASDisplayNodeAssert(self.asyncDelegate, @"ASCollectionView's asyncDelegate property must be set.");
   ASDisplayNodePerformBlockOnMainThread(^{
     [super reloadData];
   });
-  [_dataController reloadDataWithAnimationOption:kASCollectionViewAnimationNone];
+  [_dataController reloadDataWithAnimationOption:kASCollectionViewAnimationNone completion:completion];
+}
+
+- (void)reloadData
+{
+  [self reloadDataWithCompletion:nil];
 }
 
 - (void)setDataSource:(id<UICollectionViewDataSource>)dataSource

--- a/AsyncDisplayKit/ASTableView.h
+++ b/AsyncDisplayKit/ASTableView.h
@@ -73,7 +73,8 @@
 /**
  * Reload everything from scratch, destroying the working range and all cached nodes.
  *
- * @param completion Block to run on completion or nil.
+ * @param completion block to run on completion of asynchronous loading or nil. If supplied, the block is run on 
+ * the main thread.
  * @warning This method is substantially more expensive than UITableView's version.
  */
 -(void)reloadDataWithCompletion:(void (^)())completion;

--- a/AsyncDisplayKit/ASTableView.h
+++ b/AsyncDisplayKit/ASTableView.h
@@ -73,6 +73,14 @@
 /**
  * Reload everything from scratch, destroying the working range and all cached nodes.
  *
+ * @param completion Block to run on completion or nil.
+ * @warning This method is substantially more expensive than UITableView's version.
+ */
+-(void)reloadDataWithCompletion:(void (^)())completion;
+
+/**
+ * Reload everything from scratch, destroying the working range and all cached nodes.
+ *
  * @warning This method is substantially more expensive than UITableView's version.
  */
 - (void)reloadData;

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -205,13 +205,18 @@ static BOOL _isInterceptedSelector(SEL sel)
   }
 }
 
-- (void)reloadData
+- (void)reloadDataWithCompletion:(void (^)())completion
 {
   ASDisplayNodeAssert(self.asyncDelegate, @"ASTableView's asyncDelegate property must be set.");
   ASDisplayNodePerformBlockOnMainThread(^{
     [super reloadData];
   });
-  [_dataController reloadDataWithAnimationOption:UITableViewRowAnimationNone];
+  [_dataController reloadDataWithAnimationOption:UITableViewRowAnimationNone completion:completion];
+}
+
+- (void)reloadData
+{
+  [self reloadDataWithCompletion:nil];
 }
 
 - (void)setTuningParameters:(ASRangeTuningParameters)tuningParameters forRangeType:(ASLayoutRangeType)rangeType

--- a/AsyncDisplayKit/Details/ASDataController.h
+++ b/AsyncDisplayKit/Details/ASDataController.h
@@ -155,7 +155,7 @@ typedef NSUInteger ASDataControllerAnimationOptions;
 
 - (void)moveRowAtIndexPath:(NSIndexPath *)indexPath toIndexPath:(NSIndexPath *)newIndexPath withAnimationOption:(ASDataControllerAnimationOptions)animationOption;;
 
-- (void)reloadDataWithAnimationOption:(ASDataControllerAnimationOptions)animationOption;;
+- (void)reloadDataWithAnimationOption:(ASDataControllerAnimationOptions)animationOption completion:(void (^)())completion;
 
 /** @name Data Querying */
 

--- a/AsyncDisplayKit/Details/ASDataController.mm
+++ b/AsyncDisplayKit/Details/ASDataController.mm
@@ -437,7 +437,7 @@ static void *kASSizingQueueContext = &kASSizingQueueContext;
   });
 }
 
-- (void)reloadDataWithAnimationOption:(ASDataControllerAnimationOptions)animationOption
+- (void)reloadDataWithAnimationOption:(ASDataControllerAnimationOptions)animationOption completion:(void (^)())completion
 {
   [self performDataFetchingWithBlock:^{
     // Fetching data in calling thread
@@ -478,6 +478,10 @@ static void *kASSizingQueueContext = &kASSizingQueueContext;
       }];
       
       [self _batchInsertNodes:updatedNodes atIndexPaths:updatedIndexPaths withAnimationOptions:animationOption];
+
+      if (completion) {
+        dispatch_async(dispatch_get_main_queue(), completion);
+      }
     });
   }];
 }


### PR DESCRIPTION
This PR adds an optional completion handler that is executed (on the main thread) once the async phase of `reloadData` has completed. This is a useful place to add code that needs to work with the rows & sections once they are live in the `ASTableView`/`ASCollectionView`. In my case I've used this to position my `ASTableView` using `scrollToRowAtIndexPath:atScrollPosition:animated:` 

There may be a better way to do this that I've missed. If so, I'd love to know about it. Thanks!!!