### PR TITLE
Add support for configuring `returnKeyType` on ASEditableTextNode.

### DIFF
--- a/AsyncDisplayKit/ASEditableTextNode.h
+++ b/AsyncDisplayKit/ASEditableTextNode.h
@@ -50,6 +50,11 @@
 //! @abstract The text input mode used by the receiver's keyboard, if it is visible. This value is undefined if the receiver is not the first responder.
 @property (nonatomic, readonly) UITextInputMode *textInputMode;
 
+/*
+ @abstract The returnKeyType of the keyboard. This value defaults to UIReturnKeyDefault.
+ */
+@property (nonatomic, readwrite) UIReturnKeyType returnKeyType;
+
 /**
   @abstract Indicates whether the receiver's text view is the first responder, and thus has the keyboard visible and is prepared for editing by the user.
   @result YES if the receiver's text view is the first-responder; NO otherwise.

--- a/AsyncDisplayKit/ASEditableTextNode.mm
+++ b/AsyncDisplayKit/ASEditableTextNode.mm
@@ -77,6 +77,7 @@
   _textKitComponents = [ASTextKitComponents componentsWithAttributedSeedString:nil textContainerSize:CGSizeZero];
   _textKitComponents.layoutManager.delegate = self;
   _wordKerner = [[ASTextNodeWordKerner alloc] init];
+  _returnKeyType = UIReturnKeyDefault;
 
   // Create the placeholder scaffolding.
   _placeholderTextKitComponents = [ASTextKitComponents componentsWithAttributedSeedString:nil textContainerSize:CGSizeZero];
@@ -138,6 +139,7 @@
   _textKitComponents.textView.delegate = self;
   _textKitComponents.textView.editable = YES;
   _textKitComponents.textView.typingAttributes = _typingAttributes;
+  _textKitComponents.textView.returnKeyType = _returnKeyType;
   _textKitComponents.textView.accessibilityHint = _placeholderTextKitComponents.textStorage.string;
   configureTextView(_textKitComponents.textView);
   [self.view addSubview:_textKitComponents.textView];
@@ -344,6 +346,13 @@
 {
   ASDN::MutexLocker l(_textKitLock);
   return [_textKitComponents.textView textInputMode];
+}
+
+- (void)setReturnKeyType:(UIReturnKeyType)returnKeyType
+{
+  ASDN::MutexLocker l(_textKitLock);
+  _returnKeyType = returnKeyType;
+  [_textKitComponents.textView setReturnKeyType:_returnKeyType];
 }
 
 - (BOOL)isFirstResponder

--- a/examples/EditableText/Sample/ViewController.m
+++ b/examples/EditableText/Sample/ViewController.m
@@ -31,6 +31,7 @@
 
   // simple editable text node.  here we use it synchronously, but it fully supports async layout & display
   _textNode = [[ASEditableTextNode alloc] init];
+  _textNode.returnKeyType = UIReturnKeyDone;
   _textNode.backgroundColor = [[UIColor lightGrayColor] colorWithAlphaComponent:0.1f];
 
   // with placeholder text (displayed if the user hasn't entered text)


### PR DESCRIPTION
I needed this for a feature we're building at @pinterest.

Currently, when using an `ASEditableTextNode`, there's no way to set the `returnKeyType` of the node. This adds support for that functionality.

I updated the `EditableText` demo to use this feature.