### PR TITLE
First thoughts on fixing the finalLayoutable method.

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -44,6 +44,7 @@
 
 @dynamic spacingAfter, spacingBefore, flexGrow, flexShrink, flexBasis, alignSelf, ascender, descender, sizeRange, layoutPosition, layoutOptions;
 @synthesize preferredFrameSize = _preferredFrameSize;
+@synthesize isFinalLayoutable = _isFinalLayoutable;
 
 BOOL ASDisplayNodeSubclassOverridesSelector(Class subclass, SEL selector)
 {
@@ -1849,9 +1850,9 @@ static void _recursivelySetDisplaySuspended(ASDisplayNode *node, CALayer *layer,
     return !self.layerBacked && [self.view canPerformAction:action withSender:sender];
 }
 
-- (ASLayoutSpec *)finalLayoutableWithParent:(ASLayoutSpec *)parentSpec
+- (id<ASLayoutable>)finalLayoutable
 {
-  return nil;
+  return self;
 }
 
 @end

--- a/AsyncDisplayKit/Layout/ASLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASLayoutSpec.mm
@@ -63,6 +63,20 @@ static NSString * const kDefaultChildrenKey = @"kDefaultChildrenKey";
 - (id<ASLayoutable>)layoutableToAddFromLayoutable:(id<ASLayoutable>)child
 {
   if (self.isFinalLayoutable == NO) {
+    
+    // If you are getting recursion crashes here after implementing finalLayoutable, make sure
+    // that you are setting isFinalLayoutable flag to YES BEFORE adding a child to the new ASLayoutable.
+    //
+    // For example:
+    //- (id<ASLayoutable>)finalLayoutable
+    //{
+    //  ASInsetLayoutSpec *insetSpec = [[ASInsetLayoutSpec alloc] init];
+    //  insetSpec.insets = UIEdgeInsetsMake(10,10,10,10);
+    //  insetSpec.isFinalLayoutable = YES;
+    //  [insetSpec setChild:self];
+    //  return insetSpec;
+    //}
+
     id<ASLayoutable> finalLayoutable = [child finalLayoutable];
     if (finalLayoutable != child) {
       ASLayoutOptions *layoutOptions = [child layoutOptions];

--- a/AsyncDisplayKit/Layout/ASLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASLayoutSpec.mm
@@ -31,6 +31,7 @@ static NSString * const kDefaultChildrenKey = @"kDefaultChildrenKey";
 
 @dynamic spacingAfter, spacingBefore, flexGrow, flexShrink, flexBasis, alignSelf, ascender, descender, sizeRange, layoutPosition, layoutOptions;
 @synthesize layoutChildren = _layoutChildren;
+@synthesize isFinalLayoutable = _isFinalLayoutable;
 
 - (instancetype)init
 {
@@ -49,9 +50,9 @@ static NSString * const kDefaultChildrenKey = @"kDefaultChildrenKey";
   return [ASLayout layoutWithLayoutableObject:self size:constrainedSize.min];
 }
 
-- (ASLayoutSpec *)finalLayoutableWithParent:(ASLayoutSpec *)parentSpec;
+- (id<ASLayoutable>)finalLayoutable
 {
-  return nil;
+  return self;
 }
 
 - (void)setChild:(id<ASLayoutable>)child;
@@ -61,12 +62,13 @@ static NSString * const kDefaultChildrenKey = @"kDefaultChildrenKey";
 
 - (id<ASLayoutable>)layoutableToAddFromLayoutable:(id<ASLayoutable>)child
 {
-  ASLayoutOptions *layoutOptions = [child layoutOptions];
-  
-  id<ASLayoutable> finalLayoutable = [child finalLayoutableWithParent:self];
-  if (finalLayoutable) {
-    [layoutOptions copyIntoOptions:finalLayoutable.layoutOptions];
-    return finalLayoutable;
+  if (self.isFinalLayoutable == NO) {
+    id<ASLayoutable> finalLayoutable = [child finalLayoutable];
+    if (finalLayoutable != child) {
+      ASLayoutOptions *layoutOptions = [child layoutOptions];
+      [layoutOptions copyIntoOptions:finalLayoutable.layoutOptions];
+      return finalLayoutable;
+    }
   }
   return child;
 }

--- a/AsyncDisplayKit/Layout/ASLayoutablePrivate.h
+++ b/AsyncDisplayKit/Layout/ASLayoutablePrivate.h
@@ -12,8 +12,29 @@
 
 @class ASLayoutSpec;
 @class ASLayoutOptions;
+@protocol ASLayoutable;
 
 @protocol ASLayoutablePrivate <NSObject>
-- (ASLayoutSpec *)finalLayoutableWithParent:(ASLayoutSpec *)parentSpec;
+
+/**
+ *  @abstract A display node cannot implement both calculateSizeThatFits: and layoutSpecThatFits:. This
+ *  method exists to give the user a chance to wrap an ASLayoutable in an ASLayoutSpec just before it is
+ *  added to a parent ASLayoutSpec. For example, if you wanted an ASTextNode that was always inside of an
+ *  ASInsetLayoutSpec, you could subclass ASTextNode and implement finalLayoutable so that it wraps
+ *  self in an inset spec.
+ *
+ *  Note that any ASLayoutable other than self that is returned MUST set isFinalLayoutable to YES BEFORE
+ *  adding a child.
+ *
+ *  @return The layoutable that will be added to the parent layout spec. Defaults to self.
+ */
+- (id<ASLayoutable>)finalLayoutable;
+
+/**
+ *  A flag to indicate that this ASLayoutable was created in finalLayoutable. This MUST be set to YES
+ *  before adding a child to this layoutable.
+ */
+@property (nonatomic, assign) BOOL isFinalLayoutable;
+
 @property (nonatomic, strong, readonly) ASLayoutOptions *layoutOptions;
 @end


### PR DESCRIPTION
A final layoutable method would look like:

```
- (id<ASLayoutable>)finalLayoutable
{
  ASInsetLayoutSpec *insetSpec = [[ASInsetLayoutSpec alloc] init];
  insetSpec.isFinalLayoutable = YES;
  insetSpec.insets = UIEdgeInsetsMake(4, 4, 4, 4);
  [insetSpec setChild:self];
  return insetSpec;
}
```

While I'm not wild about this for a couple of reasons (1: we require the user to set a flag instead of doing something more seamless; 2: it makes it impossible to use the convenience methods on the layoutSpecs in finalLayoutable), I think it is better than before. We can probably do better though, so let's use this as a starting point to discuss. 