### PR TITLE
Support external relayout

### DIFF
--- a/AsyncDisplayKit/Details/ASDataController.h
+++ b/AsyncDisplayKit/Details/ASDataController.h
@@ -154,6 +154,12 @@ typedef NSUInteger ASDataControllerAnimationOptions;
 
 - (void)reloadRowsAtIndexPaths:(NSArray *)indexPaths withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions;
 
+/**
+ * Re-measures all loaded nodes. Used for external relayout (relayout that is caused by a change in constrained size of each and every cell node,
+ * for example, after an orientation change).
+ */
+- (void)relayoutAllRows;
+
 - (void)moveRowAtIndexPath:(NSIndexPath *)indexPath toIndexPath:(NSIndexPath *)newIndexPath withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions;
 
 - (void)reloadDataWithAnimationOptions:(ASDataControllerAnimationOptions)animationOptions completion:(void (^)())completion;

--- a/AsyncDisplayKit/Details/ASDataController.mm
+++ b/AsyncDisplayKit/Details/ASDataController.mm
@@ -555,6 +555,26 @@ static void *kASSizingQueueContext = &kASSizingQueueContext;
   }];
 }
 
+- (void)relayoutAllRows
+{
+  [self performEditCommandWithBlock:^{
+    ASDisplayNodeAssertMainThread();
+    LOG(@"Edit Command - relayoutRows");
+    [_editingTransactionQueue waitUntilAllOperationsAreFinished];
+    
+    NSArray *indexPaths = ASIndexPathsForMultidimensionalArray(_completedNodes);
+    NSArray *loadedNodes = ASFindElementsInMultidimensionalArrayAtIndexPaths(_completedNodes, indexPaths);
+    
+    for (NSUInteger i = 0; i < loadedNodes.count && i < indexPaths.count; i++) {
+      // TODO: The current implementation does not make use of different constrained sizes per node.
+      CGSize constrainedSize = [_dataSource dataController:self constrainedSizeForNodeAtIndexPath:indexPaths[i]];
+      ASCellNode *node = loadedNodes[i];
+      [node measure:constrainedSize];
+      node.frame = CGRectMake(0.0f, 0.0f, node.calculatedSize.width, node.calculatedSize.height);
+    }
+  }];
+}
+
 - (void)moveRowAtIndexPath:(NSIndexPath *)indexPath toIndexPath:(NSIndexPath *)newIndexPath withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions
 {
   [self performEditCommandWithBlock:^{

--- a/AsyncDisplayKit/Private/ASInternalHelpers.h
+++ b/AsyncDisplayKit/Private/ASInternalHelpers.h
@@ -24,4 +24,8 @@ CGFloat ASCeilPixelValue(CGFloat f);
 
 CGFloat ASRoundPixelValue(CGFloat f);
 
+BOOL ASSystemVersionLessThan8();
+
+BOOL ASSystemVersionLessThanVersion(NSString *version);
+
 ASDISPLAYNODE_EXTERN_C_END

--- a/AsyncDisplayKit/Private/ASInternalHelpers.mm
+++ b/AsyncDisplayKit/Private/ASInternalHelpers.mm
@@ -61,3 +61,18 @@ CGFloat ASRoundPixelValue(CGFloat f)
 {
   return roundf(f * ASScreenScale()) / ASScreenScale();
 }
+
+BOOL ASSystemVersionLessThan8()
+{
+  static BOOL lessThan8;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    lessThan8 = ASSystemVersionLessThanVersion(@"8");
+  });
+  return lessThan8;
+}
+
+BOOL ASSystemVersionLessThanVersion(NSString *version)
+{
+  return [[[UIDevice currentDevice] systemVersion] compare:version options:NSNumericSearch] == NSOrderedAscending;
+}

--- a/examples/Kittens/Sample/AppDelegate.m
+++ b/examples/Kittens/Sample/AppDelegate.m
@@ -19,7 +19,7 @@
 {
   self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
   self.window.backgroundColor = [UIColor whiteColor];
-  self.window.rootViewController = [[ViewController alloc] init];
+  self.window.rootViewController = [[UINavigationController alloc] initWithRootViewController:[[ViewController alloc] init]];
   [self.window makeKeyAndVisible];
   return YES;
 }

--- a/examples/Kittens/Sample/ViewController.m
+++ b/examples/Kittens/Sample/ViewController.m
@@ -27,12 +27,13 @@ static const NSInteger kMaxLitterSize = 100;        // max number of kitten cell
   ASTableView *_tableView;
 
   // array of boxed CGSizes corresponding to placekitten.com kittens
-  NSArray *_kittenDataSource;
+  NSMutableArray *_kittenDataSource;
 
   BOOL _dataSourceLocked;
+  NSIndexPath *_blurbNodeIndexPath;
 }
 
