### PR TITLE
Possible fix for text node truncation issue

### DIFF
--- a/AsyncDisplayKit/Details/ASTextNodeWordKerner.m
+++ b/AsyncDisplayKit/Details/ASTextNodeWordKerner.m
@@ -31,7 +31,7 @@
       continue;
 
     // If we've set the whitespace control character for this space already, we have nothing to do.
-    if (properties[arrayIndex] == NSGlyphPropertyControlCharacter) {
+    if (properties[arrayIndex] == NSGlyphPropertyElastic) {
       usesWordKerning = YES;
       continue;
     }
@@ -43,7 +43,7 @@
     }
 
     // It's a space. Make it a whitespace control character.
-    newGlyphProperties[arrayIndex] = NSGlyphPropertyControlCharacter;
+    newGlyphProperties[arrayIndex] = NSGlyphPropertyElastic;
   }
 
   // If we don't have any custom glyph properties, return 0 to indicate to the layout manager that it should use the standard glyphs+properties.


### PR DESCRIPTION
This fix is related to #261.

First, the issue seems to originate from `ASTextNodeWordKerner` which is set as the `NSLayoutManager`'s delegate. If you prevent it from being the layout manager's delegate, rendering will work correctly.

Digging deeper, it seems like we are checking for the wrong glyph property.

Inside the code, we seems to be trying to search for whitespaces so that we can check its glyph property. The problem is that we are checking for `NSGlyphPropertyControlCharacter`.

In the documentation `NSGlyphPropertyControlCharacter` is described as follows:

> Control character such as tab, attachment, and so on, that has associated special behavior.

It seems like there's a mismatch here. Whitespaces are usually described with `NSGlyphPropertyElastic`. This is checked against the documentation...

> Glyphs with elastic glyph width behavior such as whitespace.

... and check against the original provided glyph property with something like this in the method...

```Objective-C
    NSGlyphProperty glyphProperty = properties[arrayIndex];
    switch (glyphProperty) {
        case NSGlyphPropertyNull: {
            NSLog(@"NSGlyphPropertyNull");
        } break;
        case NSGlyphPropertyControlCharacter: {
            NSLog(@"NSGlyphPropertyControlCharacter");
        } break;
        case NSGlyphPropertyElastic: {
            NSLog(@"NSGlyphPropertyElastic");
        } break;
        case NSGlyphPropertyNonBaseCharacter: {
            NSLog(@"NSGlyphPropertyNonBaseCharacter");
        } break;
    }
```

I'm unsure under what circumstances will whitespaces not describe as `NSGlyphPropertyElastic` by the system, thats something to ponder too.

Hope this help!