### PR TITLE
Take 2: Automatically adjust content offset for insertion/deletion

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.h
+++ b/AsyncDisplayKit/ASCollectionView.h
@@ -79,9 +79,8 @@
 @property (nonatomic, assign) CGFloat leadingScreensForBatching;
 
 /**
- *  Perform a batch of updates asynchronously, optionally disabling all animations in the batch. You can call it from background 
- *  thread (it is recommendated) and the UI collection view will be updated asynchronously. The asyncDataSource must be updated 
- *  to reflect the changes before this method is called.
+ *  Perform a batch of updates asynchronously, optionally disabling all animations in the batch. This method must be called from the main thread. 
+ *  The asyncDataSource must be updated to reflect the changes before the update block completes.
  *
  *  @param animated   NO to disable animations for this batch
  *  @param updates    The block that performs the relevant insert, delete, reload, or move operations.
@@ -92,8 +91,8 @@
 - (void)performBatchAnimated:(BOOL)animated updates:(void (^)())updates completion:(void (^)(BOOL))completion;
 
 /**
- *  Perform a batch of updates asynchronously. You can call it from background thread (it is recommendated) and the UI collection 
- *  view will be updated asynchronously. The asyncDataSource must be updated to reflect the changes before this method is called.
+ *  Perform a batch of updates asynchronously.  This method must be called from the main thread.
+ *  The asyncDataSource must be updated to reflect the changes before update block completes.
  *
  *  @param updates    The block that performs the relevant insert, delete, reload, or move operations.
  *  @param completion A completion handler block to execute when all of the operations are finished. This block takes a single
@@ -123,8 +122,7 @@
  *
  * @param sections An index set that specifies the sections to insert.
  *
- * @discussion This operation is asynchronous and thread safe. You can call it from background thread (it is recommendated)
- * and the UI collection view will be updated asynchronously. The asyncDataSource must be updated to reflect the changes
+ * @discussion This method must be called from the main thread. The asyncDataSource must be updated to reflect the changes
  * before this method is called.
  */
 - (void)insertSections:(NSIndexSet *)sections;
@@ -134,8 +132,7 @@
  *
  * @param sections An index set that specifies the sections to delete.
  *
- * @discussion This operation is asynchronous and thread safe. You can call it from background thread (it is recommendated)
- * and the UI collection view will be updated asynchronously. The asyncDataSource must be updated to reflect the changes
+ * @discussion This method must be called from the main thread. The asyncDataSource must be updated to reflect the changes
  * before this method is called.
  */
 - (void)deleteSections:(NSIndexSet *)sections;
@@ -145,8 +142,7 @@
  *
  * @param sections An index set that specifies the sections to reload.
  *
- * @discussion This operation is asynchronous and thread safe. You can call it from background thread (it is recommendated)
- * and the UI collection view will be updated asynchronously. The asyncDataSource must be updated to reflect the changes
+ * @discussion This method must be called from the main thread. The asyncDataSource must be updated to reflect the changes
  * before this method is called.
  */
 - (void)reloadSections:(NSIndexSet *)sections;
@@ -158,8 +154,7 @@
  *
  * @param newSection The index that is the destination of the move for the section.
  *
- * @discussion This operation is asynchronous and thread safe. You can call it from background thread (it is recommendated)
- * and the UI collection view will be updated asynchronously. The asyncDataSource must be updated to reflect the changes
+ * @discussion This method must be called from the main thread. The asyncDataSource must be updated to reflect the changes
  * before this method is called.
  */
 - (void)moveSection:(NSInteger)section toSection:(NSInteger)newSection;
@@ -169,8 +164,7 @@
  *
  * @param indexPaths An array of NSIndexPath objects, each representing an item index and section index that together identify an item.
  *
- * @discussion This operation is asynchronous and thread safe. You can call it from background thread (it is recommendated)
- * and the UI collection view will be updated asynchronously. The asyncDataSource must be updated to reflect the changes
+ * @discussion This method must be called from the main thread. The asyncDataSource must be updated to reflect the changes
  * before this method is called.
  */
 - (void)insertItemsAtIndexPaths:(NSArray *)indexPaths;
@@ -180,8 +174,7 @@
  *
  * @param indexPaths An array of NSIndexPath objects identifying the items to delete.
  *
