### PR TITLE
releasing downloaded image when multiplex image node exits render range

### DIFF
--- a/AsyncDisplayKit/ASMultiplexImageNode.mm
+++ b/AsyncDisplayKit/ASMultiplexImageNode.mm
@@ -139,6 +139,13 @@ typedef void(^ASMultiplexImageLoadCompletionBlock)(UIImage *image, id imageIdent
  */
 - (void)_downloadImageWithIdentifier:(id)imageIdentifier URL:(NSURL *)imageURL completion:(void (^)(UIImage *image, NSError *error))completionBlock;
 
+/**
+ @abstract Returns a Boolean value indicating whether the downloaded image should be removed when clearing fetched data
+ @discussion Downloaded image data should only be cleared out if a cache is present
+ @return YES if an image cache is available; otherwise, NO.
+ */
+- (BOOL)_shouldClearFetchedImageData;
+
 @end
 
 @implementation ASMultiplexImageNode
@@ -173,11 +180,15 @@ typedef void(^ASMultiplexImageLoadCompletionBlock)(UIImage *image, id imageIdent
   }
 }
 
-- (void)displayWillStart
+- (void)clearFetchedData
 {
-  [super displayWillStart];
-
-  [self fetchData];
+  [super clearFetchedData];
+    
+  if ([self _shouldClearFetchedImageData]) {
+    // setting this to nil makes the node fetch images the next time its display starts
+    _loadedImageIdentifier = nil;
+    self.image = nil;
+  }
 }
 
 - (void)fetchData
@@ -624,6 +635,10 @@ typedef void(^ASMultiplexImageLoadCompletionBlock)(UIImage *image, id imageIdent
   // Load our next image, if we have one to load.
   if ([self _nextImageIdentifierToDownload])
     [self _loadNextImage];
+}
+
+- (BOOL)_shouldClearFetchedImageData {
+  return _cache != nil;
 }
 
 @end


### PR DESCRIPTION
This update improves the memory consumption of `ASMultiplexImageNode` which are no longer on screen, but remain in memory. The downside to this change is that when the node gets re-rendered it will fetch images off the network, hopefully most users are using an image cache so this will not too negatively impact them.

This keeps things a bit more inline with how `ASNetworkImageNode` works, however, I noticed `ASNetworkImageNode` clears itself out in `clearFetchedData`. However, `ASMultiplexImageNode` is currently using `clearContents` for clearing itself out. I kept this logic inside `clearContents` because of that, but let me know if this is more appropriate in  `clearFetchedData`.