### PR TITLE
Fix handling of pending nodes and placeholder layer

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode+Subclasses.h
+++ b/AsyncDisplayKit/ASDisplayNode+Subclasses.h
@@ -206,8 +206,8 @@
  * @abstract Indicates that the receiver is finished displaying its subnodes. This method is not called if there are
  * no subnodes present.
  *
- * @discussion Subclasses may override this method to be notified when subnode display (asynchronous or synchronous) is
- * about to begin.
+ * @discussion Subclasses may override this method to be notified when subnode display (asynchronous or synchronous) has
+ * completed.
  */
 - (void)subnodeDisplayDidFinish:(ASDisplayNode *)subnode ASDISPLAYNODE_REQUIRES_SUPER;
 

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -117,6 +117,8 @@ void ASDisplayNodePerformBlockOnMainThread(void (^block)())
   
   _displaySentinel = [[ASSentinel alloc] init];
   
+  _pendingDisplayNodes = [[NSMutableSet alloc] init];
+
   _flags.isInHierarchy = NO;
   _flags.displaysAsynchronously = YES;
   
@@ -1382,7 +1384,11 @@ static NSInteger incrementIfFound(NSInteger i) {
   [_supernode subnodeDisplayWillStart:self];
 
   if (_placeholderImage && _placeholderLayer && self.layer.contents == nil) {
+    [CATransaction begin];
+    [CATransaction setDisableActions:YES];
     _placeholderLayer.contents = (id)_placeholderImage.CGImage;
+    _placeholderLayer.opacity = 1.0;
+    [CATransaction commit];
     [self.layer addSublayer:_placeholderLayer];
   }
 }


### PR DESCRIPTION
Some fixes to the placeholder API:
* The ```_pendingDisplayNodes``` object was never initialized.
* Placeholder opacity was not reset after being faded out once.
* Small documentation typo.