- * @discussion This operation is asynchronous and thread safe. You can call it from background thread (it is recommendated)
- * and the UI collection view will be updated asynchronously. The asyncDataSource must be updated to reflect the changes
+ * @discussion This method must be called from the main thread. The asyncDataSource must be updated to reflect the changes
  * before this method is called.
  */
 - (void)deleteItemsAtIndexPaths:(NSArray *)indexPaths;
@@ -191,8 +184,7 @@
  *
  * @param indexPaths An array of NSIndexPath objects identifying the items to reload.
  *
- * @discussion This operation is asynchronous and thread safe. You can call it from background thread (it is recommendated)
- * and the UI collection view will be updated asynchronously. The asyncDataSource must be updated to reflect the changes
+ * @discussion This method must be called from the main thread. The asyncDataSource must be updated to reflect the changes
  * before this method is called.
  */
 - (void)reloadItemsAtIndexPaths:(NSArray *)indexPaths;
@@ -204,8 +196,7 @@
  *
  * @param newIndexPath The index path that is the destination of the move for the item.
  *
- * @discussion This operation is asynchronous and thread safe. You can call it from background thread (it is recommendated)
- * and the UI collection view will be updated asynchronously. The asyncDataSource must be updated to reflect the changes
+ * @discussion This method must be called from the main thread. The asyncDataSource must be updated to reflect the changes
  * before this method is called.
  */
 - (void)moveItemAtIndexPath:(NSIndexPath *)indexPath toIndexPath:(NSIndexPath *)newIndexPath;

