### PR TITLE
ASLayoutSpec are temporarily mutable and have a more obj-c interface

### DIFF
--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -447,13 +447,13 @@
 		058D09D7195D050800B7D73C /* ASControlNode+Subclasses.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ASControlNode+Subclasses.h"; sourceTree = "<group>"; };
 		058D09D8195D050800B7D73C /* ASDisplayNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = ASDisplayNode.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		058D09D9195D050800B7D73C /* ASDisplayNode.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; lineEnding = 0; path = ASDisplayNode.mm; sourceTree = "<group>"; };
-		058D09DA195D050800B7D73C /* ASDisplayNode+Subclasses.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = "ASDisplayNode+Subclasses.h"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
+		058D09DA195D050800B7D73C /* ASDisplayNode+Subclasses.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = "ASDisplayNode+Subclasses.h"; sourceTree = "<group>"; };
 		058D09DB195D050800B7D73C /* ASDisplayNodeExtras.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASDisplayNodeExtras.h; sourceTree = "<group>"; };
 		058D09DC195D050800B7D73C /* ASDisplayNodeExtras.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASDisplayNodeExtras.mm; sourceTree = "<group>"; };
 		058D09DD195D050800B7D73C /* ASImageNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASImageNode.h; sourceTree = "<group>"; };
 		058D09DE195D050800B7D73C /* ASImageNode.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; lineEnding = 0; path = ASImageNode.mm; sourceTree = "<group>"; };
 		058D09DF195D050800B7D73C /* ASTextNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTextNode.h; sourceTree = "<group>"; };
-		058D09E0195D050800B7D73C /* ASTextNode.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; lineEnding = 0; path = ASTextNode.mm; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
+		058D09E0195D050800B7D73C /* ASTextNode.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; lineEnding = 0; path = ASTextNode.mm; sourceTree = "<group>"; };
 		058D09E2195D050800B7D73C /* _ASDisplayLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _ASDisplayLayer.h; sourceTree = "<group>"; };
 		058D09E3195D050800B7D73C /* _ASDisplayLayer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _ASDisplayLayer.mm; sourceTree = "<group>"; };
 		058D09E4195D050800B7D73C /* _ASDisplayView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _ASDisplayView.h; sourceTree = "<group>"; };
@@ -687,7 +687,9 @@
 				058D09AD195D04C000B7D73C /* Products */,
 				FD40E2760492F0CAAEAD552D /* Pods */,
 			);
+			indentWidth = 2;
 			sourceTree = "<group>";
