### PR TITLE
Avoid doing relayout during initial configuration

### DIFF
--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -149,6 +149,7 @@ static BOOL _isInterceptedSelector(SEL sel)
   BOOL _asyncDataSourceImplementsConstrainedSizeForNode;
 
   CGFloat _maxWidthForNodesConstrainedSize;
+  BOOL _ignoreMaxWidthChange;
 }
 
 @property (atomic, assign) BOOL asyncDataSourceLocked;
@@ -203,6 +204,9 @@ void ASPerformBlockWithoutAnimation(BOOL withoutAnimation, void (^block)()) {
   _automaticallyAdjustsContentOffset = NO;
   
   _maxWidthForNodesConstrainedSize = self.bounds.size.width;
+  // If the initial size is 0, expect a size change very soon which is part of the initial configuration
+  // and should not trigger a relayout.
+  _ignoreMaxWidthChange = (_maxWidthForNodesConstrainedSize == 0);
 }
 
 - (instancetype)initWithFrame:(CGRect)frame style:(UITableViewStyle)style
@@ -367,14 +371,22 @@ void ASPerformBlockWithoutAnimation(BOOL withoutAnimation, void (^block)()) {
 
 - (void)layoutSubviews
 {
-  [super layoutSubviews];
-  
   if (_maxWidthForNodesConstrainedSize != self.bounds.size.width) {
     _maxWidthForNodesConstrainedSize = self.bounds.size.width;
-    [self beginUpdates];
-    [_dataController relayoutAllRows];
-    [self endUpdates];
+
+    // First width change occurs during initial configuration. An expensive relayout pass is unnecessary at that time
+    // and should be avoided, assuming that the initial data loading automatically runs shortly afterward.
+    if (_ignoreMaxWidthChange) {
+      _ignoreMaxWidthChange = NO;
+    } else {
+      [self beginUpdates];
+      [_dataController relayoutAllRows];
+      [self endUpdates];
+    }
   }
+  
+  // To ensure _maxWidthForNodesConstrainedSize is up-to-date for every usage, this call to super must be done last
+  [super layoutSubviews];
 }
 
 #pragma mark -

--- a/AsyncDisplayKitTests/ASTableViewTests.m
+++ b/AsyncDisplayKitTests/ASTableViewTests.m
@@ -57,7 +57,8 @@
 @end
 
 @interface ASTableViewFilledDataSource : NSObject <ASTableViewDataSource, ASTableViewDelegate>
-
+/** Calculated by counting how many times a constrained size is asked for the first node on main thread. */
+@property (atomic) int numberOfRelayouts;
 @end
 
 @implementation ASTableViewFilledDataSource
@@ -78,6 +79,16 @@
   textCellNode.text = indexPath.description;
   
   return textCellNode;
+}
+
+- (ASSizeRange)tableView:(ASTableView *)tableView constrainedSizeForNodeAtIndexPath:(NSIndexPath *)indexPath
+{
+  if ([NSThread isMainThread] && indexPath.section == 0 && indexPath.row == 0) {
+    _numberOfRelayouts++;
+  }
+  CGFloat maxWidth = tableView.bounds.size.width;
+  return ASSizeRangeMake(CGSizeMake(maxWidth, 0),
+                         CGSizeMake(maxWidth, FLT_MAX));
 }
 
 @end
@@ -202,34 +213,71 @@
   }
 }
 
