### PR TITLE
This fixed the cutoff on the 'g' or 'y' character in ASTextNode

### DIFF
--- a/AsyncDisplayKit/ASTextNode.mm
+++ b/AsyncDisplayKit/ASTextNode.mm
@@ -287,11 +287,11 @@ ASDISPLAYNODE_INLINE CGFloat ceilPixelValue(CGFloat f)
   if (_renderer == nil) {
     CGSize constrainedSize = _constrainedSize.width != -INFINITY ? _constrainedSize : self.bounds.size;
     _renderer = [[ASTextNodeRenderer alloc] initWithAttributedString:_attributedString
-                                                        truncationString:_composedTruncationString
-                                                          truncationMode:_truncationMode
-                                                        maximumLineCount:_maximumLineCount
-                                                          exclusionPaths:_exclusionPaths
-                                                         constrainedSize:constrainedSize];
+                                                    truncationString:_composedTruncationString
+                                                      truncationMode:_truncationMode
+                                                    maximumLineCount:_maximumLineCount
+                                                      exclusionPaths:_exclusionPaths
+                                                     constrainedSize:constrainedSize];
   }
   return _renderer;
 }
@@ -421,9 +421,9 @@ ASDISPLAYNODE_INLINE CGFloat ceilPixelValue(CGFloat f)
   UIEdgeInsets shadowPadding = [self shadowPadding];
   CGPoint textOrigin = CGPointMake(self.bounds.origin.x - shadowPadding.left, self.bounds.origin.y - shadowPadding.top);
   return [[ASTextNodeDrawParameters alloc] initWithRenderer:[self _renderer]
-                                                       shadower:[self _shadower]
-                                                     textOrigin:textOrigin
-                                                backgroundColor:self.backgroundColor.CGColor];
+                                                   shadower:[self _shadower]
+                                                 textOrigin:textOrigin
+                                            backgroundColor:self.backgroundColor.CGColor];
 }
 
 #pragma mark - Attributes

--- a/AsyncDisplayKit/Details/ASTextNodeRenderer.mm
+++ b/AsyncDisplayKit/Details/ASTextNodeRenderer.mm
@@ -14,6 +14,7 @@
 #import "ASTextNodeTextKitHelpers.h"
 #import "ASTextNodeWordKerner.h"
 #import "ASThread.h"
+#import "ASInternalHelpers.h"
 
 static const CGFloat ASTextNodeRendererGlyphTouchHitSlop = 5.0;
 static const CGFloat ASTextNodeRendererTextCapHeightPadding = 1.3;
@@ -607,6 +608,10 @@ static const CGFloat ASTextNodeRendererTextCapHeightPadding = 1.3;
 
 - (void)drawInRect:(CGRect)bounds inContext:(CGContextRef)context
 {
+  // NSLayoutManager often missed one pixel at the last line of the text.
+  // We need to offset this extra pixel to make 'g' or 'y' rendered perfectly at the last line within ASTextNode.
+  bounds.origin.y -= 1.0/ASScreenScale();
+
   ASDisplayNodeAssert(context, @"This is no good without a context.");
   UIGraphicsPushContext(context);
   CGContextSaveGState(context);


### PR DESCRIPTION
For some reason, `NSLayoutManager` did not layout the text correctly for our ASTextNode.
After some experiment, the origin is always off by 1 pixel value.

Hacking that with 1 pixel value seems to fix this annoying bug.


# Before:
![ios simulator screen shot sep 2 2015 6 32 50 pm](https://cloud.githubusercontent.com/assets/376457/9648896/6fe3942e-51a2-11e5-891b-a4ff4917f3ba.png)

# See the cutoff from the 'g' character:
<img width="223" alt="screen shot 2015-09-02 at 6 33 17 pm" src="https://cloud.githubusercontent.com/assets/376457/9648897/6fe49ffe-51a2-11e5-8516-09bb5e333b66.png">

# After:
![ios simulator screen shot sep 2 2015 6 33 05 pm](https://cloud.githubusercontent.com/assets/376457/9648895/6fe1bcb2-51a2-11e5-80cc-f47eec9e86cb.png)
