### PR TITLE
ASTableView programmatic scrolling fix w/contiguous guarantee

### DIFF
--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -125,7 +125,7 @@ static BOOL _isInterceptedSelector(SEL sel)
 
   ASBatchContext *_batchContext;
 
-  NSMutableSet *_pendingVisibleIndexPaths;
+  NSIndexPath *_pendingVisibleIndexPath;
 }
 
 @property (atomic, assign) BOOL asyncDataSourceLocked;
@@ -174,8 +174,6 @@ void ASPerformBlockWithoutAnimation(BOOL withoutAnimation, void (^block)()) {
 
   _leadingScreensForBatching = 1.0;
   _batchContext = [[ASBatchContext alloc] init];
-  
-  _pendingVisibleIndexPaths = [[NSMutableSet alloc] init];
 }
 
 - (instancetype)initWithFrame:(CGRect)frame style:(UITableViewStyle)style
@@ -433,7 +431,7 @@ void ASPerformBlockWithoutAnimation(BOOL withoutAnimation, void (^block)()) {
 
 - (void)tableView:(UITableView *)tableView willDisplayCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath
 {
-  [_pendingVisibleIndexPaths addObject:indexPath];
+  _pendingVisibleIndexPath = indexPath;
 
   [_rangeController visibleNodeIndexPathsDidChangeWithScrollDirection:self.scrollDirection];
 
@@ -444,8 +442,8 @@ void ASPerformBlockWithoutAnimation(BOOL withoutAnimation, void (^block)()) {
 
 - (void)tableView:(UITableView *)tableView didEndDisplayingCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath*)indexPath
 {
-  if ([_pendingVisibleIndexPaths containsObject:indexPath]) {
-    [_pendingVisibleIndexPaths removeObject:indexPath];
+  if ([_pendingVisibleIndexPath isEqual:indexPath]) {
+    _pendingVisibleIndexPath = nil;
   }
 
   [_rangeController visibleNodeIndexPathsDidChangeWithScrollDirection:self.scrollDirection];
@@ -519,15 +517,20 @@ void ASPerformBlockWithoutAnimation(BOOL withoutAnimation, void (^block)()) {
 {
   ASDisplayNodeAssertMainThread();
 
-  NSMutableSet *visibleIndexPaths = [NSMutableSet setWithArray:[self indexPathsForVisibleRows]];
-  
-  // First, remove any index paths we're tracking that UIKit has now proven it can remember :)
-  [_pendingVisibleIndexPaths minusSet:visibleIndexPaths];
-  
-  // Next, add all remaining index paths that we know should be visible (from willDisplayCell) but are not in the set.
-  [visibleIndexPaths unionSet:_pendingVisibleIndexPaths];
-  
-  return visibleIndexPaths.allObjects;
+  NSArray *visibleIndexPaths = self.indexPathsForVisibleRows;
+
+  if ( _pendingVisibleIndexPath ) {
+    NSMutableSet *indexPaths = [NSMutableSet setWithArray:self.indexPathsForVisibleRows];
+
+    if ( [indexPaths containsObject:_pendingVisibleIndexPath]) {
+      _pendingVisibleIndexPath = nil; // once it has shown up in visibleIndexPaths, we can stop tracking it
+    } else {
+      [indexPaths addObject:_pendingVisibleIndexPath];
+      visibleIndexPaths = indexPaths.allObjects;
+    }
+  }
+
+  return visibleIndexPaths;
 }
 
 - (NSArray *)rangeController:(ASRangeController *)rangeController nodesAtIndexPaths:(NSArray *)indexPaths
@@ -544,7 +547,7 @@ void ASPerformBlockWithoutAnimation(BOOL withoutAnimation, void (^block)()) {
 - (void)rangeController:(ASRangeController *)rangeController didInsertNodesAtIndexPaths:(NSArray *)indexPaths withAnimationOption:(ASDataControllerAnimationOptions)animationOption
 {
   ASDisplayNodeAssertMainThread();
-  
+
   BOOL preventAnimation = animationOption == UITableViewRowAnimationNone;
   ASPerformBlockWithoutAnimation(preventAnimation, ^{
     [super insertRowsAtIndexPaths:indexPaths withRowAnimation:(UITableViewRowAnimation)animationOption];


### PR DESCRIPTION
This is a candidate fix for the race condition @appleguy tracked down in #458. This version uses the single pending `NSIndexPath` approach but adds code to validate that the pending index path is always contiguous with respect to `UITableView`'s `indexPathsForVisibleNodes`. (I had previously discovered that the approach of tracking all visible nodes using willDisplay/didEndDisplaying is flawed because `UITableView` doesn't always call didEndDisplaying. Boo. See #427)

In order to do this we may make up to two calls to `-[ASDataController  numberOfRowsInSection:]` but this *only* happens when we have a pending index that is not part of the existing visible range (a rare but important edge case.) From what I've seen this happens pretty rarely and should not impact overall system performance.

I took great pains to validate the logic for the `isAfter(...)` method, so I think we are in good shape there. (It even covers odd situations like sections with no rows.) One caveat, if the pending value is an invalid `NSIndexPath` for our dataSource for some reason, weird things can happen. If we need to cover this edge case as well it can be done, but it would require additional calls to `ASDataController` to validate it.