-@property (nonatomic, strong) NSArray *kittenDataSource;
+@property (nonatomic, strong) NSMutableArray *kittenDataSource;
 @property (atomic, assign) BOOL dataSourceLocked;
 
 @end
@@ -56,10 +57,16 @@ static const NSInteger kMaxLitterSize = 100;        // max number of kitten cell
   // populate our "data source" with some random kittens
   _kittenDataSource = [self createLitterWithSize:kLitterSize];
 
+  _blurbNodeIndexPath = [NSIndexPath indexPathForItem:0 inSection:0];
+  
+  self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemEdit
+                                                                                         target:self
+                                                                                         action:@selector(toggleEditingMode)];
+
   return self;
 }
 
-- (NSArray *)createLitterWithSize:(NSInteger)litterSize
+- (NSMutableArray *)createLitterWithSize:(NSInteger)litterSize
 {
   NSMutableArray *kittens = [NSMutableArray arrayWithCapacity:litterSize];
   for (NSInteger i = 0; i < litterSize; i++) {
@@ -75,7 +82,7 @@ static const NSInteger kMaxLitterSize = 100;        // max number of kitten cell
   return kittens;
 }
 
-- (void)setKittenDataSource:(NSArray *)kittenDataSource {
+- (void)setKittenDataSource:(NSMutableArray *)kittenDataSource {
   ASDisplayNodeAssert(!self.dataSourceLocked, @"Could not update data source when it is locked !");
 
   _kittenDataSource = kittenDataSource;
@@ -98,6 +105,11 @@ static const NSInteger kMaxLitterSize = 100;        // max number of kitten cell
   return YES;
 }
 
+- (void)toggleEditingMode
+{
+  [_tableView setEditing:!_tableView.editing animated:YES];
+}
+
 
 #pragma mark -
 #pragma mark ASTableView.
@@ -115,7 +127,7 @@ static const NSInteger kMaxLitterSize = 100;        // max number of kitten cell
 - (ASCellNode *)tableView:(ASTableView *)tableView nodeForRowAtIndexPath:(NSIndexPath *)indexPath
 {
   // special-case the first row
-  if (indexPath.section == 0 && indexPath.row == 0) {
+  if ([_blurbNodeIndexPath compare:indexPath] == NSOrderedSame) {
     BlurbNode *node = [[BlurbNode alloc] init];
     return node;
   }
@@ -134,7 +146,7 @@ static const NSInteger kMaxLitterSize = 100;        // max number of kitten cell
 - (BOOL)tableView:(UITableView *)tableView shouldHighlightRowAtIndexPath:(NSIndexPath *)indexPath
 {
   // Enable selection for kitten nodes
-  return indexPath.section != 0 || indexPath.row != 0;
+  return [_blurbNodeIndexPath compare:indexPath] != NSOrderedSame;
 }
 
 - (void)tableViewLockDataSource:(ASTableView *)tableView
@@ -173,7 +185,7 @@ static const NSInteger kMaxLitterSize = 100;        // max number of kitten cell
       }
 
       // add new kittens to the data source & notify table of new indexpaths
-      _kittenDataSource = [_kittenDataSource arrayByAddingObjectsFromArray:moarKittens];
+      [_kittenDataSource addObjectsFromArray:moarKittens];
       [tableView insertRowsAtIndexPaths:indexPaths withRowAnimation:UITableViewRowAnimationFade];
 
       [context completeBatchFetching:YES];
@@ -181,6 +193,21 @@ static const NSInteger kMaxLitterSize = 100;        // max number of kitten cell
       NSLog(@"kittens added");
     });
   });
+}
+
+- (BOOL)tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath
+{
+  // Enable editing for Kitten nodes
+  return [_blurbNodeIndexPath compare:indexPath] != NSOrderedSame;
+}
+
+- (void)tableView:(UITableView *)tableView commitEditingStyle:(UITableViewCellEditingStyle)editingStyle forRowAtIndexPath:(NSIndexPath *)indexPath
+{
+  if (editingStyle == UITableViewCellEditingStyleDelete) {
+    // Assume only kitten nodes are editable (see -tableView:canEditRowAtIndexPath:).
+    [_kittenDataSource removeObjectAtIndex:indexPath.row - 1];
+    [_tableView deleteRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
+  }
 }
 
 @end


### PR DESCRIPTION
External relayout (as defined in #594) can be handled by re-measure all relevant nodes with the new constrained size. This PR is about adding correct hooks that trigger re-measurements in response to some events, such as:
- [x] Orientation change in iOS 8 (#536).
- [x] Orientation change in iOS 7. Since we want ASTableView and ASCollectionView to handle orientation change automatically, I make these views to observe to UIDeviceOrientationDidChangeNotification and schedule a relayout for all loaded cell nodes.
- [x] Cell enters editing mode (#512).