### PR TITLE
Don’t retain an action’s target in ASControlNode

### DIFF
--- a/AsyncDisplayKit/ASControlNode.m
+++ b/AsyncDisplayKit/ASControlNode.m
@@ -226,7 +226,7 @@ void _ASEnumerateControlEventsIncludedInMaskWithBlock(ASControlNodeEvent mask, v
       if (!eventDispatchTable)
       {
         // Create the dispatch table for this event.
-        eventDispatchTable = [NSMapTable strongToStrongObjectsMapTable];
+        eventDispatchTable = [NSMapTable weakToStrongObjectsMapTable];
         [_controlEventDispatchTable setObject:eventDispatchTable forKey:eventKey];
       }
 


### PR DESCRIPTION
- addTarget:action:forControlEvents: should not retain the target. If it does
then there is a very high likelihood of a retain cycle.