### PR TITLE
Adds property for long press touch cancellation

### DIFF
--- a/AsyncDisplayKit/ASTextNode.h
+++ b/AsyncDisplayKit/ASTextNode.h
@@ -187,6 +187,12 @@ typedef NS_ENUM(NSUInteger, ASTextNodeHighlightStyle) {
  */
 @property (nonatomic, weak) id<ASTextNodeDelegate> delegate;
 
+/**
+ @abstract If YES and a long press is recognized, touches are cancelled. Default is NO
+ */
+@property (nonatomic, assign) BOOL longPressCancelsTouches;
+
+
 @end
 
 /**

--- a/AsyncDisplayKit/ASTextNode.mm
+++ b/AsyncDisplayKit/ASTextNode.mm
@@ -240,7 +240,7 @@ ASDISPLAYNODE_INLINE CGFloat ceilPixelValue(CGFloat f)
   // If we are view-backed, support gesture interaction.
   if (!self.isLayerBacked) {
     _longPressGestureRecognizer = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(_handleLongPress:)];
-    _longPressGestureRecognizer.cancelsTouchesInView = NO;
+    _longPressGestureRecognizer.cancelsTouchesInView = self.longPressCancelsTouches;
     _longPressGestureRecognizer.delegate = self;
     [self.view addGestureRecognizer:_longPressGestureRecognizer];
   }


### PR DESCRIPTION
Allows for long presses to be recognized as discrete actions without also triggering normal tap handling