### PR TITLE
change ASMutableAttributedStringBuilderTests so that it is safe against ...

### DIFF
--- a/AsyncDisplayKitTests/ASMutableAttributedStringBuilderTests.m
+++ b/AsyncDisplayKitTests/ASMutableAttributedStringBuilderTests.m
@@ -29,7 +29,8 @@
 - (NSRange)_randomizedRangeForStringBuilder:(ASMutableAttributedStringBuilder *)builder
 {
   NSUInteger loc = arc4random() % (builder.length - 1);
-  NSUInteger len = MAX(arc4random() % (builder.length - loc), 1);
+  NSUInteger len = arc4random() % (builder.length - loc);
+  len = ((len > 0) ? len : 1);
   return NSMakeRange(loc, len);
 }
 


### PR DESCRIPTION
...different MAX macro

when MAX macro is defined in such a way in "sys/params.h", this test will become flaky,
fix so that it doesn't happen