### PR TITLE
Fix offset issue for rasterized nodes 

### DIFF
--- a/AsyncDisplayKit/Private/ASDisplayNode+AsyncDisplay.mm
+++ b/AsyncDisplayKit/Private/ASDisplayNode+AsyncDisplay.mm
@@ -87,15 +87,23 @@ static void __ASDisplayLayerDecrementConcurrentDisplayCount(BOOL displayIsAsync,
   // Capture these outside the display block so they are retained.
   UIColor *backgroundColor = self.backgroundColor;
   CGRect bounds = self.bounds;
-  CGPoint position = self.position;
-  CGPoint anchorPoint = self.anchorPoint;
 
-  // Pretty hacky since full 3D transforms aren't actually supported, but attempt to compute the transformed frame of this node so that we can composite it into approximately the right spot.
-  CGAffineTransform transform = CATransform3DGetAffineTransform(self.transform);
-  CGSize scaledBoundsSize = CGSizeApplyAffineTransform(bounds.size, transform);
-  CGPoint origin = CGPointMake(position.x - scaledBoundsSize.width * anchorPoint.x,
-                               position.y - scaledBoundsSize.height * anchorPoint.y);
-  CGRect frame = CGRectMake(origin.x, origin.y, bounds.size.width, bounds.size.height);
+  CGRect frame;
+  
+  // If this is the root container node, use a frame with a zero origin to draw into. If not, calculate the correct frame using the node's position, transform and anchorPoint.
+  if (self.shouldRasterizeDescendants) {
+    frame = CGRectMake(0.0f, 0.0f, bounds.size.width, bounds.size.height);
+  } else {
+    CGPoint position = self.position;
+    CGPoint anchorPoint = self.anchorPoint;
+    
+    // Pretty hacky since full 3D transforms aren't actually supported, but attempt to compute the transformed frame of this node so that we can composite it into approximately the right spot.
+    CGAffineTransform transform = CATransform3DGetAffineTransform(self.transform);
+    CGSize scaledBoundsSize = CGSizeApplyAffineTransform(bounds.size, transform);
+    CGPoint origin = CGPointMake(position.x - scaledBoundsSize.width * anchorPoint.x,
+                                 position.y - scaledBoundsSize.height * anchorPoint.y);
+    frame = CGRectMake(origin.x, origin.y, bounds.size.width, bounds.size.height);
+  }
 
   // Get the display block for this node.
   asyncdisplaykit_async_transaction_operation_block_t displayBlock = [self _displayBlockWithAsynchronous:NO isCancelledBlock:isCancelledBlock rasterizing:YES];


### PR DESCRIPTION
This fixes an issue that causes rasterized nodes that have a non-zero origin to draw incorrectly, as seen in #471 and #318.

This is a screenshot of the issue. The second box has an offset of about 150 points, which causes the rasterization to inset the subnodes with 150 points.
![e2376ef0-0cf7-11e5-8c51-66a886017eb9](https://cloud.githubusercontent.com/assets/8394738/8145640/077306d0-1210-11e5-83c0-fe063b837bf1.png)

I've fixed it by using a frame with a zero origin when the node that's being rasterized is the container node.

![schermafbeelding 2015-06-13 om 21 14 22](https://cloud.githubusercontent.com/assets/8394738/8145668/382c3778-1211-11e5-8ae6-7e5a2c6d51e9.png)
