### PR TITLE
Implement warning assertion for supplementary views in ASCollectionView.

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -33,6 +33,9 @@ static BOOL _isInterceptedSelector(SEL sel)
           // handled by ASCollectionView node<->cell machinery
           sel == @selector(collectionView:cellForItemAtIndexPath:) ||
           sel == @selector(collectionView:layout:sizeForItemAtIndexPath:) ||
+
+          // TODO: Supplementary views are currently not supported.  An assertion is triggered if the _asyncDataSource implements this method.
+          // sel == @selector(collectionView:viewForSupplementaryElementOfKind:atIndexPath:) ||
           
           // handled by ASRangeController
           sel == @selector(numberOfSectionsInCollectionView:) ||
@@ -216,6 +219,10 @@ static BOOL _isInterceptedSelector(SEL sel)
     _proxyDataSource = nil;
   } else {
     _asyncDataSource = asyncDataSource;
+    // TODO: Support supplementary views with ASCollectionView.
+    if ([_asyncDataSource respondsToSelector:@selector(collectionView:viewForSupplementaryElementOfKind:atIndexPath:)]) {
+      ASDisplayNodeAssert(NO, @"ASCollectionView is planned to support supplementary views by September 2015.  You can work around this issue by using standard items.");
+    }
     _proxyDataSource = [[_ASCollectionViewProxy alloc] initWithTarget:_asyncDataSource interceptor:self];
     super.dataSource = (id<UICollectionViewDataSource>)_proxyDataSource;
   }

--- a/examples/ASTableViewStressTest/Sample/ViewController.m
+++ b/examples/ASTableViewStressTest/Sample/ViewController.m
@@ -110,11 +110,14 @@
   for (int i = 0; i < NumberOfReloadIterations; ++i) {
     UITableViewRowAnimation rowAnimation = (arc4random_uniform(1) == 0 ? UITableViewRowAnimationMiddle : UITableViewRowAnimationNone);
 
-    BOOL animatedScroll               = (arc4random_uniform(1) == 0 ? YES : NO);
-    BOOL reloadRowsInsteadOfSections  = (arc4random_uniform(1) == 0 ? YES : NO);
-    BOOL letRunloopProceed            = (arc4random_uniform(1) == 0 ? YES : NO);
-    BOOL addIndexPaths                = (arc4random_uniform(1) == 0 ? YES : NO);
-    BOOL useBeginEndUpdates           = (arc4random_uniform(2) == 0 ? YES : NO);
+    BOOL animatedScroll               = (arc4random_uniform(2) == 0 ? YES : NO);
+    BOOL reloadRowsInsteadOfSections  = (arc4random_uniform(2) == 0 ? YES : NO);
+    BOOL letRunloopProceed            = (arc4random_uniform(2) == 0 ? YES : NO);
+    BOOL useBeginEndUpdates           = (arc4random_uniform(3) == 0 ? YES : NO);
+    
+    // FIXME: Need to revise the logic to support mutating the data source rather than just reload thrashing.
+    // UITableView itself does not support deleting a row in the same edit transaction as reloading it, for example.
+    BOOL addIndexPaths                = NO; //(arc4random_uniform(2) == 0 ? YES : NO);
     
     if (useBeginEndUpdates) {
       [_tableView beginUpdates];


### PR DESCRIPTION
Implement warning assertion for supplementary views in ASCollectionView.
Make sure ASTableViewStressTest passes.  It was sometimes testing a scenario UITableView itself doesn't support.