### PR TITLE
Addressed comments to LayoutOptions PR

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -44,6 +44,7 @@
 
 @implementation ASDisplayNode
 
+// these dynamic properties all defined in ASLayoutOptionsPrivate.m
 @dynamic spacingAfter, spacingBefore, flexGrow, flexShrink, flexBasis, alignSelf, ascender, descender, sizeRange, layoutPosition, layoutOptions;
 @synthesize preferredFrameSize = _preferredFrameSize;
 @synthesize isFinalLayoutable = _isFinalLayoutable;

--- a/AsyncDisplayKit/Layout/ASBackgroundLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASBackgroundLayoutSpec.mm
@@ -68,4 +68,15 @@ static NSString * const kBackgroundChildKey = @"kBackgroundChildKey";
   return [super childForIdentifier:kBackgroundChildKey];
 }
 
+- (void)setChildren:(NSArray *)children
+{
+  ASDisplayNodeAssert(NO, @"not supported by this layout spec");
+}
+
+- (NSArray *)children
+{
+  ASDisplayNodeAssert(NO, @"not supported by this layout spec");
+  return nil;
+}
+
 @end

--- a/AsyncDisplayKit/Layout/ASCenterLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASCenterLayoutSpec.mm
@@ -90,4 +90,15 @@
   return [ASLayout layoutWithLayoutableObject:self size:size sublayouts:@[sublayout]];
 }
 
+- (void)setChildren:(NSArray *)children
+{
+  ASDisplayNodeAssert(NO, @"not supported by this layout spec");
+}
+
+- (NSArray *)children
+{
+  ASDisplayNodeAssert(NO, @"not supported by this layout spec");
+  return nil;
+}
+
 @end

--- a/AsyncDisplayKit/Layout/ASInsetLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASInsetLayoutSpec.mm
@@ -109,4 +109,15 @@ static CGFloat centerInset(CGFloat outer, CGFloat inner)
   return [ASLayout layoutWithLayoutableObject:self size:computedSize sublayouts:@[sublayout]];
 }
 
+- (void)setChildren:(NSArray *)children
+{
+  ASDisplayNodeAssert(NO, @"not supported by this layout spec");
+}
+
+- (NSArray *)children
+{
+  ASDisplayNodeAssert(NO, @"not supported by this layout spec");
+  return nil;
+}
+
 @end

--- a/AsyncDisplayKit/Layout/ASLayoutOptions.h
+++ b/AsyncDisplayKit/Layout/ASLayoutOptions.h
@@ -23,7 +23,7 @@
 - (void)setValuesFromLayoutable:(id<ASLayoutable>)layoutable;
 
 #pragma mark - Subclasses should implement these!
-- (void)propogateOptionsFromLayoutOptions:(ASLayoutOptions *)layoutOptions;
+- (void)propagateOptionsFromLayoutOptions:(ASLayoutOptions *)layoutOptions;
 
 #pragma mark - ASStackLayoutable
 

--- a/AsyncDisplayKit/Layout/ASLayoutOptions.h
+++ b/AsyncDisplayKit/Layout/ASLayoutOptions.h
@@ -12,8 +12,7 @@
 
 @protocol ASLayoutable;
 
-#import <AsyncDisplayKit/ASStackLayoutable.h>
-#import <AsyncDisplayKit/ASStaticLayoutable.h>
+#import <AsyncDisplayKit/ASLayoutSpec.h>
 
 @interface ASLayoutOptions : NSObject <ASStackLayoutable, ASStaticLayoutable, NSCopying>
 
@@ -24,8 +23,7 @@
 - (void)setValuesFromLayoutable:(id<ASLayoutable>)layoutable;
 
 #pragma mark - Subclasses should implement these!
-- (void)setupDefaults;
-- (void)copyIntoOptions:(ASLayoutOptions *)layoutOptions;
+- (void)propogateOptionsFromLayoutOptions:(ASLayoutOptions *)layoutOptions;
 
 #pragma mark - ASStackLayoutable
 
@@ -42,6 +40,5 @@
 
 @property (nonatomic, readwrite) ASRelativeSizeRange sizeRange;
 @property (nonatomic, readwrite) CGPoint layoutPosition;
-
 
 @end

--- a/AsyncDisplayKit/Layout/ASLayoutOptions.mm
+++ b/AsyncDisplayKit/Layout/ASLayoutOptions.mm
@@ -86,11 +86,11 @@ static Class gDefaultLayoutOptionsClass = nil;
 - (id)copyWithZone:(NSZone *)zone
 {
   ASLayoutOptions *copy = [[[self class] alloc] init];
-  [copy propogateOptionsFromLayoutOptions:self];
+  [copy propagateOptionsFromLayoutOptions:self];
   return copy;
 }
 
