### PR TITLE
Overhaul ASDataController and extensively test ASTableView.

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -1337,6 +1337,7 @@ static NSInteger incrementIfFound(NSInteger i) {
 {
   self.layer.contents = nil;
   _placeholderLayer.contents = nil;
+  _placeholderImage = nil;
 }
 
 - (void)recursivelyClearContents

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -10,7 +10,7 @@
 
 #import "ASAssert.h"
 #import "ASDataController.h"
-#import "ASFlowLayoutController.h"
+#import "ASCollectionViewLayoutController.h"
 #import "ASLayoutController.h"
 #import "ASRangeController.h"
 #import "ASDisplayNodeInternal.h"
@@ -117,7 +117,7 @@ static BOOL _isInterceptedSelector(SEL sel)
   _ASTableViewProxy *_proxyDelegate;
 
   ASDataController *_dataController;
-  ASFlowLayoutController *_layoutController;
+  ASCollectionViewLayoutController *_layoutController;
 
   ASRangeController *_rangeController;
 
@@ -159,7 +159,8 @@ void ASPerformBlockWithoutAnimation(BOOL withoutAnimation, void (^block)()) {
 
 - (void)configureWithAsyncDataFetching:(BOOL)asyncDataFetchingEnabled
 {
-  _layoutController = [[ASFlowLayoutController alloc] initWithScrollOption:ASFlowLayoutDirectionVertical];
+  UICollectionViewFlowLayout *flowLayout = [[UICollectionViewFlowLayout alloc] init];
+  _layoutController = [[ASCollectionViewLayoutController alloc] initWithScrollView:self collectionViewLayout:flowLayout];
 
   _rangeController = [[ASRangeController alloc] init];
   _rangeController.layoutController = _layoutController;
@@ -412,20 +413,12 @@ void ASPerformBlockWithoutAnimation(BOOL withoutAnimation, void (^block)()) {
 {
   CGPoint scrollVelocity = [self.panGestureRecognizer velocityInView:self.superview];
   ASScrollDirection direction = ASScrollDirectionNone;
-  if (_layoutController.layoutDirection == ASFlowLayoutDirectionHorizontal) {
-    if (scrollVelocity.x > 0) {
-      direction = ASScrollDirectionRight;
-    } else if (scrollVelocity.x < 0) {
-      direction = ASScrollDirectionLeft;
-    }
+  if (scrollVelocity.y > 0) {
+    direction = ASScrollDirectionDown;
   } else {
-    if (scrollVelocity.y > 0) {
-      direction = ASScrollDirectionDown;
-    } else {
-      direction = ASScrollDirectionUp;
-    }
+    direction = ASScrollDirectionUp;
   }
-
+  
   return direction;
 }
 

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -117,7 +117,7 @@ static BOOL _isInterceptedSelector(SEL sel)
   _ASTableViewProxy *_proxyDelegate;
 
   ASDataController *_dataController;
-  ASCollectionViewLayoutController *_layoutController;
+  ASFlowLayoutController *_layoutController;
 
   ASRangeController *_rangeController;
 
@@ -159,9 +159,8 @@ void ASPerformBlockWithoutAnimation(BOOL withoutAnimation, void (^block)()) {
 
 - (void)configureWithAsyncDataFetching:(BOOL)asyncDataFetchingEnabled
 {
-  UICollectionViewFlowLayout *flowLayout = [[UICollectionViewFlowLayout alloc] init];
-  _layoutController = [[ASCollectionViewLayoutController alloc] initWithScrollView:self collectionViewLayout:flowLayout];
-
+  _layoutController = [[ASFlowLayoutController alloc] initWithScrollOption:ASFlowLayoutDirectionVertical];
+  
   _rangeController = [[ASRangeController alloc] init];
   _rangeController.layoutController = _layoutController;
   _rangeController.delegate = self;
@@ -169,6 +168,8 @@ void ASPerformBlockWithoutAnimation(BOOL withoutAnimation, void (^block)()) {
   _dataController = [[ASDataController alloc] initWithAsyncDataFetching:asyncDataFetchingEnabled];
   _dataController.dataSource = self;
   _dataController.delegate = _rangeController;
+  
+  _layoutController.dataSource = _dataController;
 
   _asyncDataFetchingEnabled = asyncDataFetchingEnabled;
   _asyncDataSourceLocked = NO;

--- a/AsyncDisplayKit/Details/ASCollectionViewLayoutController.h
+++ b/AsyncDisplayKit/Details/ASCollectionViewLayoutController.h
@@ -14,6 +14,5 @@
 @interface ASCollectionViewLayoutController : ASAbstractLayoutController
 
 - (instancetype)initWithCollectionView:(ASCollectionView *)collectionView;
-- (instancetype)initWithScrollView:(UIScrollView *)scrollView collectionViewLayout:(UICollectionViewLayout *)layout;
 
 @end

--- a/AsyncDisplayKit/Details/ASCollectionViewLayoutController.h
+++ b/AsyncDisplayKit/Details/ASCollectionViewLayoutController.h
@@ -14,5 +14,6 @@
 @interface ASCollectionViewLayoutController : ASAbstractLayoutController
 
 - (instancetype)initWithCollectionView:(ASCollectionView *)collectionView;
+- (instancetype)initWithScrollView:(UIScrollView *)scrollView collectionViewLayout:(UICollectionViewLayout *)layout;
 
 @end

--- a/AsyncDisplayKit/Details/ASCollectionViewLayoutController.mm
+++ b/AsyncDisplayKit/Details/ASCollectionViewLayoutController.mm
@@ -78,20 +78,6 @@ typedef struct ASRangeGeometry ASRangeGeometry;
   return self;
 }
 
-- (instancetype)initWithScrollView:(UIScrollView *)scrollView collectionViewLayout:(UICollectionViewLayout *)layout
-{
-  if (!(self = [super init])) {
-    return nil;
-  }
-  
-  _scrollableDirections = ASScrollDirectionVerticalDirections;
-  _scrollView = scrollView;
-  _collectionViewLayout = layout;
-  _updateRangeBoundsIndexedByRangeType = std::vector<CGRect>(ASLayoutRangeTypeCount);
-  return self;
-}
-
-
 #pragma mark -
 #pragma mark Index Paths in Range
 

--- a/AsyncDisplayKit/Details/ASDataController.h
+++ b/AsyncDisplayKit/Details/ASDataController.h
@@ -8,7 +8,7 @@
 
 #import <UIKit/UIKit.h>
 #import <AsyncDisplayKit/ASDealloc2MainObject.h>
-
+#import "ASFlowLayoutController.h"
 
 @class ASCellNode;
 @class ASDataController;
@@ -97,7 +97,8 @@ typedef NSUInteger ASDataControllerAnimationOptions;
  * will be updated asynchronously. The dataSource must be updated to reflect the changes before these methods has been called.
  * For each data updatin, the corresponding methods in delegate will be called.
  */
-@interface ASDataController : ASDealloc2MainObject
+@protocol ASFlowLayoutControllerDataSource;
+@interface ASDataController : ASDealloc2MainObject <ASFlowLayoutControllerDataSource>
 
 /**
  Data source for fetching data info.
@@ -166,5 +167,7 @@ typedef NSUInteger ASDataControllerAnimationOptions;
 - (ASCellNode *)nodeAtIndexPath:(NSIndexPath *)indexPath;
 
 - (NSArray *)nodesAtIndexPaths:(NSArray *)indexPaths;
+
+- (NSArray *)completedNodes;  // This provides efficient access to the entire _completedNodes multidimensional array.
 
 @end

--- a/AsyncDisplayKit/Details/ASDataController.h
+++ b/AsyncDisplayKit/Details/ASDataController.h
@@ -70,25 +70,21 @@ typedef NSUInteger ASDataControllerAnimationOptions;
 /**
  Called for insertion of elements.
  */
-- (void)dataController:(ASDataController *)dataController willInsertNodes:(NSArray *)nodes atIndexPaths:(NSArray *)indexPaths withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions;
 - (void)dataController:(ASDataController *)dataController didInsertNodes:(NSArray *)nodes atIndexPaths:(NSArray *)indexPaths withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions;
 
 /**
  Called for deletion of elements.
  */
-- (void)dataController:(ASDataController *)dataController willDeleteNodesAtIndexPaths:(NSArray *)indexPaths withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions;
 - (void)dataController:(ASDataController *)dataController didDeleteNodesAtIndexPaths:(NSArray *)indexPaths withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions;
 
 /**
  Called for insertion of sections.
  */
-- (void)dataController:(ASDataController *)dataController willInsertSections:(NSArray *)sections atIndexSet:(NSIndexSet *)indexSet withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions;
 - (void)dataController:(ASDataController *)dataController didInsertSections:(NSArray *)sections atIndexSet:(NSIndexSet *)indexSet withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions;
 
 /**
  Called for deletion of sections.
  */
-- (void)dataController:(ASDataController *)dataController willDeleteSectionsAtIndexSet:(NSIndexSet *)indexSet withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions;
 - (void)dataController:(ASDataController *)dataController didDeleteSectionsAtIndexSet:(NSIndexSet *)indexSet withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions;
 
 @end
@@ -117,7 +113,7 @@ typedef NSUInteger ASDataControllerAnimationOptions;
  *  Designated iniailizer.
  *
  * @param asyncDataFetchingEnabled Enable the data fetching in async mode.
- 
+ *
  * @discussion If enabled, we will fetch data through `dataController:nodeAtIndexPath:` and `dataController:rowsInSection:` in background thread.
  * Otherwise, the methods will be invoked synchronically in calling thread. Enabling data fetching in async mode could avoid blocking main thread
  * while allocating cell on main thread, which is frequently reported issue for handling large scale data. On another hand, the application code
@@ -127,7 +123,11 @@ typedef NSUInteger ASDataControllerAnimationOptions;
  */
 - (instancetype)initWithAsyncDataFetching:(BOOL)asyncDataFetchingEnabled;
 
-/** @name Initial loading */
+/** @name Initial loading
+ *
+ * @discussion This method allows choosing an animation style for the first load of content.  It is typically used just once,
+ * for example in viewWillAppear:, to specify an animation option for the information already present in the asyncDataSource.
+ */
 
 - (void)initialDataLoadingWithAnimationOptions:(ASDataControllerAnimationOptions)animationOptions;
 

--- a/AsyncDisplayKit/Details/ASDataController.mm
+++ b/AsyncDisplayKit/Details/ASDataController.mm
@@ -54,7 +54,6 @@ static void *kASSizingQueueContext = &kASSizingQueueContext;
   _pendingEditCommandBlocks = [NSMutableArray array];
   
   _editingTransactionQueue = [[NSOperationQueue alloc] init];
-  _editingTransactionQueue.qualityOfService = NSQualityOfServiceUserInitiated;
   _editingTransactionQueue.maxConcurrentOperationCount = 1; // Serial queue
   _editingTransactionQueue.name = @"org.AsyncDisplayKit.ASDataController.editingTransactionQueue";
   
@@ -553,15 +552,13 @@ static void *kASSizingQueueContext = &kASSizingQueueContext;
 - (NSArray *)nodesAtIndexPaths:(NSArray *)indexPaths
 {
   ASDisplayNodeAssertMainThread();
-  
-  // Make sure that any asynchronous layout operations have finished so that those nodes are present.
-  // Otherwise a failure case could be:
-  // - Reload section 2, deleting all current nodes in that section.
-  // - New nodes are created and sizing is triggered, but they are not yet added to _completedNodes.
-  // - This method is called and includes an indexPath in section 2.
-  // - Unless we wait for the layout group to finish, we will crash with array out of bounds looking for the index in _completedNodes.
-
   return ASFindElementsInMultidimensionalArrayAtIndexPaths(_completedNodes, [indexPaths sortedArrayUsingSelector:@selector(compare:)]);
+}
+
+- (NSArray *)completedNodes
+{
+  ASDisplayNodeAssertMainThread();
+  return _completedNodes;
 }
 
 #pragma mark - Dealloc

--- a/AsyncDisplayKit/Details/ASFlowLayoutController.h
+++ b/AsyncDisplayKit/Details/ASFlowLayoutController.h
@@ -28,7 +28,7 @@ typedef NS_ENUM(NSUInteger, ASFlowLayoutDirection) {
 @interface ASFlowLayoutController : ASAbstractLayoutController
 
 @property (nonatomic, readonly, assign) ASFlowLayoutDirection layoutDirection;
-@property (nonatomic) id <ASFlowLayoutControllerDataSource> dataSource;
+@property (nonatomic, readwrite, weak) id <ASFlowLayoutControllerDataSource> dataSource;
 
 - (instancetype)initWithScrollOption:(ASFlowLayoutDirection)layoutDirection;
 

--- a/AsyncDisplayKit/Details/ASFlowLayoutController.h
+++ b/AsyncDisplayKit/Details/ASFlowLayoutController.h
@@ -15,12 +15,20 @@ typedef NS_ENUM(NSUInteger, ASFlowLayoutDirection) {
   ASFlowLayoutDirectionHorizontal,
 };
 
+@protocol ASFlowLayoutControllerDataSource
+
+- (NSArray *)completedNodes;  // This provides access to ASDataController's _completedNodes multidimensional array.
+
+@end
+
 /**
- * The controller for flow layout.
+ *  An optimized flow layout controller that supports only vertical or horizontal scrolling, not simultaneously two-dimensional scrolling.
+ *  It is used for all ASTableViews, and may be used with ASCollectionView.
  */
 @interface ASFlowLayoutController : ASAbstractLayoutController
 
 @property (nonatomic, readonly, assign) ASFlowLayoutDirection layoutDirection;
+@property (nonatomic) id <ASFlowLayoutControllerDataSource> dataSource;
 
 - (instancetype)initWithScrollOption:(ASFlowLayoutDirection)layoutDirection;
 

--- a/AsyncDisplayKit/Details/ASFlowLayoutController.mm
+++ b/AsyncDisplayKit/Details/ASFlowLayoutController.mm
@@ -77,8 +77,7 @@ static const CGFloat kASFlowLayoutControllerRefreshingThreshold = 0.3;
 }
 
 - (void)deleteSectionsAtIndexSet:(NSIndexSet *)indexSet {
-  [indexSet enumerateIndexesWithOptions:NSEnumerationReverse usingBlock:^(NSUInteger idx, BOOL *stop)
-  {
+  [indexSet enumerateIndexesWithOptions:NSEnumerationReverse usingBlock:^(NSUInteger idx, BOOL *stop) {
     _nodeSizes.erase(_nodeSizes.begin() +idx);
   }];
 }
@@ -148,6 +147,7 @@ static const CGFloat kASFlowLayoutControllerRefreshingThreshold = 0.3;
     [indexPathSet addObject:[NSIndexPath indexPathForRow:startIter.second inSection:startIter.first]];
     startIter.second++;
 
+    // Once we reach the end of the section, advance to the next one.  Keep advancing if the next section is zero-sized.
     while (startIter.second == _nodeSizes[startIter.first].size() && startIter.first < _nodeSizes.size()) {
       startIter.second = 0;
       startIter.first++;

--- a/AsyncDisplayKit/Details/ASFlowLayoutController.mm
+++ b/AsyncDisplayKit/Details/ASFlowLayoutController.mm
@@ -7,110 +7,66 @@
  */
 
 #import "ASFlowLayoutController.h"
+#import "ASAssert.h"
+#import "ASDisplayNode.h"
+#import "ASIndexPath.h"
 
 #include <map>
 #include <vector>
 #include <cassert>
 
-#import "ASAssert.h"
-
 static const CGFloat kASFlowLayoutControllerRefreshingThreshold = 0.3;
 
-@interface ASFlowLayoutController() {
-  std::vector<std::vector<CGSize> > _nodeSizes;
-
-  std::pair<int, int> _visibleRangeStartPos;
-  std::pair<int, int> _visibleRangeEndPos;
-
-  std::vector<std::pair<int, int>> _rangeStartPos;
-  std::vector<std::pair<int, int>> _rangeEndPos;
+@interface ASFlowLayoutController()
+{
+  ASIndexPathRange _visibleRange;
+  std::vector<ASIndexPathRange> _rangesByType;  // All ASLayoutRangeTypes besides visible.
 }
 
 @end
 
 @implementation ASFlowLayoutController
 
-- (instancetype)initWithScrollOption:(ASFlowLayoutDirection)layoutDirection {
+- (instancetype)initWithScrollOption:(ASFlowLayoutDirection)layoutDirection
+{
   if (!(self = [super init])) {
     return nil;
   }
-
   _layoutDirection = layoutDirection;
-
+  _rangesByType = std::vector<ASIndexPathRange>(ASLayoutRangeTypeCount);
   return self;
-}
-
-#pragma mark - Editing
-
-- (void)insertNodesAtIndexPaths:(NSArray *)indexPaths withSizes:(NSArray *)nodeSizes
-{
-  ASDisplayNodeAssert(indexPaths.count == nodeSizes.count, @"Inconsistent index paths and node size");
-
-  [indexPaths enumerateObjectsUsingBlock:^(NSIndexPath *indexPath, NSUInteger idx, BOOL *stop) {
-    std::vector<CGSize> &v = _nodeSizes[indexPath.section];
-    v.insert(v.begin() + indexPath.row, [(NSValue *)nodeSizes[idx] CGSizeValue]);
-  }];
-}
-
-- (void)deleteNodesAtIndexPaths:(NSArray *)indexPaths
-{
-  [indexPaths enumerateObjectsWithOptions:NSEnumerationReverse usingBlock:^(NSIndexPath *indexPath, NSUInteger idx, BOOL *stop) {
-    std::vector<CGSize> &v = _nodeSizes[indexPath.section];
-    v.erase(v.begin() + indexPath.row);
-  }];
-}
-
-- (void)insertSections:(NSArray *)sections atIndexSet:(NSIndexSet *)indexSet
-{
-  __block int cnt = 0;
-  [indexSet enumerateIndexesUsingBlock:^(NSUInteger idx, BOOL *stop) {
-    NSArray *nodes = sections[cnt++];
-    std::vector<CGSize> v;
-    v.reserve(nodes.count);
-
-    for (int i = 0; i < nodes.count; i++) {
-      v.push_back([nodes[i] CGSizeValue]);
-    }
-
-    _nodeSizes.insert(_nodeSizes.begin() + idx, v);
-  }];
-}
-
-- (void)deleteSectionsAtIndexSet:(NSIndexSet *)indexSet {
-  [indexSet enumerateIndexesWithOptions:NSEnumerationReverse usingBlock:^(NSUInteger idx, BOOL *stop) {
-    _nodeSizes.erase(_nodeSizes.begin() +idx);
-  }];
 }
 
 #pragma mark - Visible Indices
 
 - (BOOL)shouldUpdateForVisibleIndexPaths:(NSArray *)indexPaths viewportSize:(CGSize)viewportSize rangeType:(ASLayoutRangeType)rangeType
 {
-  if (!indexPaths.count) {
+  if (!indexPaths.count || rangeType >= _rangesByType.size()) {
     return NO;
   }
 
-  std::pair<int, int> rangeStartPos, rangeEndPos;
-
-  if (rangeType < _rangeStartPos.size() && rangeType < _rangeEndPos.size()) {
-    rangeStartPos = _rangeStartPos[rangeType];
-    rangeEndPos = _rangeEndPos[rangeType];
-  }
-
-  std::pair<int, int> startPos, endPos;
-  ASFindIndexPathRange(indexPaths, startPos, endPos);
-
-  if (rangeStartPos >= startPos || rangeEndPos <= endPos) {
+  ASIndexPathRange existingRange = _rangesByType[rangeType];
+  ASIndexPathRange newRange = [self indexPathRangeForIndexPaths:indexPaths];
+  
+  ASIndexPath maximumStart = ASIndexPathMaximum(existingRange.start, newRange.start);
+  ASIndexPath minimumEnd = ASIndexPathMinimum(existingRange.end, newRange.end);
+  
+  if (ASIndexPathEqualToIndexPath(maximumStart, existingRange.start) || ASIndexPathEqualToIndexPath(minimumEnd, existingRange.end)) {
     return YES;
   }
 
-  return ASFlowLayoutDistance(startPos, _visibleRangeStartPos, _nodeSizes) > ASFlowLayoutDistance(_visibleRangeStartPos, rangeStartPos, _nodeSizes) * kASFlowLayoutControllerRefreshingThreshold ||
-  ASFlowLayoutDistance(endPos, _visibleRangeEndPos, _nodeSizes) > ASFlowLayoutDistance(_visibleRangeEndPos, rangeEndPos, _nodeSizes) * kASFlowLayoutControllerRefreshingThreshold;
+  NSInteger newStartDelta       = [self flowLayoutDistanceForRange:ASIndexPathRangeMake(_visibleRange.start, newRange.start)];
+  NSInteger existingStartDelta  = [self flowLayoutDistanceForRange:ASIndexPathRangeMake(_visibleRange.start, existingRange.start)] * kASFlowLayoutControllerRefreshingThreshold;
+  
+  NSInteger newEndDelta         = [self flowLayoutDistanceForRange:ASIndexPathRangeMake(_visibleRange.end, newRange.end)];
+  NSInteger existingEndDelta    = [self flowLayoutDistanceForRange:ASIndexPathRangeMake(_visibleRange.end, existingRange.end)] * kASFlowLayoutControllerRefreshingThreshold;
+  
+  return (newStartDelta > existingStartDelta) || (newEndDelta > existingEndDelta);
 }
 
 - (void)setVisibleNodeIndexPaths:(NSArray *)indexPaths
 {
-  ASFindIndexPathRange(indexPaths, _visibleRangeStartPos, _visibleRangeEndPos);
+  _visibleRange = [self indexPathRangeForIndexPaths:indexPaths];
 }
 
 /**
@@ -138,100 +94,134 @@ static const CGFloat kASFlowLayoutControllerRefreshingThreshold = 0.3;
   CGFloat backScreens = scrollDirection == leadingDirection ? tuningParameters.leadingBufferScreenfuls : tuningParameters.trailingBufferScreenfuls;
   CGFloat frontScreens = scrollDirection == leadingDirection ? tuningParameters.trailingBufferScreenfuls : tuningParameters.leadingBufferScreenfuls;
 
-  std::pair<int, int> startIter = ASFindIndexForRange(_nodeSizes, _visibleRangeStartPos, - backScreens * viewportScreenMetric, _layoutDirection);
-  std::pair<int, int> endIter = ASFindIndexForRange(_nodeSizes, _visibleRangeEndPos, frontScreens * viewportScreenMetric, _layoutDirection);
+  
+  ASIndexPath startPath = [self findIndexPathAtDistance:(-backScreens * viewportScreenMetric) fromIndexPath:_visibleRange.start];
+  ASIndexPath endPath = [self findIndexPathAtDistance:(frontScreens * viewportScreenMetric) fromIndexPath:_visibleRange.end];
 
+  ASDisplayNodeAssert(startPath.section <= endPath.section, @"startPath should never begin at a further position than endPath");
+  
   NSMutableSet *indexPathSet = [[NSMutableSet alloc] init];
 
-  while (startIter != endIter) {
-    [indexPathSet addObject:[NSIndexPath indexPathForRow:startIter.second inSection:startIter.first]];
-    startIter.second++;
+  NSArray *completedNodes = [_dataSource completedNodes];
+  
+  while (!ASIndexPathEqualToIndexPath(startPath, endPath)) {
+    [indexPathSet addObject:[NSIndexPath indexPathWithASIndexPath:startPath]];
+    startPath.row++;
 
     // Once we reach the end of the section, advance to the next one.  Keep advancing if the next section is zero-sized.
-    while (startIter.second == _nodeSizes[startIter.first].size() && startIter.first < _nodeSizes.size()) {
-      startIter.second = 0;
-      startIter.first++;
+    while (startPath.row >= [(NSArray *)completedNodes[startPath.section] count] && startPath.section < completedNodes.count - 1) {
+      startPath.row = 0;
+      startPath.section++;
+      ASDisplayNodeAssert(startPath.section <= endPath.section, @"startPath should never reach a further section than endPath");
     }
   }
 
-  [indexPathSet addObject:[NSIndexPath indexPathForRow:endIter.second inSection:endIter.first]];
+  [indexPathSet addObject:[NSIndexPath indexPathWithASIndexPath:endPath]];
   
   return indexPathSet;
 }
 
 #pragma mark - Utility
 
-static void ASFindIndexPathRange(NSArray *indexPaths, std::pair<int, int> &startPos, std::pair<int, int> &endPos)
-
+- (ASIndexPathRange)indexPathRangeForIndexPaths:(NSArray *)indexPaths
 {
-  NSIndexPath *initialIndexPath = [indexPaths firstObject];
-  startPos = endPos = {initialIndexPath.section, initialIndexPath.row};
+  // Set up an initial value so the MIN and MAX can work in the enumeration.
+  __block ASIndexPath currentIndexPath = [[indexPaths firstObject] ASIndexPathValue];
+  __block ASIndexPathRange range;
+  range.start = currentIndexPath;
+  range.end = currentIndexPath;
+  
   [indexPaths enumerateObjectsUsingBlock:^(NSIndexPath *indexPath, NSUInteger idx, BOOL *stop) {
-    std::pair<int, int> p(indexPath.section, indexPath.row);
-    startPos = MIN(startPos, p);
-    endPos = MAX(endPos, p);
+    currentIndexPath = [indexPath ASIndexPathValue];
+    range.start = ASIndexPathMinimum(range.start, currentIndexPath);
+    range.end = ASIndexPathMaximum(range.end, currentIndexPath);
   }];
+  return range;
 }
 
-static const std::pair<int, int> ASFindIndexForRange(const std::vector<std::vector<CGSize>> &nodes,
-                                                     const std::pair<int, int> &pos,
-                                                     CGFloat range,
-                                                     ASFlowLayoutDirection layoutDirection)
+- (ASIndexPath)findIndexPathAtDistance:(CGFloat)distance fromIndexPath:(ASIndexPath)start
 {
-  std::pair<int, int> cur = pos, pre = pos;
+  // "end" is the index path we'll advance until we have gone far enough from "start" to reach "distance"
+  ASIndexPath end = start;
+  // "previous" will store one iteration before "end", in case we go too far and need to reset "end" to be "previous"
+  ASIndexPath previous = start;
 
-  if (range < 0.0 && cur.first >= 0 && cur.first < nodes.size() && cur.second >= 0 && cur.second < nodes[cur.first].size()) {
-    // search backward
-    while (range < 0.0 && cur.first >= 0 && cur.second >= 0) {
-      pre = cur;
-      CGSize size = nodes[cur.first][cur.second];
-      range += layoutDirection == ASFlowLayoutDirectionHorizontal ? size.width : size.height;
-      cur.second--;
-      while (cur.second < 0 && cur.first > 0) {
-        cur.second = (int)nodes[--cur.first].size() - 1;
+  NSArray *completedNodes = [_dataSource completedNodes];
+  NSUInteger numberOfSections = [completedNodes count];
+  NSUInteger numberOfRowsInSection = [(NSArray *)completedNodes[end.section] count];
+  
+  // If "distance" is negative, advance "end" backwards across rows and sections.
+  // Otherwise, advance forward.  In either case, bring "distance" closer to zero by the dimension of each row passed.
+  if (distance < 0.0 && end.section >= 0 && end.section < numberOfSections && end.row >= 0 && end.row < numberOfRowsInSection) {
+    while (distance < 0.0 && end.section >= 0 && end.row >= 0) {
+      previous = end;
+      ASDisplayNode *node = completedNodes[end.section][end.row];
+      CGSize size = node.calculatedSize;
+      distance += (_layoutDirection == ASFlowLayoutDirectionHorizontal ? size.width : size.height);
+      end.row--;
+      // If we've gone to a negative row, set to the last row of the previous section.  While loop is required to handle empty sections.
+      while (end.row < 0 && end.section > 0) {
+        end.section--;
+        numberOfRowsInSection = [(NSArray *)completedNodes[end.section] count];
+        end.row = numberOfRowsInSection - 1;
       }
     }
 
-    if (cur.second < 0) {
-      cur = pre;
+    if (end.row < 0) {
+      end = previous;
     }
   } else {
-    // search forward
-    while (range > 0.0 && cur.first >= 0 && cur.first < nodes.size() && cur.second >= 0 && cur.second < nodes[cur.first].size()) {
-      pre = cur;
-      CGSize size = nodes[cur.first][cur.second];
-      range -= layoutDirection == ASFlowLayoutDirectionHorizontal ? size.width : size.height;
+    while (distance > 0.0 && end.section >= 0 && end.section < numberOfSections && end.row >= 0 && end.row < numberOfRowsInSection) {
+      previous = end;
+      ASDisplayNode *node = completedNodes[end.section][end.row];
+      CGSize size = node.calculatedSize;
+      distance -= _layoutDirection == ASFlowLayoutDirectionHorizontal ? size.width : size.height;
 
-      cur.second++;
-      while (cur.second == nodes[cur.first].size() && cur.first < (int)nodes.size() - 1) {
-        cur.second = 0;
-        cur.first++;
+      end.row++;
+      // If we've gone beyond the section, reset to the beginning of the next section.  While loop is required to handle empty sections.
+      while (end.row >= numberOfRowsInSection && end.section < numberOfSections - 1) {
+        end.row = 0;
+        end.section++;
+        numberOfRowsInSection = [(NSArray *)completedNodes[end.section] count];
       }
     }
 
-    if (cur.second == nodes[cur.first].size()) {
-      cur = pre;
+    if (end.row >= numberOfRowsInSection) {
+      end = previous;
     }
   }
 
-  return cur;
+  return end;
 }
 
-static int ASFlowLayoutDistance(const std::pair<int, int> &start, const std::pair<int, int> &end, const std::vector<std::vector<CGSize>> &nodes)
+- (NSInteger)flowLayoutDistanceForRange:(ASIndexPathRange)range
 {
-  if (start == end) {
+  // This method should only be called with the range in proper order (start comes before end).
+  ASDisplayNodeAssert(ASIndexPathEqualToIndexPath(ASIndexPathMinimum(range.start, range.end), range.start), @"flowLayoutDistanceForRange: called with invalid range");
+  
+  if (ASIndexPathEqualToIndexPath(range.start, range.end)) {
     return 0;
-  } else if (start > end) {
-    return - ASFlowLayoutDistance(end, start, nodes);
   }
+  
+  NSInteger totalRowCount = 0;
+  NSUInteger numberOfRowsInSection = 0;
+  NSArray *completedNodes = [_dataSource completedNodes];
 
-  int res = 0;
-
-  for (int i = start.first; i <= end.first; i++) {
-    res += (i == end.first ? end.second + 1 : nodes[i].size()) - (i == start.first ? start.second : 0);
+  for (NSInteger section = range.start.section; section <= range.end.section; section++) {
+    numberOfRowsInSection = [(NSArray *)completedNodes[section] count];
+    totalRowCount += numberOfRowsInSection;
+    
+    if (section == range.start.section) {
+      // For the start section, make sure we don't count the rows before the start row.
+      totalRowCount -= range.start.row;
+    } else if (section == range.end.section) {
+      // For the start section, make sure we don't count the rows after the end row.
+      totalRowCount -= (numberOfRowsInSection - (range.end.row + 1));
+    }
   }
-
-  return res;
+  
+  ASDisplayNodeAssert(totalRowCount >= 0, @"totalRowCount in flowLayoutDistanceForRange: should not be negative");
+  return totalRowCount;
 }
 
 @end

--- a/AsyncDisplayKit/Details/ASIndexPath.h
+++ b/AsyncDisplayKit/Details/ASIndexPath.h
@@ -1,0 +1,84 @@
+//
+//  ASIndexPath.h
+//  Pods
+//
+//  Created by Scott Goodson on 7/4/15.
+//
+//  A much more efficient way to handle index paths than NSIndexPath.
+//  For best results, use C++ vectors; NSValue wrapping with Cocoa collections
+//  would make NSIndexPath a much better choice.
+//
+
+typedef struct {
+  NSInteger section;
+  NSInteger row;
+} ASIndexPath;
+
+typedef struct {
+  ASIndexPath start;
+  ASIndexPath end;
+} ASIndexPathRange;
+
+ASIndexPath ASIndexPathMake(NSInteger section, NSInteger row)
+{
+  ASIndexPath indexPath;
+  indexPath.section = section;
+  indexPath.row = row;
+  return indexPath;
+}
+
+BOOL ASIndexPathEqualToIndexPath(ASIndexPath first, ASIndexPath second)
+{
+  return (first.section == second.section && first.row == second.row);
+}
+
+ASIndexPath ASIndexPathMinimum(ASIndexPath first, ASIndexPath second)
+{
+  if (first.section < second.section) {
+    return first;
+  } else if (first.section > second.section) {
+    return second;
+  } else {
+    return (first.row < second.row ? first : second);
+  }
+}
+
+ASIndexPath ASIndexPathMaximum(ASIndexPath first, ASIndexPath second)
+{
+  if (first.section > second.section) {
+    return first;
+  } else if (first.section < second.section) {
+    return second;
+  } else {
+    return (first.row > second.row ? first : second);
+  }
+}
+
+ASIndexPathRange ASIndexPathRangeMake(ASIndexPath first, ASIndexPath second)
+{
+  ASIndexPathRange range;
+  range.start = ASIndexPathMinimum(first, second);
+  range.end = ASIndexPathMaximum(first, second);
+  return range;
+}
+
+BOOL ASIndexPathRangeEqualToIndexPathRange(ASIndexPathRange first, ASIndexPathRange second)
+{
+  return ASIndexPathEqualToIndexPath(first.start, second.start) && ASIndexPathEqualToIndexPath(first.end, second.end);
+}
+
+@interface NSIndexPath (ASIndexPathAdditions)
++ (NSIndexPath *)indexPathWithASIndexPath:(ASIndexPath)indexPath;
+- (ASIndexPath)ASIndexPathValue;
+@end
+
+@implementation NSIndexPath (ASIndexPathAdditions)
++ (NSIndexPath *)indexPathWithASIndexPath:(ASIndexPath)indexPath
+{
+  return [NSIndexPath indexPathForRow:indexPath.row inSection:indexPath.section];;
+}
+- (ASIndexPath)ASIndexPathValue
+{
+  return ASIndexPathMake(self.section, self.row);
+}
+@end

--- a/AsyncDisplayKit/Details/ASMultidimensionalArrayUtils.h
+++ b/AsyncDisplayKit/Details/ASMultidimensionalArrayUtils.h
@@ -44,7 +44,7 @@ extern NSArray *ASFindElementsInMultidimensionalArrayAtIndexPaths(NSMutableArray
 extern NSArray *ASIndexPathsForMultidimensionalArrayAtIndexSet(NSArray *MultidimensionalArray, NSIndexSet *indexSet);
 
 /**
- * Reteurn all the index paths of mutable multidimensional array, in ascending order.
+ * Return all the index paths of mutable multidimensional array, in ascending order.
  */
 extern NSArray *ASIndexPathsForMultidimensionalArray(NSArray *MultidimensionalArray);
 

--- a/AsyncDisplayKit/Details/ASRangeController.h
+++ b/AsyncDisplayKit/Details/ASRangeController.h
@@ -107,26 +107,4 @@
  */
 - (void)rangeController:(ASRangeController *)rangeController didDeleteSectionsAtIndexSet:(NSIndexSet *)indexSet withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions;
 
-@optional
-
-/**
- * Called before nodes insertion.
- */
-- (void)rangeController:(ASRangeController *)rangeController willInsertNodesAtIndexPaths:(NSArray *)indexPaths withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions;
-
-/**
- * Called before nodes deletion.
- */
-- (void)rangeController:(ASRangeController *)rangeController willDeleteNodesAtIndexPaths:(NSArray *)indexPaths withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions;
-
-/**
- * Called before section insertion.
- */
-- (void)rangeController:(ASRangeController *)rangeController willInsertSectionsAtIndexSet:(NSIndexSet *)indexSet withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions;
-
-/**
- * Called before section deletion.
- */
-- (void)rangeController:(ASRangeController *)rangeController willDeleteSectionsAtIndexSet:(NSIndexSet *)indexSet withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions;
-
 @end

--- a/AsyncDisplayKit/Details/ASRangeController.mm
+++ b/AsyncDisplayKit/Details/ASRangeController.mm
@@ -111,6 +111,7 @@
       NSMutableSet *removedIndexPaths = _rangeIsValid ? [[_rangeTypeIndexPaths objectForKey:rangeKey] mutableCopy] : [NSMutableSet set];
       [removedIndexPaths minusSet:indexPaths];
       [removedIndexPaths minusSet:visibleNodePathsSet];
+
       if (removedIndexPaths.count) {
         NSArray *removedNodes = [_delegate rangeController:self nodesAtIndexPaths:[removedIndexPaths allObjects]];
         [removedNodes enumerateObjectsUsingBlock:^(ASCellNode *node, NSUInteger idx, BOOL *stop) {
@@ -129,7 +130,7 @@
       if ([self shouldSkipVisibleNodesForRangeType:rangeType]) {
         [addedIndexPaths minusSet:visibleNodePathsSet];
       }
-
+      
       if (addedIndexPaths.count) {
         NSArray *addedNodes = [_delegate rangeController:self nodesAtIndexPaths:[addedIndexPaths allObjects]];
         [addedNodes enumerateObjectsUsingBlock:^(ASCellNode *node, NSUInteger idx, BOOL *stop) {
@@ -181,14 +182,6 @@
   });
 }
 
-- (void)dataController:(ASDataController *)dataController willInsertNodes:(NSArray *)nodes atIndexPaths:(NSArray *)indexPaths withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions {
-  ASDisplayNodePerformBlockOnMainThread(^{
-    if ([_delegate respondsToSelector:@selector(rangeController:willInsertNodesAtIndexPaths:withAnimationOptions:)]) {
-      [_delegate rangeController:self willInsertNodesAtIndexPaths:indexPaths withAnimationOptions:animationOptions];
-    }
-  });
-}
-
 - (void)dataController:(ASDataController *)dataController didInsertNodes:(NSArray *)nodes atIndexPaths:(NSArray *)indexPaths withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions {
   ASDisplayNodeAssert(nodes.count == indexPaths.count, @"Invalid index path");
 
@@ -206,14 +199,6 @@
   });
 }
 
-- (void)dataController:(ASDataController *)dataController willDeleteNodesAtIndexPaths:(NSArray *)indexPaths withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions {
-  ASDisplayNodePerformBlockOnMainThread(^{
-    if ([_delegate respondsToSelector:@selector(rangeController:willDeleteNodesAtIndexPaths:withAnimationOptions:)]) {
-      [_delegate rangeController:self willDeleteNodesAtIndexPaths:indexPaths withAnimationOptions:animationOptions];
-    }
-  });
-}
-
 - (void)dataController:(ASDataController *)dataController didDeleteNodesAtIndexPaths:(NSArray *)indexPaths withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions {
   ASDisplayNodePerformBlockOnMainThread(^{
     if ([_layoutController respondsToSelector:@selector(deleteNodesAtIndexPaths:)]) {
@@ -221,14 +206,6 @@
     }
     _rangeIsValid = NO;
     [_delegate rangeController:self didDeleteNodesAtIndexPaths:indexPaths withAnimationOptions:animationOptions];
-  });
-}
-
-- (void)dataController:(ASDataController *)dataController willInsertSections:(NSArray *)sections atIndexSet:(NSIndexSet *)indexSet withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions {
-  ASDisplayNodePerformBlockOnMainThread(^{
-    if ([_delegate respondsToSelector:@selector(rangeController:willInsertSectionsAtIndexSet:withAnimationOptions:)]) {
-      [_delegate rangeController:self willInsertSectionsAtIndexSet:indexSet withAnimationOptions:animationOptions];
-    }
   });
 }
 
@@ -251,14 +228,6 @@
     }
     _rangeIsValid = NO;
     [_delegate rangeController:self didInsertSectionsAtIndexSet:indexSet withAnimationOptions:animationOptions];
-  });
-}
-
-- (void)dataController:(ASDataController *)dataController willDeleteSectionsAtIndexSet:(NSIndexSet *)indexSet withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions {
-  ASDisplayNodePerformBlockOnMainThread(^{
-    if ([_delegate respondsToSelector:@selector(rangeController:willDeleteSectionsAtIndexSet:withAnimationOptions:)]) {
-      [_delegate rangeController:self willDeleteSectionsAtIndexSet:indexSet withAnimationOptions:animationOptions];
-    }
   });
 }
 

--- a/AsyncDisplayKit/Details/ASRangeController.mm
+++ b/AsyncDisplayKit/Details/ASRangeController.mm
@@ -191,9 +191,6 @@
   }];
 
   ASDisplayNodePerformBlockOnMainThread(^{
-    if ([_layoutController respondsToSelector:@selector(insertNodesAtIndexPaths:withSizes:)]) {
-      [_layoutController insertNodesAtIndexPaths:indexPaths withSizes:nodeSizes];
-    }
     _rangeIsValid = NO;
     [_delegate rangeController:self didInsertNodesAtIndexPaths:indexPaths withAnimationOptions:animationOptions];
   });
@@ -201,9 +198,6 @@
 
 - (void)dataController:(ASDataController *)dataController didDeleteNodesAtIndexPaths:(NSArray *)indexPaths withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions {
   ASDisplayNodePerformBlockOnMainThread(^{
-    if ([_layoutController respondsToSelector:@selector(deleteNodesAtIndexPaths:)]) {
-      [_layoutController deleteNodesAtIndexPaths:indexPaths];
-    }
     _rangeIsValid = NO;
     [_delegate rangeController:self didDeleteNodesAtIndexPaths:indexPaths withAnimationOptions:animationOptions];
   });
@@ -223,9 +217,6 @@
   }];
 
   ASDisplayNodePerformBlockOnMainThread(^{
-    if ([_layoutController respondsToSelector:@selector(insertSections:atIndexSet:)]) {
-      [_layoutController insertSections:sectionNodeSizes atIndexSet:indexSet];
-    }
     _rangeIsValid = NO;
     [_delegate rangeController:self didInsertSectionsAtIndexSet:indexSet withAnimationOptions:animationOptions];
   });
@@ -233,9 +224,6 @@
 
 - (void)dataController:(ASDataController *)dataController didDeleteSectionsAtIndexSet:(NSIndexSet *)indexSet withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions {
   ASDisplayNodePerformBlockOnMainThread(^{
-    if ([_layoutController respondsToSelector:@selector(deleteSectionsAtIndexSet:)]) {
-      [_layoutController deleteSectionsAtIndexSet:indexSet];
-    }
     _rangeIsValid = NO;
     [_delegate rangeController:self didDeleteSectionsAtIndexSet:indexSet withAnimationOptions:animationOptions];
   });

--- a/examples/ASTableViewStressTest/Sample.xcodeproj/xcshareddata/xcschemes/Sample.xcscheme
+++ b/examples/ASTableViewStressTest/Sample.xcodeproj/xcshareddata/xcschemes/Sample.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0620"
+   LastUpgradeVersion = "0630"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/examples/ASTableViewStressTest/Sample/ViewController.m
+++ b/examples/ASTableViewStressTest/Sample/ViewController.m
@@ -16,11 +16,12 @@
 
 #define NumberOfSections 10
 #define NumberOfRowsPerSection 20
-#define NumberOfReloadIterations 50
+#define NumberOfReloadIterations 500
 
 @interface ViewController () <ASTableViewDataSource, ASTableViewDelegate>
 {
   ASTableView *_tableView;
+  NSMutableArray *_sections; // Contains arrays of indexPaths representing rows
 }
 
 @end
@@ -28,18 +29,24 @@
 
 @implementation ViewController
 
-#pragma mark -
-#pragma mark UIViewController.
-
 - (instancetype)init
 {
   if (!(self = [super init]))
     return nil;
 
   _tableView = [[ASTableView alloc] initWithFrame:CGRectZero style:UITableViewStylePlain asyncDataFetching:YES];
-  _tableView.separatorStyle = UITableViewCellSeparatorStyleNone; // KittenNode has its own separator
   _tableView.asyncDataSource = self;
   _tableView.asyncDelegate = self;
+  _tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
+  
+  _sections = [NSMutableArray arrayWithCapacity:NumberOfSections];
+  for (int i = 0; i < NumberOfSections; i++) {
+    NSMutableArray *rowsArray = [NSMutableArray arrayWithCapacity:NumberOfRowsPerSection];
+    for (int j = 0; j < NumberOfRowsPerSection; j++) {
+      [rowsArray addObject:[NSIndexPath indexPathForRow:j inSection:i]];
+    }
+    [_sections addObject:rowsArray];
+  }
 
   return self;
 }
@@ -63,42 +70,99 @@
   [self thrashTableView];
 }
 
+- (NSIndexSet *)randomIndexSet
+{
+  u_int32_t upperBound = (u_int32_t)_sections.count - 1;
+  u_int32_t randA = arc4random_uniform(upperBound);
+  u_int32_t randB = arc4random_uniform(upperBound);
+
+  return [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(MIN(randA, randB), MAX(randA, randB) - MIN(randA, randB))];
+}
+
+- (NSArray *)randomIndexPathsExisting:(BOOL)existing
+{
+  NSMutableArray *indexPaths = [NSMutableArray array];
+  [[self randomIndexSet] enumerateIndexesUsingBlock:^(NSUInteger idx, BOOL *stop) {
+    NSUInteger rowNum = [self tableView:_tableView numberOfRowsInSection:idx];
+    NSIndexPath *sectionIndex = [[NSIndexPath alloc] initWithIndex:idx];
+    for (NSUInteger i = (existing ? 0 : rowNum); i < (existing ? rowNum : rowNum * 2); i++) {
+      // Maximize evility by sporadically skipping indicies 1/3rd of the time, but only if reloading existing rows
+      if (existing && arc4random_uniform(2) == 0) {
+        continue;
+      }
+      
+      NSIndexPath *indexPath = [sectionIndex indexPathByAddingIndex:i];
+      [indexPaths addObject:indexPath];
+    }
+  }];
+  return indexPaths;
+}
+
 - (void)thrashTableView
 {
-  // Keep the viewport moderately sized so that new cells are loaded on scrolling
-  ASTableView *tableView = [[ASTableView alloc] initWithFrame:CGRectMake(0, 0, 100, 500)
-                                                        style:UITableViewStylePlain
-                                            asyncDataFetching:NO];
+  _tableView.asyncDelegate = self;
+  _tableView.asyncDataSource = self;
   
-  tableView.asyncDelegate = self;
-  tableView.asyncDataSource = self;
+  [_tableView reloadData];
   
-  [tableView reloadData];
-  
-  [tableView reloadSections:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(1,2)] withRowAnimation:UITableViewRowAnimationNone];
-  
+  NSArray *indexPathsAddedAndRemoved = nil;
+
   for (int i = 0; i < NumberOfReloadIterations; ++i) {
-    NSInteger randA = arc4random_uniform(NumberOfSections - 1);
-    NSInteger randB = arc4random_uniform(NumberOfSections - 1);
+    UITableViewRowAnimation rowAnimation = (arc4random_uniform(1) == 0 ? UITableViewRowAnimationMiddle : UITableViewRowAnimationNone);
+
+    BOOL animatedScroll               = (arc4random_uniform(1) == 0 ? YES : NO);
+    BOOL reloadRowsInsteadOfSections  = (arc4random_uniform(1) == 0 ? YES : NO);
+    BOOL letRunloopProceed            = (arc4random_uniform(1) == 0 ? YES : NO);
+    BOOL addIndexPaths                = (arc4random_uniform(1) == 0 ? YES : NO);
+    BOOL useBeginEndUpdates           = (arc4random_uniform(2) == 0 ? YES : NO);
     
-    [tableView reloadSections:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(MIN(randA, randB), MAX(randA, randB) - MIN(randA, randB))] withRowAnimation:UITableViewRowAnimationNone];
+    if (useBeginEndUpdates) {
+      [_tableView beginUpdates];
+    }
     
-    BOOL animated = (arc4random_uniform(1) == 0 ? YES : NO);
+    if (reloadRowsInsteadOfSections) {
+      [_tableView reloadRowsAtIndexPaths:[self randomIndexPathsExisting:YES] withRowAnimation:rowAnimation];
+    } else {
+      [_tableView reloadSections:[self randomIndexSet] withRowAnimation:rowAnimation];
+    }
     
-    [tableView setContentOffset:CGPointMake(0, arc4random_uniform(tableView.contentSize.height - tableView.bounds.size.height)) animated:animated];
+    if (addIndexPaths && !indexPathsAddedAndRemoved) {
+      indexPathsAddedAndRemoved = [self randomIndexPathsExisting:NO];
+      for (NSIndexPath *indexPath in indexPathsAddedAndRemoved) {
+        [_sections[indexPath.section] addObject:indexPath];
+      }
+      [_tableView insertRowsAtIndexPaths:indexPathsAddedAndRemoved withRowAnimation:rowAnimation];
+    }
     
-    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.01]];
+    [_tableView setContentOffset:CGPointMake(0, arc4random_uniform(_tableView.contentSize.height - _tableView.bounds.size.height)) animated:animatedScroll];
+    
+    if (letRunloopProceed) {
+      // Run other stuff on the main queue for between 2ms and 1000ms.
+      [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:(1 / (1 + arc4random_uniform(500)))]];
+      
+      if (indexPathsAddedAndRemoved) {
+        for (NSIndexPath *indexPath in indexPathsAddedAndRemoved) {
+          [_sections[indexPath.section] removeObjectIdenticalTo:indexPath];
+        }
+        [_tableView deleteRowsAtIndexPaths:indexPathsAddedAndRemoved withRowAnimation:rowAnimation];
+        indexPathsAddedAndRemoved = nil;
+      }
+    }
+    
+    if (useBeginEndUpdates) {
+      [_tableView endUpdates];
+    }
   }
 }
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView
 {
-  return NumberOfSections;
+  return _sections.count;
 }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section
 {
-  return NumberOfRowsPerSection;
+  return [(NSArray *)[_sections objectAtIndex:section] count];
 }
 
 - (ASCellNode *)tableView:(ASTableView *)tableView nodeForRowAtIndexPath:(NSIndexPath *)indexPath


### PR DESCRIPTION
This diff resolves all known consistency issues with ASTableView and ASCollectionView.
It includes significantly more aggressive thrash-testing in ASTableViewStressTest,
which now passes on a variety of device and simulator configurations.  It also updates
the unit tests run on every commit to ensure any regression is caught quickly.

A few of the salient changes in this diff:
- ASTableView now uses Rene's ASCollectionViewLayoutController, and actually uses a
UICollectionViewFlowLayout without any UICollectionView.  This resolves an issue where
ASFlowLayoutController was generating slightly out-of-bounds indicies when programmatically
scrolling past the end of the table content.  Because the custom implementation is likely
faster, I will revisit this later with profiling and possibly returning to the custom impl.
- There is now a second copy of the _nodes array maintained by ASDataController.  It shares
the same node instances, but this does add some overhead to manipulating the arrays. I've
filed a task to follow up with optimization, as there are several great opportunities to
make it faster.  However, I don't believe the overhead is a significant issue, and it does
guarantee correctness in even the toughest app usage scenarios.
- ASDataController no longer supports calling its delegate /before/ edit operations.  No
other class was relying on this behavior, and it would be unusual for an app developer to
use ASDataController directly.  However, it is possible that someone with a custom view
that integrates with ASDataController and ASRangeController could be affected by this.
- Further cleanup of organization, naming, additional comments, reduced code length
wherever possible.  Overall, significantly more accessible to a new reader.