### PR TITLE
Support different constrained size range per node

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.h
+++ b/AsyncDisplayKit/ASCollectionView.h
@@ -262,6 +262,17 @@
 @optional
 
 /**
+ * Provides the constrained size range for measuring the node at the index path.
+ *
+ * @param collectionView The sender.
+ *
+ * @param indexPath The index path of the node.
+ *
+ * @returns A constrained size range for layout the node at this index path.
+ */
+- (ASSizeRange)collectionView:(ASCollectionView *)collectionView constrainedSizeForNodeAtIndexPath:(NSIndexPath *)indexPath;
+
+/**
  * Indicator to lock the data source for data fetching in async mode.
  * We should not update the data source until the data source has been unlocked. Otherwise, it will incur data inconsistence or exception
  * due to the data access in async mode.

--- a/AsyncDisplayKit/ASTableView.h
+++ b/AsyncDisplayKit/ASTableView.h
@@ -272,6 +272,17 @@
 @optional
 
 /**
+ * Provides the constrained size range for measuring the node at the index path.
+ *
+ * @param tableView The sender.
+ *
+ * @param indexPath The index path of the node.
+ *
+ * @returns A constrained size range for layout the node at this index path.
+ */
+- (ASSizeRange)tableView:(ASTableView *)tableView constrainedSizeForNodeAtIndexPath:(NSIndexPath *)indexPath;
+
+/**
  * Indicator to lock the data source for data fetching in async mode.
  * We should not update the data source until the data source has been unlocked. Otherwise, it will incur data inconsistence or exception
  * due to the data access in async mode.

--- a/AsyncDisplayKit/Details/ASDataController.h
+++ b/AsyncDisplayKit/Details/ASDataController.h
@@ -8,6 +8,7 @@
 
 #import <UIKit/UIKit.h>
 #import <AsyncDisplayKit/ASDealloc2MainObject.h>
+#import <AsyncDisplayKit/ASDimension.h>
 #import "ASFlowLayoutController.h"
 
 @class ASCellNode;
@@ -27,9 +28,9 @@ typedef NSUInteger ASDataControllerAnimationOptions;
 - (ASCellNode *)dataController:(ASDataController *)dataController nodeAtIndexPath:(NSIndexPath *)indexPath;
 
 /**
- The constrained size for layout.
+ The constrained size range for layout.
  */
-- (CGSize)dataController:(ASDataController *)dataController constrainedSizeForNodeAtIndexPath:(NSIndexPath *)indexPath;
+- (ASSizeRange)dataController:(ASDataController *)dataController constrainedSizeForNodeAtIndexPath:(NSIndexPath *)indexPath;
 
 /**
  Fetch the number of rows in specific section.


### PR DESCRIPTION
Since the return type is ASSizeRange, the min size, ASStackLayoutAlignItems and ASStackLayoutAlignSelf can now be fully utilized. 

One particular use case of min size can be found [here](https://github.com/nguyenhuy/AsyncMessagesViewController/commit/1d409ca8395054caa2cf03acf383ebc6d81a5ac1). In short, I need each cell node to have a positive min width. The min width acts as the min cross size of a vertical stack layout spec. Without a big enough min cross, I won't be able to do right alignment (via ASStackLayoutAlignItemsEnd), because the stack will [hug its content](https://github.com/facebook/AsyncDisplayKit/blob/master/AsyncDisplayKit/Private/ASStackPositionedLayout.mm#L46). (And yes, I've completely replaced manual layout with box-model layout in my AsyncMessagesViewController lib).