### PR TITLE
Fixed bounds in ASDisplayNode

### DIFF
--- a/AsyncDisplayKit/Private/ASDisplayNode+UIViewBridge.mm
+++ b/AsyncDisplayKit/Private/ASDisplayNode+UIViewBridge.mm
@@ -144,13 +144,17 @@
 #endif
 
   if (_layer && ASDisplayNodeThreadIsMain()) {
+    CGRect oldBounds = _layer.bounds;
+    _layer.bounds = CGRectMake(oldBounds.origin.x, oldBounds.origin.y, rect.size.width, rect.size.height);
+    
     CGPoint anchorPoint = _layer.anchorPoint;
-    _layer.bounds = CGRectMake(0, 0, rect.size.width, rect.size.height);
     _layer.position = CGPointMake(rect.origin.x + rect.size.width * anchorPoint.x,
                                  rect.origin.y + rect.size.height * anchorPoint.y);
   } else {
+    CGRect oldBounds = self.bounds;
+    self.bounds = CGRectMake(oldBounds.origin.x, oldBounds.origin.y, rect.size.width, rect.size.height);
+
     CGPoint anchorPoint = self.anchorPoint;
-    self.bounds = CGRectMake(0, 0, rect.size.width, rect.size.height);
     self.position = CGPointMake(rect.origin.x + rect.size.width * anchorPoint.x,
                                 rect.origin.y + rect.size.height * anchorPoint.y);
   }

--- a/AsyncDisplayKit/Private/ASDisplayNode+UIViewBridge.mm
+++ b/AsyncDisplayKit/Private/ASDisplayNode+UIViewBridge.mm
@@ -144,15 +144,15 @@
 #endif
 
   if (_layer && ASDisplayNodeThreadIsMain()) {
-    CGRect oldBounds = _layer.bounds;
-    _layer.bounds = CGRectMake(oldBounds.origin.x, oldBounds.origin.y, rect.size.width, rect.size.height);
+    CGPoint oldBoundsOrigin = _layer.bounds.origin;
+    _layer.bounds = CGRectMake(oldBoundsOrigin.x, oldBoundsOrigin.y, rect.size.width, rect.size.height);
     
     CGPoint anchorPoint = _layer.anchorPoint;
     _layer.position = CGPointMake(rect.origin.x + rect.size.width * anchorPoint.x,
                                  rect.origin.y + rect.size.height * anchorPoint.y);
   } else {
-    CGRect oldBounds = self.bounds;
-    self.bounds = CGRectMake(oldBounds.origin.x, oldBounds.origin.y, rect.size.width, rect.size.height);
+    CGPoint oldBoundsOrigin = self.bounds.origin;
+    self.bounds = CGRectMake(oldBoundsOrigin.x, oldBoundsOrigin.y, rect.size.width, rect.size.height);
 
     CGPoint anchorPoint = self.anchorPoint;
     self.position = CGPointMake(rect.origin.x + rect.size.width * anchorPoint.x,

--- a/AsyncDisplayKitTests/ASDisplayNodeTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeTests.m
@@ -1680,5 +1680,16 @@ static bool stringContainsPointer(NSString *description, const void *p) {
   [self checkNameInDescriptionIsLayerBacked:NO];
 }
 
+- (void)testBounds
+{
+  ASDisplayNode *node = [[ASDisplayNode alloc] init];
+  node.bounds = CGRectMake(1, 2, 3, 4);
+  node.frame = CGRectMake(5, 6, 7, 8);
+
+  XCTAssert(node.bounds.origin.x == 1, @"Wrong ASDisplayNode.bounds.origin.x");
+  XCTAssert(node.bounds.origin.y == 2, @"Wrong ASDisplayNode.bounds.origin.y");
+  XCTAssert(node.bounds.size.width == 7, @"Wrong ASDisplayNode.bounds.size.width");
+  XCTAssert(node.bounds.size.height == 8, @"Wrong ASDisplayNode.bounds.size.height");
+}
 
 @end


### PR DESCRIPTION
Bounds.origin shouldn't be affected by -[ASDisplayNode setFrame:] method. This affects many nodes, for example ASScrollNode scrolls to top after frame changing.
