### PR TITLE
Remove -[_ASDisplayView layoutSubviews] and use only -[_ASDisplayLayer layoutSublayers]

### DIFF
--- a/AsyncDisplayKit/ASScrollNode.m
+++ b/AsyncDisplayKit/ASScrollNode.m
@@ -7,6 +7,19 @@
  */
 
 #import "ASScrollNode.h"
+#import "_ASDisplayLayer.h"
+
+@interface ASScrollView : UIScrollView
+@end
+
+@implementation ASScrollView
+
++ (Class)layerClass
+{
+  return [_ASDisplayLayer class];
+}
+
+@end
 
 @implementation ASScrollNode
 @dynamic view;
@@ -14,7 +27,7 @@
 - (instancetype)init
 {
   return [super initWithViewBlock:^UIView *{
-    return [[UIScrollView alloc] init];
+    return [[ASScrollView alloc] init];
   }];
 }
 

--- a/AsyncDisplayKit/Details/_ASDisplayLayer.mm
+++ b/AsyncDisplayKit/Details/_ASDisplayLayer.mm
@@ -93,10 +93,13 @@
   [super layoutSublayers];
 
   ASDisplayNode *node = self.asyncdisplaykit_node;
-  // If our associated node is layer-backed, we cannot rely on the view's -layoutSubviews calling the node's -layout implementation, so do it ourselves.
-  if (node.isLayerBacked) {
-    ASDisplayNodeAssertMainThread();
+  if (ASDisplayNodeThreadIsMain()) {
     [node __layout];
+  } else {
+    ASDisplayNodeFailAssert(@"not reached assertion");
+    dispatch_async(dispatch_get_main_queue(), ^ {
+      [node __layout];
+    });
   }
 }
 

--- a/AsyncDisplayKit/Details/_ASDisplayView.mm
+++ b/AsyncDisplayKit/Details/_ASDisplayView.mm
@@ -122,19 +122,6 @@
   }
 }
 
-- (void)layoutSubviews
-{
-  if (ASDisplayNodeThreadIsMain()) {
-    [_node __layout];
-  } else {
-    // FIXME: CRASH This should not be happening because of the way we gate -setNeedsLayout, but it has been seen.
-    ASDisplayNodeFailAssert(@"not reached assertion");
-    dispatch_async(dispatch_get_main_queue(), ^ {
-      [_node __layout];
-    });
-  }
-}
-
 - (UIViewContentMode)contentMode
 {
   return ASDisplayNodeUIContentModeFromCAContentsGravity(self.layer.contentsGravity);


### PR DESCRIPTION
Remove -[_ASDisplayView layoutSubviews] and use only -[_ASDisplayLayer layoutSublayers]

This helps us support special cases such as ASScrollNode correctly driving the -layout
method for subclasses even though it is based on UIScrollView & can't use _ASDisplayView.

I suspect this will be useful for ASCollectionNode and ASTableNode as well, which would
allow nesting those classes inside of other collections / tables (e.g. horizontal
unit within a vertical unit).