-- (void)propogateOptionsFromLayoutOptions:(ASLayoutOptions *)layoutOptions
+- (void)propagateOptionsFromLayoutOptions:(ASLayoutOptions *)layoutOptions
 {
   ASDN::MutexLocker l(_propertyLock);
   self.flexBasis = layoutOptions.flexBasis;

--- a/AsyncDisplayKit/Layout/ASLayoutOptionsPrivate.h
+++ b/AsyncDisplayKit/Layout/ASLayoutOptionsPrivate.h
@@ -10,25 +10,24 @@
 
 #import <AsyncDisplayKit/ASDisplayNode.h>
 #import <AsyncDisplayKit/ASLayoutSpec.h>
-
-
-@interface ASDisplayNode()
-{
-  ASLayoutOptions *_layoutOptions;
-  dispatch_once_t _layoutOptionsInitializeToken;
-}
-@end
+#import <AsyncDisplayKit/ASThread.h>
 
 @interface ASDisplayNode(ASLayoutOptions)<ASLayoutable>
 @end
 
-@interface ASLayoutSpec()
+@interface ASDisplayNode()
 {
   ASLayoutOptions *_layoutOptions;
-  dispatch_once_t _layoutOptionsInitializeToken;
+  ASDN::RecursiveMutex _layoutOptionsLock;
 }
 @end
 
 @interface ASLayoutSpec(ASLayoutOptions)<ASLayoutable>
 @end
 
+@interface ASLayoutSpec()
+{
+  ASLayoutOptions *_layoutOptions;
+  ASDN::RecursiveMutex _layoutOptionsLock;
+}
+@end

--- a/AsyncDisplayKit/Layout/ASLayoutOptionsPrivate.mm
+++ b/AsyncDisplayKit/Layout/ASLayoutOptionsPrivate.mm
@@ -10,16 +10,27 @@
 
 #import "ASLayoutOptionsPrivate.h"
 #import <AsyncDisplayKit/ASDisplayNodeInternal.h>
+#import "ASThread.h"
 
 
+/**
+ *  Both an ASDisplayNode and an ASLayoutSpec conform to ASLayoutable. There are several properties
+ *  in ASLayoutable that are used as layoutOptions when a node or spec is used in a layout spec.
+ *  These properties are provided for convenience, as they are forwards to the node or spec's
+ *  ASLayoutOptions class. Instead of duplicating the property forwarding in both classes, we 
+ *  create a define that allows us to easily implement the forwards in one place.
+ *
+ *  If you create a custom layout spec, we recommend this stragety if you decide to extend
+ *  ASDisplayNode and ASLAyoutSpec to provide convenience properties for any options that your 
+ *  layoutSpec may require.
+ */
 #define ASLayoutOptionsForwarding \
 - (ASLayoutOptions *)layoutOptions\
 {\
-dispatch_once(&_layoutOptionsInitializeToken, ^{\
+ASDN::MutexLocker l(_layoutOptionsLock);\
 if (_layoutOptions == nil) {\
 _layoutOptions = [[[ASLayoutOptions defaultLayoutOptionsClass] alloc] initWithLayoutable:self];\
 }\
-});\
 return _layoutOptions;\
 }\
 \

--- a/AsyncDisplayKit/Layout/ASLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASLayoutSpec.h
@@ -22,10 +22,37 @@
 
 - (instancetype)init;
 
+/**
+ *  Set child methods
+ *
+ *  Every ASLayoutSpec must act on at least one child. The ASLayoutSpec base class takes the
+ *  reponsibility of holding on to the spec children. For a layout spec like ASInsetLayoutSpec that
+ *  only requires a single child, the child can be added by calling setChild:.
+ *
+ *  For layout specs that require a known number of children (ASBackgroundLayoutSpec, for example)
+ *  a subclass should use the setChild to set the "primary" child. It can then use setChild:forIdentifier:
+ *  to set any other required children. Ideally a subclass would hide this from the user, and use the
+ *  setChildWithIdentifier: internally. For example, ASBackgroundLayoutSpec exposes a backgroundChild
+ *  property that behind the scenes is calling setChild:forIdentifier:.
+ *
+ *  Finally, a layout spec like ASStackLayoutSpec can take an unknown number of children. In this case, 
+ *  the setChildren: method should be used. For good measure, in these layout specs it probably makes
+ *  sense to define setChild: to do something appropriate or to assert.
+ */
 - (void)setChild:(id<ASLayoutable>)child;
 - (void)setChild:(id<ASLayoutable>)child forIdentifier:(NSString *)identifier;
 - (void)setChildren:(NSArray *)children;
 
+/**
+ *  Get child methods
+ *
+ *  There is a corresponding "getChild" method for the above "setChild" methods.  If a subclass
+ *  has extra layoutable children, it is recommended to make a corresponding get method for that 
+ *  child. For example, the ASBackgroundLayoutSpec responds to backgroundChild.
+ *
+ *  If a get method is called on a spec that doesn't make sense, then the standard is to assert. 
+ *  For example, calling children on an ASInsetLayoutSpec will assert.
+ */
 - (id<ASLayoutable>)child;
 - (id<ASLayoutable>)childForIdentifier:(NSString *)identifier;
 - (NSArray *)children;

--- a/AsyncDisplayKit/Layout/ASLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASLayoutSpec.mm
@@ -17,6 +17,7 @@
 #import "ASLayout.h"
 #import "ASLayoutOptions.h"
 #import "ASLayoutOptionsPrivate.h"
+#import "ASThread.h"
 
 #import <objc/runtime.h>
 
@@ -29,6 +30,7 @@ static NSString * const kDefaultChildrenKey = @"kDefaultChildrenKey";
 
 @implementation ASLayoutSpec
 
+// these dynamic properties all defined in ASLayoutOptionsPrivate.m
 @dynamic spacingAfter, spacingBefore, flexGrow, flexShrink, flexBasis, alignSelf, ascender, descender, sizeRange, layoutPosition, layoutOptions;
 @synthesize layoutChildren = _layoutChildren;
 @synthesize isFinalLayoutable = _isFinalLayoutable;
@@ -80,8 +82,7 @@ static NSString * const kDefaultChildrenKey = @"kDefaultChildrenKey";
 
     id<ASLayoutable> finalLayoutable = [child finalLayoutable];
     if (finalLayoutable != child) {
-      ASLayoutOptions *layoutOptions = [child layoutOptions];
-      [layoutOptions copyIntoOptions:finalLayoutable.layoutOptions];
+      [finalLayoutable.layoutOptions propogateOptionsFromLayoutOptions:child.layoutOptions];
       return finalLayoutable;
     }
   }

--- a/AsyncDisplayKit/Layout/ASLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASLayoutSpec.mm
@@ -82,7 +82,7 @@ static NSString * const kDefaultChildrenKey = @"kDefaultChildrenKey";
 
     id<ASLayoutable> finalLayoutable = [child finalLayoutable];
     if (finalLayoutable != child) {
-      [finalLayoutable.layoutOptions propogateOptionsFromLayoutOptions:child.layoutOptions];
+      [finalLayoutable.layoutOptions propagateOptionsFromLayoutOptions:child.layoutOptions];
       return finalLayoutable;
     }
   }

