### PR TITLE
Fix a crash in setAsyncDelegate: that happens randomly (UIScrollViewAccessibility or NSProxy)

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -78,11 +78,17 @@ static BOOL _isInterceptedSelector(SEL sel)
 
 - (BOOL)respondsToSelector:(SEL)aSelector
 {
+  ASDisplayNodeAssert(_target, @"target must not be nil"); // catch weak ref's being nilled early
+  ASDisplayNodeAssert(_interceptor, @"interceptor must not be nil");
+
   return (_isInterceptedSelector(aSelector) || [_target respondsToSelector:aSelector]);
 }
 
 - (id)forwardingTargetForSelector:(SEL)aSelector
 {
+  ASDisplayNodeAssert(_target, @"target must not be nil"); // catch weak ref's being nilled early
+  ASDisplayNodeAssert(_interceptor, @"interceptor must not be nil");
+
   if (_isInterceptedSelector(aSelector)) {
     return _interceptor;
   }
@@ -159,6 +165,12 @@ static BOOL _isInterceptedSelector(SEL sel)
   return self;
 }
 
+-(void)dealloc {
+  // a little defense move here.
+  super.delegate  = nil;
+  super.dataSource = nil;
+}
+
 #pragma mark -
 #pragma mark Overrides.
 
@@ -189,8 +201,10 @@ static BOOL _isInterceptedSelector(SEL sel)
 
 - (void)setAsyncDataSource:(id<ASCollectionViewDataSource>)asyncDataSource
 {
-  if (_asyncDataSource == asyncDataSource)
-    return;
+  // Note: It's common to check if the value hasn't changed and short-circuit but we aren't doing that here to handle
+  // the (common) case of nilling the asyncDataSource in the ViewController's dealloc. In this case our _asyncDataSource
+  // will return as nil (ARC magic) even though the _proxyDataSource still exists. It's really important to nil out
+  // super.dataSource in this case because calls to _ASTableViewProxy will start failing and cause crashes.
 
   if (asyncDataSource == nil) {
     super.dataSource = nil;
@@ -205,8 +219,10 @@ static BOOL _isInterceptedSelector(SEL sel)
 
 - (void)setAsyncDelegate:(id<ASCollectionViewDelegate>)asyncDelegate
 {
-  if (_asyncDelegate == asyncDelegate)
-    return;
+  // Note: It's common to check if the value hasn't changed and short-circuit but we aren't doing that here to handle
+  // the (common) case of nilling the asyncDelegate in the ViewController's dealloc. In this case our _asyncDelegate
+  // will return as nil (ARC magic) even though the _proxyDelegate still exists. It's really important to nil out
+  // super.delegate in this case because calls to _ASTableViewProxy will start failing and cause crashes.
 
   if (asyncDelegate == nil) {
     // order is important here, the delegate must be callable while nilling super.delegate to avoid random crashes

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -193,9 +193,9 @@ static BOOL _isInterceptedSelector(SEL sel)
     return;
 
   if (asyncDataSource == nil) {
+    super.dataSource = nil;
     _asyncDataSource = nil;
     _proxyDataSource = nil;
-    super.dataSource = nil;
   } else {
     _asyncDataSource = asyncDataSource;
     _proxyDataSource = [[_ASCollectionViewProxy alloc] initWithTarget:_asyncDataSource interceptor:self];
@@ -209,9 +209,11 @@ static BOOL _isInterceptedSelector(SEL sel)
     return;
 
   if (asyncDelegate == nil) {
+    // order is important here, the delegate must be callable while nilling super.delegate to avoid random crashes
+    // in UIScrollViewAccessibility.
+    super.delegate = nil;
     _asyncDelegate = nil;
     _proxyDelegate = nil;
-    super.delegate = nil;
   } else {
     _asyncDelegate = asyncDelegate;
     _proxyDelegate = [[_ASCollectionViewProxy alloc] initWithTarget:_asyncDelegate interceptor:self];

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -77,11 +77,17 @@ static BOOL _isInterceptedSelector(SEL sel)
 
 - (BOOL)respondsToSelector:(SEL)aSelector
 {
+  ASDisplayNodeAssert(_target, @"target must not be nil"); // catch weak ref's being nilled early
+  ASDisplayNodeAssert(_interceptor, @"interceptor must not be nil");
+
   return (_isInterceptedSelector(aSelector) || [_target respondsToSelector:aSelector]);
 }
 
 - (id)forwardingTargetForSelector:(SEL)aSelector
 {
+  ASDisplayNodeAssert(_target, @"target must not be nil"); // catch weak ref's being nilled early
+  ASDisplayNodeAssert(_interceptor, @"interceptor must not be nil");
+
   if (_isInterceptedSelector(aSelector)) {
     return _interceptor;
   }
@@ -159,6 +165,12 @@ static BOOL _isInterceptedSelector(SEL sel)
   return self;
 }
 
+-(void)dealloc {
+  // a little defense move here.
+  super.delegate  = nil;
+  super.dataSource = nil;
+}
+
 #pragma mark -
 #pragma mark Overrides
 
@@ -175,8 +187,10 @@ static BOOL _isInterceptedSelector(SEL sel)
 
 - (void)setAsyncDataSource:(id<ASTableViewDataSource>)asyncDataSource
 {
-  if (_asyncDataSource == asyncDataSource)
-    return;
+  // Note: It's common to check if the value hasn't changed and short-circuit but we aren't doing that here to handle
+  // the (common) case of nilling the asyncDataSource in the ViewController's dealloc. In this case our _asyncDataSource
+  // will return as nil (ARC magic) even though the _proxyDataSource still exists. It's really important to nil out
+  // super.dataSource in this case because calls to _ASTableViewProxy will start failing and cause crashes.
 
   if (asyncDataSource == nil) {
     super.dataSource = nil;
@@ -191,8 +205,10 @@ static BOOL _isInterceptedSelector(SEL sel)
 
 - (void)setAsyncDelegate:(id<ASTableViewDelegate>)asyncDelegate
 {
-  if (_asyncDelegate == asyncDelegate)
-    return;
+  // Note: It's common to check if the value hasn't changed and short-circuit but we aren't doing that here to handle
+  // the (common) case of nilling the asyncDelegate in the ViewController's dealloc. In this case our _asyncDelegate
+  // will return as nil (ARC magic) even though the _proxyDelegate still exists. It's really important to nil out
+  // super.delegate in this case because calls to _ASTableViewProxy will start failing and cause crashes.
 
   if (asyncDelegate == nil) {
     // order is important here, the delegate must be callable while nilling super.delegate to avoid random crashes

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -179,9 +179,9 @@ static BOOL _isInterceptedSelector(SEL sel)
     return;
 
   if (asyncDataSource == nil) {
+    super.dataSource = nil;
     _asyncDataSource = nil;
     _proxyDataSource = nil;
-    super.dataSource = nil;
   } else {
     _asyncDataSource = asyncDataSource;
     _proxyDataSource = [[_ASTableViewProxy alloc] initWithTarget:_asyncDataSource interceptor:self];
@@ -195,9 +195,11 @@ static BOOL _isInterceptedSelector(SEL sel)
     return;
 
   if (asyncDelegate == nil) {
-    _asyncDelegate = nil;
-    _proxyDelegate = nil;
+    // order is important here, the delegate must be callable while nilling super.delegate to avoid random crashes
+    // in UIScrollViewAccessibility.
     super.delegate = nil;
+    _asyncDelegate = nil;
+    _proxyDelegate = nil; 
   } else {
     _asyncDelegate = asyncDelegate;
     _proxyDelegate = [[_ASTableViewProxy alloc] initWithTarget:asyncDelegate interceptor:self];


### PR DESCRIPTION
change the order we tear things down in `setAsyncDelegate`/`setDataSource` to avoid a random crash in `UIScrollViewAccessibility` or an `NSProxy` exception. I'm not sure exactly why, but it appears the `UIScrollView` will sometimes attempt to call the delegate while it is being nilled out. Previous code was deallocing the proxy before clearing `super.delegate`. 

This can manifest as a null ref in `UIScrollViewAccessibility` or as an illegal call to `NSProx`y, depending on exactly the order things happen.

**Update:** I've made some additional changes that help solve this problem, but it's important to manually nil `asyncDelegate` (and `asyncDataSource`) to avoid crashes. If you depend on ARC bad things will happen currently and I'm not sure exactly how to handle it. Root cause is that it's possible for the `_AS(Table|Collection)ViewProxy` objects to still exist and be wired when the underlying target has been nilled by arc. At this point any calls to the `delegate` or `dataSource` will throw an exception. Yuck. Would love suggestions on how to handle this. (Essentially we need to set `super.delegate|dataSource` to nil when `_proxyDelegate|DataSource` are nilled.)