### PR TITLE
Node init performance: Use shares UIColor/NSAttributedString instances

### DIFF
--- a/AsyncDisplayKit/ASDisplayNodeExtras.h
+++ b/AsyncDisplayKit/ASDisplayNodeExtras.h
@@ -60,6 +60,7 @@ extern id ASDisplayNodeFindFirstSubnode(ASDisplayNode *start, BOOL (^block)(ASDi
 extern id ASDisplayNodeFindFirstSubnodeOfClass(ASDisplayNode *start, Class c);
 
 extern UIColor *ASDisplayNodeDefaultPlaceholderColor();
+extern UIColor *ASDisplayNodeDefaultTintColor();
 
 /**
  Disable willAppear / didAppear / didDisappear notifications for a sub-hierarchy, then re-enable when done. Nested calls are supported.

--- a/AsyncDisplayKit/ASDisplayNodeExtras.mm
+++ b/AsyncDisplayKit/ASDisplayNodeExtras.mm
@@ -126,7 +126,24 @@ extern id ASDisplayNodeFindFirstSubnodeOfClass(ASDisplayNode *start, Class c)
 
 UIColor *ASDisplayNodeDefaultPlaceholderColor()
 {
-  return [UIColor colorWithWhite:0.95 alpha:1.0];
+  static UIColor *defaultPlaceholderColor;
+
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    defaultPlaceholderColor = [UIColor colorWithWhite:0.95 alpha:1.0];
+  });
+  return defaultPlaceholderColor;
+}
+
+UIColor *ASDisplayNodeDefaultTintColor()
+{
+  static UIColor *defaultTintColor;
+
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    defaultTintColor = [UIColor colorWithRed:0.0 green:0.478 blue:1.0 alpha:1.0];
+  });
+  return defaultTintColor;
 }
 
 #pragma mark - Hierarchy Notifications

--- a/AsyncDisplayKit/ASTextNode.mm
+++ b/AsyncDisplayKit/ASTextNode.mm
@@ -126,7 +126,7 @@ ASDISPLAYNODE_INLINE CGFloat ceilPixelValue(CGFloat f)
     self.needsDisplayOnBoundsChange = YES;
 
     _truncationMode = NSLineBreakByWordWrapping;
-    _truncationAttributedString = [[NSAttributedString alloc] initWithString:NSLocalizedString(@"\u2026", @"Default truncation string")];
+    _truncationAttributedString = DefaultTruncationAttributedString();
 
     // The common case is for a text node to be non-opaque and blended over some background.
     self.opaque = NO;
@@ -964,6 +964,16 @@ ASDISPLAYNODE_INLINE CGFloat ceilPixelValue(CGFloat f)
 }
 
 #pragma mark - Truncation Message
+
+static NSAttributedString *DefaultTruncationAttributedString()
+{
+  static NSAttributedString *defaultTruncationAttributedString;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    defaultTruncationAttributedString = [[NSAttributedString alloc] initWithString:NSLocalizedString(@"\u2026", @"Default truncation string")];
+  });
+  return defaultTruncationAttributedString;
+}
 
 - (void)setTruncationAttributedString:(NSAttributedString *)truncationAttributedString
 {


### PR DESCRIPTION
Re-use global instances of UIColor and NSAttributedString (since they are immutable) for a couple key init methods.