### PR TITLE
Add option to pass through touches to non-link text in ASTextNode

### DIFF
--- a/AsyncDisplayKit/ASTextNode.h
+++ b/AsyncDisplayKit/ASTextNode.h
@@ -192,6 +192,11 @@ typedef NS_ENUM(NSUInteger, ASTextNodeHighlightStyle) {
  */
 @property (nonatomic, assign) BOOL longPressCancelsTouches;
 
+/**
+ @abstract if YES will not intercept touches for non-link areas of the text. Default is NO.
+ */
+@property (nonatomic, assign) BOOL passthroughNonlinkTouches;
+
 
 @end
 

--- a/AsyncDisplayKit/ASTextNode.mm
+++ b/AsyncDisplayKit/ASTextNode.mm
@@ -749,6 +749,33 @@ ASDISPLAYNODE_INLINE CGFloat ceilPixelValue(CGFloat f)
 
 #pragma mark - Touch Handling
 
+-(BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event
+{
+  if (!_passthroughNonlinkTouches) {
+    return [super pointInside:point withEvent:event];
+  }
+
+  NSRange range = NSMakeRange(0, 0);
+  NSString *linkAttributeName = nil;
+  BOOL inAdditionalTruncationMessage = NO;
+
+  id linkAttributeValue = [self _linkAttributeValueAtPoint:point
+                                             attributeName:&linkAttributeName
+                                                     range:&range
+                             inAdditionalTruncationMessage:&inAdditionalTruncationMessage];
+
+  NSUInteger lastCharIndex = NSIntegerMax;
+  BOOL linkCrossesVisibleRange = (lastCharIndex > range.location) && (lastCharIndex < NSMaxRange(range) - 1);
+
+  if (inAdditionalTruncationMessage) {
+    return YES;
+  } else if (range.length && !linkCrossesVisibleRange && linkAttributeValue != nil && linkAttributeName != nil) {
+    return YES;
+  } else {
+    return NO;
+  }
+}
+
 - (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event
 {
   [super touchesBegan:touches withEvent:event];


### PR DESCRIPTION
Adds a new property, `passthroughNonlinkTouches` that will allow touches in non-link areas to pass through to other event handlers event with `userInateractionEnabled` for an `ASTextNode`.