--- a/AsyncDisplayKit/ASCollectionView.h
+++ b/AsyncDisplayKit/ASCollectionView.h
@@ -79,6 +79,30 @@
 @property (nonatomic, assign) CGFloat leadingScreensForBatching;
 
 /**
+ *  Perform a batch of updates asynchronously, optionally disabling all animations in the batch. You can call it from background 
+ *  thread (it is recommendated) and the UI collection view will be updated asynchronously. The asyncDataSource must be updated 
+ *  to reflect the changes before this method is called.
+ *
+ *  @param animated   NO to disable animations for this batch
+ *  @param updates    The block that performs the relevant insert, delete, reload, or move operations.
+ *  @param completion A completion handler block to execute when all of the operations are finished. This block takes a single 
+ *                    Boolean parameter that contains the value YES if all of the related animations completed successfully or 
+ *                    NO if they were interrupted. This parameter may be nil. If supplied, the block is run on the main thread.
+ */
+- (void)performBatchAnimated:(BOOL)animated updates:(void (^)())updates completion:(void (^)(BOOL))completion;
+
+/**
+ *  Perform a batch of updates asynchronously. You can call it from background thread (it is recommendated) and the UI collection 
+ *  view will be updated asynchronously. The asyncDataSource must be updated to reflect the changes before this method is called.
+ *
+ *  @param updates    The block that performs the relevant insert, delete, reload, or move operations.
+ *  @param completion A completion handler block to execute when all of the operations are finished. This block takes a single
+ *                    Boolean parameter that contains the value YES if all of the related animations completed successfully or
+ *                    NO if they were interrupted. This parameter may be nil. If supplied, the block is run on the main thread.
+ */
+- (void)performBatchUpdates:(void (^)())updates completion:(void (^)(BOOL))completion;
+
+/**
  * Reload everything from scratch, destroying the working range and all cached nodes.
  *
  * @param completion block to run on completion of asynchronous loading or nil. If supplied, the block is run on

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -281,11 +281,16 @@ static BOOL _isInterceptedSelector(SEL sel)
 
 #pragma mark Assertions.
 
-- (void)performBatchUpdates:(void (^)())updates completion:(void (^)(BOOL))completion
+- (void)performBatchAnimated:(BOOL)animated updates:(void (^)())updates completion:(void (^)(BOOL))completion
 {
   [_dataController beginUpdates];
   updates();
-  [_dataController endUpdatesWithCompletion:completion];
+  [_dataController endUpdatesAnimated:animated completion:completion];
+}
+
+- (void)performBatchUpdates:(void (^)())updates completion:(void (^)(BOOL))completion
+{
+  [self performBatchAnimated:YES updates:updates completion:completion];
 }
 
 - (void)insertSections:(NSIndexSet *)sections
@@ -540,7 +545,7 @@ static BOOL _isInterceptedSelector(SEL sel)
   _performingBatchUpdates = YES;
 }
 
-- (void)rangeControllerEndUpdates:(ASRangeController *)rangeController completion:(void (^)(BOOL))completion {
+- (void)rangeController:(ASRangeController *)rangeController endUpdatesAnimated:(BOOL)animated completion:(void (^)(BOOL))completion {
   ASDisplayNodeAssertMainThread();
 
   if (!self.asyncDataSource) {
@@ -550,11 +555,21 @@ static BOOL _isInterceptedSelector(SEL sel)
     return; // if the asyncDataSource has become invalid while we are processing, ignore this request to avoid crashes
   }
 
+  BOOL animationsEnabled = NO;
+
+  if (!animated) {
+    animationsEnabled = [UIView areAnimationsEnabled];
+    [UIView setAnimationsEnabled:NO];
+  }
+
   [super performBatchUpdates:^{
     [_batchUpdateBlocks enumerateObjectsUsingBlock:^(dispatch_block_t block, NSUInteger idx, BOOL *stop) {
       block();
     }];
   } completion:^(BOOL finished) {
+    if (!animated) {
+      [UIView setAnimationsEnabled:animationsEnabled];
+    }
     if (completion) {
       completion(finished);
     }
@@ -581,7 +596,7 @@ static BOOL _isInterceptedSelector(SEL sel)
   return [_dataController nodesAtIndexPaths:indexPaths];
 }
 
-- (void)rangeController:(ASRangeController *)rangeController didInsertNodesAtIndexPaths:(NSArray *)indexPaths withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions
+- (void)rangeController:(ASRangeController *)rangeController didInsertNodes:(NSArray *)nodes atIndexPaths:(NSArray *)indexPaths withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions
 {
   ASDisplayNodeAssertMainThread();
 
@@ -600,7 +615,7 @@ static BOOL _isInterceptedSelector(SEL sel)
   }
 }
 
-- (void)rangeController:(ASRangeController *)rangeController didDeleteNodesAtIndexPaths:(NSArray *)indexPaths withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions
+- (void)rangeController:(ASRangeController *)rangeController didDeleteNodes:(NSArray *)nodes atIndexPaths:(NSArray *)indexPaths withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions
 {
   ASDisplayNodeAssertMainThread();
 

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -283,6 +283,8 @@ static BOOL _isInterceptedSelector(SEL sel)
 
 - (void)performBatchAnimated:(BOOL)animated updates:(void (^)())updates completion:(void (^)(BOOL))completion
 {
+  ASDisplayNodeAssertMainThread();
+
   [_dataController beginUpdates];
   updates();
   [_dataController endUpdatesAnimated:animated completion:completion];
@@ -295,41 +297,49 @@ static BOOL _isInterceptedSelector(SEL sel)
 
 - (void)insertSections:(NSIndexSet *)sections
 {
+  ASDisplayNodeAssertMainThread();
   [_dataController insertSections:sections withAnimationOptions:kASCollectionViewAnimationNone];
 }
 
 - (void)deleteSections:(NSIndexSet *)sections
 {
+  ASDisplayNodeAssertMainThread();
   [_dataController deleteSections:sections withAnimationOptions:kASCollectionViewAnimationNone];
 }
 
 - (void)reloadSections:(NSIndexSet *)sections
 {
+  ASDisplayNodeAssertMainThread();
   [_dataController reloadSections:sections withAnimationOptions:kASCollectionViewAnimationNone];
 }
 
 - (void)moveSection:(NSInteger)section toSection:(NSInteger)newSection
 {
+  ASDisplayNodeAssertMainThread();
   [_dataController moveSection:section toSection:newSection withAnimationOptions:kASCollectionViewAnimationNone];
 }
 
 - (void)insertItemsAtIndexPaths:(NSArray *)indexPaths
 {
+  ASDisplayNodeAssertMainThread();
   [_dataController insertRowsAtIndexPaths:indexPaths withAnimationOptions:kASCollectionViewAnimationNone];
 }
 
 - (void)deleteItemsAtIndexPaths:(NSArray *)indexPaths
 {
+  ASDisplayNodeAssertMainThread();
   [_dataController deleteRowsAtIndexPaths:indexPaths withAnimationOptions:kASCollectionViewAnimationNone];
 }
 
 - (void)reloadItemsAtIndexPaths:(NSArray *)indexPaths
 {
+  ASDisplayNodeAssertMainThread();
   [_dataController reloadRowsAtIndexPaths:indexPaths withAnimationOptions:kASCollectionViewAnimationNone];
 }
 
 - (void)moveItemAtIndexPath:(NSIndexPath *)indexPath toIndexPath:(NSIndexPath *)newIndexPath
 {
+  ASDisplayNodeAssertMainThread();
   [_dataController moveRowAtIndexPath:indexPath toIndexPath:newIndexPath withAnimationOptions:kASCollectionViewAnimationNone];
 }
 

--- a/AsyncDisplayKit/ASTableView.h
+++ b/AsyncDisplayKit/ASTableView.h
@@ -93,14 +93,39 @@
  */
 - (void)reloadData;
 
