### PR TITLE
Support internal relayout

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -506,7 +506,18 @@ typedef CALayer *(^ASDisplayNodeLayerBlock)();
 @interface ASDisplayNode (UIViewBridge)
 
 - (void)setNeedsDisplay;    // Marks the view as needing display. Convenience for use whether view is created or not, or from a background thread.
-- (void)setNeedsLayout;     // Marks the view as needing layout.  Convenience for use whether view is created or not, or from a background thread.
+
+/**
+ * Marks the view as needing layout. Convenience for use whether view is created or not, or from a background thread.
+ * 
+ * If this node was measured, calling this method triggers an internal relayout: the calculated layout is invalidated,
+ * and the supernode is notified or (if this node is the root one) a full measurement pass is executed using the old constrained size.
+ * 
+ * Note: If the relayout causes a change in size of the root node that is attached to a container view
+ * (table or collection view, for example), the container view must be notified to redraw. 
+ * In case of table or collection view, calling -beginUpdates and -endUpdates is enough.
+ */
+- (void)setNeedsLayout;
 
 @property (atomic, retain)           id contents;                           // default=nil
 @property (atomic, assign)           BOOL clipsToBounds;                    // default==NO

--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -505,10 +505,13 @@ typedef CALayer *(^ASDisplayNodeLayerBlock)();
  */
 @interface ASDisplayNode (UIViewBridge)
 
-- (void)setNeedsDisplay;    // Marks the view as needing display. Convenience for use whether view is created or not, or from a background thread.
+/**
+ * Marks the view as needing display. Convenience for use whether the view / layer is loaded or not. Safe to call from a background thread.
+ */
+- (void)setNeedsDisplay;
 
 /**
- * Marks the view as needing layout. Convenience for use whether view is created or not, or from a background thread.
+ * Marks the node as needing layout. Convenience for use whether the view / layer is loaded or not. Safe to call from a background thread.
  * 
  * If this node was measured, calling this method triggers an internal relayout: the calculated layout is invalidated,
  * and the supernode is notified or (if this node is the root one) a full measurement pass is executed using the old constrained size.

--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -517,8 +517,8 @@ typedef CALayer *(^ASDisplayNodeLayerBlock)();
  * and the supernode is notified or (if this node is the root one) a full measurement pass is executed using the old constrained size.
  * 
  * Note: If the relayout causes a change in size of the root node that is attached to a container view
- * (table or collection view, for example), the container view must be notified to redraw. 
- * In case of table or collection view, calling -beginUpdates and -endUpdates is enough.
+ * (table or collection view, for example), the container view must be notified to relayout.
+ * For ASTableView and ASCollectionView, an empty batch editing transaction must be triggered to animate to new row / item sizes.
  */
 - (void)setNeedsLayout;
 

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -578,7 +578,9 @@ void ASDisplayNodePerformBlockOnMainThread(void (^block)())
   } else {
     // This is the root node. Trigger a full measurement pass on *current* thread. Old constrained size is re-used.
     [self measureWithSizeRange:oldConstrainedSize];
-    self.frame = CGRectMake(0.0f, 0.0f, _layout.size.width, _layout.size.height);
+    CGRect bounds = self.bounds;
+    bounds.size = CGSizeMake(_layout.size.width, _layout.size.height);
+    self.bounds = bounds;
   }
 }
 

--- a/AsyncDisplayKit/Private/ASDisplayNode+UIViewBridge.mm
+++ b/AsyncDisplayKit/Private/ASDisplayNode+UIViewBridge.mm
@@ -174,6 +174,7 @@
 - (void)setNeedsLayout
 {
   _bridge_prologue;
+  [self __setNeedsLayout];
   _messageToViewOrLayer(setNeedsLayout);
 }
 

--- a/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
+++ b/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
@@ -121,6 +121,7 @@ typedef NS_OPTIONS(NSUInteger, ASDisplayNodeMethodOverrides) {
 // Core implementation of -measureWithSizeRange:. Must be called with _propertyLock held.
 - (ASLayout *)__measureWithSizeRange:(ASSizeRange)constrainedSize;
 
+- (void)__setNeedsLayout;
 - (void)__layout;
 - (void)__setSupernode:(ASDisplayNode *)supernode;
 

--- a/examples/Kittens/Sample/KittenNode.h
+++ b/examples/Kittens/Sample/KittenNode.h
@@ -19,4 +19,6 @@
 
 - (instancetype)initWithKittenOfSize:(CGSize)size;
 
+- (void)toggleImageEnlargement;
+
 @end

--- a/examples/Kittens/Sample/KittenNode.mm
+++ b/examples/Kittens/Sample/KittenNode.mm
@@ -29,6 +29,8 @@ static const CGFloat kInnerPadding = 10.0f;
   ASNetworkImageNode *_imageNode;
   ASTextNode *_textNode;
   ASDisplayNode *_divider;
+  BOOL _isImageEnlarged;
+  BOOL _isNodesSwapped;
 }
 
 @end
@@ -84,6 +86,7 @@ static const CGFloat kInnerPadding = 10.0f;
                                                                    (NSInteger)roundl(_kittenSize.width),
                                                                    (NSInteger)roundl(_kittenSize.height)]];
 //  _imageNode.contentMode = UIViewContentModeCenter;
+  [_imageNode addTarget:self action:@selector(toggleNodesSwap) forControlEvents:ASControlNodeEventTouchUpInside];
   [self addSubnode:_imageNode];
 
   // lorem ipsum text, plus some nice styling
