### PR TITLE
Add support for sectionInset in ASCollectionView in property and delegate form

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.h
+++ b/AsyncDisplayKit/ASCollectionView.h
@@ -320,6 +320,19 @@
  */
 - (BOOL)shouldBatchFetchForCollectionView:(ASCollectionView *)collectionView;
 
+/**
+ * Passthrough support to UICollectionViewDelegateFlowLayout sectionInset behavior.
+ *
+ * @param collectionView The sender.
+ * @param collectionViewLayout The layout object requesting the information.
+ * #param section The index number of the section whose insets are needed.
+ *
+ * @discussion The same rules apply as the UICollectionView implementation, but this can also be used without a UICollectionViewFlowLayout.
+ * https://developer.apple.com/library/ios/documentation/UIKit/Reference/UICollectionViewDelegateFlowLayout_protocol/index.html#//apple_ref/occ/intfm/UICollectionViewDelegateFlowLayout/collectionView:layout:insetForSectionAtIndex:
+ *
+ */
+- (UIEdgeInsets)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout insetForSectionAtIndex:(NSInteger)section;
+
 @end
 
 @interface ASCollectionView (Deprecated)

--- a/examples/ASCollectionView/Sample/ViewController.m
+++ b/examples/ASCollectionView/Sample/ViewController.m
@@ -95,4 +95,8 @@
   [context completeBatchFetching:YES];
 }
 
+- (UIEdgeInsets)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout insetForSectionAtIndex:(NSInteger)section {
+  return UIEdgeInsetsMake(20.0, 20.0, 20.0, 20.0);
+}
+
 @end


### PR DESCRIPTION
This is something we added internally that I want to bring back upstream. I saw that there was a similar implementation at #352, so I followed the feedback given to that patch and brought it up to speed.

Added a small inset to the example project so people could see it in a action.