### PR TITLE
Custom layout enabled. Removes UICollectionViewFlowLayout requirement.

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -142,7 +142,6 @@ static BOOL _isInterceptedSelector(SEL sel)
   // https://github.com/facebook/AsyncDisplayKit/issues/385
   asyncDataFetchingEnabled = NO;
 
-  ASDisplayNodeAssert([layout asdk_isFlowLayout], @"only flow layouts are currently supported");
   _layoutController = [[ASCollectionViewLayoutController alloc] initWithCollectionView:self];
 
   _rangeController = [[ASRangeController alloc] init];


### PR DESCRIPTION
I think we might want to hold off on merging this until we verify that the new layout controller works well with flow layout as a first step.