@@ -132,7 +135,7 @@ static const CGFloat kInnerPadding = 10.0f;
 - (ASLayoutSpec *)layoutSpecThatFits:(ASSizeRange)constrainedSize
 {
   ASRatioLayoutSpec *imagePlaceholder = [ASRatioLayoutSpec newWithRatio:1.0 child:_imageNode];
-  imagePlaceholder.flexBasis = ASRelativeDimensionMakeWithPoints(kImageSize);
+  imagePlaceholder.flexBasis = ASRelativeDimensionMakeWithPoints(kImageSize * (!_isImageEnlarged ? 1 : 2));
   
   _textNode.flexShrink = YES;
   
@@ -145,7 +148,7 @@ static const CGFloat kInnerPadding = 10.0f;
       .direction = ASStackLayoutDirectionHorizontal,
       .spacing = kInnerPadding
     }
-    children:@[imagePlaceholder, _textNode]]];
+    children:!_isNodesSwapped ? @[imagePlaceholder, _textNode] : @[_textNode, imagePlaceholder]]];
 }
 
 // With box model, you don't need to override this method, unless you want to add custom logic.
@@ -180,5 +183,17 @@ static const CGFloat kInnerPadding = 10.0f;
   _textNode.frame = CGRectMake(kOuterPadding + kImageSize + kInnerPadding, kOuterPadding, textSize.width, textSize.height);
 }
 #endif
+
+- (void)toggleImageEnlargement
+{
+  _isImageEnlarged = !_isImageEnlarged;
+  [self setNeedsLayout];
+}
+
+- (void)toggleNodesSwap
+{
+  _isNodesSwapped = !_isNodesSwapped;
+  [self setNeedsLayout];
+}
 
 @end

--- a/examples/Kittens/Sample/KittenNode.mm
+++ b/examples/Kittens/Sample/KittenNode.mm
@@ -30,7 +30,7 @@ static const CGFloat kInnerPadding = 10.0f;
   ASTextNode *_textNode;
   ASDisplayNode *_divider;
   BOOL _isImageEnlarged;
-  BOOL _isNodesSwapped;
+  BOOL _swappedTextAndImage;
 }
 
 @end
@@ -148,7 +148,7 @@ static const CGFloat kInnerPadding = 10.0f;
       .direction = ASStackLayoutDirectionHorizontal,
       .spacing = kInnerPadding
     }
-    children:!_isNodesSwapped ? @[imagePlaceholder, _textNode] : @[_textNode, imagePlaceholder]]];
+    children:!_swappedTextAndImage ? @[imagePlaceholder, _textNode] : @[_textNode, imagePlaceholder]]];
 }
 
 // With box model, you don't need to override this method, unless you want to add custom logic.
@@ -192,7 +192,7 @@ static const CGFloat kInnerPadding = 10.0f;
 
 - (void)toggleNodesSwap
 {
-  _isNodesSwapped = !_isNodesSwapped;
+  _swappedTextAndImage = !_swappedTextAndImage;
   [self setNeedsLayout];
 }
 

--- a/examples/Kittens/Sample/ViewController.m
+++ b/examples/Kittens/Sample/ViewController.m
@@ -102,6 +102,16 @@ static const NSInteger kMaxLitterSize = 100;        // max number of kitten cell
 #pragma mark -
 #pragma mark ASTableView.
 
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
+{
+  [_tableView deselectRowAtIndexPath:indexPath animated:YES];
+  [_tableView beginUpdates];
+  // Assume only kitten nodes are selectable (see -tableView:shouldHighlightRowAtIndexPath:).
+  KittenNode *node = (KittenNode *)[_tableView nodeForRowAtIndexPath:indexPath];
+  [node toggleImageEnlargement];
+  [_tableView endUpdates];
+}
+
 - (ASCellNode *)tableView:(ASTableView *)tableView nodeForRowAtIndexPath:(NSIndexPath *)indexPath
 {
   // special-case the first row
@@ -123,8 +133,8 @@ static const NSInteger kMaxLitterSize = 100;        // max number of kitten cell
 
 - (BOOL)tableView:(UITableView *)tableView shouldHighlightRowAtIndexPath:(NSIndexPath *)indexPath
 {
-  // disable row selection
-  return NO;
+  // Enable selection for kitten nodes
+  return indexPath.section != 0 || indexPath.row != 0;
 }
 
 - (void)tableViewLockDataSource:(ASTableView *)tableView


### PR DESCRIPTION
This PR is the first in a series of PRs that aim to support relayout. Relayouts can be categorized into 2 types: external and internal.
- External relayouts are caused by a new constrained size applied to the root node (like orientation change). This can be easily supported by calling -measure on every nodes.
- Internal relayouts are not caused by a different constrained size used on the root node. Instead, they are caused by internal layout changes, like subnodes re-arrangement and/or subnodes' size change.

Internal relayouts are triggers by calling -setNeedsLayout. The method does following things:
- Invalidates calculated layout of the display node.
- If the node is not a root node, -setNeedsLayout will be recursively called on higher-level nodes, until the root node gets the message. This will cause a certain branch in the node tree to be marked as "dirty".
- If the node is the root one, a full measurement pass is executed on the current thread, using the old constrained size. Dirty nodes will then re-measure their layout. [Depends on each scenario](https://goo.gl/photos/N8HsgSsvYf9DVzKL7), clean nodes might reuse their calculated layout.

A layout pass will then be trigger automatically. But depends on the new layout, 2 scenarios will happen:
- If the root node has the same size as before, everything should be fine. A good example is the way image and text nodes in KittenNode are swapped (see -toggleNodesSwap).
- If the root node has a different size and it is attached to a container view (table or collection view, for example), the container view must be notified to redraw. In case of table or collection view, calling beginUpdates and endUpdates is enough (see -toggleImageEnlargement in Kittens example).
