### PR TITLE
Add UIResponder methods to ASDisplayNode

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -468,6 +468,15 @@ typedef CALayer *(^ASDisplayNodeLayerBlock)();
 - (void)setNeedsDisplay;    // Marks the view as needing display. Convenience for use whether view is created or not, or from a background thread.
 - (void)setNeedsLayout;     // Marks the view as needing layout.  Convenience for use whether view is created or not, or from a background thread.
 
+// UIResponder methods
+// By default these fall through to the underlying view, but can be overridden.
+- (BOOL)canBecomeFirstResponder;                                            // default==NO
+- (BOOL)becomeFirstResponder;                                               // default==NO (no-op)
+- (BOOL)canResignFirstResponder;                                            // default==YES
+- (BOOL)resignFirstResponder;                                               // default==YES (no-op)
+- (BOOL)isFirstResponder;
+- (BOOL)canPerformAction:(SEL)action withSender:(id)sender;
+
 @property (atomic, retain)           id contents;                           // default=nil
 @property (atomic, assign)           BOOL clipsToBounds;                    // default==NO
 @property (atomic, getter=isOpaque)  BOOL opaque;                           // default==YES

--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -432,6 +432,16 @@ typedef CALayer *(^ASDisplayNodeLayerBlock)();
  */
 - (CGRect)convertRect:(CGRect)rect fromNode:(ASDisplayNode *)node;
 
+/** @name UIResponder methods */
+
+// By default these fall through to the underlying view, but can be overridden.
+- (BOOL)canBecomeFirstResponder;                                            // default==NO
+- (BOOL)becomeFirstResponder;                                               // default==NO (no-op)
+- (BOOL)canResignFirstResponder;                                            // default==YES
+- (BOOL)resignFirstResponder;                                               // default==NO (no-op)
+- (BOOL)isFirstResponder;
+- (BOOL)canPerformAction:(SEL)action withSender:(id)sender;
+
 @end
 
 
@@ -467,15 +477,6 @@ typedef CALayer *(^ASDisplayNodeLayerBlock)();
 
 - (void)setNeedsDisplay;    // Marks the view as needing display. Convenience for use whether view is created or not, or from a background thread.
 - (void)setNeedsLayout;     // Marks the view as needing layout.  Convenience for use whether view is created or not, or from a background thread.
-
-// UIResponder methods
-// By default these fall through to the underlying view, but can be overridden.
-- (BOOL)canBecomeFirstResponder;                                            // default==NO
-- (BOOL)becomeFirstResponder;                                               // default==NO (no-op)
-- (BOOL)canResignFirstResponder;                                            // default==YES
-- (BOOL)resignFirstResponder;                                               // default==YES (no-op)
-- (BOOL)isFirstResponder;
-- (BOOL)canPerformAction:(SEL)action withSender:(id)sender;
 
 @property (atomic, retain)           id contents;                           // default=nil
 @property (atomic, assign)           BOOL clipsToBounds;                    // default==NO

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -1697,6 +1697,30 @@ static void _recursivelySetDisplaySuspended(ASDisplayNode *node, CALayer *layer,
 
 }
 
+- (BOOL)canBecomeFirstResponder {
+    return NO;
+}
+
+- (BOOL)becomeFirstResponder {
+    return [self.view becomeFirstResponder];
+}
+
+- (BOOL)canResignFirstResponder {
+    return YES;
+}
+
+- (BOOL)resignFirstResponder {
+    return [self.view resignFirstResponder];
+}
+
+- (BOOL)isFirstResponder {
+    return [self.view isFirstResponder];
+}
+
+- (BOOL)canPerformAction:(SEL)action withSender:(id)sender {
+    return [self.view canPerformAction:action withSender:sender];
+}
+
 @end
 
 @implementation ASDisplayNode (Debugging)

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -1701,24 +1701,29 @@ static void _recursivelySetDisplaySuspended(ASDisplayNode *node, CALayer *layer,
     return NO;
 }
 
-- (BOOL)becomeFirstResponder {
-    return [self.view becomeFirstResponder];
-}
-
 - (BOOL)canResignFirstResponder {
     return YES;
 }
 
