### PR TITLE
Fix small bugs related to preferredFrameSize

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -1382,7 +1382,10 @@ static NSInteger incrementIfFound(NSInteger i) {
 - (void)setPreferredFrameSize:(CGSize)preferredFrameSize
 {
   ASDN::MutexLocker l(_propertyLock);
-  _preferredFrameSize = preferredFrameSize;
+  if (! CGSizeEqualToSize(_preferredFrameSize, preferredFrameSize)) {
+    _preferredFrameSize = preferredFrameSize;
+    [self invalidateCalculatedLayout];
+  }
 }
 
 - (CGSize)preferredFrameSize

--- a/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
+++ b/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
@@ -28,7 +28,7 @@ typedef NS_OPTIONS(NSUInteger, ASDisplayNodeMethodOverrides) {
   ASDisplayNodeMethodOverrideTouchesCancelled      = 1 << 1,
   ASDisplayNodeMethodOverrideTouchesEnded          = 1 << 2,
   ASDisplayNodeMethodOverrideTouchesMoved          = 1 << 3,
-  ASDisplayNodeMethodOverrideCalculateSizeThatFits = 1 << 4
+  ASDisplayNodeMethodOverrideLayoutSpecThatFits    = 1 << 4
 };
 
 @class _ASPendingState;


### PR DESCRIPTION
- Fix bug that causes preferred size to not be used if it is set after a layout pass.
- Fix bug that causes preferred size to not be used if -calculateSizeThatFits is not overridden.