+			tabWidth = 2;
 		};
 		058D09AD195D04C000B7D73C /* Products */ = {
 			isa = PBXGroup;

--- a/AsyncDisplayKit/ASCellNode.m
+++ b/AsyncDisplayKit/ASCellNode.m
@@ -111,7 +111,7 @@ static const CGFloat kFontSize = 18.0f;
   static const CGFloat kHorizontalPadding = 15.0f;
   static const CGFloat kVerticalPadding = 11.0f;
   UIEdgeInsets insets = UIEdgeInsetsMake(kVerticalPadding, kHorizontalPadding, kVerticalPadding, kHorizontalPadding);
-  return [ASInsetLayoutSpec newWithInsets:insets child:_textNode];
+  return [ASInsetLayoutSpec insetLayoutSpecWithInsets:insets child:_textNode];
 }
 
 - (void)setText:(NSString *)text

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -1333,12 +1333,13 @@ static NSInteger incrementIfFound(NSInteger i) {
 {
   ASDisplayNodeAssertThreadAffinity(self);
   if (_methodOverrides & ASDisplayNodeMethodOverrideLayoutSpecThatFits) {
-    id<ASLayoutable> layoutSpec = [self layoutSpecThatFits:constrainedSize];
+    ASLayoutSpec *layoutSpec = [self layoutSpecThatFits:constrainedSize];
+    layoutSpec.isMutable = NO;
     ASLayout *layout = [layoutSpec measureWithSizeRange:constrainedSize];
     // Make sure layoutableObject of the root layout is `self`, so that the flattened layout will be structurally correct.
     if (layout.layoutableObject != self) {
       layout.position = CGPointZero;
-      layout = [ASLayout newWithLayoutableObject:self size:layout.size sublayouts:@[layout]];
+      layout = [ASLayout layoutWithLayoutableObject:self size:layout.size sublayouts:@[layout]];
     }
     return [layout flattenedLayoutUsingPredicateBlock:^BOOL(ASLayout *evaluatedLayout) {
       return [_subnodes containsObject:evaluatedLayout.layoutableObject];
@@ -1347,7 +1348,7 @@ static NSInteger incrementIfFound(NSInteger i) {
     // If neither -layoutSpecThatFits: nor -calculateSizeThatFits: is overridden by subclassses, preferredFrameSize should be used,
     // assume that the default implementation of -calculateSizeThatFits: returns it.
     CGSize size = [self calculateSizeThatFits:constrainedSize.max];
-    return [ASLayout newWithLayoutableObject:self size:ASSizeRangeClamp(constrainedSize, size)];
+    return [ASLayout layoutWithLayoutableObject:self size:ASSizeRangeClamp(constrainedSize, size)];
   }
 }
 

--- a/AsyncDisplayKit/Layout/ASBackgroundLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASBackgroundLayoutSpec.h
@@ -15,11 +15,14 @@
  */
 @interface ASBackgroundLayoutSpec : ASLayoutSpec
 
+@property (nonatomic, strong) id<ASLayoutable> child;
+@property (nonatomic, strong) id<ASLayoutable> background;
+
 /**
  @param child A child that is laid out to determine the size of this spec. If this is nil, then this method
         returns nil.
  @param background A layoutable object that is laid out behind the child. May be nil, in which case the background is omitted.
  */
-+ (instancetype)newWithChild:(id<ASLayoutable>)child background:(id<ASLayoutable>)background;
++ (instancetype)backgroundLayoutSpecWithChild:(id<ASLayoutable>)child background:(id<ASLayoutable>)background;
 
 @end

--- a/AsyncDisplayKit/Layout/ASBackgroundLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASBackgroundLayoutSpec.mm
@@ -25,12 +25,13 @@
 
 - (instancetype)initWithChild:(id<ASLayoutable>)child background:(id<ASLayoutable>)background
 {
-  self = [super init];
-  if (self) {
-    ASDisplayNodeAssertNotNil(child, @"Child cannot be nil");
-    _child = child;
-    _background = background;
+  if (!(self = [super init])) {
+    return nil;
   }
+  
+  ASDisplayNodeAssertNotNil(child, @"Child cannot be nil");
+  _child = child;
+  _background = background;
   return self;
 }
 

--- a/AsyncDisplayKit/Layout/ASBackgroundLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASBackgroundLayoutSpec.mm
@@ -23,20 +23,21 @@
 
 @implementation ASBackgroundLayoutSpec
 
-+ (instancetype)newWithChild:(id<ASLayoutable>)child background:(id<ASLayoutable>)background
+- (instancetype)initWithChild:(id<ASLayoutable>)child background:(id<ASLayoutable>)background
 {
-  if (child == nil) {
-    return nil;
+  self = [super init];
+  if (self) {
+    ASDisplayNodeAssertNotNil(child, @"Child cannot be nil");
+    _child = child;
+    _background = background;
   }
-  ASBackgroundLayoutSpec *spec = [super new];
-  spec->_child = child;
-  spec->_background = background;
-  return spec;
+  return self;
 }
 
-+ (instancetype)new
+
++ (instancetype)backgroundLayoutSpecWithChild:(id<ASLayoutable>)child background:(id<ASLayoutable>)background;
 {
-  ASDISPLAYNODE_NOT_DESIGNATED_INITIALIZER();
+  return [[self alloc] initWithChild:child background:background];
 }
 
 /**
@@ -56,7 +57,19 @@
   contentsLayout.position = CGPointZero;
   [sublayouts addObject:contentsLayout];
 
-  return [ASLayout newWithLayoutableObject:self size:contentsLayout.size sublayouts:sublayouts];
+  return [ASLayout layoutWithLayoutableObject:self size:contentsLayout.size sublayouts:sublayouts];
+}
+
+- (void)setBackground:(id<ASLayoutable>)background
+{
+  ASDisplayNodeAssert(self.isMutable, @"Cannot set properties when layout spec is not mutable");
+  _background = background;
+}
+
+- (void)setChild:(id<ASLayoutable>)child
+{
+  ASDisplayNodeAssert(self.isMutable, @"Cannot set properties when layout spec is not mutable");
+  _child = child;
 }
 
 @end

--- a/AsyncDisplayKit/Layout/ASCenterLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASCenterLayoutSpec.h
@@ -37,6 +37,10 @@ typedef NS_OPTIONS(NSUInteger, ASCenterLayoutSpecSizingOptions) {
 /** Lays out a single layoutable child and position it so that it is centered into the layout bounds. */
 @interface ASCenterLayoutSpec : ASLayoutSpec
 
+@property (nonatomic, assign) ASCenterLayoutSpecCenteringOptions centeringOptions;
+@property (nonatomic, assign) ASCenterLayoutSpecSizingOptions sizingOptions;
+@property (nonatomic, strong) id<ASLayoutable> child;
+
 /**
  * Initializer.
  *
@@ -46,8 +50,8 @@ typedef NS_OPTIONS(NSUInteger, ASCenterLayoutSpecSizingOptions) {
  *
  * @param child The child to center.
  */
-+ (instancetype)newWithCenteringOptions:(ASCenterLayoutSpecCenteringOptions)centeringOptions
-                          sizingOptions:(ASCenterLayoutSpecSizingOptions)sizingOptions
-                                  child:(id<ASLayoutable>)child;
++ (instancetype)centerLayoutSpecWithCenteringOptions:(ASCenterLayoutSpecCenteringOptions)centeringOptions
+                                       sizingOptions:(ASCenterLayoutSpecSizingOptions)sizingOptions
+                                               child:(id<ASLayoutable>)child;
 
 @end

--- a/AsyncDisplayKit/Layout/ASCenterLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASCenterLayoutSpec.mm
@@ -20,22 +20,43 @@
   id<ASLayoutable> _child;
 }
 
-+ (instancetype)newWithCenteringOptions:(ASCenterLayoutSpecCenteringOptions)centeringOptions
-                          sizingOptions:(ASCenterLayoutSpecSizingOptions)sizingOptions
-                                  child:(id<ASLayoutable>)child
+- (instancetype)initWithCenteringOptions:(ASCenterLayoutSpecCenteringOptions)centeringOptions
+                           sizingOptions:(ASCenterLayoutSpecSizingOptions)sizingOptions
+                                   child:(id<ASLayoutable>)child;
 {
-  ASCenterLayoutSpec *spec = [super new];
-  if (spec) {
-    spec->_centeringOptions = centeringOptions;
-    spec->_sizingOptions = sizingOptions;
-    spec->_child = child;
+  self = [super init];
+  if (self) {
+    ASDisplayNodeAssertNotNil(child, @"Child cannot be nil");
+    _centeringOptions = centeringOptions;
+    _sizingOptions = sizingOptions;
+    _child = child;
   }
-  return spec;
+  return self;
 }
 
-+ (instancetype)new
++ (instancetype)centerLayoutSpecWithCenteringOptions:(ASCenterLayoutSpecCenteringOptions)centeringOptions
+                                       sizingOptions:(ASCenterLayoutSpecSizingOptions)sizingOptions
+                                               child:(id<ASLayoutable>)child
 {
-  ASDISPLAYNODE_NOT_DESIGNATED_INITIALIZER();
+  return [[self alloc] initWithCenteringOptions:centeringOptions sizingOptions:sizingOptions child:child];
+}
+
+- (void)setChild:(id<ASLayoutable>)child
+{
+  ASDisplayNodeAssert(self.isMutable, @"Cannot set properties when layout spec is not mutable");
+  _child = child;
+}
+
+- (void)setCenteringOptions:(ASCenterLayoutSpecCenteringOptions)centeringOptions
+{
+  ASDisplayNodeAssert(self.isMutable, @"Cannot set properties when layout spec is not mutable");
+  _centeringOptions = centeringOptions;
+}
+
+- (void)setSizingOptions:(ASCenterLayoutSpecSizingOptions)sizingOptions
+{
+  ASDisplayNodeAssert(self.isMutable, @"Cannot set properties when layout spec is not mutable");
+  _sizingOptions = sizingOptions;
 }
 
 - (ASLayout *)measureWithSizeRange:(ASSizeRange)constrainedSize
@@ -73,7 +94,7 @@
     ASRoundPixelValue(shouldCenterAlongY ? (size.height - sublayout.size.height) * 0.5f : 0)
   };
 
-  return [ASLayout newWithLayoutableObject:self size:size sublayouts:@[sublayout]];
+  return [ASLayout layoutWithLayoutableObject:self size:size sublayouts:@[sublayout]];
 }
 
 @end

--- a/AsyncDisplayKit/Layout/ASCenterLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASCenterLayoutSpec.mm
@@ -24,13 +24,13 @@
                            sizingOptions:(ASCenterLayoutSpecSizingOptions)sizingOptions
                                    child:(id<ASLayoutable>)child;
 {
-  self = [super init];
-  if (self) {
-    ASDisplayNodeAssertNotNil(child, @"Child cannot be nil");
-    _centeringOptions = centeringOptions;
-    _sizingOptions = sizingOptions;
-    _child = child;
+  if (!(self = [super init])) {
+    return nil;
   }
+  ASDisplayNodeAssertNotNil(child, @"Child cannot be nil");
+  _centeringOptions = centeringOptions;
+  _sizingOptions = sizingOptions;
+  _child = child;
   return self;
 }
 

--- a/AsyncDisplayKit/Layout/ASInsetLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASInsetLayoutSpec.h
@@ -29,10 +29,13 @@
  */
 @interface ASInsetLayoutSpec : ASLayoutSpec
 
+@property (nonatomic, strong) id<ASLayoutable> child;
+@property (nonatomic, assign) UIEdgeInsets insets;
+
 /**
  @param insets The amount of space to inset on each side.
  @param child The wrapped child to inset. If nil, this method returns nil.
  */
-+ (instancetype)newWithInsets:(UIEdgeInsets)insets child:(id<ASLayoutable>)child;
++ (instancetype)insetLayoutSpecWithInsets:(UIEdgeInsets)insets child:(id<ASLayoutable>)child;
 
 @end

--- a/AsyncDisplayKit/Layout/ASInsetLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASInsetLayoutSpec.mm
@@ -45,12 +45,12 @@ static CGFloat centerInset(CGFloat outer, CGFloat inner)
 
 - (instancetype)initWithInsets:(UIEdgeInsets)insets child:(id<ASLayoutable>)child;
 {
-  self = [super init];
-  if (self) {
-    ASDisplayNodeAssertNotNil(child, @"Child cannot be nil");
-    _insets = insets;
-    _child = child;
+  if (!(self = [super init])) {
+    return nil;
   }
+  ASDisplayNodeAssertNotNil(child, @"Child cannot be nil");
+  _insets = insets;
+  _child = child;
   return self;
 }
 

--- a/AsyncDisplayKit/Layout/ASInsetLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASInsetLayoutSpec.mm
@@ -43,22 +43,32 @@ static CGFloat centerInset(CGFloat outer, CGFloat inner)
 
 @implementation ASInsetLayoutSpec
 
-+ (instancetype)newWithInsets:(UIEdgeInsets)insets child:(id<ASLayoutable>)child
+- (instancetype)initWithInsets:(UIEdgeInsets)insets child:(id<ASLayoutable>)child;
 {
-  if (child == nil) {
-    return nil;
+  self = [super init];
+  if (self) {
+    ASDisplayNodeAssertNotNil(child, @"Child cannot be nil");
+    _insets = insets;
+    _child = child;
   }
-  ASInsetLayoutSpec *spec = [super new];
-  if (spec) {
-    spec->_insets = insets;
-    spec->_child = child;
-  }
-  return spec;
+  return self;
 }
 
-+ (instancetype)new
++ (instancetype)insetLayoutSpecWithInsets:(UIEdgeInsets)insets child:(id<ASLayoutable>)child
 {
-  ASDISPLAYNODE_NOT_DESIGNATED_INITIALIZER();
+  return [[self alloc] initWithInsets:insets child:child];
+}
+
+- (void)setChild:(id<ASLayoutable>)child
+{
+  ASDisplayNodeAssert(self.isMutable, @"Cannot set properties when layout spec is not mutable");
+  _child = child;
+}
+
+- (void)setInsets:(UIEdgeInsets)insets
+{
+  ASDisplayNodeAssert(self.isMutable, @"Cannot set properties when layout spec is not mutable");
+  _insets = insets;
 }
 
 /**
@@ -103,7 +113,7 @@ static CGFloat centerInset(CGFloat outer, CGFloat inner)
   
   sublayout.position = CGPointMake(x, y);
   
-  return [ASLayout newWithLayoutableObject:self size:computedSize sublayouts:@[sublayout]];
+  return [ASLayout layoutWithLayoutableObject:self size:computedSize sublayouts:@[sublayout]];
 }
 
 @end

--- a/AsyncDisplayKit/Layout/ASLayout.h
+++ b/AsyncDisplayKit/Layout/ASLayout.h
@@ -43,10 +43,10 @@ extern BOOL CGPointIsNull(CGPoint point);
  *
  * @param sublayouts Sublayouts belong to the new layout.
  */
-+ (instancetype)newWithLayoutableObject:(id<ASLayoutable>)layoutableObject
-                                   size:(CGSize)size
-                               position:(CGPoint)position
-                             sublayouts:(NSArray *)sublayouts;
++ (instancetype)layoutWithLayoutableObject:(id<ASLayoutable>)layoutableObject
+                                      size:(CGSize)size
+                                  position:(CGPoint)position
+                                sublayouts:(NSArray *)sublayouts;
 
 /**
  * Convenience initializer that has CGPointNull position.
@@ -60,9 +60,9 @@ extern BOOL CGPointIsNull(CGPoint point);
  *
  * @param sublayouts Sublayouts belong to the new layout.
  */
-+ (instancetype)newWithLayoutableObject:(id<ASLayoutable>)layoutableObject
-                                   size:(CGSize)size
-                             sublayouts:(NSArray *)sublayouts;
++ (instancetype)layoutWithLayoutableObject:(id<ASLayoutable>)layoutableObject
+                                      size:(CGSize)size
+                                sublayouts:(NSArray *)sublayouts;
 
 /**
  * Convenience that has CGPointNull position and no sublayouts. 
@@ -73,7 +73,7 @@ extern BOOL CGPointIsNull(CGPoint point);
  *
  * @param size The size of this layout.
  */
-+ (instancetype)newWithLayoutableObject:(id<ASLayoutable>)layoutableObject size:(CGSize)size;
++ (instancetype)layoutWithLayoutableObject:(id<ASLayoutable>)layoutableObject size:(CGSize)size;
 
 
 /**

--- a/AsyncDisplayKit/Layout/ASLayout.mm
+++ b/AsyncDisplayKit/Layout/ASLayout.mm
@@ -22,10 +22,10 @@ extern BOOL CGPointIsNull(CGPoint point)
 
 @implementation ASLayout
 
-+ (instancetype)newWithLayoutableObject:(id<ASLayoutable>)layoutableObject
-                                   size:(CGSize)size
-                               position:(CGPoint)position
-                             sublayouts:(NSArray *)sublayouts
++ (instancetype)layoutWithLayoutableObject:(id<ASLayoutable>)layoutableObject
+                                      size:(CGSize)size
+                                  position:(CGPoint)position
+                                sublayouts:(NSArray *)sublayouts
 {
   ASDisplayNodeAssert(layoutableObject, @"layoutableObject is required.");
   for (ASLayout *sublayout in sublayouts) {
@@ -42,16 +42,16 @@ extern BOOL CGPointIsNull(CGPoint point)
   return l;
 }
 
-+ (instancetype)newWithLayoutableObject:(id<ASLayoutable>)layoutableObject
-                                   size:(CGSize)size
-                             sublayouts:(NSArray *)sublayouts
++ (instancetype)layoutWithLayoutableObject:(id<ASLayoutable>)layoutableObject
+                                      size:(CGSize)size
+                                sublayouts:(NSArray *)sublayouts
 {
-  return [self newWithLayoutableObject:layoutableObject size:size position:CGPointNull sublayouts:sublayouts];
+  return [self layoutWithLayoutableObject:layoutableObject size:size position:CGPointNull sublayouts:sublayouts];
 }
 
-+ (instancetype)newWithLayoutableObject:(id<ASLayoutable>)layoutableObject size:(CGSize)size
++ (instancetype)layoutWithLayoutableObject:(id<ASLayoutable>)layoutableObject size:(CGSize)size
 {
-  return [self newWithLayoutableObject:layoutableObject size:size sublayouts:nil];
+  return [self layoutWithLayoutableObject:layoutableObject size:size sublayouts:nil];
 }
 
 - (ASLayout *)flattenedLayoutUsingPredicateBlock:(BOOL (^)(ASLayout *))predicateBlock
@@ -76,10 +76,10 @@ extern BOOL CGPointIsNull(CGPoint point)
       context.visited = YES;
       
       if (predicateBlock(context.layout)) {
-        [flattenedSublayouts addObject:[ASLayout newWithLayoutableObject:context.layout.layoutableObject
-                                                                  size:context.layout.size
-                                                              position:context.absolutePosition
-                                                            sublayouts:nil]];
+        [flattenedSublayouts addObject:[ASLayout layoutWithLayoutableObject:context.layout.layoutableObject
+                                                                       size:context.layout.size
+                                                                   position:context.absolutePosition
+                                                                 sublayouts:nil]];
       }
       
       for (ASLayout *sublayout in context.layout.sublayouts) {
@@ -88,7 +88,7 @@ extern BOOL CGPointIsNull(CGPoint point)
     }
   }
   
-  return [ASLayout newWithLayoutableObject:_layoutableObject size:_size sublayouts:flattenedSublayouts];
+  return [ASLayout layoutWithLayoutableObject:_layoutableObject size:_size sublayouts:flattenedSublayouts];
 }
 
 @end

--- a/AsyncDisplayKit/Layout/ASLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASLayoutSpec.h
@@ -10,7 +10,16 @@
 
 #import <AsyncDisplayKit/ASLayoutable.h>
 
-/** A layout spec is an immutable object that describes a layout, loosely inspired by React. */
+/** A layout spec is an temporarly mutable object that describes a layout, loosely inspired by React. */
 @interface ASLayoutSpec : NSObject <ASLayoutable>
+
+/** 
+ Creation of a layout spec should only happen by a user in layoutSpecThatFits:. During that method, a
+ layout spec can be created and mutated. Once it is passed back to ASDK, the isMutable flag will be 
+ set to NO and any further mutations will cause an assert.
+ */
+@property (nonatomic, assign) BOOL isMutable;
+
+- (instancetype)init;
 
 @end

--- a/AsyncDisplayKit/Layout/ASLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASLayoutSpec.mm
@@ -27,11 +27,11 @@
 
 - (instancetype)init
 {
-  self = [super init];
-  if (self) {
-    _flexBasis = ASRelativeDimensionUnconstrained;
-    _isMutable = YES;
+  if (!(self = [super init])) {
+    return nil;
   }
+  _flexBasis = ASRelativeDimensionUnconstrained;
+  _isMutable = YES;
   return self;
 }
 

--- a/AsyncDisplayKit/Layout/ASLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASLayoutSpec.mm
@@ -25,20 +25,21 @@
 @synthesize flexBasis = _flexBasis;
 @synthesize alignSelf = _alignSelf;
 
-+ (instancetype)new
+- (instancetype)init
 {
-  ASLayoutSpec *spec = [super new];
-  if (spec) {
-    spec->_flexBasis = ASRelativeDimensionUnconstrained;
+  self = [super init];
+  if (self) {
+    _flexBasis = ASRelativeDimensionUnconstrained;
+    _isMutable = YES;
   }
-  return spec;
+  return self;
 }
 
 #pragma mark - Layout
 
 - (ASLayout *)measureWithSizeRange:(ASSizeRange)constrainedSize
 {
-  return [ASLayout newWithLayoutableObject:self size:constrainedSize.min];
+  return [ASLayout layoutWithLayoutableObject:self size:constrainedSize.min];
 }
 
 @end

--- a/AsyncDisplayKit/Layout/ASOverlayLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASOverlayLayoutSpec.h
@@ -18,6 +18,6 @@
 @property (nonatomic, strong) id<ASLayoutable> child;
 @property (nonatomic, strong) id<ASLayoutable> overlay;
 
-+ (instancetype)overlayLayoutWithChild:(id<ASLayoutable>)child overlay:(id<ASLayoutable>)overlay;
++ (instancetype)overlayLayoutSpecWithChild:(id<ASLayoutable>)child overlay:(id<ASLayoutable>)overlay;
 
 @end

--- a/AsyncDisplayKit/Layout/ASOverlayLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASOverlayLayoutSpec.h
@@ -15,6 +15,9 @@
  */
 @interface ASOverlayLayoutSpec : ASLayoutSpec
 
-+ (instancetype)newWithChild:(id<ASLayoutable>)child overlay:(id<ASLayoutable>)overlay;
+@property (nonatomic, strong) id<ASLayoutable> child;
+@property (nonatomic, strong) id<ASLayoutable> overlay;
+
++ (instancetype)overlayLayoutWithChild:(id<ASLayoutable>)child overlay:(id<ASLayoutable>)overlay;
 
 @end

--- a/AsyncDisplayKit/Layout/ASOverlayLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASOverlayLayoutSpec.mm
@@ -20,20 +20,32 @@
   id<ASLayoutable> _child;
 }
 
-+ (instancetype)newWithChild:(id<ASLayoutable>)child overlay:(id<ASLayoutable>)overlay
+- (instancetype)initWithChild:(id<ASLayoutable>)child overlay:(id<ASLayoutable>)overlay
 {
-  ASOverlayLayoutSpec *spec = [super new];
-  if (spec) {
+  self = [super init];
+  if (self) {
     ASDisplayNodeAssertNotNil(child, @"Child that will be overlayed on shouldn't be nil");
-    spec->_overlay = overlay;
-    spec->_child = child;
+    _overlay = overlay;
+    _child = child;
   }
-  return spec;
+  return self;
 }
 
-+ (instancetype)new
++ (instancetype)overlayLayoutWithChild:(id<ASLayoutable>)child overlay:(id<ASLayoutable>)overlay
 {
-  ASDISPLAYNODE_NOT_DESIGNATED_INITIALIZER();
+  return [[self alloc] initWithChild:child overlay:overlay];
+}
+
+- (void)setChild:(id<ASLayoutable>)child
+{
+  ASDisplayNodeAssert(self.isMutable, @"Cannot set properties when layout spec is not mutable");
+  _child = child;
+}
+
+- (void)setOverlay:(id<ASLayoutable>)overlay
+{
+  ASDisplayNodeAssert(self.isMutable, @"Cannot set properties when layout spec is not mutable");
+  _overlay = overlay;
 }
 
 /**
@@ -50,7 +62,7 @@
     [sublayouts addObject:overlayLayout];
   }
   
-  return [ASLayout newWithLayoutableObject:self size:contentsLayout.size sublayouts:sublayouts];
+  return [ASLayout layoutWithLayoutableObject:self size:contentsLayout.size sublayouts:sublayouts];
 }
 
 @end

--- a/AsyncDisplayKit/Layout/ASOverlayLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASOverlayLayoutSpec.mm
@@ -22,16 +22,16 @@
 
 - (instancetype)initWithChild:(id<ASLayoutable>)child overlay:(id<ASLayoutable>)overlay
 {
-  self = [super init];
-  if (self) {
-    ASDisplayNodeAssertNotNil(child, @"Child that will be overlayed on shouldn't be nil");
-    _overlay = overlay;
-    _child = child;
+  if (!(self = [super init])) {
+    return nil;
   }
+  ASDisplayNodeAssertNotNil(child, @"Child that will be overlayed on shouldn't be nil");
+  _overlay = overlay;
+  _child = child;
   return self;
 }
 
-+ (instancetype)overlayLayoutWithChild:(id<ASLayoutable>)child overlay:(id<ASLayoutable>)overlay
++ (instancetype)overlayLayoutSpecWithChild:(id<ASLayoutable>)child overlay:(id<ASLayoutable>)overlay
 {
   return [[self alloc] initWithChild:child overlay:overlay];
 }

--- a/AsyncDisplayKit/Layout/ASRatioLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASRatioLayoutSpec.h
@@ -31,6 +31,10 @@
  **/
 @interface ASRatioLayoutSpec : ASLayoutSpec
 
-+ (instancetype)newWithRatio:(CGFloat)ratio child:(id<ASLayoutable>)child;
+
+@property (nonatomic, strong) id<ASLayoutable> child;
+@property (nonatomic, assign) CGFloat ratio;
+
++ (instancetype)ratioLayoutSpecWithRatio:(CGFloat)ratio child:(id<ASLayoutable>)child;
 
 @end

--- a/AsyncDisplayKit/Layout/ASRatioLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASRatioLayoutSpec.mm
@@ -32,13 +32,13 @@
 
 - (instancetype)initWithRatio:(CGFloat)ratio child:(id<ASLayoutable>)child;
 {
-  self = [super init];
-  if (self) {
-    ASDisplayNodeAssertNotNil(child, @"Child cannot be nil");
-    ASDisplayNodeAssert(ratio > 0, @"Ratio should be strictly positive, but received %f", ratio);
-    _ratio = ratio;
-    _child = child;
+  if (!(self = [super init])) {
+    return nil;
   }
+  ASDisplayNodeAssertNotNil(child, @"Child cannot be nil");
+  ASDisplayNodeAssert(ratio > 0, @"Ratio should be strictly positive, but received %f", ratio);
+  _ratio = ratio;
+  _child = child;
   return self;
 }
 

--- a/AsyncDisplayKit/Layout/ASRatioLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASRatioLayoutSpec.mm
@@ -25,24 +25,33 @@
   id<ASLayoutable> _child;
 }
 
-+ (instancetype)newWithRatio:(CGFloat)ratio child:(id<ASLayoutable>)child
++ (instancetype)ratioLayoutSpecWithRatio:(CGFloat)ratio child:(id<ASLayoutable>)child
 {
-  ASDisplayNodeAssert(ratio > 0, @"Ratio should be strictly positive, but received %f", ratio);
-  if (child == nil) {
-    return nil;
-  }
-
-  ASRatioLayoutSpec *spec = [super new];
-  if (spec) {
-    spec->_ratio = ratio;
-    spec->_child = child;
-  }
-  return spec;
+  return [[self alloc] initWithRatio:ratio child:child];
 }
 
-+ (instancetype)new
+- (instancetype)initWithRatio:(CGFloat)ratio child:(id<ASLayoutable>)child;
 {
-    ASDISPLAYNODE_NOT_DESIGNATED_INITIALIZER();
+  self = [super init];
+  if (self) {
+    ASDisplayNodeAssertNotNil(child, @"Child cannot be nil");
+    ASDisplayNodeAssert(ratio > 0, @"Ratio should be strictly positive, but received %f", ratio);
+    _ratio = ratio;
+    _child = child;
+  }
+  return self;
+}
+
+- (void)setChild:(id<ASLayoutable>)child
+{
+  ASDisplayNodeAssert(self.isMutable, @"Cannot set properties when layout spec is not mutable");
+  _child = child;
+}
+
+- (void)setRatio:(CGFloat)ratio
+{
+  ASDisplayNodeAssert(self.isMutable, @"Cannot set properties when layout spec is not mutable");
+  _ratio = ratio;
 }
 
 - (ASLayout *)measureWithSizeRange:(ASSizeRange)constrainedSize
@@ -70,7 +79,7 @@
   const ASSizeRange childRange = (bestSize == sizeOptions.end()) ? constrainedSize : ASSizeRangeMake(*bestSize, *bestSize);
   ASLayout *sublayout = [_child measureWithSizeRange:childRange];
   sublayout.position = CGPointZero;
-  return [ASLayout newWithLayoutableObject:self size:sublayout.size sublayouts:@[sublayout]];
+  return [ASLayout layoutWithLayoutableObject:self size:sublayout.size sublayouts:@[sublayout]];
 }
 
 @end

--- a/AsyncDisplayKit/Layout/ASStackLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASStackLayoutSpec.h
@@ -49,16 +49,6 @@ typedef NS_ENUM(NSUInteger, ASStackLayoutAlignItems) {
   ASStackLayoutAlignItemsStretch,
 };
 
-typedef struct {
-  /** Specifies the direction children are stacked in. */
-  ASStackLayoutDirection direction;
-  /** The amount of space between each child. */
-  CGFloat spacing;
-  /** How children are aligned if there are no flexible children. */
-  ASStackLayoutJustifyContent justifyContent;
-  /** Orientation of children along cross axis */
-  ASStackLayoutAlignItems alignItems;
-} ASStackLayoutSpecStyle;
 
 /**
  A simple layout spec that stacks a list of children vertically or horizontally.
@@ -83,10 +73,29 @@ typedef struct {
  */
 @interface ASStackLayoutSpec : ASLayoutSpec
 
+/** Specifies the direction children are stacked in. */
+@property (nonatomic, assign) ASStackLayoutDirection direction;
+/** The amount of space between each child. */
+@property (nonatomic, assign) CGFloat spacing;
+/** The amount of space between each child. */
+@property (nonatomic, assign) ASStackLayoutJustifyContent justifyContent;
+/** Orientation of children along cross axis */
+@property (nonatomic, assign) ASStackLayoutAlignItems alignItems;
+
+- (instancetype)init;
+
 /**
  @param style Specifies how children are laid out.
  @param children ASLayoutable children to be positioned.
  */
-+ (instancetype)newWithStyle:(ASStackLayoutSpecStyle)style children:(NSArray *)children;
++ (instancetype)satckLayoutSpecWithDirection:(ASStackLayoutDirection)direction
+                                     spacing:(CGFloat)spacing
+                        contentJustification:(ASStackLayoutJustifyContent)justifyContent
+                               itemAlignment:(ASStackLayoutAlignItems)alignItems
+                                    children:(NSArray *)children;
+
+
+- (void)addChild:(id<ASLayoutable>)child;
+- (void)addChildren:(NSArray *)children;
 
 @end

--- a/AsyncDisplayKit/Layout/ASStackLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASStackLayoutSpec.h
@@ -85,15 +85,13 @@ typedef NS_ENUM(NSUInteger, ASStackLayoutAlignItems) {
 - (instancetype)init;
 
 /**
- @param style Specifies how children are laid out.
+ @param direction The direction of the stack view (horizontal or vertical)
+ @param spacing The spacing between the children
+ @param justifyContent If no children are flexible, this describes how to fill any extra space
+ @param alignItems Orientation of the children along the cross axis
  @param children ASLayoutable children to be positioned.
  */
-+ (instancetype)satckLayoutSpecWithDirection:(ASStackLayoutDirection)direction
-                                     spacing:(CGFloat)spacing
-                        contentJustification:(ASStackLayoutJustifyContent)justifyContent
-                               itemAlignment:(ASStackLayoutAlignItems)alignItems
-                                    children:(NSArray *)children;
-
++ (instancetype)stackLayoutSpecWithDirection:(ASStackLayoutDirection)direction spacing:(CGFloat)spacing justifyContent:(ASStackLayoutJustifyContent)justifyContent alignItems:(ASStackLayoutAlignItems)alignItems children:(NSArray *)children;
 
 - (void)addChild:(id<ASLayoutable>)child;
 - (void)addChildren:(NSArray *)children;

--- a/AsyncDisplayKit/Layout/ASStackLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASStackLayoutSpec.mm
@@ -28,43 +28,27 @@
 
 - (instancetype)init
 {
-  return [self initWithDirection:ASStackLayoutDirectionHorizontal
-                         spacing:0.0
-            contentJustification:ASStackLayoutJustifyContentStart
-                   itemAlignment:ASStackLayoutAlignItemsStart
-                        children:nil];
+  return [self initWithDirection:ASStackLayoutDirectionHorizontal spacing:0.0 justifyContent:ASStackLayoutJustifyContentStart alignItems:ASStackLayoutAlignItemsStart children:nil];
 }
 
-+ (instancetype)satckLayoutSpecWithDirection:(ASStackLayoutDirection)direction
-                                     spacing:(CGFloat)spacing
-                        contentJustification:(ASStackLayoutJustifyContent)justifyContent
-                               itemAlignment:(ASStackLayoutAlignItems)alignItems
-                                    children:(NSArray *)children
++ (instancetype)stackLayoutSpecWithDirection:(ASStackLayoutDirection)direction spacing:(CGFloat)spacing justifyContent:(ASStackLayoutJustifyContent)justifyContent alignItems:(ASStackLayoutAlignItems)alignItems children:(NSArray *)children
 {
-  return [[self alloc] initWithDirection:direction
-                                 spacing:spacing
-                    contentJustification:justifyContent
-                           itemAlignment:alignItems
-                                children:children];
+  return [[self alloc] initWithDirection:direction spacing:spacing justifyContent:justifyContent alignItems:alignItems children:children];
 }
 
-- (instancetype)initWithDirection:(ASStackLayoutDirection)direction
-                          spacing:(CGFloat)spacing
-             contentJustification:(ASStackLayoutJustifyContent)justifyContent
-                    itemAlignment:(ASStackLayoutAlignItems)alignItems
-                         children:(NSArray *)children;
+- (instancetype)initWithDirection:(ASStackLayoutDirection)direction spacing:(CGFloat)spacing justifyContent:(ASStackLayoutJustifyContent)justifyContent alignItems:(ASStackLayoutAlignItems)alignItems children:(NSArray *)children
 {
-  self = [super init];
-  if (self) {
-    _direction = direction;
-    _alignItems = alignItems;
-    _spacing = spacing;
-    _justifyContent = justifyContent;
-    
-    _children = std::vector<id<ASLayoutable>>();
-    for (id<ASLayoutable> child in children) {
-      _children.push_back(child);
-    }
+  if (!(self = [super init])) {
+    return nil;
+  }
+  _direction = direction;
+  _alignItems = alignItems;
+  _spacing = spacing;
+  _justifyContent = justifyContent;
+  
+  _children = std::vector<id<ASLayoutable>>();
+  for (id<ASLayoutable> child in children) {
+    _children.push_back(child);
   }
   return self;
 }
@@ -81,7 +65,6 @@
     [self addChild:child];
   }
 }
-
 
 - (void)setDirection:(ASStackLayoutDirection)direction
 {
@@ -109,11 +92,7 @@
 
 - (ASLayout *)measureWithSizeRange:(ASSizeRange)constrainedSize
 {
-  ASStackLayoutSpecStyle style = {.direction = _direction,
-    .spacing = _spacing,
-    .justifyContent = _justifyContent,
-    .alignItems = _alignItems
-  };
+  ASStackLayoutSpecStyle style = {.direction = _direction, .spacing = _spacing, .justifyContent = _justifyContent, .alignItems = _alignItems};
   const auto unpositionedLayout = ASStackUnpositionedLayout::compute(_children, style, constrainedSize);
   const auto positionedLayout = ASStackPositionedLayout::compute(unpositionedLayout, style, constrainedSize);
   const CGSize finalSize = directionSize(style.direction, unpositionedLayout.stackDimensionSum, positionedLayout.crossSize);

--- a/AsyncDisplayKit/Layout/ASStackLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASStackLayoutSpec.mm
@@ -23,37 +23,104 @@
 
 @implementation ASStackLayoutSpec
 {
-  ASStackLayoutSpecStyle _style;
   std::vector<id<ASLayoutable>> _children;
 }
 
-+ (instancetype)newWithStyle:(ASStackLayoutSpecStyle)style children:(NSArray *)children
+- (instancetype)init
 {
-  ASStackLayoutSpec *spec = [super new];
-  if (spec) {
-    spec->_style = style;
-    spec->_children = std::vector<id<ASLayoutable>>();
-    for (id<ASLayoutable> child in children) {
-      spec->_children.push_back(child);
-    }
-  }
-  return spec;
+  return [self initWithDirection:ASStackLayoutDirectionHorizontal
+                         spacing:0.0
+            contentJustification:ASStackLayoutJustifyContentStart
+                   itemAlignment:ASStackLayoutAlignItemsStart
+                        children:nil];
 }
 
-+ (instancetype)new
++ (instancetype)satckLayoutSpecWithDirection:(ASStackLayoutDirection)direction
+                                     spacing:(CGFloat)spacing
+                        contentJustification:(ASStackLayoutJustifyContent)justifyContent
+                               itemAlignment:(ASStackLayoutAlignItems)alignItems
+                                    children:(NSArray *)children
 {
-  ASDISPLAYNODE_NOT_DESIGNATED_INITIALIZER();
+  return [[self alloc] initWithDirection:direction
+                                 spacing:spacing
+                    contentJustification:justifyContent
+                           itemAlignment:alignItems
+                                children:children];
+}
+
+- (instancetype)initWithDirection:(ASStackLayoutDirection)direction
+                          spacing:(CGFloat)spacing
+             contentJustification:(ASStackLayoutJustifyContent)justifyContent
+                    itemAlignment:(ASStackLayoutAlignItems)alignItems
+                         children:(NSArray *)children;
+{
+  self = [super init];
+  if (self) {
+    _direction = direction;
+    _alignItems = alignItems;
+    _spacing = spacing;
+    _justifyContent = justifyContent;
+    
+    _children = std::vector<id<ASLayoutable>>();
+    for (id<ASLayoutable> child in children) {
+      _children.push_back(child);
+    }
+  }
+  return self;
+}
+
+- (void)addChild:(id<ASLayoutable>)child
+{
+  ASDisplayNodeAssert(self.isMutable, @"Cannot set properties when layout spec is not mutable");
+  _children.push_back(child);
+}
+
+- (void)addChildren:(NSArray *)children
+{
+  for (id<ASLayoutable> child in children) {
+    [self addChild:child];
+  }
+}
+
+
+- (void)setDirection:(ASStackLayoutDirection)direction
+{
+  ASDisplayNodeAssert(self.isMutable, @"Cannot set properties when layout spec is not mutable");
+  _direction = direction;
+}
+
+- (void)setAlignItems:(ASStackLayoutAlignItems)alignItems
+{
+  ASDisplayNodeAssert(self.isMutable, @"Cannot set properties when layout spec is not mutable");
+  _alignItems = alignItems;
+}
+
+- (void)setJustifyContent:(ASStackLayoutJustifyContent)justifyContent
+{
+  ASDisplayNodeAssert(self.isMutable, @"Cannot set properties when layout spec is not mutable");
+  _justifyContent = justifyContent;
+}
+
+- (void)setSpacing:(CGFloat)spacing
+{
+  ASDisplayNodeAssert(self.isMutable, @"Cannot set properties when layout spec is not mutable");
+  _spacing = spacing;
 }
 
 - (ASLayout *)measureWithSizeRange:(ASSizeRange)constrainedSize
 {
-  const auto unpositionedLayout = ASStackUnpositionedLayout::compute(_children, _style, constrainedSize);
-  const auto positionedLayout = ASStackPositionedLayout::compute(unpositionedLayout, _style, constrainedSize);
-  const CGSize finalSize = directionSize(_style.direction, unpositionedLayout.stackDimensionSum, positionedLayout.crossSize);
+  ASStackLayoutSpecStyle style = {.direction = _direction,
+    .spacing = _spacing,
+    .justifyContent = _justifyContent,
+    .alignItems = _alignItems
+  };
+  const auto unpositionedLayout = ASStackUnpositionedLayout::compute(_children, style, constrainedSize);
+  const auto positionedLayout = ASStackPositionedLayout::compute(unpositionedLayout, style, constrainedSize);
+  const CGSize finalSize = directionSize(style.direction, unpositionedLayout.stackDimensionSum, positionedLayout.crossSize);
   NSArray *sublayouts = [NSArray arrayWithObjects:&positionedLayout.sublayouts[0] count:positionedLayout.sublayouts.size()];
-  return [ASLayout newWithLayoutableObject:self
-                                      size:ASSizeRangeClamp(constrainedSize, finalSize)
-                                sublayouts:sublayouts];
+  return [ASLayout layoutWithLayoutableObject:self
+                                         size:ASSizeRangeClamp(constrainedSize, finalSize)
+                                   sublayouts:sublayouts];
 }
 
 @end

--- a/AsyncDisplayKit/Layout/ASStaticLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASStaticLayoutSpec.h
@@ -34,7 +34,7 @@
  *
  * @param size The size range that this child's size is trstricted according to.
  */
-+ (instancetype)newWithPosition:(CGPoint)position layoutableObject:(id<ASLayoutable>)layoutableObject size:(ASRelativeSizeRange)size;
++ (instancetype)staticLayoutChildWithPosition:(CGPoint)position layoutableObject:(id<ASLayoutable>)layoutableObject size:(ASRelativeSizeRange)size;
 
 /**
  * Convenience initializer with default size is Unconstrained in both dimensions, which sets the child's min size to zero
@@ -44,7 +44,7 @@
  *
  * @param layoutableObject The backing ASLayoutable object of this child.
  */
-+ (instancetype)newWithPosition:(CGPoint)position layoutableObject:(id<ASLayoutable>)layoutableObject;
++ (instancetype)staticLayoutChildWithPosition:(CGPoint)position layoutableObject:(id<ASLayoutable>)layoutableObject;
 
 @end
 
@@ -58,6 +58,8 @@
 /**
  @param children Children to be positioned at fixed positions, each is of type ASStaticLayoutSpecChild.
  */
-+ (instancetype)newWithChildren:(NSArray *)children;
++ (instancetype)staticLayoutSpecWithChildren:(NSArray *)children;
+
+- (void)addChild:(ASStaticLayoutSpecChild *)child;
 
 @end

--- a/AsyncDisplayKit/Layout/ASStaticLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASStaticLayoutSpec.mm
@@ -16,9 +16,9 @@
 
 @implementation ASStaticLayoutSpecChild
 
-+ (instancetype)newWithPosition:(CGPoint)position layoutableObject:(id<ASLayoutable>)layoutableObject size:(ASRelativeSizeRange)size
++ (instancetype)staticLayoutChildWithPosition:(CGPoint)position layoutableObject:(id<ASLayoutable>)layoutableObject size:(ASRelativeSizeRange)size;
 {
-  ASStaticLayoutSpecChild *c = [super new];
+  ASStaticLayoutSpecChild *c = [[super alloc] init];
   if (c) {
     c->_position = position;
     c->_layoutableObject = layoutableObject;
@@ -27,9 +27,9 @@
   return c;
 }
 
-+ (instancetype)newWithPosition:(CGPoint)position layoutableObject:(id<ASLayoutable>)layoutableObject
++ (instancetype)staticLayoutChildWithPosition:(CGPoint)position layoutableObject:(id<ASLayoutable>)layoutableObject
 {
-  return [self newWithPosition:position layoutableObject:layoutableObject size:ASRelativeSizeRangeUnconstrained];
+  return [self staticLayoutChildWithPosition:position layoutableObject:layoutableObject size:ASRelativeSizeRangeUnconstrained];
 }
 
 @end
@@ -39,18 +39,24 @@
   NSArray *_children;
 }
 
-+ (instancetype)newWithChildren:(NSArray *)children
++ (instancetype)staticLayoutSpecWithChildren:(NSArray *)children
 {
-  ASStaticLayoutSpec *spec = [super new];
-  if (spec) {
-    spec->_children = children;
-  }
-  return spec;
+  return [[self alloc] initWithChildren:children];
 }
 
-+ (instancetype)new
+- (instancetype)initWithChildren:(NSArray *)children
 {
-  ASDISPLAYNODE_NOT_DESIGNATED_INITIALIZER();
+  self = [super init];
+  if (self) {
+    _children = children;
+  }
+  return self;
+}
+
+- (void)addChild:(ASStaticLayoutSpecChild *)child
+{
+  ASDisplayNodeAssert(self.isMutable, @"Cannot set properties when layout spec is not mutable");
+  _children = [_children arrayByAddingObject:child];
 }
 
 - (ASLayout *)measureWithSizeRange:(ASSizeRange)constrainedSize
@@ -88,9 +94,9 @@
     }
   }
 
-  return [ASLayout newWithLayoutableObject:self
-                                      size:ASSizeRangeClamp(constrainedSize, size)
-                                sublayouts:sublayouts];
+  return [ASLayout layoutWithLayoutableObject:self
+                                         size:ASSizeRangeClamp(constrainedSize, size)
+                                   sublayouts:sublayouts];
 }
 
 @end

--- a/AsyncDisplayKit/Layout/ASStaticLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASStaticLayoutSpec.mm
@@ -46,10 +46,10 @@
 
 - (instancetype)initWithChildren:(NSArray *)children
 {
-  self = [super init];
-  if (self) {
-    _children = children;
+  if (!(self = [super init])) {
+    return nil;
   }
+  _children = children;
   return self;
 }
 

--- a/AsyncDisplayKit/Private/ASStackLayoutSpecUtilities.h
+++ b/AsyncDisplayKit/Private/ASStackLayoutSpecUtilities.h
@@ -10,6 +10,13 @@
 
 #import "ASStackLayoutSpec.h"
 
+typedef struct {
+  ASStackLayoutDirection direction;
+  CGFloat spacing;
+  ASStackLayoutJustifyContent justifyContent;
+  ASStackLayoutAlignItems alignItems;
+} ASStackLayoutSpecStyle;
+
 inline CGFloat stackDimension(const ASStackLayoutDirection direction, const CGSize size)
 {
   return (direction == ASStackLayoutDirectionVertical) ? size.height : size.width;

--- a/AsyncDisplayKit/Private/ASStackUnpositionedLayout.h
+++ b/AsyncDisplayKit/Private/ASStackUnpositionedLayout.h
@@ -11,6 +11,7 @@
 #import <vector>
 
 #import "ASLayout.h"
+#import "ASStackLayoutSpecUtilities.h"
 #import "ASStackLayoutSpec.h"
 
 struct ASStackUnpositionedItem {

--- a/AsyncDisplayKit/Private/ASStackUnpositionedLayout.mm
+++ b/AsyncDisplayKit/Private/ASStackUnpositionedLayout.mm
@@ -297,7 +297,7 @@ static std::vector<ASStackUnpositionedItem> layoutChildrenAlongUnconstrainedStac
     const CGFloat exactStackDimension = ASRelativeDimensionResolve(child.flexBasis, stackDimension(style.direction, size));
 
     if (useOptimizedFlexing && isFlexibleInBothDirections(child)) {
-      return { child, [ASLayout newWithLayoutableObject:child size:{0, 0}] };
+      return { child, [ASLayout layoutWithLayoutableObject:child size:{0, 0}] };
     } else {
       return {
         child,

--- a/AsyncDisplayKitTests/ASCenterLayoutSpecSnapshotTests.mm
+++ b/AsyncDisplayKitTests/ASCenterLayoutSpecSnapshotTests.mm
@@ -52,9 +52,9 @@ static const ASSizeRange kSize = {{100, 120}, {320, 160}};
 
   ASLayoutSpec *layoutSpec =
   [ASBackgroundLayoutSpec
-   newWithChild:
+   backgroundLayoutSpecWithChild:
    [ASCenterLayoutSpec
-    newWithCenteringOptions:options
+    centerLayoutSpecWithCenteringOptions:options
     sizingOptions:sizingOptions
     child:foregroundNode]
    background:backgroundNode];
@@ -98,11 +98,11 @@ static NSString *suffixForCenteringOptions(ASCenterLayoutSpecCenteringOptions ce
   
   ASCenterLayoutSpec *layoutSpec =
   [ASCenterLayoutSpec
-   newWithCenteringOptions:ASCenterLayoutSpecCenteringNone
+   centerLayoutSpecWithCenteringOptions:ASCenterLayoutSpecCenteringNone
    sizingOptions:{}
    child:
    [ASBackgroundLayoutSpec
-    newWithChild:[ASStackLayoutSpec newWithStyle:{} children:@[foregroundNode]]
+    backgroundLayoutSpecWithChild:[ASStackLayoutSpec stackLayoutSpecWithDirection:ASStackLayoutDirectionVertical spacing:0 justifyContent:ASStackLayoutJustifyContentStart alignItems:ASStackLayoutAlignItemsStart children:@[foregroundNode]]
     background:backgroundNode]];
 
   [self testLayoutSpec:layoutSpec sizeRange:kSize subnodes:@[backgroundNode, foregroundNode] identifier:nil];

--- a/AsyncDisplayKitTests/ASInsetLayoutSpecSnapshotTests.mm
+++ b/AsyncDisplayKitTests/ASInsetLayoutSpecSnapshotTests.mm
@@ -61,7 +61,7 @@ static NSString *nameForInsets(UIEdgeInsets insets)
     
     ASLayoutSpec *layoutSpec =
     [ASBackgroundLayoutSpec
-     newWithChild:[ASInsetLayoutSpec newWithInsets:insets child:foregroundNode]
+     backgroundLayoutSpecWithChild:[ASInsetLayoutSpec insetLayoutSpecWithInsets:insets child:foregroundNode]
      background:backgroundNode];
     
     static ASSizeRange kVariableSize = {{0, 0}, {300, 300}};
@@ -82,7 +82,7 @@ static NSString *nameForInsets(UIEdgeInsets insets)
     
     ASLayoutSpec *layoutSpec =
     [ASBackgroundLayoutSpec
-     newWithChild:[ASInsetLayoutSpec newWithInsets:insets child:foregroundNode]
+     backgroundLayoutSpecWithChild:[ASInsetLayoutSpec insetLayoutSpecWithInsets:insets child:foregroundNode]
      background:backgroundNode];
 
     static ASSizeRange kFixedSize = {{300, 300}, {300, 300}};
@@ -104,7 +104,7 @@ static NSString *nameForInsets(UIEdgeInsets insets)
 
     ASLayoutSpec *layoutSpec =
     [ASBackgroundLayoutSpec
-     newWithChild:[ASInsetLayoutSpec newWithInsets:insets child:foregroundNode]
+     backgroundLayoutSpecWithChild:[ASInsetLayoutSpec insetLayoutSpecWithInsets:insets child:foregroundNode]
      background:backgroundNode];
 
     static ASSizeRange kFixedSize = {{300, 300}, {300, 300}};

--- a/AsyncDisplayKitTests/ASLayoutSpecSnapshotTestsHelper.m
+++ b/AsyncDisplayKitTests/ASLayoutSpecSnapshotTestsHelper.m
@@ -55,7 +55,7 @@
 {
   ASLayout *layout = [layoutSpecUnderTest measureWithSizeRange:sizeRange];
   layout.position = CGPointZero;
-  layout = [ASLayout newWithLayoutableObject:self size:layout.size sublayouts:@[layout]];
+  layout = [ASLayout layoutWithLayoutableObject:self size:layout.size sublayouts:@[layout]];
   _layoutUnderTest = [layout flattenedLayoutUsingPredicateBlock:^BOOL(ASLayout *evaluatedLayout) {
     return [self.subnodes containsObject:evaluatedLayout.layoutableObject];
   }];

--- a/AsyncDisplayKitTests/ASOverlayLayoutSpecSnapshotTests.mm
+++ b/AsyncDisplayKitTests/ASOverlayLayoutSpecSnapshotTests.mm
@@ -34,10 +34,10 @@ static const ASSizeRange kSize = {{320, 320}, {320, 320}};
   
   ASLayoutSpec *layoutSpec =
   [ASOverlayLayoutSpec
-   newWithChild:backgroundNode
+   overlayLayoutSpecWithChild:backgroundNode
    overlay:
    [ASCenterLayoutSpec
-    newWithCenteringOptions:ASCenterLayoutSpecCenteringXY
+    centerLayoutSpecWithCenteringOptions:ASCenterLayoutSpecCenteringXY
     sizingOptions:{}
     child:foregroundNode]];
   

--- a/AsyncDisplayKitTests/ASRatioLayoutSpecSnapshotTests.mm
+++ b/AsyncDisplayKitTests/ASRatioLayoutSpecSnapshotTests.mm
@@ -30,7 +30,7 @@ static const ASSizeRange kFixedSize = {{0, 0}, {100, 100}};
   ASStaticSizeDisplayNode *subnode = ASDisplayNodeWithBackgroundColor([UIColor greenColor]);
   subnode.staticSize = childSize;
   
-  ASLayoutSpec *layoutSpec = [ASRatioLayoutSpec newWithRatio:ratio child:subnode];
+  ASLayoutSpec *layoutSpec = [ASRatioLayoutSpec ratioLayoutSpecWithRatio:ratio child:subnode];
   
   [self testLayoutSpec:layoutSpec sizeRange:kFixedSize subnodes:@[subnode] identifier:identifier];
 }

--- a/AsyncDisplayKitTests/ASStackLayoutSpecSnapshotTests.mm
+++ b/AsyncDisplayKitTests/ASStackLayoutSpecSnapshotTests.mm
@@ -11,6 +11,7 @@
 #import "ASLayoutSpecSnapshotTestsHelper.h"
 
 #import "ASStackLayoutSpec.h"
+#import "ASStackLayoutSpecUtilities.h"
 #import "ASBackgroundLayoutSpec.h"
 #import "ASRatioLayoutSpec.h"
 #import "ASInsetLayoutSpec.h"
@@ -79,7 +80,7 @@ static NSArray *defaultSubnodesWithSameSize(CGSize subnodeSize, BOOL flex)
   
   ASLayoutSpec *layoutSpec =
   [ASBackgroundLayoutSpec
-   newWithChild:[ASStackLayoutSpec newWithStyle:style children:children]
+   backgroundLayoutSpecWithChild:[ASStackLayoutSpec stackLayoutSpecWithDirection:style.direction spacing:style.spacing justifyContent:style.justifyContent alignItems:style.alignItems children:children]
    background:backgroundNode];
   
   NSMutableArray *newSubnodes = [NSMutableArray arrayWithObject:backgroundNode];
@@ -179,17 +180,12 @@ static NSArray *defaultSubnodesWithSameSize(CGSize subnodeSize, BOOL flex)
 
   ASLayoutSpec *layoutSpec =
   [ASInsetLayoutSpec
-   newWithInsets:{10, 10, 10 ,10}
+   insetLayoutSpecWithInsets:{10, 10, 10 ,10}
    child:
    [ASBackgroundLayoutSpec
-    newWithChild:
+    backgroundLayoutSpecWithChild:
     [ASStackLayoutSpec
-     newWithStyle:{
-       .direction = ASStackLayoutDirectionVertical,
-       .spacing = 10,
-       .alignItems = ASStackLayoutAlignItemsStretch
-     }
-     children:@[]]
+     stackLayoutSpecWithDirection:ASStackLayoutDirectionVertical spacing:10 justifyContent:ASStackLayoutJustifyContentStart alignItems:ASStackLayoutAlignItemsStretch children:@[]]
     background:backgroundNode]];
   
   // width 300px; height 0-300px
@@ -257,7 +253,7 @@ static NSArray *defaultSubnodesWithSameSize(CGSize subnodeSize, BOOL flex)
   ASStaticSizeDisplayNode * subnode2 = ASDisplayNodeWithBackgroundColor([UIColor redColor]);
   subnode2.staticSize = {50, 50};
   
-  ASRatioLayoutSpec *child1 = [ASRatioLayoutSpec newWithRatio:1.5 child:subnode1];
+  ASRatioLayoutSpec *child1 = [ASRatioLayoutSpec ratioLayoutSpecWithRatio:1.5 child:subnode1];
   child1.flexBasis = ASRelativeDimensionMakeWithPercent(1);
   child1.flexGrow = YES;
   child1.flexShrink = YES;
@@ -481,7 +477,7 @@ static NSArray *defaultSubnodesWithSameSize(CGSize subnodeSize, BOOL flex)
   ((ASStaticSizeDisplayNode *)subnodes[1]).staticSize = {10, 0};
   ((ASStaticSizeDisplayNode *)subnodes[2]).staticSize = {3000, 3000};
   
-  ASRatioLayoutSpec *child2 = [ASRatioLayoutSpec newWithRatio:1.0 child:subnodes[2]];
+  ASRatioLayoutSpec *child2 = [ASRatioLayoutSpec ratioLayoutSpecWithRatio:1.0 child:subnodes[2]];
   child2.flexGrow = YES;
   child2.flexShrink = YES;
 
@@ -489,16 +485,12 @@ static NSArray *defaultSubnodesWithSameSize(CGSize subnodeSize, BOOL flex)
   // Instead it should be stretched to 300 points tall, matching the red child and not overlapping the green inset.
   ASLayoutSpec *layoutSpec =
   [ASBackgroundLayoutSpec
-   newWithChild:
+   backgroundLayoutSpecWithChild:
    [ASInsetLayoutSpec
-    newWithInsets:UIEdgeInsetsMake(10, 10, 10, 10)
+    insetLayoutSpecWithInsets:UIEdgeInsetsMake(10, 10, 10, 10)
     child:
-    [ASStackLayoutSpec
-     newWithStyle:{
-      .direction = ASStackLayoutDirectionHorizontal,
-      .alignItems = ASStackLayoutAlignItemsStretch,
-     }
-     children:@[subnodes[1], child2,]]]
+    [ASStackLayoutSpec stackLayoutSpecWithDirection:ASStackLayoutDirectionHorizontal spacing:0 justifyContent:ASStackLayoutJustifyContentStart alignItems:ASStackLayoutAlignItemsStretch children:@[subnodes[1], child2,]]
+    ]
    background:subnodes[0]];
 
   static ASSizeRange kSize = {{300, 0}, {300, INFINITY}};

--- a/examples/Kittens/Sample.xcodeproj/project.pbxproj
+++ b/examples/Kittens/Sample.xcodeproj/project.pbxproj
@@ -58,7 +58,9 @@
 				1A943BF0259746F18D6E423F /* Frameworks */,
 				1AE410B73DA5C3BD087ACDD7 /* Pods */,
 			);
+			indentWidth = 2;
 			sourceTree = "<group>";
+			tabWidth = 2;
 		};
 		05E2128219D4DB510098F589 /* Products */ = {
 			isa = PBXGroup;

--- a/examples/Kittens/Sample/BlurbNode.m
+++ b/examples/Kittens/Sample/BlurbNode.m
@@ -81,9 +81,8 @@ static NSString *kLinkAttributeName = @"PlaceKittenNodeLinkAttributeName";
   centerSpec.sizingOptions = ASCenterLayoutSpecSizingOptionMinimumY;
   centerSpec.child = _textNode;
   
-  
-  return [ASInsetLayoutSpec insetLayoutSpecWithInsets:UIEdgeInsetsMake(kTextPadding, kTextPadding, kTextPadding, kTextPadding)
-                                                child:centerSpec];
+  UIEdgeInsets padding =UIEdgeInsetsMake(kTextPadding, kTextPadding, kTextPadding, kTextPadding);
+  return [ASInsetLayoutSpec insetLayoutSpecWithInsets:padding child:centerSpec];
 }
 #else
 - (CGSize)calculateSizeThatFits:(CGSize)constrainedSize

--- a/examples/Kittens/Sample/BlurbNode.m
+++ b/examples/Kittens/Sample/BlurbNode.m
@@ -76,14 +76,14 @@ static NSString *kLinkAttributeName = @"PlaceKittenNodeLinkAttributeName";
 #if UseAutomaticLayout
 - (ASLayoutSpec *)layoutSpecThatFits:(ASSizeRange)constrainedSize
 {
-  return
-  [ASInsetLayoutSpec
-   newWithInsets:UIEdgeInsetsMake(kTextPadding, kTextPadding, kTextPadding, kTextPadding)
-   child:
-   [ASCenterLayoutSpec
-    newWithCenteringOptions:ASCenterLayoutSpecCenteringX // Center the text horizontally
-    sizingOptions:ASCenterLayoutSpecSizingOptionMinimumY // Takes up minimum height
-    child:_textNode]];
+  ASCenterLayoutSpec *centerSpec = [[ASCenterLayoutSpec alloc] init];
+  centerSpec.centeringOptions = ASCenterLayoutSpecCenteringX;
+  centerSpec.sizingOptions = ASCenterLayoutSpecSizingOptionMinimumY;
+  centerSpec.child = _textNode;
+  
+  
+  return [ASInsetLayoutSpec insetLayoutSpecWithInsets:UIEdgeInsetsMake(kTextPadding, kTextPadding, kTextPadding, kTextPadding)
+                                                child:centerSpec];
 }
 #else
 - (CGSize)calculateSizeThatFits:(CGSize)constrainedSize

--- a/examples/Kittens/Sample/KittenNode.mm
+++ b/examples/Kittens/Sample/KittenNode.mm
@@ -137,16 +137,16 @@ static const CGFloat kInnerPadding = 10.0f;
   _imageNode.preferredFrameSize = _isImageEnlarged ? CGSizeMake(2.0 * kImageSize, 2.0 * kImageSize) : CGSizeMake(kImageSize, kImageSize);
   _textNode.flexShrink = YES;
   
-  return
-  [ASInsetLayoutSpec
-   newWithInsets:UIEdgeInsetsMake(kOuterPadding, kOuterPadding, kOuterPadding, kOuterPadding)
-   child:
-   [ASStackLayoutSpec
-    newWithStyle:{
-      .direction = ASStackLayoutDirectionHorizontal,
-      .spacing = kInnerPadding
-    }
-    children:!_swappedTextAndImage ? @[_imageNode, _textNode] : @[_textNode, _imageNode]]];
+  ASStackLayoutSpec *stackSpec = [[ASStackLayoutSpec alloc] init];
+  stackSpec.direction = ASStackLayoutDirectionHorizontal;
+  stackSpec.spacing = kInnerPadding;
+  [stackSpec addChildren:!_swappedTextAndImage ? @[_imageNode, _textNode] : @[_textNode, _imageNode]];
+  
+  ASInsetLayoutSpec *insetSpec = [[ASInsetLayoutSpec alloc] init];
+  insetSpec.insets = UIEdgeInsetsMake(kOuterPadding, kOuterPadding, kOuterPadding, kOuterPadding);
+  insetSpec.child = stackSpec;
+  
+  return insetSpec;
 }
 
 // With box model, you don't need to override this method, unless you want to add custom logic.


### PR DESCRIPTION
`ASLayoutSpec` was given an isMutable property the is set to YES on initialization. `ASDisplayNode`'s `calculateLayoutThatFits:` immediately sets this flag to NO upon return of `layoutSpecThatFits`, meaning that the spec is only mutable within `layoutSpecThatFits`.

This allows for an easier to work with interface for the layout specs. For example, a stack spec can now be created like:

```
  ASStackLayoutSpec *stackSpec = [[ASStackLayoutSpec alloc] init];
  stackSpec.direction = ASStackLayoutDirectionHorizontal;
  stackSpec.spacing = kInnerPadding;
  [stackSpec addChildren:@[_imageNode, _textNode]];
```

I also made the interface more Objective-C like. For example, I replaced all of the class new methods with more objective-c like names:
```
+ (instancetype)newWithInsets:(UIEdgeInsets)insets child:(id<ASLayoutable>)child;
```
became:
```
+ (instancetype)insetLayoutSpecWithInsets:(UIEdgeInsets)insets child:(id<ASLayoutable>)child;
``` 

Feedback is welcome! Should `ASLayoutSpec` have an `addChild` method? 

https://github.com/facebook/AsyncDisplayKit/issues/605