-- (void)testRelayoutAllRows
+- (void)testRelayoutAllRowsWithNonZeroSizeInitially
 {
-  // Initial width of the table view is 0 and all nodes are measured with this size.
-  ASTestTableView *tableView = [[ASTestTableView alloc] initWithFrame:CGRectMake(0, 0, 0, 500)
+  // Initial width of the table view is non-zero and all nodes are measured with this size.
+  // Any subsequence size change must trigger a relayout.
+  CGSize tableViewFinalSize = CGSizeMake(100, 500);
+  // Width and height are swapped so that a later size change will simulate a rotation
+  ASTestTableView *tableView = [[ASTestTableView alloc] initWithFrame:CGRectMake(0, 0, tableViewFinalSize.height, tableViewFinalSize.width)
                                                                 style:UITableViewStylePlain
                                                     asyncDataFetching:YES];
-  CGSize tableViewFinalSize = CGSizeMake(100, 500);
   
   ASTableViewFilledDataSource *dataSource = [ASTableViewFilledDataSource new];
 
   tableView.asyncDelegate = dataSource;
   tableView.asyncDataSource = dataSource;
   
+  // Trigger layout measurement on all nodes
   [tableView reloadData];
+  
+  [self triggerSizeChangeAndAssertRelayoutAllRowsForTableView:tableView newSize:tableViewFinalSize];
+}
+
+- (void)testRelayoutAllRowsWithZeroSizeInitially
+{
+  // Initial width of the table view is 0. The first size change is part of the initial config.
+  // Any subsequence size change after that must trigger a relayout.
+  CGSize tableViewFinalSize = CGSizeMake(100, 500);
+  ASTestTableView *tableView = [[ASTestTableView alloc] initWithFrame:CGRectZero
+                                                                style:UITableViewStylePlain
+                                                    asyncDataFetching:YES];
+  ASTableViewFilledDataSource *dataSource = [ASTableViewFilledDataSource new];
+
+  tableView.asyncDelegate = dataSource;
+  tableView.asyncDataSource = dataSource;
+  
+  // Initial configuration
+  UIView *superview = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 500, 500)];
+  [superview addSubview:tableView];
+  // Width and height are swapped so that a later size change will simulate a rotation
+  tableView.frame = CGRectMake(0, 0, tableViewFinalSize.height, tableViewFinalSize.width);
+  // Trigger layout measurement on all nodes
+  [tableView layoutIfNeeded];
+  
+  [self triggerSizeChangeAndAssertRelayoutAllRowsForTableView:tableView newSize:tableViewFinalSize];
+}
+
+- (void)triggerSizeChangeAndAssertRelayoutAllRowsForTableView:(ASTableView *)tableView newSize:(CGSize)newSize
+{
+  XCTestExpectation *nodesMeasuredUsingNewConstrainedSizeExpectation = [self expectationWithDescription:@"nodesMeasuredUsingNewConstrainedSizeExpectation"];
   
   [tableView beginUpdates];
   
-  tableView.frame = CGRectMake(0, 0, tableViewFinalSize.width, tableViewFinalSize.height);
+  CGRect frame = tableView.frame;
+  frame.size = newSize;
+  tableView.frame = frame;
   [tableView layoutIfNeeded];
   
-  XCTestExpectation *nodesMeasuredUsingNewConstrainedSizeExpectation = [self expectationWithDescription:@"nodesMeasuredUsingNewConstrainedSize"];
-
   [tableView endUpdatesAnimated:NO completion:^(BOOL completed) {
+    int numberOfRelayouts = ((ASTableViewFilledDataSource *)(tableView.asyncDataSource)).numberOfRelayouts;
+    XCTAssertEqual(numberOfRelayouts, 1);
+    
     for (int section = 0; section < NumberOfSections; section++) {
       for (int row = 0; row < NumberOfRowsPerSection; row++) {
         NSIndexPath *indexPath = [NSIndexPath indexPathForRow:row inSection:section];
         ASCellNode *node = [tableView nodeForRowAtIndexPath:indexPath];
-        XCTAssertEqual(node.constrainedSizeForCalculatedLayout.max.width, tableViewFinalSize.width);
+        XCTAssertEqual(node.constrainedSizeForCalculatedLayout.max.width, newSize.width);
       }
     }
     [nodesMeasuredUsingNewConstrainedSizeExpectation fulfill];


### PR DESCRIPTION
First size change occurs during initial configuration. An expensive relayout pass is unnecessary at that time and should be avoided.

This PR proposes a simple fix for this problem, that is adding a new boolean flag. With the fix in place, my ~~manual~~ tests showed that main thread was not blocked at startup by an expensive relayout call. I also tested the use case in which a rotation occurred after initial configuration. The new size was picked up correctly via a relayout.

Another alternative fix would be to completely ignore size changes to *and* from a zero size. With this solution, we will also gain some optimizations in case the scroll view size is changed from a non-zero size (A) to zero, then back to A or another non-zero size (B), for example as the result of hide and unhide animations. The implementation of that solution is more complex. So it may not be a good idea to implement now, because we are trying to push 2.0 out and there are many bugs need to be handled (I suspect most of them ~~are~~ were introduced by me :(
