### PR TITLE
Propagate ASCellNode's clipsToBounds value to the __ASTableViewCell

### DIFF
--- a/AsyncDisplayKit/ASCellNode.m
+++ b/AsyncDisplayKit/ASCellNode.m
@@ -25,6 +25,7 @@
 
   // use UITableViewCell defaults
   _selectionStyle = UITableViewCellSelectionStyleDefault;
+  self.clipsToBounds = YES;
 
   return self;
 }

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -389,6 +389,11 @@ void ASPerformBlockWithoutAnimation(BOOL withoutAnimation, void (^block)()) {
   cell.backgroundColor = node.backgroundColor;
   cell.selectionStyle = node.selectionStyle;
 
+  // the following ensures that we clip the entire cell to it's bounds if node.clipsToBounds is set (the default)
+  // This is actually a workaround for a bug we are seeing in some rare cases (selected background view
+  // overlaps other cells if size of ASCellNode has changed.)
+  cell.clipsToBounds = node.clipsToBounds;
+
   return cell;
 }
 


### PR DESCRIPTION
This helps work around a bug we are seeing in some rare cases (selected background view overlaps other cells if size of ASCellNode has changed.)

There is an edge case I ignored for this PR - if you set ASCellNode clipsToBounds while the cell is currently visible it will not propagate to the Cell until it is next displayed. (Just because it doesn't seem worth the added complexity.)

@appleguy I've tested this with my ADKFlicker test and my internal project and it masks the issue in both cases.