### PR TITLE
Travis use Xcode 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: objective-c
+osx_image: xcode7
 before_install:
   - brew update
   - brew reinstall xctool

--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # **** Update me when new Xcode versions are released! ****
-PLATFORM="platform=iOS Simulator,OS=8.1,name=iPhone 6"
-SDK="iphonesimulator8.1"
+PLATFORM="platform=iOS Simulator,OS=9.0,name=iPhone 6"
+SDK="iphonesimulator9.0"
 
 
 # It is pitch black.

--- a/examples/Swift/Sample.xcodeproj/project.pbxproj
+++ b/examples/Swift/Sample.xcodeproj/project.pbxproj
@@ -129,6 +129,7 @@
 		050E7C6619D22E19004363C2 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftUpdateCheck = 0700;
 				LastUpgradeCheck = 0600;
 				ORGANIZATIONNAME = Facebook;
 				TargetAttributes = {

--- a/examples/Swift/Sample/ViewController.swift
+++ b/examples/Swift/Sample/ViewController.swift
@@ -27,7 +27,7 @@ class ViewController: UIViewController, ASTableViewDataSource, ASTableViewDelega
     self.tableView.asyncDelegate = self
   }
 
-  required init(coder aDecoder: NSCoder) {
+  required init?(coder aDecoder: NSCoder) {
     fatalError("storyboards are incompatible with truth and beauty")
   }
 


### PR DESCRIPTION
@appleguy Pursuant to https://github.com/facebook/AsyncDisplayKit/pull/664#issuecomment-141697512 , here's a branch that just has the Travis updates. On my local machine using Xcode 7A220 I still get the same unrecognized selector errors for category properties like `CALayer.asyncdisplaykit_node`