### PR TITLE
Allow ASTableView to be loaded in a xib/storyboard

### DIFF
--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -129,17 +129,7 @@ static BOOL _isInterceptedSelector(SEL sel)
 #pragma mark -
 #pragma mark Lifecycle
 
-- (instancetype)initWithFrame:(CGRect)frame style:(UITableViewStyle)style
-{
-  return [self initWithFrame:frame style:style asyncDataFetching:NO];
-}
-
-- (instancetype)initWithFrame:(CGRect)frame style:(UITableViewStyle)style asyncDataFetching:(BOOL)asyncDataFetchingEnabled
-{
-
-  if (!(self = [super initWithFrame:frame style:style]))
-    return nil;
-
+- (void)configureWithAsyncDataFetching:(BOOL)asyncDataFetchingEnabled {
   _layoutController = [[ASFlowLayoutController alloc] initWithScrollOption:ASFlowLayoutDirectionVertical];
 
   _rangeController = [[ASRangeController alloc] init];
@@ -155,6 +145,28 @@ static BOOL _isInterceptedSelector(SEL sel)
 
   _leadingScreensForBatching = 1.0;
   _batchContext = [[ASBatchContext alloc] init];
+}
+
+- (instancetype)initWithFrame:(CGRect)frame style:(UITableViewStyle)style
+{
+  return [self initWithFrame:frame style:style asyncDataFetching:NO];
+}
+
+- (instancetype)initWithFrame:(CGRect)frame style:(UITableViewStyle)style asyncDataFetching:(BOOL)asyncDataFetchingEnabled
+{
+  if (!(self = [super initWithFrame:frame style:style]))
+    return nil;
+
+  [self configureWithAsyncDataFetching:asyncDataFetchingEnabled];
+
+  return self;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder {
+  if (!(self = [super initWithCoder:aDecoder]))
+    return nil;
+
+  [self configureWithAsyncDataFetching:NO];
 
   return self;
 }


### PR DESCRIPTION
This code moves the initialization code to a shared method and uses it to initialize correctly in `-initWithCoder:` so it can be used in a xib or  storyboard. Note that when initializing this way `asyncDataFetching` is defaulted to NO, so it's not possible to use asyncDataFetching in this configuration. (We could do this by making `asyncDataFetching` an `IBInspectable` property but that was a bit more refactoring than I'm comfortable with at the moment.)

It might be worth double-checking `ASCollectionView` to see if it could benefit form a similar refactor. (Next time I'm in that code I'll take a look if someone else doesn't.)