### PR TITLE
Access to underlying UITextView for more configuration options.

### DIFF
--- a/AsyncDisplayKit/ASEditableTextNode.h
+++ b/AsyncDisplayKit/ASEditableTextNode.h
@@ -19,7 +19,10 @@
 
 #pragma mark - Configuration
 
-//! @abstract Access to underlying UITextView for more configuration options.
+/**
+  @abstract Access to underlying UITextView for more configuration options.
+  @warning This property should only be used on the main thread and should not be accessed before the editable text node's view is created.
+ */
 @property (nonatomic, readwrite, strong) UITextView *textView;
 
 //! @abstract The attributes to apply to new text being entered by the user.

--- a/AsyncDisplayKit/ASEditableTextNode.h
+++ b/AsyncDisplayKit/ASEditableTextNode.h
@@ -19,6 +19,9 @@
 
 #pragma mark - Configuration
 
+//! @abstract Access to underlying UITextView for more configuration options.
+@property (nonatomic, readwrite, strong) UITextView *textView;
+
 //! @abstract The attributes to apply to new text being entered by the user.
 @property (nonatomic, readwrite, strong) NSDictionary *typingAttributes;
 

--- a/AsyncDisplayKit/ASEditableTextNode.h
+++ b/AsyncDisplayKit/ASEditableTextNode.h
@@ -23,7 +23,7 @@
   @abstract Access to underlying UITextView for more configuration options.
   @warning This property should only be used on the main thread and should not be accessed before the editable text node's view is created.
  */
-@property (nonatomic, readwrite, strong) UITextView *textView;
+@property (nonatomic, readonly, strong) UITextView *textView;
 
 //! @abstract The attributes to apply to new text being entered by the user.
 @property (nonatomic, readwrite, strong) NSDictionary *typingAttributes;