-
 /**
- * We don't support the these methods for animation yet.
- *
- * TODO: support animations.
+ *  begins a batch of insert, delete reload and move operations. Batches are asynchronous an thread safe.
  */
 - (void)beginUpdates;
+
+/**
+ *  Concludes a series of method calls that insert, delete, select, or reload rows and sections of the table view.
+ *  You call this method to bracket a series of method calls that begins with beginUpdates and that consists of operations
+ *  to insert, delete, select, and reload rows and sections of the table view. When you call endUpdates, ASTableView begins animating
+ *  the operations simultaneously. This method is asynchronous and thread safe. It's important to remeber that the ASTableView will
+ *  be processing the updates asynchronously after this call is completed.
+ *
+ *  @param animated   NO to disable all animations.
+ *  @param completion A completion handler block to execute when all of the operations are finished. This block takes a single
+ *                    Boolean parameter that contains the value YES if all of the related animations completed successfully or
+ *                    NO if they were interrupted. This parameter may be nil. If supplied, the block is run on the main thread.
+ */
 - (void)endUpdates;
+
+/**
+ *  Concludes a series of method calls that insert, delete, select, or reload rows and sections of the table view.
+ *  You call this method to bracket a series of method calls that begins with beginUpdates and that consists of operations 
+ *  to insert, delete, select, and reload rows and sections of the table view. When you call endUpdates, ASTableView begins animating
+ *  the operations simultaneously. This method is asynchronous and thread safe. It's important to remeber that the ASTableView will
+ *  be processing the updates asynchronously after this call and are not guaranteed to be reflected in the ASTableView until
+ *  the completion block is executed.
+ *
+ *  @param animated   NO to disable all animations.
+ *  @param completion A completion handler block to execute when all of the operations are finished. This block takes a single
+ *                    Boolean parameter that contains the value YES if all of the related animations completed successfully or
+ *                    NO if they were interrupted. This parameter may be nil. If supplied, the block is run on the main thread.
+ */
+- (void)endUpdatesAnimated:(BOOL)animated completion:(void (^)(BOOL completed))completion;
 
 /**
  * Inserts one or more sections, with an option to animate the insertion.
@@ -221,6 +246,14 @@
  * @returns an array containing the nodes being displayed on screen.
  */
 - (NSArray *)visibleNodes;
+
+/**
+ * YES to automatically adjust the contentOffset when cells are inserted or deleted "before"
+ * visible cells, maintaining the users' visible scroll position.
+ *
+ * default is NO.
+ */
+@property (nonatomic) BOOL automaticallyAdjustsContentOffset;
 
 @end
 

--- a/AsyncDisplayKit/ASTableView.h
+++ b/AsyncDisplayKit/ASTableView.h
@@ -94,7 +94,7 @@
 - (void)reloadData;
 
 /**
- *  begins a batch of insert, delete reload and move operations. Batches are asynchronous an thread safe.
+ *  begins a batch of insert, delete reload and move operations. This method must be called from the main thread.
  */
 - (void)beginUpdates;
 
@@ -102,7 +102,7 @@
  *  Concludes a series of method calls that insert, delete, select, or reload rows and sections of the table view.
  *  You call this method to bracket a series of method calls that begins with beginUpdates and that consists of operations
  *  to insert, delete, select, and reload rows and sections of the table view. When you call endUpdates, ASTableView begins animating
- *  the operations simultaneously. This method is asynchronous and thread safe. It's important to remeber that the ASTableView will
+ *  the operations simultaneously. This method is must be called from the main thread. It's important to remeber that the ASTableView will
  *  be processing the updates asynchronously after this call is completed.
  *
  *  @param animated   NO to disable all animations.