-- (BOOL)resignFirstResponder {
-    return [self.view resignFirstResponder];
+- (BOOL)isFirstResponder {
+    ASDisplayNodeAssertMainThread();
+    return _view != nil && [_view isFirstResponder];
 }
 
-- (BOOL)isFirstResponder {
-    return [self.view isFirstResponder];
+// Note: this implicitly loads the view if it hasn't been loaded yet.
+- (BOOL)becomeFirstResponder {
+    ASDisplayNodeAssertMainThread();
+    return !self.layerBacked && [self canBecomeFirstResponder] && [self.view becomeFirstResponder];
+}
+
+- (BOOL)resignFirstResponder {
+    ASDisplayNodeAssertMainThread();
+    return !self.layerBacked && [self canResignFirstResponder] && [_view resignFirstResponder];
 }
 
 - (BOOL)canPerformAction:(SEL)action withSender:(id)sender {
-    return [self.view canPerformAction:action withSender:sender];
+    ASDisplayNodeAssertMainThread();
+    return !self.layerBacked && [self.view canPerformAction:action withSender:sender];
 }
 
 @end

--- a/AsyncDisplayKit/ASEditableTextNode.h
+++ b/AsyncDisplayKit/ASEditableTextNode.h
@@ -57,10 +57,10 @@
 - (BOOL)isFirstResponder;
 
 //! @abstract Makes the receiver's text view the first responder.
-- (void)becomeFirstResponder;
+- (BOOL)becomeFirstResponder;
 
 //! @abstract Resigns the receiver's text view from first-responder status, if it has it.
-- (void)resignFirstResponder;
+- (BOOL)resignFirstResponder;
 
 #pragma mark - Geometry
 /**

--- a/AsyncDisplayKit/ASEditableTextNode.mm
+++ b/AsyncDisplayKit/ASEditableTextNode.mm
@@ -352,16 +352,26 @@
   return [_textKitComponents.textView isFirstResponder];
 }
 
-- (void)becomeFirstResponder
-{
-  ASDN::MutexLocker l(_textKitLock);
-  [_textKitComponents.textView becomeFirstResponder];
+- (BOOL)canBecomeFirstResponder {
+    ASDN::MutexLocker l(_textKitLock);
+    return [_textKitComponents.textView canBecomeFirstResponder];
 }
 
-- (void)resignFirstResponder
+- (BOOL)becomeFirstResponder
 {
   ASDN::MutexLocker l(_textKitLock);
-  [_textKitComponents.textView resignFirstResponder];
+  return [_textKitComponents.textView becomeFirstResponder];
+}
+
+- (BOOL)canResignFirstResponder {
+    ASDN::MutexLocker l(_textKitLock);
+    return [_textKitComponents.textView canResignFirstResponder];
+}
+
+- (BOOL)resignFirstResponder
+{
+  ASDN::MutexLocker l(_textKitLock);
+  return [_textKitComponents.textView resignFirstResponder];
 }
 
 #pragma mark - UITextView Delegate

--- a/AsyncDisplayKit/Details/_ASDisplayView.mm
+++ b/AsyncDisplayKit/Details/_ASDisplayView.mm
@@ -243,6 +243,14 @@
     [_node tintColorDidChange];
 }
 
+- (BOOL)canBecomeFirstResponder {
+    return [_node canBecomeFirstResponder];
+}
+
+- (BOOL)canResignFirstResponder {
+    return [_node canResignFirstResponder];
+}
+
 - (BOOL)canPerformAction:(SEL)action withSender:(id)sender
 {
   // We forward responder-chain actions to our node if we can't handle them ourselves. See -targetForAction:withSender:.

--- a/AsyncDisplayKitTests/ASDisplayNodeTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeTests.m
@@ -71,6 +71,9 @@ for (ASDisplayNode *n in @[ nodes ]) {\
 @property (atomic, copy) CGSize(^calculateSizeBlock)(ASTestDisplayNode *node, CGSize size);
 @end
 
+@interface ASTestResponderNode : ASTestDisplayNode
+@end
+
 @implementation ASTestDisplayNode
 
 - (CGSize)calculateSizeThatFits:(CGSize)constrainedSize
@@ -91,7 +94,55 @@ for (ASDisplayNode *n in @[ nodes ]) {\
 @interface UIDisplayNodeTestView : UIView
 @end
 
+@interface UIResponderNodeTestView : _ASDisplayView
+@property(nonatomic) BOOL isFirstResponder;
+@end
+
 @implementation UIDisplayNodeTestView
+@end
+
+@interface ASTestWindow : UIWindow
+@end
+
+@implementation ASTestWindow
+
+- (id)firstResponder {
+  return self.subviews.firstObject;
+}
+
+@end
+
+@implementation ASTestResponderNode
+
++ (Class)viewClass {
+  return [UIResponderNodeTestView class];
+}
+
+- (BOOL)canBecomeFirstResponder {
+  return YES;
+}
+
+@end
+
+@implementation UIResponderNodeTestView
+
+- (BOOL)becomeFirstResponder {
+  self.isFirstResponder = YES;
+  return YES;
+}
+
+- (BOOL)canResignFirstResponder {
+  return YES;
+}
+
+- (BOOL)resignFirstResponder {
+  if (self.isFirstResponder) {
+    self.isFirstResponder = NO;
+    return YES;
+  }
+  return NO;
+}
+
 @end
 
 @interface ASDisplayNodeTests : XCTestCase
@@ -100,6 +151,25 @@ for (ASDisplayNode *n in @[ nodes ]) {\
 @implementation ASDisplayNodeTests
 {
   dispatch_queue_t queue;
+}
+
+- (void)testOverriddenFirstResponderBehavior {
+  ASTestDisplayNode *node = [[ASTestResponderNode alloc] init];
+  XCTAssertTrue([node canBecomeFirstResponder]);
+  XCTAssertTrue([node becomeFirstResponder]);
+}
+
+- (void)testDefaultFirstResponderBehavior {
+  ASTestDisplayNode *node = [[ASTestDisplayNode alloc] init];
+  XCTAssertFalse([node canBecomeFirstResponder]);
+  XCTAssertFalse([node becomeFirstResponder]);
+}
+
+- (void)testLayerBackedFirstResponderBehavior {
+  ASTestDisplayNode *node = [[ASTestResponderNode alloc] init];
+  node.layerBacked = YES;
+  XCTAssertTrue([node canBecomeFirstResponder]);
+  XCTAssertFalse([node becomeFirstResponder]);
 }
 
 - (void)setUp


### PR DESCRIPTION
(Note: this is the same PR as #513, which I've closed - I wanted to issue this PR from a different fork, and don't know of a more elegant way to do it).

@appleguy: thanks for the review. I'm not 100% sure of things here, since I'm not insanely experienced working with the responder chain, but here are my thoughts so far regarding your questions:
- layer-backed/rasterized nodes shouldn't ever care about becoming first responder, as this only really pertains to `UIView` hierarchies. To be more explicit about this, I now check if a node is `layerBacked` when calling `becomeFirstResponder`/`resignFirstResponder` and immediately return `NO` if so.
- I'm not really sure how to measure the performance degradation you're worried about. I don't know how UIKit keeps track of what views can become the first responder - presumably it tracks some kind of internal state on each view in the hierarchy to avoid having to recompute the first responder every time it's handling a touch event. That feels pretty lightweight in concept to me, but I suppose you could probably devise a worst-case scenario that might require traversing a lot of views when adding/removing children. Honestly, I'd be surprised if the responder chain was really a performance bottleneck when dealing with complex view hierarchies, but  ¯\\\_(ツ)\_/¯
- My intended use case is actually the same as #11 - I'd like to allow long-pressing on an `ASTextNode` subclass in order to show a `UIMenuController` and copy its contents. I'm currently doing this is in the app I'm working on (pointing at my branch of ASDK) and it's working well. Also, not sure if this really counts as a use case, but I've also updated `ASEditableTextNode` to implement these methods properly and it feels sane to me.
- I've added a couple of simple unit tests. They mostly just test that the default/subclassed/`layerBacked` behavior works as intended.

Ultimately, given that the changes here require opting-in via subclassing anyway, I'm in favor of merging early and waiting to see if anyone actually encounters any performance issues in practice, but I'm obviously a bit biased : )