--- a/AsyncDisplayKit/ASEditableTextNode.mm
+++ b/AsyncDisplayKit/ASEditableTextNode.mm
@@ -41,6 +41,7 @@
 {
   @private
   // Configuration.
+  UITextView *_textView;
   NSDictionary *_typingAttributes;
 
   // Core.
@@ -134,7 +135,7 @@
   [self.view addSubview:_placeholderTextKitComponents.textView];
 
   // Create and configure our text view.
-    _textKitComponents.textView = _textView;
+  _textKitComponents.textView = _textView;
   //_textKitComponents.textView = NO; // Unfortunately there's a bug here with iOS 7 DP5 that causes the text-view to only be one line high when scrollEnabled is NO. rdar://14729288
   _textKitComponents.textView.delegate = self;
   _textKitComponents.textView.editable = YES;
@@ -188,6 +189,21 @@
 
 #pragma mark - Configuration
 @synthesize delegate = _delegate;
+
+#pragma mark -
+@dynamic textView;
+
+- (UITextView *)textView{
+  ASDisplayNodeAssertMainThread();
+  return _textView;
+}
+
+- (void)setTextView:(UITextView *)textView
+{
+  ASDisplayNodeAssertMainThread();
+  _textView = textView;
+}
+
 
 #pragma mark -
 @dynamic typingAttributes;

--- a/AsyncDisplayKit/ASEditableTextNode.mm
+++ b/AsyncDisplayKit/ASEditableTextNode.mm
@@ -196,6 +196,7 @@
 - (UITextView *)textView
 {
   ASDisplayNodeAssertMainThread();
+  ASDisplayNodeAssert(_textView != nil, @"ASEditableTextNode's text view has not been allocated yet — access it in -didLoad or after accessing the .view property instead");
   return _textView;
 }
 

--- a/AsyncDisplayKit/ASEditableTextNode.mm
+++ b/AsyncDisplayKit/ASEditableTextNode.mm
@@ -193,7 +193,8 @@
 #pragma mark -
 @dynamic textView;
 
-- (UITextView *)textView{
+- (UITextView *)textView
+{
   ASDisplayNodeAssertMainThread();
   return _textView;
 }

--- a/AsyncDisplayKit/ASEditableTextNode.mm
+++ b/AsyncDisplayKit/ASEditableTextNode.mm
@@ -196,7 +196,9 @@
 - (UITextView *)textView
 {
   ASDisplayNodeAssertMainThread();
-  ASDisplayNodeAssert(_textView != nil, @"ASEditableTextNode's text view has not been allocated yet — access it in -didLoad or after accessing the .view property instead");
+  if (!_textView) {
+    _textView = [[_ASDisabledPanUITextView alloc] initWithFrame:CGRectZero textContainer:_textKitComponents.textContainer];
+  }
   return _textView;
 }
 

--- a/AsyncDisplayKit/ASEditableTextNode.mm
+++ b/AsyncDisplayKit/ASEditableTextNode.mm
@@ -77,6 +77,7 @@
   _textKitComponents = [ASTextKitComponents componentsWithAttributedSeedString:nil textContainerSize:CGSizeZero];
   _textKitComponents.layoutManager.delegate = self;
   _wordKerner = [[ASTextNodeWordKerner alloc] init];
+  _textView = [[_ASDisabledPanUITextView alloc] initWithFrame:CGRectZero textContainer:_textKitComponents.textContainer];
 
   // Create the placeholder scaffolding.
   _placeholderTextKitComponents = [ASTextKitComponents componentsWithAttributedSeedString:nil textContainerSize:CGSizeZero];
@@ -133,7 +134,7 @@
   [self.view addSubview:_placeholderTextKitComponents.textView];
 
   // Create and configure our text view.
-  _textKitComponents.textView = [[_ASDisabledPanUITextView alloc] initWithFrame:CGRectZero textContainer:_textKitComponents.textContainer];
+    _textKitComponents.textView = _textView;
   //_textKitComponents.textView = NO; // Unfortunately there's a bug here with iOS 7 DP5 that causes the text-view to only be one line high when scrollEnabled is NO. rdar://14729288
   _textKitComponents.textView.delegate = self;
   _textKitComponents.textView.editable = YES;

--- a/AsyncDisplayKit/ASEditableTextNode.mm
+++ b/AsyncDisplayKit/ASEditableTextNode.mm
@@ -41,7 +41,6 @@
 {
   @private
   // Configuration.
-  UITextView *_textView;
   NSDictionary *_typingAttributes;
 
   // Core.
@@ -78,7 +77,6 @@
   _textKitComponents = [ASTextKitComponents componentsWithAttributedSeedString:nil textContainerSize:CGSizeZero];
   _textKitComponents.layoutManager.delegate = self;
   _wordKerner = [[ASTextNodeWordKerner alloc] init];
-  _textView = [[_ASDisabledPanUITextView alloc] initWithFrame:CGRectZero textContainer:_textKitComponents.textContainer];
 
   // Create the placeholder scaffolding.
   _placeholderTextKitComponents = [ASTextKitComponents componentsWithAttributedSeedString:nil textContainerSize:CGSizeZero];
@@ -135,7 +133,7 @@
   [self.view addSubview:_placeholderTextKitComponents.textView];
 
   // Create and configure our text view.
-  _textKitComponents.textView = _textView;
+  _textKitComponents.textView = self.textView;
   //_textKitComponents.textView = NO; // Unfortunately there's a bug here with iOS 7 DP5 that causes the text-view to only be one line high when scrollEnabled is NO. rdar://14729288
   _textKitComponents.textView.delegate = self;
   _textKitComponents.textView.editable = YES;
@@ -190,24 +188,14 @@
 #pragma mark - Configuration
 @synthesize delegate = _delegate;
 
-#pragma mark -
-@dynamic textView;
-
 - (UITextView *)textView
 {
   ASDisplayNodeAssertMainThread();
-  if (!_textView) {
-    _textView = [[_ASDisabledPanUITextView alloc] initWithFrame:CGRectZero textContainer:_textKitComponents.textContainer];
+  if (!_textKitComponents.textView) {
+    _textKitComponents.textView = [[_ASDisabledPanUITextView alloc] initWithFrame:CGRectZero textContainer:_textKitComponents.textContainer];
   }
-  return _textView;
+  return _textKitComponents.textView;
 }
-
-- (void)setTextView:(UITextView *)textView
-{
-  ASDisplayNodeAssertMainThread();
-  _textView = textView;
-}
-
 
 #pragma mark -
 @dynamic typingAttributes;


### PR DESCRIPTION
This allows much more control over the display of ASEditableTextNodes and closes #549 