@@ -116,7 +116,7 @@
  *  Concludes a series of method calls that insert, delete, select, or reload rows and sections of the table view.
  *  You call this method to bracket a series of method calls that begins with beginUpdates and that consists of operations 
  *  to insert, delete, select, and reload rows and sections of the table view. When you call endUpdates, ASTableView begins animating
- *  the operations simultaneously. This method is asynchronous and thread safe. It's important to remeber that the ASTableView will
+ *  the operations simultaneously. This method is must be called from the main thread. It's important to remeber that the ASTableView will
  *  be processing the updates asynchronously after this call and are not guaranteed to be reflected in the ASTableView until
  *  the completion block is executed.
  *
@@ -134,8 +134,7 @@
  * 
  * @param animation A constant that indicates how the insertion is to be animated. See UITableViewRowAnimation.
  *
- * @discussion This operation is asynchronous and thread safe. You can call it from background thread (it is recommendated)
- * and the UI table view will be updated asynchronously. The asyncDataSource must be updated to reflect the changes
+ * @discussion This method must be called from the main thread. The asyncDataSource must be updated to reflect the changes
  * before this method is called.
  */
 - (void)insertSections:(NSIndexSet *)sections withRowAnimation:(UITableViewRowAnimation)animation;
@@ -147,8 +146,7 @@
  *
  * @param animation A constant that indicates how the deletion is to be animated. See UITableViewRowAnimation.
  *
- * @discussion This operation is asynchronous and thread safe. You can call it from background thread (it is recommendated)
- * and the UI table view will be updated asynchronously. The asyncDataSource must be updated to reflect the changes
+ * @discussion This method must be called from the main thread. The asyncDataSource must be updated to reflect the changes
  * before this method is called.
  */
 - (void)deleteSections:(NSIndexSet *)sections withRowAnimation:(UITableViewRowAnimation)animation;
@@ -160,8 +158,7 @@
  *
  * @param animation A constant that indicates how the reloading is to be animated. See UITableViewRowAnimation.
  *
- * @discussion This operation is asynchronous and thread safe. You can call it from background thread (it is recommendated)
- * and the UI table view will be updated asynchronously. The asyncDataSource must be updated to reflect the changes
+ * @discussion This method must be called from the main thread. The asyncDataSource must be updated to reflect the changes
  * before this method is called.
  */
 - (void)reloadSections:(NSIndexSet *)sections withRowAnimation:(UITableViewRowAnimation)animation;
@@ -173,8 +170,7 @@
  *
  * @param newSection The index that is the destination of the move for the section.
  *
- * @discussion This operation is asynchronous and thread safe. You can call it from background thread (it is recommendated)
- * and the UI table view will be updated asynchronously. The asyncDataSource must be updated to reflect the changes
+ * @discussion This method must be called from the main thread. The asyncDataSource must be updated to reflect the changes
  * before this method is called.
  */
 - (void)moveSection:(NSInteger)section toSection:(NSInteger)newSection;
@@ -186,8 +182,7 @@
  *
  * @param animation A constant that indicates how the insertion is to be animated. See UITableViewRowAnimation.
  *
- * @discussion This operation is asynchronous and thread safe. You can call it from background thread (it is recommendated)
- * and the UI table view will be updated asynchronously. The asyncDataSource must be updated to reflect the changes
+ * @discussion This method must be called from the main thread. The asyncDataSource must be updated to reflect the changes
  * before this method is called.
  */
 - (void)insertRowsAtIndexPaths:(NSArray *)indexPaths withRowAnimation:(UITableViewRowAnimation)animation;
@@ -199,8 +194,7 @@
  *
  * @param animation A constant that indicates how the deletion is to be animated. See UITableViewRowAnimation.
  *
- * @discussion This operation is asynchronous and thread safe. You can call it from background thread (it is recommendated)
- * and the UI table view will be updated asynchronously. The asyncDataSource must be updated to reflect the changes
+ * @discussion This method must be called from the main thread. The asyncDataSource must be updated to reflect the changes
  * before this method is called.
  */
 - (void)deleteRowsAtIndexPaths:(NSArray *)indexPaths withRowAnimation:(UITableViewRowAnimation)animation;
@@ -212,8 +206,7 @@
  *
  * @param animation A constant that indicates how the reloading is to be animated. See UITableViewRowAnimation.
  *