--- a/AsyncDisplayKit/Layout/ASLayoutable.h
+++ b/AsyncDisplayKit/Layout/ASLayoutable.h
@@ -20,11 +20,22 @@
 @class ASLayoutSpec;
 
 /** 
- * The ASLayoutable protocol declares a method for measuring the layout of an object. A class must implement the method
- * so that instances of that class can be used to build layout trees. The protocol also provides information 
- * about how an object should be laid out within an ASStackLayoutSpec.
+ * The ASLayoutable protocol declares a method for measuring the layout of an object. A layout
+ * is defined by an ASLayout return value, and must specify 1) the size (but not position) of the
+ * layoutable object, and 2) the size and position of all of its immediate child objects. The tree 
+ * recursion is driven by parents requesting layouts from their children in order to determine their 
+ * size, followed by the parents setting the position of the children once the size is known
+ *
+ * The protocol also implements a "family" of Layoutable protocols. These protocols contain layout 
+ * options that can be used for specific layout specs. For example, ASStackLayoutSpec has options
+ * defining how a layoutable should shrink or grow based upon available space.
+ *
+ * These layout options are all stored in an ASLayoutOptions class (that is defined in ASLayoutablePrivate).
+ * Generally you needn't worry about the layout options class, as the layoutable protocols allow all direct
+ * access to the options via convenience properties. If you are creating custom layout spec, then you can
+ * extend the backing layout options class to accomodate any new layout options.
  */
-@protocol ASLayoutable <ASLayoutablePrivate, ASStackLayoutable, ASStaticLayoutable>
+@protocol ASLayoutable <ASStackLayoutable, ASStaticLayoutable, ASLayoutablePrivate>
 
 /**
  * @abstract Calculate a layout based on given size range.
@@ -34,5 +45,65 @@
  * @return An ASLayout instance defining the layout of the receiver and its children.
  */
 - (ASLayout *)measureWithSizeRange:(ASSizeRange)constrainedSize;
+
+
+#pragma mark - Layout options from the Layoutable Protocols
+
+#pragma mark - ASStackLayoutable
+/**
+ * @abstract Additional space to place before this object in the stacking direction.
+ * Used when attached to a stack layout.
+ */
+@property (nonatomic, readwrite) CGFloat spacingBefore;
+
+/**
+ * @abstract Additional space to place after this object in the stacking direction.
+ * Used when attached to a stack layout.
+ */
+@property (nonatomic, readwrite) CGFloat spacingAfter;
+
+/**
+ * @abstract If the sum of childrens' stack dimensions is less than the minimum size, should this object grow?
+ * Used when attached to a stack layout.
+ */
+@property (nonatomic, readwrite) BOOL flexGrow;
+
+/**
+ * @abstract If the sum of childrens' stack dimensions is greater than the maximum size, should this object shrink?
+ * Used when attached to a stack layout.
+ */
+@property (nonatomic, readwrite) BOOL flexShrink;
+
+/**
+ * @abstract Specifies the initial size in the stack dimension for this object.
+ * Default to ASRelativeDimensionUnconstrained.
+ * Used when attached to a stack layout.
+ */
+@property (nonatomic, readwrite) ASRelativeDimension flexBasis;
+
+/**
+ * @abstract Orientation of the object along cross axis, overriding alignItems
+ * Used when attached to a stack layout.
+ */
+@property (nonatomic, readwrite) ASStackLayoutAlignSelf alignSelf;
+
+/**
+ *  @abstract Used for baseline alignment. The distance from the top of the object to its baseline.
+ */
+@property (nonatomic, readwrite) CGFloat ascender;
+
+/**
+ *  @abstract Used for baseline alignment. The distance from the baseline of the object to its bottom.
+ */
+@property (nonatomic, readwrite) CGFloat descender;
+
+#pragma mark - ASStaticLayoutable
+/**
+ If specified, the child's size is restricted according to this size. Percentages are resolved relative to the static layout spec.
+ */
+@property (nonatomic, assign) ASRelativeSizeRange sizeRange;
+
+/** The position of this object within its parent spec. */
+@property (nonatomic, assign) CGPoint layoutPosition;
 
 @end

--- a/AsyncDisplayKit/Layout/ASOverlayLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASOverlayLayoutSpec.mm
@@ -61,4 +61,15 @@ static NSString * const kOverlayChildKey = @"kOverlayChildKey";
   return [ASLayout layoutWithLayoutableObject:self size:contentsLayout.size sublayouts:sublayouts];
 }
 
+- (void)setChildren:(NSArray *)children
+{
+  ASDisplayNodeAssert(NO, @"not supported by this layout spec");
+}
+
+- (NSArray *)children
+{
+  ASDisplayNodeAssert(NO, @"not supported by this layout spec");
+  return nil;
+}
+
 @end

--- a/AsyncDisplayKit/Layout/ASRatioLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASRatioLayoutSpec.mm
@@ -75,4 +75,15 @@
   return [ASLayout layoutWithLayoutableObject:self size:sublayout.size sublayouts:@[sublayout]];
 }
 
+- (void)setChildren:(NSArray *)children
+{
+  ASDisplayNodeAssert(NO, @"not supported by this layout spec");
+}
+
+- (NSArray *)children
+{
+  ASDisplayNodeAssert(NO, @"not supported by this layout spec");
+  return nil;
+}
+
 @end

--- a/AsyncDisplayKit/Layout/ASStackLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASStackLayoutSpec.mm
@@ -87,6 +87,12 @@
   ASDisplayNodeAssert(NO, @"ASStackLayoutSpec only supports setChildren");
 }
 
+- (id<ASLayoutable>)childForIdentifier:(NSString *)identifier
+{
+  ASDisplayNodeAssert(NO, @"ASStackLayoutSpec only supports children");
+  return nil;
+}
+
 - (ASLayout *)measureWithSizeRange:(ASSizeRange)constrainedSize
 {
   ASStackLayoutSpecStyle style = {.direction = _direction, .spacing = _spacing, .justifyContent = _justifyContent, .alignItems = _alignItems, .baselineRelativeArrangement = _baselineRelativeArrangement};

--- a/AsyncDisplayKit/Layout/ASStaticLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASStaticLayoutSpec.mm
@@ -47,16 +47,15 @@
 
   NSMutableArray *sublayouts = [NSMutableArray arrayWithCapacity:self.children.count];
   for (id<ASLayoutable> child in self.children) {
-    ASLayoutOptions *layoutOptions = child.layoutOptions;
     CGSize autoMaxSize = {
-      constrainedSize.max.width - layoutOptions.layoutPosition.x,
-      constrainedSize.max.height - layoutOptions.layoutPosition.y
+      constrainedSize.max.width - child.layoutPosition.x,
+      constrainedSize.max.height - child.layoutPosition.y
     };
-    ASSizeRange childConstraint = ASRelativeSizeRangeEqualToRelativeSizeRange(ASRelativeSizeRangeUnconstrained, layoutOptions.sizeRange)
+    ASSizeRange childConstraint = ASRelativeSizeRangeEqualToRelativeSizeRange(ASRelativeSizeRangeUnconstrained, child.sizeRange)
       ? ASSizeRangeMake({0, 0}, autoMaxSize)
-      : ASRelativeSizeRangeResolve(layoutOptions.sizeRange, size);
+      : ASRelativeSizeRangeResolve(child.sizeRange, size);
     ASLayout *sublayout = [child measureWithSizeRange:childConstraint];
-    sublayout.position = layoutOptions.layoutPosition;
+    sublayout.position = child.layoutPosition;
     [sublayouts addObject:sublayout];
   }
   
@@ -77,6 +76,17 @@
   return [ASLayout layoutWithLayoutableObject:self
                                          size:ASSizeRangeClamp(constrainedSize, size)
                                    sublayouts:sublayouts];
+}
+
+- (void)setChild:(id<ASLayoutable>)child forIdentifier:(NSString *)identifier
+{
+  ASDisplayNodeAssert(NO, @"ASStackLayoutSpec only supports setChildren");
+}
+
+- (id<ASLayoutable>)childForIdentifier:(NSString *)identifier
+{
+  ASDisplayNodeAssert(NO, @"ASStackLayoutSpec only supports children");
+  return nil;
 }
 
 @end

