### PR TITLE
Fix appledoc warnings

### DIFF
--- a/AsyncDisplayKit/ASCollectionNode.h
+++ b/AsyncDisplayKit/ASCollectionNode.h
@@ -8,6 +8,10 @@
 
 #import <AsyncDisplayKit/AsyncDisplayKit.h>
 
+/**
+ * ASCollectionNode is a node based class that wraps an ASCollectionView. It can be used
+ * as a subnode of another node, and provide room for many (great) features and improvements later on.
+ */
 @interface ASCollectionNode : ASDisplayNode
 
 - (instancetype)initWithCollectionViewLayout:(UICollectionViewLayout *)layout NS_DESIGNATED_INITIALIZER;

--- a/AsyncDisplayKit/ASTableView.h
+++ b/AsyncDisplayKit/ASTableView.h
@@ -99,16 +99,11 @@
 - (void)beginUpdates;
 
 /**
- *  Concludes a series of method calls that insert, delete, select, or reload rows and sections of the table view.
+ *  Concludes a series of method calls that insert, delete, select, or reload rows and sections of the table view, with animation enabled and no completion block.
  *  You call this method to bracket a series of method calls that begins with beginUpdates and that consists of operations
  *  to insert, delete, select, and reload rows and sections of the table view. When you call endUpdates, ASTableView begins animating
  *  the operations simultaneously. This method is must be called from the main thread. It's important to remeber that the ASTableView will
  *  be processing the updates asynchronously after this call is completed.
- *
- *  @param animated   NO to disable all animations.
- *  @param completion A completion handler block to execute when all of the operations are finished. This block takes a single
- *                    Boolean parameter that contains the value YES if all of the related animations completed successfully or
- *                    NO if they were interrupted. This parameter may be nil. If supplied, the block is run on the main thread.
  */
 - (void)endUpdates;
 

--- a/AsyncDisplayKit/Details/ASRangeController.h
+++ b/AsyncDisplayKit/Details/ASRangeController.h
@@ -85,7 +85,7 @@
  * End updates.
  *
  * @param rangeController Sender.
- *
+ * @param animated NO if all animations are disabled. YES otherwise.
  * @param completion Completion block.
  */
 - (void)rangeController:(ASRangeController * )rangeController endUpdatesAnimated:(BOOL)animated completion:(void (^)(BOOL))completion;
@@ -104,6 +104,8 @@
  *
  * @param rangeController Sender.
  *
+ * @param nodes Inserted nodes.
+ *
  * @param indexPaths Index path of inserted nodes.
  *
  * @param animationOptions Animation options. See ASDataControllerAnimationOptions.
@@ -114,6 +116,8 @@
  * Called for nodes deletion.
  *
  * @param rangeController Sender.
+ *
+ * @param nodes Deleted nodes.
  *
  * @param indexPaths Index path of deleted nodes.
  *

--- a/AsyncDisplayKit/Layout/ASLayoutOptions.h
+++ b/AsyncDisplayKit/Layout/ASLayoutOptions.h
@@ -9,10 +9,9 @@
  */
 
 #import <Foundation/Foundation.h>
+#import <AsyncDisplayKit/ASLayoutSpec.h>
 
 @protocol ASLayoutable;
-
-#import <AsyncDisplayKit/ASLayoutSpec.h>
 
 @interface ASLayoutOptions : NSObject <ASStackLayoutable, ASStaticLayoutable, NSCopying>
 


### PR DESCRIPTION
There are still some warnings left (see below). @rcancro will look at them later on.

```
WARN | ASLayoutOptions is not documented!
WARN | ASLayoutSpec.h@25: Description for parameter 'child' missing for -[ASLayoutSpec setChild:]!
WARN | ASLayoutablePrivate is not documented!
WARN | ASStackLayoutable is not documented!
WARN | ASStaticLayoutable is not documented!
```