### PR TITLE
Fill image context with background color if image node is opaque

### DIFF
--- a/AsyncDisplayKit/ASImageNode.mm
+++ b/AsyncDisplayKit/ASImageNode.mm
@@ -231,7 +231,7 @@
   // if view is opaque, fill the context with background color
   if (parameters.opaque && parameters.backgroundColor) {
     [parameters.backgroundColor setFill];
-    [[UIBezierPath bezierPathWithRect:{ .size = backingSize }] fill];
+    UIRectFill({ .size = backingSize });
   }
 
   [image drawInRect:imageDrawRect];

--- a/AsyncDisplayKit/ASImageNode.mm
+++ b/AsyncDisplayKit/ASImageNode.mm
@@ -227,6 +227,12 @@
   // Use contentsScale of 1.0 and do the contentsScale handling in boundsSizeInPixels so ASCroppedImageBackingSizeAndDrawRectInBounds
   // will do its rounding on pixel instead of point boundaries
   UIGraphicsBeginImageContextWithOptions(backingSize, parameters.opaque, 1.0);
+  
+  // if view is opaque, fill the context with background color
+  if (parameters.opaque && parameters.backgroundColor) {
+    [parameters.backgroundColor setFill];
+    [[UIBezierPath bezierPathWithRect:{ .size = backingSize }] fill];
+  }
 
   [image drawInRect:imageDrawRect];
 


### PR DESCRIPTION
This way you can get a performance boost by marking your image nodes as opaque. Before this PR, no matter what the background color, opaque image nodes with partially-transparent images always show a black background.