### PR TITLE
Add UIResponder methods to ASDisplayNode

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -468,6 +468,15 @@ typedef CALayer *(^ASDisplayNodeLayerBlock)();
 - (void)setNeedsDisplay;    // Marks the view as needing display. Convenience for use whether view is created or not, or from a background thread.
 - (void)setNeedsLayout;     // Marks the view as needing layout.  Convenience for use whether view is created or not, or from a background thread.
 
+// UIResponder methods
+// By default these fall through to the underlying view, but can be overridden.
+- (BOOL)canBecomeFirstResponder;                                            // default==NO
+- (BOOL)becomeFirstResponder;                                               // default==NO (no-op)
+- (BOOL)canResignFirstResponder;                                            // default==YES
+- (BOOL)resignFirstResponder;                                               // default==YES (no-op)
+- (BOOL)isFirstResponder;
+- (BOOL)canPerformAction:(SEL)action withSender:(id)sender;
+
 @property (atomic, retain)           id contents;                           // default=nil
 @property (atomic, assign)           BOOL clipsToBounds;                    // default==NO
 @property (atomic, getter=isOpaque)  BOOL opaque;                           // default==YES

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -1697,6 +1697,30 @@ static void _recursivelySetDisplaySuspended(ASDisplayNode *node, CALayer *layer,
 
 }
 
+- (BOOL)canBecomeFirstResponder {
+    return NO;
+}
+
+- (BOOL)becomeFirstResponder {
+    return [self.view becomeFirstResponder];
+}
+
+- (BOOL)canResignFirstResponder {
+    return YES;
+}
+
+- (BOOL)resignFirstResponder {
+    return [self.view resignFirstResponder];
+}
+
+- (BOOL)isFirstResponder {
+    return [self.view isFirstResponder];
+}
+
+- (BOOL)canPerformAction:(SEL)action withSender:(id)sender {
+    return [self.view canPerformAction:action withSender:sender];
+}
+
 @end
 
 @implementation ASDisplayNode (Debugging)

--- a/AsyncDisplayKit/Details/_ASDisplayView.mm
+++ b/AsyncDisplayKit/Details/_ASDisplayView.mm
@@ -243,6 +243,14 @@
     [_node tintColorDidChange];
 }
 
+- (BOOL)canBecomeFirstResponder {
+    return [_node canBecomeFirstResponder];
+}
+
+- (BOOL)canResignFirstResponder {
+    return [_node canResignFirstResponder];
+}
+
 - (BOOL)canPerformAction:(SEL)action withSender:(id)sender
 {
   // We forward responder-chain actions to our node if we can't handle them ourselves. See -targetForAction:withSender:.


### PR DESCRIPTION
This adds several `UIResponder` methods to `ASDisplayNode`, further increasing its API-compatibility with `UIView`. These methods include:
- `canBecomeFirstResponder`
- `becomeFirstResponder`
- `canResignFirstResponder`
- `resignFirstResponder`
- `isFirstResponder`
- `canPerformAction:withSender`

These by default just forward along to their underlying `_ASDisplayView`, which should already implement them correctly. The exception to this is `canBecomeFirstResponder` and `canResignFirstResponder`, which by default return `NO` and `YES`, respectively (this is so the `_ASDisplayView` can in turn ask its `ASDisplayNode` if it can become the first responder without having to expose `_ASDisplayView` directly).

I put this together to make it easy to close #11. However, the work's not fully done: it's still up to implementors to actually create a copyable `ASTextNode` subclass. This is intentional - that's pretty much the state of things with `UILabel` as well (see nshipster.com/uimenucontroller/ for an example of how to properly subclass and implement this). If you'd like me to contribute an `ASCopyableTextNode` class, I'd be happy to, although it feels a bit out-of-scope for this library.