- * @discussion This operation is asynchronous and thread safe. You can call it from background thread (it is recommendated)
- * and the UI table view will be updated asynchronously. The asyncDataSource must be updated to reflect the changes
+ * @discussion This method must be called from the main thread. The asyncDataSource must be updated to reflect the changes
  * before this method is called.
  */
 - (void)reloadRowsAtIndexPaths:(NSArray *)indexPaths withRowAnimation:(UITableViewRowAnimation)animation;
@@ -225,8 +218,7 @@
  *
  * @param newIndexPath The index path that is the destination of the move for the row.
  *
- * @discussion This operation is asynchronous and thread safe. You can call it from background thread (it is recommendated)
- * and the UI table view will be updated asynchronously. The asyncDataSource must be updated to reflect the changes
+ * @discussion This method must be called from the main thread. The asyncDataSource must be updated to reflect the changes
  * before this method is called.
  */
 - (void)moveRowAtIndexPath:(NSIndexPath *)indexPath toIndexPath:(NSIndexPath *)newIndexPath;
@@ -249,7 +241,8 @@
 
 /**
  * YES to automatically adjust the contentOffset when cells are inserted or deleted "before"
- * visible cells, maintaining the users' visible scroll position.
+ * visible cells, maintaining the users' visible scroll position. Currently this feature tracks insertions, moves and deletions of
+ * cells, but section edits are ignored.
  *
  * default is NO.
  */

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -328,6 +328,7 @@ void ASPerformBlockWithoutAnimation(BOOL withoutAnimation, void (^block)()) {
 
 - (void)beginUpdates
 {
+  ASDisplayNodeAssertMainThread();
   [_dataController beginUpdates];
 }
 
@@ -338,6 +339,7 @@ void ASPerformBlockWithoutAnimation(BOOL withoutAnimation, void (^block)()) {
 
 - (void)endUpdatesAnimated:(BOOL)animated completion:(void (^)(BOOL completed))completion;
 {
+  ASDisplayNodeAssertMainThread();
   [_dataController endUpdatesAnimated:animated completion:completion];
 }
 
@@ -346,41 +348,49 @@ void ASPerformBlockWithoutAnimation(BOOL withoutAnimation, void (^block)()) {
 
 - (void)insertSections:(NSIndexSet *)sections withRowAnimation:(UITableViewRowAnimation)animation
 {
+  ASDisplayNodeAssertMainThread();
   [_dataController insertSections:sections withAnimationOptions:animation];
 }
 
 - (void)deleteSections:(NSIndexSet *)sections withRowAnimation:(UITableViewRowAnimation)animation
 {
+  ASDisplayNodeAssertMainThread();
   [_dataController deleteSections:sections withAnimationOptions:animation];
 }
 
 - (void)reloadSections:(NSIndexSet *)sections withRowAnimation:(UITableViewRowAnimation)animation
 {
+  ASDisplayNodeAssertMainThread();
   [_dataController reloadSections:sections withAnimationOptions:animation];
 }
 
 - (void)moveSection:(NSInteger)section toSection:(NSInteger)newSection
 {
+  ASDisplayNodeAssertMainThread();
   [_dataController moveSection:section toSection:newSection withAnimationOptions:UITableViewRowAnimationNone];
 }
 
 - (void)insertRowsAtIndexPaths:(NSArray *)indexPaths withRowAnimation:(UITableViewRowAnimation)animation
 {
+  ASDisplayNodeAssertMainThread();
   [_dataController insertRowsAtIndexPaths:indexPaths withAnimationOptions:animation];
 }
 
 - (void)deleteRowsAtIndexPaths:(NSArray *)indexPaths withRowAnimation:(UITableViewRowAnimation)animation
 {
+  ASDisplayNodeAssertMainThread();
   [_dataController deleteRowsAtIndexPaths:indexPaths withAnimationOptions:animation];
 }
 
 - (void)reloadRowsAtIndexPaths:(NSArray *)indexPaths withRowAnimation:(UITableViewRowAnimation)animation
 {
+  ASDisplayNodeAssertMainThread();
   [_dataController reloadRowsAtIndexPaths:indexPaths withAnimationOptions:animation];
 }
 
 - (void)moveRowAtIndexPath:(NSIndexPath *)indexPath toIndexPath:(NSIndexPath *)newIndexPath
 {
+  ASDisplayNodeAssertMainThread();
   [_dataController moveRowAtIndexPath:indexPath toIndexPath:newIndexPath withAnimationOptions:UITableViewRowAnimationNone];
 }
 
@@ -416,7 +426,7 @@ void ASPerformBlockWithoutAnimation(BOOL withoutAnimation, void (^block)()) {
   CGFloat adjustment = 0;
   NSIndexPath *top = _contentOffsetAdjustmentTopVisibleRow ?: self.indexPathsForVisibleRows.firstObject;
 
-  for (int index=0; index<indexPaths.count; index++) {
+  for (int index = 0; index < indexPaths.count; index++) {
     NSIndexPath *indexPath = indexPaths[index];
     if ([indexPath compare:top] <= 0) { // if this row is before or equal to the topmost visible row, make adjustments...
       ASCellNode *cellNode = nodes[index];
@@ -429,7 +439,7 @@ void ASPerformBlockWithoutAnimation(BOOL withoutAnimation, void (^block)()) {
 
   if (_contentOffsetAdjustmentTopVisibleRow) { // true of we are in a begin/end update block (see beginAdjustingContentOffset)
     _contentOffsetAdjustmentTopVisibleRow = top;
-     _contentOffsetAdjustment += adjustment;
+    _contentOffsetAdjustment += adjustment;
   } else if (adjustment != 0) {
     self.contentOffset = CGPointMake(0, self.contentOffset.y+adjustment);
   }

--- a/AsyncDisplayKit/Details/ASDataController.h
+++ b/AsyncDisplayKit/Details/ASDataController.h
@@ -65,7 +65,7 @@ typedef NSUInteger ASDataControllerAnimationOptions;
  Called for batch update.
  */
 - (void)dataControllerBeginUpdates:(ASDataController *)dataController;
-- (void)dataControllerEndUpdates:(ASDataController *)dataController completion:(void (^)(BOOL))completion;
+- (void)dataController:(ASDataController *)dataController endUpdatesAnimated:(BOOL)animated completion:(void (^)(BOOL))completion;
 
 /**
  Called for insertion of elements.
@@ -75,7 +75,7 @@ typedef NSUInteger ASDataControllerAnimationOptions;
 /**
  Called for deletion of elements.
  */
-- (void)dataController:(ASDataController *)dataController didDeleteNodesAtIndexPaths:(NSArray *)indexPaths withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions;
+- (void)dataController:(ASDataController *)dataController didDeleteNodes:(NSArray *)nodes atIndexPaths:(NSArray *)indexPaths withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions;
 
 /**
  Called for insertion of sections.
@@ -138,7 +138,7 @@ typedef NSUInteger ASDataControllerAnimationOptions;
 
 - (void)endUpdates;
 
-- (void)endUpdatesWithCompletion:(void (^)(BOOL))completion;
+- (void)endUpdatesAnimated:(BOOL)animated completion:(void (^)(BOOL))completion;
 
 - (void)insertSections:(NSIndexSet *)sections withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions;
 

--- a/AsyncDisplayKit/Details/ASDataController.mm
+++ b/AsyncDisplayKit/Details/ASDataController.mm
@@ -328,8 +328,6 @@ static void *kASSizingQueueContext = &kASSizingQueueContext;
   [_editingTransactionQueue waitUntilAllOperationsAreFinished];
   // Begin queuing up edit calls that happen on the main thread.
   // This will prevent further operations from being scheduled on _editingTransactionQueue.
-  // It's fine if there is an in-flight operation on _editingTransactionQueue,
-  // as once the command queue is unpaused, each edit command will wait for the _editingTransactionQueue to be flushed.
   _batchUpdateCounter++;
 }
 

--- a/AsyncDisplayKit/Details/ASFlowLayoutController.mm
+++ b/AsyncDisplayKit/Details/ASFlowLayoutController.mm
@@ -103,16 +103,18 @@ static const CGFloat kASFlowLayoutControllerRefreshingThreshold = 0.3;
   NSMutableSet *indexPathSet = [[NSMutableSet alloc] init];
 
   NSArray *completedNodes = [_dataSource completedNodes];
+
+  ASIndexPath currPath = startPath;
   
-  while (!ASIndexPathEqualToIndexPath(startPath, endPath)) {
-    [indexPathSet addObject:[NSIndexPath indexPathWithASIndexPath:startPath]];
-    startPath.row++;
+  while (!ASIndexPathEqualToIndexPath(currPath, endPath)) {
+    [indexPathSet addObject:[NSIndexPath indexPathWithASIndexPath:currPath]];
+    currPath.row++;
 
     // Once we reach the end of the section, advance to the next one.  Keep advancing if the next section is zero-sized.
-    while (startPath.row >= [(NSArray *)completedNodes[startPath.section] count] && startPath.section < completedNodes.count - 1) {
-      startPath.row = 0;
-      startPath.section++;
-      ASDisplayNodeAssert(startPath.section <= endPath.section, @"startPath should never reach a further section than endPath");
+    while (currPath.row >= [(NSArray *)completedNodes[currPath.section] count] && currPath.section < completedNodes.count - 1) {
+      currPath.row = 0;
+      currPath.section++;
+      ASDisplayNodeAssert(currPath.section <= endPath.section, @"currPath should never reach a further section than endPath");
     }
   }
 

--- a/AsyncDisplayKit/Details/ASRangeController.h
+++ b/AsyncDisplayKit/Details/ASRangeController.h
@@ -88,7 +88,7 @@
  *
  * @param completion Completion block.
  */
-- (void)rangeControllerEndUpdates:(ASRangeController * )rangeController completion:(void (^)(BOOL))completion ;
+- (void)rangeController:(ASRangeController * )rangeController endUpdatesAnimated:(BOOL)animated completion:(void (^)(BOOL))completion;
 
 /**
  * Fetch nodes at specific index paths.
@@ -108,7 +108,7 @@
  *
  * @param animationOptions Animation options. See ASDataControllerAnimationOptions.
  */
-- (void)rangeController:(ASRangeController *)rangeController didInsertNodesAtIndexPaths:(NSArray *)indexPaths withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions;
+- (void)rangeController:(ASRangeController *)rangeController didInsertNodes:(NSArray *)nodes atIndexPaths:(NSArray *)indexPaths withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions;
 
 /**
  * Called for nodes deletion.
@@ -119,7 +119,7 @@
  *
  * @param animationOptions Animation options. See ASDataControllerAnimationOptions.
  */
-- (void)rangeController:(ASRangeController *)rangeController didDeleteNodesAtIndexPaths:(NSArray *)indexPaths withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions;
+- (void)rangeController:(ASRangeController *)rangeController didDeleteNodes:(NSArray *)nodes atIndexPaths:(NSArray *)indexPaths withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions;
 
 /**
  * Called for section insertion.


### PR DESCRIPTION
This is a merged and cleaned-up version of PR #548.

This PR adds a new property for ASTableView (automaticallyAdjustsContentOffset) that, when enabled, will adjust the contentOffset for inserts and deletes before the visible viewport so the users view is maintained. In order to use this effectively, animations must be disabled while performing updates. To facilitate this an option has been added to endUpdates (and also a completion handler that has many uses.) Because this only works well with animations are disabled and it may require some thought to use effectively, it defaults to off.

There is a performance trade-off for this feature that I'd like anyone to weigh in on. In order to make this work, we need to know the heights of the nodes being inserted or deleted. (well we actually only need to know the heights of the ones before the visible cells.) I've extended our delegates to pass that information own to the ASTableView, but if it's not used it is a waste. These data is pretty easily available for inserting nodes, but in the case of deleting nodes, there is the additional overhead of capturing the deleted items and passing them down. There are alternative approaches I'm sure we could work out of this seems like it could be a big performance hit.

I think this handles the common cases for virtualization, but there's more that could be added to it to make it even more robust. Right now, it doesn't handle insertion/deletion of sections and you must explicitly disable animations in endUpdate to make it work correctly. If we wanted to make things more automatic we could separate the items that would be inserted before the visual window and make those insertions/deletions without animations (in a separate begin/end update block) and then follow up with any other updates in an animated fashion. It's considerably more work, but that would make this an "it just works" feature which I like ;)

You can see this in action with a simple demo app at: https://github.com/eanagel/ASDKVirtualizationDemo

Additionally, this includes a fix for a problem where ASDataController appears to be calling it's beginUpdate and endUpdates delegate method before the didInsert/Delete delegate methods.. See issue #564 for more details.

There is also a fix for a crash in ASRangeController caused when it doesn't correctly refresh its internal cache of indexPaths when inserts or deletes happen. This is a fix for #566.