### PR TITLE
Improve relayout when constrained size of all nodes is changed

### DIFF
--- a/AsyncDisplayKit/Details/ASDataController.h
+++ b/AsyncDisplayKit/Details/ASDataController.h
@@ -156,8 +156,8 @@ typedef NSUInteger ASDataControllerAnimationOptions;
 - (void)reloadRowsAtIndexPaths:(NSArray *)indexPaths withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions;
 
 /**
- * Re-measures all loaded nodes. Used for external relayout (relayout that is caused by a change in constrained size of each and every cell node,
- * for example, after an orientation change).
+ * Re-measures all loaded nodes. Used to respond to a change in size of the containing view 
+ * (e.g. ASTableView or ASCollectionView after an orientation change).
  */
 - (void)relayoutAllRows;
 

--- a/AsyncDisplayKit/Details/ASDataController.mm
+++ b/AsyncDisplayKit/Details/ASDataController.mm
@@ -564,15 +564,14 @@ static void *kASSizingQueueContext = &kASSizingQueueContext;
     LOG(@"Edit Command - relayoutRows");
     [_editingTransactionQueue waitUntilAllOperationsAreFinished];
     
-    NSArray *indexPaths = ASIndexPathsForMultidimensionalArray(_completedNodes);
-    NSArray *loadedNodes = ASFindElementsInMultidimensionalArrayAtIndexPaths(_completedNodes, indexPaths);
-    
-    for (NSUInteger i = 0; i < loadedNodes.count && i < indexPaths.count; i++) {
-      ASSizeRange constrainedSize = [_dataSource dataController:self constrainedSizeForNodeAtIndexPath:indexPaths[i]];
-      ASCellNode *node = loadedNodes[i];
-      [node measureWithSizeRange:constrainedSize];
-      node.frame = CGRectMake(0.0f, 0.0f, node.calculatedSize.width, node.calculatedSize.height);
-    }
+    [_completedNodes enumerateObjectsUsingBlock:^(NSMutableArray *section, NSUInteger sectionIndex, BOOL *stop) {
+      [section enumerateObjectsUsingBlock:^(ASCellNode *node, NSUInteger rowIndex, BOOL *stop) {
+        ASSizeRange constrainedSize = [_dataSource dataController:self
+                                constrainedSizeForNodeAtIndexPath:[NSIndexPath indexPathForRow:rowIndex inSection:sectionIndex]];
+        [node measureWithSizeRange:constrainedSize];
+        node.frame = CGRectMake(0.0f, 0.0f, node.calculatedSize.width, node.calculatedSize.height);
+      }];
+    }];
   }];
 }
 

--- a/AsyncDisplayKit/Private/ASInternalHelpers.h
+++ b/AsyncDisplayKit/Private/ASInternalHelpers.h
@@ -24,8 +24,4 @@ CGFloat ASCeilPixelValue(CGFloat f);
 
 CGFloat ASRoundPixelValue(CGFloat f);
 
-BOOL ASSystemVersionLessThan8();
-
-BOOL ASSystemVersionLessThanVersion(NSString *version);
-
 ASDISPLAYNODE_EXTERN_C_END

--- a/AsyncDisplayKit/Private/ASInternalHelpers.mm
+++ b/AsyncDisplayKit/Private/ASInternalHelpers.mm
@@ -61,18 +61,3 @@ CGFloat ASRoundPixelValue(CGFloat f)
 {
   return roundf(f * ASScreenScale()) / ASScreenScale();
 }
-
-BOOL ASSystemVersionLessThan8()
-{
-  static BOOL lessThan8;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    lessThan8 = ASSystemVersionLessThanVersion(@"8");
-  });
-  return lessThan8;
-}
-
-BOOL ASSystemVersionLessThanVersion(NSString *version)
-{
-  return [[[UIDevice currentDevice] systemVersion] compare:version options:NSNumericSearch] == NSOrderedAscending;
-}

--- a/examples/Kittens/Sample.xcodeproj/project.pbxproj
+++ b/examples/Kittens/Sample.xcodeproj/project.pbxproj
@@ -314,6 +314,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -326,6 +327,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};

--- a/examples/Kittens/Sample/ViewController.m
+++ b/examples/Kittens/Sample/ViewController.m
@@ -59,6 +59,7 @@ static const NSInteger kMaxLitterSize = 100;        // max number of kitten cell
 
   _blurbNodeIndexPath = [NSIndexPath indexPathForItem:0 inSection:0];
   
+  self.title = @"Kittens";
   self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemEdit
                                                                                          target:self
                                                                                          action:@selector(toggleEditingMode)];


### PR DESCRIPTION
- In -layoutSubviews of table and collection views, detect changes that cause a different constrained size for nodes, and trigger relayout immediately.
- Orientation change can be handled by this solution. So, no need to observe to its events.
- Clean up #595.
- Update Kittens example to support iPad (easier to catch bugs on these devices) and add a title to navigation bar (looks a bit nicer).

There is 1 bug left that hopefully I will be able to fix in the next few days:
- Invisible nodes are not re-measured after entering editing mode.