### PR TITLE
New min constrained width for cell nodes in table view

### DIFF
--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -791,7 +791,8 @@ void ASPerformBlockWithoutAnimation(BOOL withoutAnimation, void (^block)()) {
   }
   
   // Default size range
-  return ASSizeRangeMake(CGSizeZero, CGSizeMake(_maxWidthForNodesConstrainedSize, FLT_MAX));
+  return ASSizeRangeMake(CGSizeMake(_maxWidthForNodesConstrainedSize, 0),
+                         CGSizeMake(_maxWidthForNodesConstrainedSize, FLT_MAX));
 }
 
 - (void)dataControllerLockDataSource

--- a/examples/Kittens/Sample/KittenNode.mm
+++ b/examples/Kittens/Sample/KittenNode.mm
@@ -136,6 +136,7 @@ static const CGFloat kInnerPadding = 10.0f;
 {
   _imageNode.preferredFrameSize = _isImageEnlarged ? CGSizeMake(2.0 * kImageSize, 2.0 * kImageSize) : CGSizeMake(kImageSize, kImageSize);
   _textNode.flexShrink = YES;
+  _textNode.flexGrow = YES;
   
   return
   [ASInsetLayoutSpec


### PR DESCRIPTION
Cell nodes in table view should almost always fill its width. To enforce this behaviour, this PR updates the default min constrained width. This new behaviour requires each cell node to have at least 1 flexible object that can fill available space (for example, a flexible shrink and grow text node, or a center layout spec). Users can always op-out of this behaviour by overriding data source's -tableView:constrainedSizeForNodeAtIndexPath:.

Here are screenshots of Kittens sample before and after this diff.

![ios simulator screen shot 21 aug 2015 5 41 35 pm](https://cloud.githubusercontent.com/assets/587874/9411455/b526cd94-482e-11e5-9b6b-ab5cbfddbad6.png)

![ios simulator screen shot 21 aug 2015 5 42 21 pm](https://cloud.githubusercontent.com/assets/587874/9411458/b7f3b384-482e-11e5-8fef-5c77fba2eb65.png)
