### PR TITLE
Optimization: use only layers for offscreen working range window.

### DIFF
--- a/AsyncDisplayKit/Details/ASRangeHandlerRender.mm
+++ b/AsyncDisplayKit/Details/ASRangeHandlerRender.mm
@@ -39,8 +39,12 @@
 
   [node recursivelySetDisplaySuspended:NO];
 
-  // add the node to an off-screen window to force display and preserve its contents
-  [[self.class workingWindow] addSubnode:node];
+  // Add the node's layer to an off-screen window to trigger display and mark its contents as non-volatile.
+  // Use the layer directly to avoid the substantial overhead of UIView heirarchy manipulations.
+  // Any view-backed nodes will still create their views in order to assemble the layer heirarchy, and they will
+  // also assemble a view subtree for the node, but we avoid the much more significant expense triggered by a view
+  // being added or removed from an onscreen window (responder chain setup, will/DidMoveToWindow: recursive calls, etc)
+  [[[self.class workingWindow] layer] addSublayer:node.layer];
 }
 
 - (void)node:(ASDisplayNode *)node exitedRangeOfType:(ASLayoutRangeType)rangeType
@@ -49,7 +53,7 @@
   ASDisplayNodeAssert(rangeType == ASLayoutRangeTypeRender, @"Render delegate should not handle other ranges");
 
   [node recursivelySetDisplaySuspended:YES];
-  [node.view removeFromSuperview];
+  [node.layer removeFromSuperlayer];
 
   [node recursivelyClearContents];
 }


### PR DESCRIPTION
ASDK layout and display calls don't depend on UIView in any way, so this will reduce UIView-specific overhead from heirarchy manipulation.

I have a separate project to completely eliminate the working range window, but was impressed to see that this solution reduces the add / remove call by well over an order of magnitude — about 25x.  It is now so small, about 50ms -> 2ms on an iPhone 4 in my test case, that the main reason to remove the working window is no longer performance.  Rather, it is to support more advanced display features such as blocking on any unfinished display work if an app wants to ensure placeholders can never appear onscreen.