### PR TITLE
ASDataController dealloc, ensure cell nodes are not in a superview

### DIFF
--- a/AsyncDisplayKit/Details/ASDataController.mm
+++ b/AsyncDisplayKit/Details/ASDataController.mm
@@ -514,8 +514,12 @@ static void *kASSizingQueueContext = &kASSizingQueueContext;
   ASDisplayNodeAssertMainThread();
   [_nodes enumerateObjectsUsingBlock:^(NSMutableArray *section, NSUInteger sectionIndex, BOOL *stop) {
     [section enumerateObjectsUsingBlock:^(ASCellNode *node, NSUInteger rowIndex, BOOL *stop) {
-      if (node.isNodeLoaded && node.view.superview) {
-        [node.view removeFromSuperview];
+      if (node.isNodeLoaded) {
+        if (node.layerBacked) {
+          [node.layer removeFromSuperlayer];
+        } else {
+          [node.view removeFromSuperview];
+        }
       }
     }];
   }];

--- a/AsyncDisplayKit/Details/ASDataController.mm
+++ b/AsyncDisplayKit/Details/ASDataController.mm
@@ -508,4 +508,17 @@ static void *kASSizingQueueContext = &kASSizingQueueContext;
   return ASFindElementsInMultidimensionalArrayAtIndexPaths(_nodes, [indexPaths sortedArrayUsingSelector:@selector(compare:)]);
 }
 
+#pragma mark - Dealloc
+
+- (void)dealloc {
+  ASDisplayNodeAssertMainThread();
+  [_nodes enumerateObjectsUsingBlock:^(NSMutableArray *section, NSUInteger sectionIndex, BOOL *stop) {
+    [section enumerateObjectsUsingBlock:^(ASCellNode *node, NSUInteger rowIndex, BOOL *stop) {
+      if (node.isNodeLoaded && node.view.superview) {
+        [node.view removeFromSuperview];
+      }
+    }];
+  }];
+}
+
 @end


### PR DESCRIPTION
For reasons I don't fully understand, this avoids a retain cycle with the currently displayed cells.

This is an alternate implementation of "[Ensure all nodes are dealloc'd in ASDataController teardown #409](https://github.com/facebook/AsyncDisplayKit/pull/409)" that works with multiple sections and IMO should supersede that one. (Thanks @barfoon for working this out in the first place. I was quite mystified until I saw his PR.)

In our application, this fix reduced AsyncDisplayKit's retained memory significantly. (There are still other issues I haven't tracked down, but this one is the biggest by far.)