--- a/AsyncDisplayKit/Private/ASStackBaselinePositionedLayout.mm
+++ b/AsyncDisplayKit/Private/ASStackBaselinePositionedLayout.mm
@@ -20,9 +20,9 @@ static CGFloat baselineForItem(const ASStackLayoutSpecStyle &style,
   __weak id<ASLayoutable> child = layout.layoutableObject;
   switch (style.alignItems) {
     case ASStackLayoutAlignItemsBaselineFirst:
-      return child.layoutOptions.ascender;
+      return child.ascender;
     case ASStackLayoutAlignItemsBaselineLast:
-      return layout.size.height + child.layoutOptions.descender;
+      return layout.size.height + child.descender;
     default:
       return 0;
   }
@@ -38,7 +38,7 @@ static CGFloat baselineOffset(const ASStackLayoutSpecStyle &style,
     __weak id<ASLayoutable> child = l.layoutableObject;
     switch (style.alignItems) {
       case ASStackLayoutAlignItemsBaselineFirst:
-        return maxAscender - child.layoutOptions.ascender;
+        return maxAscender - child.ascender;
       case ASStackLayoutAlignItemsBaselineLast:
         return maxBaseline - baselineForItem(style, l);
         
@@ -91,9 +91,9 @@ ASStackBaselinePositionedLayout ASStackBaselinePositionedLayout::compute(const A
     our layoutSpec to have it so that it can be baseline aligned with another text node or baseline layout spec.
    */
   const auto ascenderIt = std::max_element(positionedLayout.sublayouts.begin(), positionedLayout.sublayouts.end(), [&](const ASLayout *a, const ASLayout *b){
-    return a.layoutableObject.layoutOptions.ascender < b.layoutableObject.layoutOptions.ascender;
+    return a.layoutableObject.ascender < b.layoutableObject.ascender;
   });
-  const CGFloat maxAscender = baselineIt == positionedLayout.sublayouts.end() ? 0 : (*ascenderIt).layoutableObject.layoutOptions.ascender;
+  const CGFloat maxAscender = baselineIt == positionedLayout.sublayouts.end() ? 0 : (*ascenderIt).layoutableObject.ascender;
   
   /*
     Step 3: Take each child and update its layout position based on the baseline offset.
@@ -107,7 +107,7 @@ ASStackBaselinePositionedLayout ASStackBaselinePositionedLayout::compute(const A
   BOOL first = YES;
   auto stackedChildren = AS::map(positionedLayout.sublayouts, [&](ASLayout *l) -> ASLayout *{
     __weak id<ASLayoutable> child = l.layoutableObject;
-    p = p + directionPoint(style.direction, child.layoutOptions.spacingBefore, 0);
+    p = p + directionPoint(style.direction, child.spacingBefore, 0);
     if (first) {
       // if this is the first item use the previously computed start point
       p = l.position;
@@ -124,9 +124,9 @@ ASStackBaselinePositionedLayout ASStackBaselinePositionedLayout::compute(const A
     // node from baselines and not bounding boxes.
     CGFloat spacingAfterBaseline = 0;
     if (style.direction == ASStackLayoutDirectionVertical) {
-      spacingAfterBaseline = child.layoutOptions.descender;
+      spacingAfterBaseline = child.descender;
     }
-    p = p + directionPoint(style.direction, stackDimension(style.direction, l.size) + child.layoutOptions.spacingAfter + spacingAfterBaseline, 0);
+    p = p + directionPoint(style.direction, stackDimension(style.direction, l.size) + child.spacingAfter + spacingAfterBaseline, 0);
     
     return l;
   });
@@ -156,7 +156,7 @@ ASStackBaselinePositionedLayout ASStackBaselinePositionedLayout::compute(const A
   const auto descenderIt = std::max_element(stackedChildren.begin(), stackedChildren.end(), [&](const ASLayout *a, const ASLayout *b){
     return  a.position.y + a.size.height <  b.position.y + b.size.height;
   });
-  const CGFloat minDescender = descenderIt == stackedChildren.end() ? 0 : (*descenderIt).layoutableObject.layoutOptions.descender;
+  const CGFloat minDescender = descenderIt == stackedChildren.end() ? 0 : (*descenderIt).layoutableObject.descender;
 
   return {stackedChildren, crossSize, maxAscender, minDescender};
 }

--- a/AsyncDisplayKit/Private/ASStackPositionedLayout.mm
+++ b/AsyncDisplayKit/Private/ASStackPositionedLayout.mm
@@ -20,7 +20,7 @@ static CGFloat crossOffset(const ASStackLayoutSpecStyle &style,
                            const ASStackUnpositionedItem &l,
                            const CGFloat crossSize)
 {
-  switch (alignment(l.child.layoutOptions.alignSelf, style.alignItems)) {
+  switch (alignment(l.child.alignSelf, style.alignItems)) {
     case ASStackLayoutAlignItemsEnd:
       return crossSize - crossDimension(style.direction, l.layout.size);
     case ASStackLayoutAlignItemsCenter:
@@ -51,14 +51,14 @@ static ASStackPositionedLayout stackedLayout(const ASStackLayoutSpecStyle &style
   CGPoint p = directionPoint(style.direction, offset, 0);
   BOOL first = YES;
   auto stackedChildren = AS::map(unpositionedLayout.items, [&](const ASStackUnpositionedItem &l) -> ASLayout *{
-    p = p + directionPoint(style.direction, l.child.layoutOptions.spacingBefore, 0);
+    p = p + directionPoint(style.direction, l.child.spacingBefore, 0);
     if (!first) {
       p = p + directionPoint(style.direction, style.spacing, 0);
     }
     first = NO;
     l.layout.position = p + directionPoint(style.direction, 0, crossOffset(style, l, crossSize));
     
-    p = p + directionPoint(style.direction, stackDimension(style.direction, l.layout.size) + l.child.layoutOptions.spacingAfter, 0);
+    p = p + directionPoint(style.direction, stackDimension(style.direction, l.layout.size) + l.child.spacingAfter, 0);
     return l.layout;
   });
   return {stackedChildren, crossSize};

--- a/AsyncDisplayKit/Private/ASStackUnpositionedLayout.mm
+++ b/AsyncDisplayKit/Private/ASStackUnpositionedLayout.mm
@@ -26,7 +26,7 @@ static ASLayout *crossChildLayout(const id<ASLayoutable> child,
                                   const CGFloat crossMin,
                                   const CGFloat crossMax)
 {
-  const ASStackLayoutAlignItems alignItems = alignment(child.layoutOptions.alignSelf, style.alignItems);
+  const ASStackLayoutAlignItems alignItems = alignment(child.alignSelf, style.alignItems);
   // stretched children will have a cross dimension of at least crossMin
   const CGFloat childCrossMin = alignItems == ASStackLayoutAlignItemsStretch ? crossMin : 0;
   const ASSizeRange childSizeRange = directionSizeRange(style.direction, stackMin, stackMax, childCrossMin, crossMax);
@@ -76,7 +76,7 @@ static void stretchChildrenAlongCrossDimension(std::vector<ASStackUnpositionedIt
 
   const CGFloat childCrossMax = it == layouts.end() ? 0 : crossDimension(style.direction, it->layout.size);
   for (auto &l : layouts) {
-    const ASStackLayoutAlignItems alignItems = alignment(l.child.layoutOptions.alignSelf, style.alignItems);
+    const ASStackLayoutAlignItems alignItems = alignment(l.child.alignSelf, style.alignItems);
 
     const CGFloat cross = crossDimension(style.direction, l.layout.size);
     const CGFloat stack = stackDimension(style.direction, l.layout.size);
@@ -112,7 +112,7 @@ static CGFloat computeStackDimensionSum(const std::vector<ASStackUnpositionedIte
                                                   // Start from default spacing between each child:
                                                   children.empty() ? 0 : style.spacing * (children.size() - 1),
                                                   [&](CGFloat x, const ASStackUnpositionedItem &l) {
-                                                    return x + l.child.layoutOptions.spacingBefore + l.child.layoutOptions.spacingAfter;
+                                                    return x + l.child.spacingBefore + l.child.spacingAfter;
                                                   });
 
   // Sum up the childrens' dimensions (including spacing) in the stack direction.
@@ -181,15 +181,15 @@ static std::function<BOOL(const ASStackUnpositionedItem &)> isFlexibleInViolatio
   if (fabs(violation) < kViolationEpsilon) {
     return [](const ASStackUnpositionedItem &l) { return NO; };
   } else if (violation > 0) {
-    return [](const ASStackUnpositionedItem &l) { return l.child.layoutOptions.flexGrow; };
+    return [](const ASStackUnpositionedItem &l) { return l.child.flexGrow; };
   } else {
-    return [](const ASStackUnpositionedItem &l) { return l.child.layoutOptions.flexShrink; };
+    return [](const ASStackUnpositionedItem &l) { return l.child.flexShrink; };
   }
 }
 
 ASDISPLAYNODE_INLINE BOOL isFlexibleInBothDirections(id<ASLayoutable> child)
 {
-  return child.layoutOptions.flexGrow && child.layoutOptions.flexShrink;
+  return child.flexGrow && child.flexShrink;
 }
 
 /**
@@ -294,8 +294,8 @@ static std::vector<ASStackUnpositionedItem> layoutChildrenAlongUnconstrainedStac
   const CGFloat maxCrossDimension = crossDimension(style.direction, sizeRange.max);
   
   return AS::map(children, [&](id<ASLayoutable> child) -> ASStackUnpositionedItem {
-    const BOOL isUnconstrainedFlexBasis = ASRelativeDimensionEqualToRelativeDimension(ASRelativeDimensionUnconstrained, child.layoutOptions.flexBasis);
-    const CGFloat exactStackDimension = ASRelativeDimensionResolve(child.layoutOptions.flexBasis, stackDimension(style.direction, size));
+    const BOOL isUnconstrainedFlexBasis = ASRelativeDimensionEqualToRelativeDimension(ASRelativeDimensionUnconstrained, child.flexBasis);
+    const CGFloat exactStackDimension = ASRelativeDimensionResolve(child.flexBasis, stackDimension(style.direction, size));
 
     if (useOptimizedFlexing && isFlexibleInBothDirections(child)) {
       return { child, [ASLayout layoutWithLayoutableObject:child size:{0, 0}] };

--- a/AsyncDisplayKitTests/ASCenterLayoutSpecSnapshotTests.mm
+++ b/AsyncDisplayKitTests/ASCenterLayoutSpecSnapshotTests.mm
@@ -95,7 +95,7 @@ static NSString *suffixForCenteringOptions(ASCenterLayoutSpecCenteringOptions ce
   ASDisplayNode *backgroundNode = ASDisplayNodeWithBackgroundColor([UIColor redColor]);
   ASStaticSizeDisplayNode *foregroundNode = ASDisplayNodeWithBackgroundColor([UIColor redColor]);
   foregroundNode.staticSize = {10, 10};
-  foregroundNode.layoutOptions.flexGrow = YES;
+  foregroundNode.flexGrow = YES;
   
   ASCenterLayoutSpec *layoutSpec =
   [ASCenterLayoutSpec

--- a/AsyncDisplayKitTests/ASStackLayoutSpecSnapshotTests.mm
+++ b/AsyncDisplayKitTests/ASStackLayoutSpecSnapshotTests.mm
@@ -42,8 +42,8 @@ static NSArray *defaultSubnodesWithSameSize(CGSize subnodeSize, BOOL flex)
                         ];
   for (ASStaticSizeDisplayNode *subnode in subnodes) {
     subnode.staticSize = subnodeSize;
-    subnode.layoutOptions.flexGrow = flex;
-    subnode.layoutOptions.flexShrink = flex;
+    subnode.flexGrow = flex;
+    subnode.flexShrink = flex;
   }
   return subnodes;
 }
@@ -115,7 +115,7 @@ static NSArray *defaultSubnodesWithSameSize(CGSize subnodeSize, BOOL flex)
   ASStackLayoutSpecStyle style = {.direction = ASStackLayoutDirectionHorizontal};
 
   NSArray *subnodes = defaultSubnodesWithSameSize({50, 50}, NO);
-  ((ASDisplayNode *)subnodes[1]).layoutOptions.flexShrink = YES;
+  ((ASDisplayNode *)subnodes[1]).flexShrink = YES;
   
   // Width is 75px--that's less than the sum of the widths of the children, which is 100px.
   static ASSizeRange kSize = {{75, 0}, {75, 150}};
@@ -205,23 +205,23 @@ static NSArray *defaultSubnodesWithSameSize(CGSize subnodeSize, BOOL flex)
   ((ASStaticSizeDisplayNode *)subnodes[1]).staticSize = {100, 70};
   ((ASStaticSizeDisplayNode *)subnodes[2]).staticSize = {150, 90};
   
-  ((ASStaticSizeDisplayNode *)subnodes[1]).layoutOptions.spacingBefore = 10;
-  ((ASStaticSizeDisplayNode *)subnodes[2]).layoutOptions.spacingBefore = 20;
+  ((ASStaticSizeDisplayNode *)subnodes[1]).spacingBefore = 10;
+  ((ASStaticSizeDisplayNode *)subnodes[2]).spacingBefore = 20;
   [self testStackLayoutSpecWithStyle:style sizeRange:kAnySize subnodes:subnodes identifier:@"spacingBefore"];
   // Reset above spacing values
-  ((ASStaticSizeDisplayNode *)subnodes[1]).layoutOptions.spacingBefore = 0;
-  ((ASStaticSizeDisplayNode *)subnodes[2]).layoutOptions.spacingBefore = 0;
+  ((ASStaticSizeDisplayNode *)subnodes[1]).spacingBefore = 0;
+  ((ASStaticSizeDisplayNode *)subnodes[2]).spacingBefore = 0;
 
-  ((ASStaticSizeDisplayNode *)subnodes[1]).layoutOptions.spacingAfter = 10;
-  ((ASStaticSizeDisplayNode *)subnodes[2]).layoutOptions.spacingAfter = 20;
+  ((ASStaticSizeDisplayNode *)subnodes[1]).spacingAfter = 10;
+  ((ASStaticSizeDisplayNode *)subnodes[2]).spacingAfter = 20;
   [self testStackLayoutSpecWithStyle:style sizeRange:kAnySize subnodes:subnodes identifier:@"spacingAfter"];
   // Reset above spacing values
-  ((ASStaticSizeDisplayNode *)subnodes[1]).layoutOptions.spacingAfter = 0;
-  ((ASStaticSizeDisplayNode *)subnodes[2]).layoutOptions.spacingAfter = 0;
+  ((ASStaticSizeDisplayNode *)subnodes[1]).spacingAfter = 0;
+  ((ASStaticSizeDisplayNode *)subnodes[2]).spacingAfter = 0;
   
   style.spacing = 10;
-  ((ASStaticSizeDisplayNode *)subnodes[1]).layoutOptions.spacingBefore = -10;
-  ((ASStaticSizeDisplayNode *)subnodes[1]).layoutOptions.spacingAfter = -10;
+  ((ASStaticSizeDisplayNode *)subnodes[1]).spacingBefore = -10;
+  ((ASStaticSizeDisplayNode *)subnodes[1]).spacingAfter = -10;
   [self testStackLayoutSpecWithStyle:style sizeRange:kAnySize subnodes:subnodes identifier:@"spacingBalancedOut"];
 }
 
@@ -237,9 +237,9 @@ static NSArray *defaultSubnodesWithSameSize(CGSize subnodeSize, BOOL flex)
   ((ASStaticSizeDisplayNode *)subnodes[1]).staticSize = {100, 70};
   ((ASStaticSizeDisplayNode *)subnodes[2]).staticSize = {150, 90};
 
-  ((ASStaticSizeDisplayNode *)subnodes[0]).layoutOptions.spacingBefore = 0;
-  ((ASStaticSizeDisplayNode *)subnodes[1]).layoutOptions.spacingBefore = 20;
-  ((ASStaticSizeDisplayNode *)subnodes[2]).layoutOptions.spacingBefore = 30;
+  ((ASStaticSizeDisplayNode *)subnodes[0]).spacingBefore = 0;
+  ((ASStaticSizeDisplayNode *)subnodes[1]).spacingBefore = 20;
+  ((ASStaticSizeDisplayNode *)subnodes[2]).spacingBefore = 30;
 
   // width 0-300px; height 300px
   static ASSizeRange kVariableHeight = {{0, 300}, {300, 300}};
@@ -255,9 +255,9 @@ static NSArray *defaultSubnodesWithSameSize(CGSize subnodeSize, BOOL flex)
   subnode2.staticSize = {50, 50};
   
   ASRatioLayoutSpec *child1 = [ASRatioLayoutSpec ratioLayoutSpecWithRatio:1.5 child:subnode1];
-  child1.layoutOptions.flexBasis = ASRelativeDimensionMakeWithPercent(1);
-  child1.layoutOptions.flexGrow = YES;
-  child1.layoutOptions.flexShrink = YES;
+  child1.flexBasis = ASRelativeDimensionMakeWithPercent(1);
+  child1.flexGrow = YES;
+  child1.flexShrink = YES;
   
   static ASSizeRange kFixedWidth = {{150, 0}, {150, INFINITY}};
   [self testStackLayoutSpecWithStyle:style children:@[child1, subnode2] sizeRange:kFixedWidth subnodes:@[subnode1, subnode2] identifier:nil];
@@ -272,11 +272,11 @@ static NSArray *defaultSubnodesWithSameSize(CGSize subnodeSize, BOOL flex)
 
   ASStaticSizeDisplayNode *subnode1 = ASDisplayNodeWithBackgroundColor([UIColor redColor]);
   subnode1.staticSize = {100, 100};
-  subnode1.layoutOptions.flexShrink = YES;
+  subnode1.flexShrink = YES;
 
   ASStaticSizeDisplayNode *subnode2 = ASDisplayNodeWithBackgroundColor([UIColor blueColor]);
   subnode2.staticSize = {50, 50};
-  subnode2.layoutOptions.flexShrink = YES;
+  subnode2.flexShrink = YES;
 
   NSArray *subnodes = @[subnode1, subnode2];
   static ASSizeRange kFixedWidth = {{150, 0}, {150, 100}};
@@ -292,7 +292,7 @@ static NSArray *defaultSubnodesWithSameSize(CGSize subnodeSize, BOOL flex)
   
   ASStaticSizeDisplayNode *subnode2 = ASDisplayNodeWithBackgroundColor([UIColor blueColor]);
   subnode2.staticSize = {50, 50};
-  subnode2.layoutOptions.alignSelf = ASStackLayoutAlignSelfCenter;
+  subnode2.alignSelf = ASStackLayoutAlignSelfCenter;
 
   NSArray *subnodes = @[subnode1, subnode2];
   static ASSizeRange kFixedWidth = {{150, 0}, {150, INFINITY}};
@@ -312,9 +312,9 @@ static NSArray *defaultSubnodesWithSameSize(CGSize subnodeSize, BOOL flex)
   ((ASStaticSizeDisplayNode *)subnodes[1]).staticSize = {100, 70};
   ((ASStaticSizeDisplayNode *)subnodes[2]).staticSize = {150, 90};
   
-  ((ASStaticSizeDisplayNode *)subnodes[0]).layoutOptions.spacingBefore = 0;
-  ((ASStaticSizeDisplayNode *)subnodes[1]).layoutOptions.spacingBefore = 20;
-  ((ASStaticSizeDisplayNode *)subnodes[2]).layoutOptions.spacingBefore = 30;
+  ((ASStaticSizeDisplayNode *)subnodes[0]).spacingBefore = 0;
+  ((ASStaticSizeDisplayNode *)subnodes[1]).spacingBefore = 20;
+  ((ASStaticSizeDisplayNode *)subnodes[2]).spacingBefore = 30;
 
   static ASSizeRange kExactSize = {{300, 300}, {300, 300}};
   [self testStackLayoutSpecWithStyle:style sizeRange:kExactSize subnodes:subnodes identifier:nil];
@@ -333,9 +333,9 @@ static NSArray *defaultSubnodesWithSameSize(CGSize subnodeSize, BOOL flex)
   ((ASStaticSizeDisplayNode *)subnodes[1]).staticSize = {100, 70};
   ((ASStaticSizeDisplayNode *)subnodes[2]).staticSize = {150, 90};
   
-  ((ASStaticSizeDisplayNode *)subnodes[0]).layoutOptions.spacingBefore = 0;
-  ((ASStaticSizeDisplayNode *)subnodes[1]).layoutOptions.spacingBefore = 20;
-  ((ASStaticSizeDisplayNode *)subnodes[2]).layoutOptions.spacingBefore = 30;
+  ((ASStaticSizeDisplayNode *)subnodes[0]).spacingBefore = 0;
+  ((ASStaticSizeDisplayNode *)subnodes[1]).spacingBefore = 20;
+  ((ASStaticSizeDisplayNode *)subnodes[2]).spacingBefore = 30;
 
   static ASSizeRange kExactSize = {{300, 300}, {300, 300}};
   [self testStackLayoutSpecWithStyle:style sizeRange:kExactSize subnodes:subnodes identifier:nil];
@@ -354,9 +354,9 @@ static NSArray *defaultSubnodesWithSameSize(CGSize subnodeSize, BOOL flex)
   ((ASStaticSizeDisplayNode *)subnodes[1]).staticSize = {100, 70};
   ((ASStaticSizeDisplayNode *)subnodes[2]).staticSize = {150, 90};
   
-  ((ASStaticSizeDisplayNode *)subnodes[0]).layoutOptions.spacingBefore = 0;
-  ((ASStaticSizeDisplayNode *)subnodes[1]).layoutOptions.spacingBefore = 20;
-  ((ASStaticSizeDisplayNode *)subnodes[2]).layoutOptions.spacingBefore = 30;
+  ((ASStaticSizeDisplayNode *)subnodes[0]).spacingBefore = 0;
+  ((ASStaticSizeDisplayNode *)subnodes[1]).spacingBefore = 20;
+  ((ASStaticSizeDisplayNode *)subnodes[2]).spacingBefore = 30;
 
   static ASSizeRange kExactSize = {{300, 300}, {300, 300}};
   [self testStackLayoutSpecWithStyle:style sizeRange:kExactSize subnodes:subnodes identifier:nil];
@@ -375,9 +375,9 @@ static NSArray *defaultSubnodesWithSameSize(CGSize subnodeSize, BOOL flex)
   ((ASStaticSizeDisplayNode *)subnodes[1]).staticSize = {100, 70};
   ((ASStaticSizeDisplayNode *)subnodes[2]).staticSize = {150, 90};
 
-  ((ASStaticSizeDisplayNode *)subnodes[0]).layoutOptions.spacingBefore = 0;
-  ((ASStaticSizeDisplayNode *)subnodes[1]).layoutOptions.spacingBefore = 20;
-  ((ASStaticSizeDisplayNode *)subnodes[2]).layoutOptions.spacingBefore = 30;
+  ((ASStaticSizeDisplayNode *)subnodes[0]).spacingBefore = 0;
+  ((ASStaticSizeDisplayNode *)subnodes[1]).spacingBefore = 20;
+  ((ASStaticSizeDisplayNode *)subnodes[2]).spacingBefore = 30;
 
   static ASSizeRange kVariableSize = {{200, 200}, {300, 300}};
   // all children should be 200px wide
@@ -397,9 +397,9 @@ static NSArray *defaultSubnodesWithSameSize(CGSize subnodeSize, BOOL flex)
   ((ASStaticSizeDisplayNode *)subnodes[1]).staticSize = {100, 70};
   ((ASStaticSizeDisplayNode *)subnodes[2]).staticSize = {150, 90};
   
-  ((ASStaticSizeDisplayNode *)subnodes[0]).layoutOptions.spacingBefore = 0;
-  ((ASStaticSizeDisplayNode *)subnodes[1]).layoutOptions.spacingBefore = 20;
-  ((ASStaticSizeDisplayNode *)subnodes[2]).layoutOptions.spacingBefore = 30;
+  ((ASStaticSizeDisplayNode *)subnodes[0]).spacingBefore = 0;
+  ((ASStaticSizeDisplayNode *)subnodes[1]).spacingBefore = 20;
+  ((ASStaticSizeDisplayNode *)subnodes[2]).spacingBefore = 30;
 
   static ASSizeRange kVariableSize = {{50, 50}, {300, 300}};
   // all children should be 150px wide
@@ -420,8 +420,8 @@ static NSArray *defaultSubnodesWithSameSize(CGSize subnodeSize, BOOL flex)
   ((ASStaticSizeDisplayNode *)subnodes[1]).staticSize = {150, 150};
 
   for (ASStaticSizeDisplayNode *subnode in subnodes) {
-    subnode.layoutOptions.flexGrow = YES;
-    subnode.layoutOptions.flexBasis = ASRelativeDimensionMakeWithPoints(10);
+    subnode.flexGrow = YES;
+    subnode.flexBasis = ASRelativeDimensionMakeWithPoints(10);
   }
 
   // width 300px; height 0-150px.
@@ -440,12 +440,12 @@ static NSArray *defaultSubnodesWithSameSize(CGSize subnodeSize, BOOL flex)
   NSArray *subnodes = defaultSubnodesWithSameSize({50, 50}, NO);
   
   for (ASStaticSizeDisplayNode *subnode in subnodes) {
-    subnode.layoutOptions.flexGrow = YES;
+    subnode.flexGrow = YES;
   }
 
   // This should override the intrinsic size of 50pts and instead compute to 50% = 100pts.
   // The result should be that the red box is twice as wide as the blue and gree boxes after flexing.
-  ((ASStaticSizeDisplayNode *)subnodes[0]).layoutOptions.flexBasis = ASRelativeDimensionMakeWithPercent(0.5);
+  ((ASStaticSizeDisplayNode *)subnodes[0]).flexBasis = ASRelativeDimensionMakeWithPercent(0.5);
 
   static ASSizeRange kSize = {{200, 0}, {200, INFINITY}};
   [self testStackLayoutSpecWithStyle:style sizeRange:kSize subnodes:subnodes identifier:nil];
@@ -461,7 +461,7 @@ static NSArray *defaultSubnodesWithSameSize(CGSize subnodeSize, BOOL flex)
   ((ASStaticSizeDisplayNode *)subnodes[2]).staticSize = {50, 50};
 
   for (ASStaticSizeDisplayNode *subnode in subnodes) {
-    subnode.layoutOptions.flexBasis = ASRelativeDimensionMakeWithPoints(20);
+    subnode.flexBasis = ASRelativeDimensionMakeWithPoints(20);
   }
   
   static ASSizeRange kSize = {{300, 0}, {300, 150}};
@@ -479,8 +479,8 @@ static NSArray *defaultSubnodesWithSameSize(CGSize subnodeSize, BOOL flex)
   ((ASStaticSizeDisplayNode *)subnodes[2]).staticSize = {3000, 3000};
   
   ASRatioLayoutSpec *child2 = [ASRatioLayoutSpec ratioLayoutSpecWithRatio:1.0 child:subnodes[2]];
-  child2.layoutOptions.flexGrow = YES;
-  child2.layoutOptions.flexShrink = YES;
+  child2.flexGrow = YES;
+  child2.flexShrink = YES;
 
   // If cross axis stretching occurred *before* flexing, then the blue child would be stretched to 3000 points tall.
   // Instead it should be stretched to 300 points tall, matching the red child and not overlapping the green inset.
@@ -505,13 +505,13 @@ static NSArray *defaultSubnodesWithSameSize(CGSize subnodeSize, BOOL flex)
   NSArray *subnodes = defaultSubnodes();
   
   ((ASStaticSizeDisplayNode *)subnodes[0]).staticSize = {300, 50};
-  ((ASStaticSizeDisplayNode *)subnodes[0]).layoutOptions.flexShrink = YES;
+  ((ASStaticSizeDisplayNode *)subnodes[0]).flexShrink = YES;
   
   ((ASStaticSizeDisplayNode *)subnodes[1]).staticSize = {100, 50};
-  ((ASStaticSizeDisplayNode *)subnodes[1]).layoutOptions.flexShrink = NO;
+  ((ASStaticSizeDisplayNode *)subnodes[1]).flexShrink = NO;
   
   ((ASStaticSizeDisplayNode *)subnodes[2]).staticSize = {200, 50};
-  ((ASStaticSizeDisplayNode *)subnodes[2]).layoutOptions.flexShrink = YES;
+  ((ASStaticSizeDisplayNode *)subnodes[2]).flexShrink = YES;
   
   // A width of 400px results in a violation of 200px. This is distributed equally among each flexible child,
   // causing both of them to be shrunk by 100px, resulting in widths of 300px, 100px, and 50px.


### PR DESCRIPTION
Addressed comments from the PR: https://github.com/facebook/AsyncDisplayKit/pull/644

Note: I did not change how the ASLayoutOptions are propagated. I did change the "copyInto" method to `propagateOptionsFromLayoutOptions:` (I even spelled it right on my second try). The reasoning behind this is I worry that traversing children to get a valid value for an option may be error prone. 

For example, imagine a stack of 3 text nodes wrapped in inset specs. You want the first 2 to align on the baseline but not the third. You set the 3rd nodes inset spec to have ascender/descender to 0.

While laying out the textNodes the stack spec starts traversing the 3rd node. It sees an inset spec with an ascender/descender of 0. This is the default value. What does it do? Does it assume that since this is a default value, it should keep traversing until it finds a value for ascender/descender? That would be wrong. Does it take whatever is in the top node? If we aren't propagating options then that method will be wrong for the first two text nodes. It seems to me the best way to keep the options unambiguous is to propagate them up each time. Then any user overrides are explicit.

