### PR TITLE
606 sizezero nil text

### DIFF
--- a/AsyncDisplayKit/Details/ASTextNodeRenderer.mm
+++ b/AsyncDisplayKit/Details/ASTextNodeRenderer.mm
@@ -173,8 +173,12 @@ static const CGFloat ASTextNodeRendererTextCapHeightPadding = 1.3;
 {
   ASDN::MutexLocker l(_textKitLock);
 
+  if (_attributedString.string.length == 0) {
+    _calculatedSize = CGSizeZero;
+    return;
+  }
+    
   [self _initializeTextKitComponentsIfNeeded];
-
 
   // Force glyph generation and layout, which may not have happened yet (and
   // isn't triggered by -usedRectForTextContainer:).

--- a/AsyncDisplayKit/Details/ASTextNodeRenderer.mm
+++ b/AsyncDisplayKit/Details/ASTextNodeRenderer.mm
@@ -173,7 +173,7 @@ static const CGFloat ASTextNodeRendererTextCapHeightPadding = 1.3;
 {
   ASDN::MutexLocker l(_textKitLock);
 
-  if (_attributedString.string.length == 0) {
+  if (_attributedString.length == 0) {
     _calculatedSize = CGSizeZero;
     return;
   }

--- a/AsyncDisplayKitTests/ASTextNodeRendererTests.m
+++ b/AsyncDisplayKitTests/ASTextNodeRendererTests.m
@@ -69,6 +69,22 @@
   XCTAssertTrue(size.height > 0, @"Should have a nonzero height");
 }
 
+- (void)testCalculateSizeWithEmptyString
+{
+    _attributedString = [[NSAttributedString alloc] initWithString:@""];
+    [self setUpRenderer];
+    CGSize size = [_renderer size];
+    XCTAssertTrue(CGSizeEqualToSize(CGSizeZero, size), @"Empty NSAttributedString should result in CGSizeZero");
+}
+
+- (void)testCalculateSizeWithNilString
+{
+    _attributedString = nil;
+    [self setUpRenderer];
+    CGSize size = [_renderer size];
+    XCTAssertTrue(CGSizeEqualToSize(CGSizeZero, size), @"Nil NSAttributedString should result in CGSizeZero");
+}
+
 - (void)testNumberOfLines
 {
   [self setUpRenderer];


### PR DESCRIPTION
@appleguy In reference to issue #606 

This modifies the ASTextNodeRenderer to set `_calculatedSize` to `CGSizeZero` when the attributedString is either nil or an empty string

I've also added test coverage for these expectations :sunglasses: 

I thought this was the most logical place, but if you think it belongs else where please let me know!

