### PR TITLE
Added finalLayoutable and updated ASStaticLayoutSpec

### DIFF
--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -229,6 +229,8 @@
 		9C3061091B857EC400D0530B /* ASBaselineLayoutSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9C3061051B857EC400D0530B /* ASBaselineLayoutSpec.mm */; };
 		9C49C36F1B853957000B0DD5 /* ASStackLayoutable.h in Headers */ = {isa = PBXBuildFile; fileRef = 9C49C36E1B853957000B0DD5 /* ASStackLayoutable.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9C49C3701B853961000B0DD5 /* ASStackLayoutable.h in Headers */ = {isa = PBXBuildFile; fileRef = 9C49C36E1B853957000B0DD5 /* ASStackLayoutable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9C6BB3B21B8CC9C200F13F52 /* ASStaticLayoutable.h in Headers */ = {isa = PBXBuildFile; fileRef = 9C6BB3B01B8CC9C200F13F52 /* ASStaticLayoutable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9C6BB3B31B8CC9C200F13F52 /* ASStaticLayoutable.h in Headers */ = {isa = PBXBuildFile; fileRef = 9C6BB3B01B8CC9C200F13F52 /* ASStaticLayoutable.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9F06E5CD1B4CAF4200F015D8 /* ASCollectionViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F06E5CC1B4CAF4200F015D8 /* ASCollectionViewTests.m */; };
 		AC21EC101B3D0BF600C8B19A /* ASStackLayoutDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = AC21EC0F1B3D0BF600C8B19A /* ASStackLayoutDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AC3C4A511A1139C100143C57 /* ASCollectionView.h in Headers */ = {isa = PBXBuildFile; fileRef = AC3C4A4F1A1139C100143C57 /* ASCollectionView.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -574,6 +576,7 @@
 		9C3061041B857EC400D0530B /* ASBaselineLayoutSpec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASBaselineLayoutSpec.h; path = AsyncDisplayKit/Layout/ASBaselineLayoutSpec.h; sourceTree = "<group>"; };
 		9C3061051B857EC400D0530B /* ASBaselineLayoutSpec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = ASBaselineLayoutSpec.mm; path = AsyncDisplayKit/Layout/ASBaselineLayoutSpec.mm; sourceTree = "<group>"; };
 		9C49C36E1B853957000B0DD5 /* ASStackLayoutable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASStackLayoutable.h; path = AsyncDisplayKit/Layout/ASStackLayoutable.h; sourceTree = "<group>"; };
+		9C6BB3B01B8CC9C200F13F52 /* ASStaticLayoutable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASStaticLayoutable.h; path = AsyncDisplayKit/Layout/ASStaticLayoutable.h; sourceTree = "<group>"; };
 		9F06E5CC1B4CAF4200F015D8 /* ASCollectionViewTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASCollectionViewTests.m; sourceTree = "<group>"; };
 		AC21EC0F1B3D0BF600C8B19A /* ASStackLayoutDefines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASStackLayoutDefines.h; path = AsyncDisplayKit/Layout/ASStackLayoutDefines.h; sourceTree = "<group>"; };
 		AC3C4A4F1A1139C100143C57 /* ASCollectionView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASCollectionView.h; sourceTree = "<group>"; };
@@ -985,6 +988,7 @@
 				AC21EC0F1B3D0BF600C8B19A /* ASStackLayoutDefines.h */,
 				ACF6ED161B17843500DA7C62 /* ASStackLayoutSpec.h */,
 				ACF6ED171B17843500DA7C62 /* ASStackLayoutSpec.mm */,
+				9C6BB3B01B8CC9C200F13F52 /* ASStaticLayoutable.h */,
 				ACF6ED181B17843500DA7C62 /* ASStaticLayoutSpec.h */,
 				ACF6ED191B17843500DA7C62 /* ASStaticLayoutSpec.mm */,
 				9C3061041B857EC400D0530B /* ASBaselineLayoutSpec.h */,
@@ -1038,6 +1042,7 @@
 				ACF6ED201B17843500DA7C62 /* ASDimension.h in Headers */,
 				ACF6ED2B1B17843500DA7C62 /* ASOverlayLayoutSpec.h in Headers */,
 				ACF6ED1C1B17843500DA7C62 /* ASCenterLayoutSpec.h in Headers */,
+				9C6BB3B21B8CC9C200F13F52 /* ASStaticLayoutable.h in Headers */,
 				ACF6ED2A1B17843500DA7C62 /* ASLayoutable.h in Headers */,
 				ACF6ED311B17843500DA7C62 /* ASStaticLayoutSpec.h in Headers */,
 				ACF6ED241B17843500DA7C62 /* ASLayout.h in Headers */,
@@ -1152,6 +1157,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9C6BB3B31B8CC9C200F13F52 /* ASStaticLayoutable.h in Headers */,
 				B35062321B010EFD0018CF92 /* ASTextNodeShadower.h in Headers */,
 				34EFC7651B701CCC00AD841F /* ASRelativeSize.h in Headers */,
 				B35062431B010EFD0018CF92 /* UIView+ASConvenience.h in Headers */,

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -659,6 +659,11 @@ static inline BOOL _ASDisplayNodeIsAncestorOfDisplayNode(ASDisplayNode *possible
   return NO;
 }
 
+- (id<ASLayoutable>)finalLayoutable
+{
+  return self;
+}
+
 /**
  * NOTE: It is an error to try to convert between nodes which do not share a common ancestor. This behavior is
  * disallowed in UIKit documentation and the behavior is left undefined. The output does not have a rigorously defined

--- a/AsyncDisplayKit/Layout/ASBackgroundLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASBackgroundLayoutSpec.mm
@@ -14,11 +14,9 @@
 #import "ASBaseDefines.h"
 #import "ASLayout.h"
 
+static NSString * const kBackgroundChildKey = @"kBackgroundChildKey";
+
 @interface ASBackgroundLayoutSpec ()
-{
-  id<ASLayoutable> _child;
-  id<ASLayoutable> _background;
-}
 @end
 
 @implementation ASBackgroundLayoutSpec
@@ -30,11 +28,10 @@
   }
   
   ASDisplayNodeAssertNotNil(child, @"Child cannot be nil");
-  _child = child;
-  _background = background;
+  [self setChild:child];
+  self.background = background;
   return self;
 }
-
 
 + (instancetype)backgroundLayoutSpecWithChild:(id<ASLayoutable>)child background:(id<ASLayoutable>)background;
 {
@@ -46,12 +43,12 @@
  */
 - (ASLayout *)measureWithSizeRange:(ASSizeRange)constrainedSize
 {
-  ASLayout *contentsLayout = [_child measureWithSizeRange:constrainedSize];
+  ASLayout *contentsLayout = [[self child] measureWithSizeRange:constrainedSize];
 
   NSMutableArray *sublayouts = [NSMutableArray arrayWithCapacity:2];
-  if (_background) {
+  if (self.background) {
     // Size background to exactly the same size.
-    ASLayout *backgroundLayout = [_background measureWithSizeRange:{contentsLayout.size, contentsLayout.size}];
+    ASLayout *backgroundLayout = [self.background measureWithSizeRange:{contentsLayout.size, contentsLayout.size}];
     backgroundLayout.position = CGPointZero;
     [sublayouts addObject:backgroundLayout];
   }
@@ -63,14 +60,12 @@
 
 - (void)setBackground:(id<ASLayoutable>)background
 {
-  ASDisplayNodeAssert(self.isMutable, @"Cannot set properties when layout spec is not mutable");
-  _background = background;
+  [super setChild:background forIdentifier:kBackgroundChildKey];
 }
 
-- (void)setChild:(id<ASLayoutable>)child
+- (id<ASLayoutable>)background
 {
-  ASDisplayNodeAssert(self.isMutable, @"Cannot set properties when layout spec is not mutable");
-  _child = child;
+  return [super childForIdentifier:kBackgroundChildKey];
 }
 
 @end

--- a/AsyncDisplayKit/Layout/ASBaselineLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASBaselineLayoutSpec.h
@@ -42,9 +42,6 @@ typedef NS_ENUM(NSUInteger, ASBaselineLayoutBaselineAlignment) {
 /** The type of baseline alignment */
 @property (nonatomic, assign) ASBaselineLayoutBaselineAlignment baselineAlignment;
 
-- (void)addChild:(id<ASBaselineLayoutable>)child;
-- (void)addChildren:(NSArray *)children;
-
 /**
  @param direction The direction of the stack view (horizontal or vertical)
  @param spacing The spacing between the children

--- a/AsyncDisplayKit/Layout/ASCenterLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASCenterLayoutSpec.mm
@@ -17,7 +17,6 @@
 {
   ASCenterLayoutSpecCenteringOptions _centeringOptions;
   ASCenterLayoutSpecSizingOptions _sizingOptions;
-  id<ASLayoutable> _child;
 }
 
 - (instancetype)initWithCenteringOptions:(ASCenterLayoutSpecCenteringOptions)centeringOptions
@@ -30,7 +29,7 @@
   ASDisplayNodeAssertNotNil(child, @"Child cannot be nil");
   _centeringOptions = centeringOptions;
   _sizingOptions = sizingOptions;
-  _child = child;
+  [self setChild:child];
   return self;
 }
 
@@ -39,12 +38,6 @@
                                                child:(id<ASLayoutable>)child
 {
   return [[self alloc] initWithCenteringOptions:centeringOptions sizingOptions:sizingOptions child:child];
-}
-
-- (void)setChild:(id<ASLayoutable>)child
-{
-  ASDisplayNodeAssert(self.isMutable, @"Cannot set properties when layout spec is not mutable");
-  _child = child;
 }
 
 - (void)setCenteringOptions:(ASCenterLayoutSpecCenteringOptions)centeringOptions
@@ -71,7 +64,7 @@
     (_centeringOptions & ASCenterLayoutSpecCenteringX) != 0 ? 0 : constrainedSize.min.width,
     (_centeringOptions & ASCenterLayoutSpecCenteringY) != 0 ? 0 : constrainedSize.min.height,
   };
-  ASLayout *sublayout = [_child measureWithSizeRange:ASSizeRangeMake(minChildSize, constrainedSize.max)];
+  ASLayout *sublayout = [self.child measureWithSizeRange:ASSizeRangeMake(minChildSize, constrainedSize.max)];
 
   // If we have an undetermined height or width, use the child size to define the layout
   // size

--- a/AsyncDisplayKit/Layout/ASInsetLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASInsetLayoutSpec.mm
@@ -19,7 +19,6 @@
 @interface ASInsetLayoutSpec ()
 {
   UIEdgeInsets _insets;
-  id<ASLayoutable> _child;
 }
 @end
 
@@ -50,19 +49,13 @@ static CGFloat centerInset(CGFloat outer, CGFloat inner)
   }
   ASDisplayNodeAssertNotNil(child, @"Child cannot be nil");
   _insets = insets;
-  _child = child;
+  [self setChild:child];
   return self;
 }
 
 + (instancetype)insetLayoutSpecWithInsets:(UIEdgeInsets)insets child:(id<ASLayoutable>)child
 {
   return [[self alloc] initWithInsets:insets child:child];
-}
-
-- (void)setChild:(id<ASLayoutable>)child
-{
-  ASDisplayNodeAssert(self.isMutable, @"Cannot set properties when layout spec is not mutable");
-  _child = child;
 }
 
 - (void)setInsets:(UIEdgeInsets)insets
@@ -95,7 +88,7 @@ static CGFloat centerInset(CGFloat outer, CGFloat inner)
       MAX(0, constrainedSize.max.height - insetsY),
     }
   };
-  ASLayout *sublayout = [_child measureWithSizeRange:insetConstrainedSize];
+  ASLayout *sublayout = [self.child measureWithSizeRange:insetConstrainedSize];
 
   const CGSize computedSize = ASSizeRangeClamp(constrainedSize, {
     finite(sublayout.size.width + _insets.left + _insets.right, constrainedSize.max.width),

--- a/AsyncDisplayKit/Layout/ASLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASLayoutSpec.h
@@ -22,4 +22,13 @@
 
 - (instancetype)init;
 
+- (void)setChild:(id<ASLayoutable>)child;
+- (id<ASLayoutable>)child;
+
+- (void)setChild:(id<ASLayoutable>)child forIdentifier:(NSString *)identifier;
+- (id<ASLayoutable>)childForIdentifier:(NSString *)identifier;
+
+- (void)setChildren:(NSArray *)children;
+- (NSArray *)children;
+
 @end

--- a/AsyncDisplayKit/Layout/ASLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASLayoutSpec.mm
@@ -16,6 +16,13 @@
 #import "ASInternalHelpers.h"
 #import "ASLayout.h"
 
+static NSString * const kDefaultChildKey = @"kDefaultChildKey";
+static NSString * const kDefaultChildrenKey = @"kDefaultChildrenKey";
+
+@interface ASLayoutSpec()
+@property (nonatomic, strong) NSMutableDictionary *layoutChildren;
+@end
+
 @implementation ASLayoutSpec
 
 @synthesize spacingBefore = _spacingBefore;
@@ -24,12 +31,14 @@
 @synthesize flexShrink = _flexShrink;
 @synthesize flexBasis = _flexBasis;
 @synthesize alignSelf = _alignSelf;
+@synthesize layoutChildren = _layoutChildren;
 
 - (instancetype)init
 {
   if (!(self = [super init])) {
     return nil;
   }
+  _layoutChildren = [NSMutableDictionary dictionary];
   _flexBasis = ASRelativeDimensionUnconstrained;
   _isMutable = YES;
   return self;
@@ -40,6 +49,47 @@
 - (ASLayout *)measureWithSizeRange:(ASSizeRange)constrainedSize
 {
   return [ASLayout layoutWithLayoutableObject:self size:constrainedSize.min];
+}
+
+- (id<ASLayoutable>)finalLayoutable
+{
+  return self;
+}
+
+- (void)setChild:(id<ASLayoutable>)child;
+{
+  [self setChild:child forIdentifier:kDefaultChildKey];
+}
+
+- (id<ASLayoutable>)child
+{
+  return self.layoutChildren[kDefaultChildKey];
+}
+
+- (void)setChild:(id<ASLayoutable>)child forIdentifier:(NSString *)identifier
+{
+  ASDisplayNodeAssert(self.isMutable, @"Cannot set properties when layout spec is not mutable");
+  self.layoutChildren[identifier] = [child finalLayoutable];
+}
+
+- (id<ASLayoutable>)childForIdentifier:(NSString *)identifier
+{
+  return self.layoutChildren[identifier];
+}
+
+- (void)setChildren:(NSArray *)children
+{
+  ASDisplayNodeAssert(self.isMutable, @"Cannot set properties when layout spec is not mutable");
+  NSMutableArray *finalChildren = [NSMutableArray arrayWithCapacity:children.count];
+  for (id<ASLayoutable> child in children) {
+    [finalChildren addObject:[child finalLayoutable]];
+  }
+  self.layoutChildren[kDefaultChildrenKey] = [NSArray arrayWithArray:finalChildren];
+}
+
+- (NSArray *)children
+{
+  return self.layoutChildren[kDefaultChildrenKey];
 }
 
 @end

--- a/AsyncDisplayKit/Layout/ASLayoutable.h
+++ b/AsyncDisplayKit/Layout/ASLayoutable.h
@@ -12,6 +12,7 @@
 #import <AsyncDisplayKit/ASStackLayoutDefines.h>
 
 @class ASLayout;
+@class ASLayoutSpec;
 
 /** 
  * The ASLayoutable protocol declares a method for measuring the layout of an object. A class must implement the method
@@ -28,5 +29,17 @@
  * @return An ASLayout instance defining the layout of the receiver and its children.
  */
 - (ASLayout *)measureWithSizeRange:(ASSizeRange)constrainedSize;
+
+/**
+ @abstract Give this object a last chance to add itself to a container ASLayoutable (most likely an ASLayoutSpec) before
+ being added to a ASLayoutSpec.
+ 
+ For example, consider a node whose superclass is laid out via calculateLayoutThatFits:. The subclass cannot implement
+ layoutSpecThatFits: since its ASLayout is already being created by calculateLayoutThatFits:. By implementing this method
+ a subclass can wrap itself in an ASLayoutSpec right before it is added to a layout spec.
+ 
+ It is rare that a class will need to implement this method.
+ */
+- (id<ASLayoutable>)finalLayoutable;
 
 @end

--- a/AsyncDisplayKit/Layout/ASOverlayLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASOverlayLayoutSpec.mm
@@ -14,11 +14,9 @@
 #import "ASBaseDefines.h"
 #import "ASLayout.h"
 
+static NSString * const kOverlayChildKey = @"kOverlayChildKey";
+
 @implementation ASOverlayLayoutSpec
-{
-  id<ASLayoutable> _overlay;
-  id<ASLayoutable> _child;
-}
 
 - (instancetype)initWithChild:(id<ASLayoutable>)child overlay:(id<ASLayoutable>)overlay
 {
@@ -26,8 +24,8 @@
     return nil;
   }
   ASDisplayNodeAssertNotNil(child, @"Child that will be overlayed on shouldn't be nil");
-  _overlay = overlay;
-  _child = child;
+  self.overlay = overlay;
+  [self setChild:child];
   return self;
 }
 
@@ -36,16 +34,14 @@
   return [[self alloc] initWithChild:child overlay:overlay];
 }
 
-- (void)setChild:(id<ASLayoutable>)child
-{
-  ASDisplayNodeAssert(self.isMutable, @"Cannot set properties when layout spec is not mutable");
-  _child = child;
-}
-
 - (void)setOverlay:(id<ASLayoutable>)overlay
 {
-  ASDisplayNodeAssert(self.isMutable, @"Cannot set properties when layout spec is not mutable");
-  _overlay = overlay;
+  [super setChild:overlay forIdentifier:kOverlayChildKey];
+}
+
+- (id<ASLayoutable>)overlay
+{
+  return [super childForIdentifier:kOverlayChildKey];
 }
 
 /**
@@ -56,8 +52,8 @@
   ASLayout *contentsLayout = [_child measureWithSizeRange:constrainedSize];
   contentsLayout.position = CGPointZero;
   NSMutableArray *sublayouts = [NSMutableArray arrayWithObject:contentsLayout];
-  if (_overlay) {
-    ASLayout *overlayLayout = [_overlay measureWithSizeRange:{contentsLayout.size, contentsLayout.size}];
+  if (self.overlay) {
+    ASLayout *overlayLayout = [self.overlay measureWithSizeRange:{contentsLayout.size, contentsLayout.size}];
     overlayLayout.position = CGPointZero;
     [sublayouts addObject:overlayLayout];
   }

--- a/AsyncDisplayKit/Layout/ASRatioLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASRatioLayoutSpec.mm
@@ -22,7 +22,6 @@
 @implementation ASRatioLayoutSpec
 {
   CGFloat _ratio;
-  id<ASLayoutable> _child;
 }
 
 + (instancetype)ratioLayoutSpecWithRatio:(CGFloat)ratio child:(id<ASLayoutable>)child
@@ -38,14 +37,8 @@
   ASDisplayNodeAssertNotNil(child, @"Child cannot be nil");
   ASDisplayNodeAssert(ratio > 0, @"Ratio should be strictly positive, but received %f", ratio);
   _ratio = ratio;
-  _child = child;
+  [self setChild:child];
   return self;
-}
-
-- (void)setChild:(id<ASLayoutable>)child
-{
-  ASDisplayNodeAssert(self.isMutable, @"Cannot set properties when layout spec is not mutable");
-  _child = child;
 }
 
 - (void)setRatio:(CGFloat)ratio
@@ -77,7 +70,7 @@
 
   // If there is no max size in *either* dimension, we can't apply the ratio, so just pass our size range through.
   const ASSizeRange childRange = (bestSize == sizeOptions.end()) ? constrainedSize : ASSizeRangeMake(*bestSize, *bestSize);
-  ASLayout *sublayout = [_child measureWithSizeRange:childRange];
+  ASLayout *sublayout = [self.child measureWithSizeRange:childRange];
   sublayout.position = CGPointZero;
   return [ASLayout layoutWithLayoutableObject:self size:sublayout.size sublayouts:@[sublayout]];
 }

--- a/AsyncDisplayKit/Layout/ASStackLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASStackLayoutSpec.h
@@ -55,7 +55,4 @@
  */
 + (instancetype)stackLayoutSpecWithDirection:(ASStackLayoutDirection)direction spacing:(CGFloat)spacing justifyContent:(ASStackLayoutJustifyContent)justifyContent alignItems:(ASStackLayoutAlignItems)alignItems children:(NSArray *)children;
 
-- (void)addChild:(id<ASStackLayoutable>)child;
-- (void)addChildren:(NSArray *)children;
-
 @end

--- a/AsyncDisplayKit/Layout/ASStackLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASStackLayoutSpec.mm
@@ -23,9 +23,6 @@
 #import "ASThread.h"
 
 @implementation ASStackLayoutSpec
-{
-  std::vector<id<ASStackLayoutable>> _children;
-}
 
 - (instancetype)init
 {
@@ -47,24 +44,8 @@
   _spacing = spacing;
   _justifyContent = justifyContent;
   
-  _children = std::vector<id<ASStackLayoutable>>();
-  for (id<ASStackLayoutable> child in children) {
-    _children.push_back(child);
-  }
+  [self setChildren:children];
   return self;
-}
-
-- (void)addChild:(id<ASStackLayoutable>)child
-{
-  ASDisplayNodeAssert(self.isMutable, @"Cannot set properties when layout spec is not mutable");
-  _children.push_back(child);
-}
-
-- (void)addChildren:(NSArray *)children
-{
-  for (id<ASStackLayoutable> child in children) {
-    [self addChild:child];
-  }
 }
 
 - (void)setDirection:(ASStackLayoutDirection)direction
@@ -91,10 +72,32 @@
   _spacing = spacing;
 }
 
+- (void)setChildren:(NSArray *)children
+{
+  [super setChildren:children];
+  
+#if DEBUG
+  for (id<ASStackLayoutable> child in children) {
+    ASDisplayNodeAssert(([child finalLayoutable] == child && [child conformsToProtocol:@protocol(ASStackLayoutable)]) || ([child finalLayoutable] != child && [[child finalLayoutable] conformsToProtocol:@protocol(ASStackLayoutable)]), @"child must conform to ASBaselineLayoutable");
+  }
+#endif
+}
+
+- (void)setChild:(id<ASLayoutable>)child forIdentifier:(NSString *)identifier
+{
+  ASDisplayNodeAssert(NO, @"ASStackLayoutSpec only supports setChildren");
+}
+
 - (ASLayout *)measureWithSizeRange:(ASSizeRange)constrainedSize
 {
   ASStackLayoutSpecStyle style = {.direction = _direction, .spacing = _spacing, .justifyContent = _justifyContent, .alignItems = _alignItems};
-  const auto unpositionedLayout = ASStackUnpositionedLayout::compute(_children, style, constrainedSize);
+  std::vector<id<ASStackLayoutable>> stackChildren = std::vector<id<ASStackLayoutable>>();
+  for (id<ASStackLayoutable> child in self.children) {
+    NSAssert([child conformsToProtocol:@protocol(ASStackLayoutable)], @"Child must implement ASStackLayoutable");
+    stackChildren.push_back(child);
+  }
+  
+  const auto unpositionedLayout = ASStackUnpositionedLayout::compute(stackChildren, style, constrainedSize);
   const auto positionedLayout = ASStackPositionedLayout::compute(unpositionedLayout, style, constrainedSize);
   const CGSize finalSize = directionSize(style.direction, unpositionedLayout.stackDimensionSum, positionedLayout.crossSize);
   NSArray *sublayouts = [NSArray arrayWithObjects:&positionedLayout.sublayouts[0] count:positionedLayout.sublayouts.size()];

--- a/AsyncDisplayKit/Layout/ASStaticLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASStaticLayoutSpec.h
@@ -11,43 +11,6 @@
 #import <AsyncDisplayKit/ASLayoutSpec.h>
 #import <AsyncDisplayKit/ASRelativeSize.h>
 
-/** 
- * An ASStaticLayoutSpecChild object wraps an ASLayoutable object and provides position and size information,
- * to be used as a child of an ASStaticLayoutSpec. 
- */
-@interface ASStaticLayoutSpecChild : NSObject
-
-@property (nonatomic, readonly) CGPoint position;
-@property (nonatomic, readonly) id<ASLayoutable> layoutableObject;
-
-/**
- If specified, the child's size is restricted according to this size. Percentages are resolved relative to the static layout spec.
- */
-@property (nonatomic, readonly) ASRelativeSizeRange size;
-
-/**
- * Initializer.
- *
- * @param position The position of this child within its parent spec.
- *
- * @param layoutableObject The backing ASLayoutable object of this child.
- *
- * @param size The size range that this child's size is trstricted according to.
- */
-+ (instancetype)staticLayoutChildWithPosition:(CGPoint)position layoutableObject:(id<ASLayoutable>)layoutableObject size:(ASRelativeSizeRange)size;
-
-/**
- * Convenience initializer with default size is Unconstrained in both dimensions, which sets the child's min size to zero
- * and max size to the maximum available space it can consume without overflowing the spec's bounds.
- *
- * @param position The position of this child within its parent spec.
- *
- * @param layoutableObject The backing ASLayoutable object of this child.
- */
-+ (instancetype)staticLayoutChildWithPosition:(CGPoint)position layoutableObject:(id<ASLayoutable>)layoutableObject;
-
-@end
-
 /**
  * A layout spec that positions children at fixed positions.
  * 
@@ -56,10 +19,8 @@
 @interface ASStaticLayoutSpec : ASLayoutSpec
 
 /**
- @param children Children to be positioned at fixed positions, each is of type ASStaticLayoutSpecChild.
+ @param children Children to be positioned at fixed positions, each conforms to ASStaticLayoutable
  */
 + (instancetype)staticLayoutSpecWithChildren:(NSArray *)children;
-
-- (void)addChild:(ASStaticLayoutSpecChild *)child;
 
 @end

--- a/AsyncDisplayKit/Layout/ASStaticLayoutable.h
+++ b/AsyncDisplayKit/Layout/ASStaticLayoutable.h
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <AsyncDisplayKit/ASLayoutable.h>
+#import <AsyncDisplayKit/ASRelativeSize.h>
+
+@protocol ASStaticLayoutable<ASLayoutable>
+
+/**
+ If specified, the child's size is restricted according to this size. Percentages are resolved relative to the static layout spec.
+ */
+@property (nonatomic, assign) ASRelativeSizeRange sizeRange;
+
+/** The position of this object within its parent spec. */
+@property (nonatomic, assign) CGPoint position;
+
+@end

--- a/examples/Kittens/Sample/KittenNode.mm
+++ b/examples/Kittens/Sample/KittenNode.mm
@@ -140,7 +140,7 @@ static const CGFloat kInnerPadding = 10.0f;
   ASStackLayoutSpec *stackSpec = [[ASStackLayoutSpec alloc] init];
   stackSpec.direction = ASStackLayoutDirectionHorizontal;
   stackSpec.spacing = kInnerPadding;
-  [stackSpec addChildren:!_swappedTextAndImage ? @[_imageNode, _textNode] : @[_textNode, _imageNode]];
+  [stackSpec setChildren:!_swappedTextAndImage ? @[_imageNode, _textNode] : @[_textNode, _imageNode]];
   
   ASInsetLayoutSpec *insetSpec = [[ASInsetLayoutSpec alloc] init];
   insetSpec.insets = UIEdgeInsetsMake(kOuterPadding, kOuterPadding, kOuterPadding, kOuterPadding);


### PR DESCRIPTION
Added a method to `ASLayoutable` called `- (id<ASLayoutable>)finalLayoutable` that allows a layoutable object to override how it is added to a ASLayoutSpec. This could, for example, allow a subclass of ASTextNode to wrap itself inside an ASInsetLayoutSpec before it is added to its parent ASLayoutSpec.

The base class `ASLayoutSpec` was changed to hold all of a layout spec's children. This allows the override method to be called in only one place.

Also updated the interface to ASStaticLayoutSpec so that it could work better with the new ASLayoutSpec baseclass. Much like `ASStackLayoutable` and `ASBaselineLayoutable`, I created `ASStaticLayoutable` protocol with the required properties `sizeRange` and `position`.

