### PR TITLE
Exclude ASDealloc2MainObject.h from main spec

### DIFF
--- a/AsyncDisplayKit.podspec
+++ b/AsyncDisplayKit.podspec
@@ -25,7 +25,10 @@ Pod::Spec.new do |spec|
 
   # ASDealloc2MainObject must be compiled with MRR
   spec.requires_arc = true
-  spec.exclude_files = ['AsyncDisplayKit/Details/ASDealloc2MainObject.m']
+  spec.exclude_files = [
+    'AsyncDisplayKit/Details/ASDealloc2MainObject.h',
+    'AsyncDisplayKit/Details/ASDealloc2MainObject.m',
+  ]
   spec.subspec 'ASDealloc2MainObject' do |mrr|
     mrr.requires_arc = false
     mrr.source_files = [


### PR DESCRIPTION
Currently when using Cocoapods to install the latest version of AsyncDisplayKit using the `use_frameworks!` option, `ASDealloc2MainObject.h` is added to the headers build phase twice due to its inclusion in both the main podspec as well as the `ASDealloc2MainObject` subspec. This leads to a "Multiple build commands for output file" warning in Xcode.

In this case the fix is pretty simple - just exclude that header from the main spec (you're already doing this for `ASDealloc2MainObject.m`).