### PR TITLE
Ensure all nodes are dealloc'd in ASDataController teardown

### DIFF
--- a/AsyncDisplayKit/Details/ASDataController.mm
+++ b/AsyncDisplayKit/Details/ASDataController.mm
@@ -508,4 +508,23 @@ static void *kASSizingQueueContext = &kASSizingQueueContext;
   return ASFindElementsInMultidimensionalArrayAtIndexPaths(_nodes, [indexPaths sortedArrayUsingSelector:@selector(compare:)]);
 }
 
+
+#pragma mark - Dealloc
+
+- (void)dealloc {
+  [self _cleanupNodes];
+}
+
+#pragma mark - Node Cleanup
+
+- (void)_cleanupNodes {
+  if (nil != _nodes && [_nodes count] > 0) {
+    for (id nodeObj in [_nodes objectAtIndex:0]) {
+      if ([nodeObj isKindOfClass:[ASDisplayNode class]]) {
+        [((ASDisplayNode *) nodeObj).view removeFromSuperview];
+      }
+    }
+  }
+}
+
 @end


### PR DESCRIPTION
This is a proposed fix for https://github.com/facebook/AsyncDisplayKit/issues/406.

This ensures that all node instances used with an instance of `ASCollectionView` are dealloc'd when the dataController is dealloc'd.

<hr>

Memory consumption using an `ASCollectionView` with `ASCellNode`

**Before**

![image](https://cloud.githubusercontent.com/assets/1120510/6932956/2d10ac54-d7ef-11e4-9036-3c423d89ec95.png)

**After**

![image](https://cloud.githubusercontent.com/assets/1120510/6932958/34e20f5e-d7ef-11e4-936d-2f4fa40635f5.png)

<hr>

**Without changeset applied:**

**Node alloc's**
```
[MyNode:65] node init | 0x15fd49530
[MyNode:65] node init | 0x15fe649d0
[MyNode:65] node init | 0x15fd4a470
[MyNode:65] node init | 0x15fd4dd50
[MyNode:65] node init | 0x15fe6af90
[MyNode:65] node init | 0x15fe6e910
[MyNode:65] node init | 0x15fd507f0
[MyNode:65] node init | 0x15fd52ce0
[MyNode:65] node init | 0x15fd55f40
[MyNode:65] node init | 0x15fe73ae0
[MyNode:65] node init | 0x15fe75a80
[MyNode:65] node init | 0x15fd59aa0
[MyNode:65] node init | 0x15fe7ae90
[MyNode:65] node init | 0x15fe7d0d0
[MyNode:65] node init | 0x15fe80980
[MyNode:65] node init | 0x15fe83a50
```

**Controller dealloc**
```
[MyCollectionViewController:336] dealloc | controller dealloc'd!
```

**Node dealloc's**
```
[MyNode:96] dealloc | 0x15fd52ce0
[MyNode:96] dealloc | 0x15fd507f0
[MyNode:96] dealloc | 0x15fe6e910
[MyNode:96] dealloc | 0x15fe6af90
[MyNode:96] dealloc | 0x15fd4dd50
[MyNode:96] dealloc | 0x15fd4a470
[MyNode:96] dealloc | 0x15fe649d0
[MyNode:96] dealloc | 0x15fd49530
```


<hr>

**With changeset applied:**

**Node alloc's**
```
[MyNode:65] node init | 0x13e548460
[MyNode:65] node init | 0x13e548910
[MyNode:65] node init | 0x13e54b9e0
[MyNode:65] node init | 0x13e54ea40
[MyNode:65] node init | 0x13e552500
[MyNode:65] node init | 0x13e66aff0
[MyNode:65] node init | 0x13e66e080
[MyNode:65] node init | 0x13e670470
[MyNode:65] node init | 0x13e673610
[MyNode:65] node init | 0x13e676780
[MyNode:65] node init | 0x13e679d70
[MyNode:65] node init | 0x13e558ec0
[MyNode:65] node init | 0x13e67db50
[MyNode:65] node init | 0x13e67f620
[MyNode:65] node init | 0x13e55cf00
[MyNode:65] node init | 0x13e684880
```


**Controller dealloc**
```
[MyCollectionViewController:336] dealloc | controller dealloc'd!
```

**Node dealloc's**
```
[MyNode:96] dealloc | 0x13e548460
[MyNode:96] dealloc | 0x13e548910
[MyNode:96] dealloc | 0x13e54b9e0
[MyNode:96] dealloc | 0x13e54ea40
[MyNode:96] dealloc | 0x13e552500
[MyNode:96] dealloc | 0x13e66aff0
[MyNode:96] dealloc | 0x13e66e080
[MyNode:96] dealloc | 0x13e670470
[MyNode:96] dealloc | 0x13e684880
[MyNode:96] dealloc | 0x13e55cf00
[MyNode:96] dealloc | 0x13e67f620
[MyNode:96] dealloc | 0x13e67db50
[MyNode:96] dealloc | 0x13e558ec0
[MyNode:96] dealloc | 0x13e679d70
[MyNode:96] dealloc | 0x13e676780
[MyNode:96] dealloc | 0x13e673610
```

<hr>