### PR TITLE
Set line width on path instead of context.

### DIFF
--- a/AsyncDisplayKit/ASImageNode.mm
+++ b/AsyncDisplayKit/ASImageNode.mm
@@ -347,7 +347,7 @@ extern asimagenode_modification_block_t ASImageNodeRoundBorderModificationBlock(
     // Draw a border on top.
     if (borderWidth > 0.0) {
       [borderColor setStroke];
-      CGContextSetLineWidth(UIGraphicsGetCurrentContext(), borderWidth);
+      [roundOutline setLineWidth:borderWidth];
       [roundOutline stroke];
     }
 


### PR DESCRIPTION
I’m not confident why the original implementation doesn’t work, but
this version is stylistically cleaner regardless.  Resolves task #450.