### PR TITLE
Fix collection view data inconsistency

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -129,8 +129,7 @@ static BOOL _isInterceptedSelector(SEL sel)
   BOOL _ignoreMaxSizeChange;
   
   /**
-   If YES, the `UICollectionView` will reload its data on next `layoutSubviews` so we should
-   not forward any updates to it.
+   If YES, the `UICollectionView` will reload its data on next layout pass so we should not forward any updates to it.
    
    Rationale:
    In `reloadData`, a collection view invalidates its data and marks itself as needing reload, and waits until `layoutSubviews` to requery its data source. This can lead to data inconsistency problems. Say you have an empty collection view. You call `reloadData`, then immediately insert an item into your data source and call `insertItemsAtIndexPaths:[0,0]`. You will get an assertion failure saying "Invalid number of items in section 0. The number of items after the update (1) must be equal to the number of items before the update (1) plus or minus the items added and removed (1 added, 0 removed)." The collection view never queried your data source before the update to see that it actually had 0 items.

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -127,18 +127,18 @@ static BOOL _isInterceptedSelector(SEL sel)
   
   CGSize _maxSizeForNodesConstrainedSize;
   BOOL _ignoreMaxSizeChange;
+  
+  /**
+   If YES, the `UICollectionView` will reload its data on next `layoutSubviews` so we should
+   not forward any updates to it.
+   
+   Rationale:
+   In `reloadData`, a collection view invalidates its data and marks itself as needing reload, and waits until `layoutSubviews` to requery its data source. This can lead to data inconsistency problems. Say you have an empty collection view. You call `reloadData`, then immediately insert an item into your data source and call `insertItemsAtIndexPaths:[0,0]`. You will get an assertion failure saying "Invalid number of items in section 0. The number of items after the update (1) must be equal to the number of items before the update (1) plus or minus the items added and removed (1 added, 0 removed)." The collection view never queried your data source before the update to see that it actually had 0 items.
+  */
+  BOOL _pendingReloadData;
 }
 
 @property (atomic, assign) BOOL asyncDataSourceLocked;
-
-/**
- If YES, the `UICollectionView` will reload its data on next `layoutSubviews` so we should
- not forward any updates to it.
- 
- Rationale:
- In `reloadData`, a collection view invalidates its data and marks itself as needing reload, and waits until `layoutSubviews` to requery its data source. This can lead to data inconsistency problems. Say you have an empty collection view. You call `reloadData`, then immediately insert an item into your data source and call `insertItemsAtIndexPaths:[0,0]`. You will get an assertion failure saying "Invalid number of items in section 0. The number of items after the update (1) must be equal to the number of items before the update (1) plus or minus the items added and removed (1 added, 0 removed)." The collection view never queried your data source before the update to see that it actually had 0 items.
- */
-@property (nonatomic) BOOL pendingReloadData;
 
 @end
 
@@ -215,8 +215,8 @@ static BOOL _isInterceptedSelector(SEL sel)
 {
   ASDisplayNodeAssert(self.asyncDelegate, @"ASCollectionView's asyncDelegate property must be set.");
   ASDisplayNodePerformBlockOnMainThread(^{
+    _pendingReloadData = YES;
     [super reloadData];
-    self.pendingReloadData = YES;
   });
   [_dataController reloadDataWithAnimationOptions:kASCollectionViewAnimationNone completion:completion];
 }
@@ -413,7 +413,7 @@ static BOOL _isInterceptedSelector(SEL sel)
 
 - (NSInteger)numberOfSectionsInCollectionView:(UICollectionView *)collectionView
 {
-  self.pendingReloadData = NO;
+  _pendingReloadData = NO;
   return [_dataController numberOfSections];
 }
 
@@ -496,7 +496,7 @@ static BOOL _isInterceptedSelector(SEL sel)
 
 - (void)layoutSubviews
 {
-  if (!self.pendingReloadData && ! CGSizeEqualToSize(_maxSizeForNodesConstrainedSize, self.bounds.size)) {
+  if (! CGSizeEqualToSize(_maxSizeForNodesConstrainedSize, self.bounds.size)) {
     _maxSizeForNodesConstrainedSize = self.bounds.size;
     
     // First size change occurs during initial configuration. An expensive relayout pass is unnecessary at that time
@@ -649,7 +649,7 @@ static BOOL _isInterceptedSelector(SEL sel)
 - (void)rangeController:(ASRangeController *)rangeController endUpdatesAnimated:(BOOL)animated completion:(void (^)(BOOL))completion {
   ASDisplayNodeAssertMainThread();
 
-  if (!self.asyncDataSource || self.pendingReloadData) {
+  if (!self.asyncDataSource || _pendingReloadData) {
     if (completion) {
       completion(NO);
     }
@@ -701,7 +701,7 @@ static BOOL _isInterceptedSelector(SEL sel)
 {
   ASDisplayNodeAssertMainThread();
 
-  if (!self.asyncDataSource || self.pendingReloadData) {
+  if (!self.asyncDataSource || _pendingReloadData) {
     return; // if the asyncDataSource has become invalid while we are processing, ignore this request to avoid crashes
   }
 
@@ -720,7 +720,7 @@ static BOOL _isInterceptedSelector(SEL sel)
 {
   ASDisplayNodeAssertMainThread();
 
-  if (!self.asyncDataSource || self.pendingReloadData) {
+  if (!self.asyncDataSource || _pendingReloadData) {
     return; // if the asyncDataSource has become invalid while we are processing, ignore this request to avoid crashes
   }
 
@@ -739,7 +739,7 @@ static BOOL _isInterceptedSelector(SEL sel)
 {
   ASDisplayNodeAssertMainThread();
 
-  if (!self.asyncDataSource || self.pendingReloadData) {
+  if (!self.asyncDataSource || _pendingReloadData) {
     return; // if the asyncDataSource has become invalid while we are processing, ignore this request to avoid crashes
   }
 
@@ -758,7 +758,7 @@ static BOOL _isInterceptedSelector(SEL sel)
 {
   ASDisplayNodeAssertMainThread();
 
-  if (!self.asyncDataSource || self.pendingReloadData) {
+  if (!self.asyncDataSource || _pendingReloadData) {
     return; // if the asyncDataSource has become invalid while we are processing, ignore this request to avoid crashes
   }
 

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -129,12 +129,17 @@ static BOOL _isInterceptedSelector(SEL sel)
   BOOL _ignoreMaxSizeChange;
   
   /**
-   If YES, the `UICollectionView` will reload its data on next layout pass so we should not forward any updates to it.
+   * If YES, the `UICollectionView` will reload its data on next layout pass so we should not forward any updates to it.
    
-   Rationale:
-   In `reloadData`, a collection view invalidates its data and marks itself as needing reload, and waits until `layoutSubviews` to requery its data source. This can lead to data inconsistency problems. Say you have an empty collection view. You call `reloadData`, then immediately insert an item into your data source and call `insertItemsAtIndexPaths:[0,0]`. You will get an assertion failure saying "Invalid number of items in section 0. The number of items after the update (1) must be equal to the number of items before the update (1) plus or minus the items added and removed (1 added, 0 removed)." The collection view never queried your data source before the update to see that it actually had 0 items.
+   * Rationale:
+   * In `reloadData`, a collection view invalidates its data and marks itself as needing reload, and waits until `layoutSubviews` to requery its data source.
+   * This can lead to data inconsistency problems.
+   * Say you have an empty collection view. You call `reloadData`, then immediately insert an item into your data source and call `insertItemsAtIndexPaths:[0,0]`.
+   * You will get an assertion failure saying `Invalid number of items in section 0.
+   * The number of items after the update (1) must be equal to the number of items before the update (1) plus or minus the items added and removed (1 added, 0 removed).`
+   * The collection view never queried your data source before the update to see that it actually had 0 items.
   */
-  BOOL _pendingReloadData;
+  BOOL _superIsPendingDataLoad;
 }
 
 @property (atomic, assign) BOOL asyncDataSourceLocked;
@@ -185,6 +190,8 @@ static BOOL _isInterceptedSelector(SEL sel)
   _performingBatchUpdates = NO;
   _batchUpdateBlocks = [NSMutableArray array];
 
+  _superIsPendingDataLoad = YES;
+  
   _collectionViewLayoutImplementsInsetSection = [layout respondsToSelector:@selector(sectionInset)];
 
   _maxSizeForNodesConstrainedSize = self.bounds.size;
@@ -214,7 +221,7 @@ static BOOL _isInterceptedSelector(SEL sel)
 {
   ASDisplayNodeAssert(self.asyncDelegate, @"ASCollectionView's asyncDelegate property must be set.");
   ASDisplayNodePerformBlockOnMainThread(^{
-    _pendingReloadData = YES;
+    _superIsPendingDataLoad = YES;
     [super reloadData];
   });
   [_dataController reloadDataWithAnimationOptions:kASCollectionViewAnimationNone completion:completion];
@@ -412,7 +419,7 @@ static BOOL _isInterceptedSelector(SEL sel)
 
 - (NSInteger)numberOfSectionsInCollectionView:(UICollectionView *)collectionView
 {
-  _pendingReloadData = NO;
+  _superIsPendingDataLoad = NO;
   return [_dataController numberOfSections];
 }
 
@@ -648,7 +655,7 @@ static BOOL _isInterceptedSelector(SEL sel)
 - (void)rangeController:(ASRangeController *)rangeController endUpdatesAnimated:(BOOL)animated completion:(void (^)(BOOL))completion {
   ASDisplayNodeAssertMainThread();
 
-  if (!self.asyncDataSource || _pendingReloadData) {
+  if (!self.asyncDataSource || _superIsPendingDataLoad) {
     if (completion) {
       completion(NO);
     }
@@ -700,7 +707,7 @@ static BOOL _isInterceptedSelector(SEL sel)
 {
   ASDisplayNodeAssertMainThread();
 
-  if (!self.asyncDataSource || _pendingReloadData) {
+  if (!self.asyncDataSource || _superIsPendingDataLoad) {
     return; // if the asyncDataSource has become invalid while we are processing, ignore this request to avoid crashes
   }
 
@@ -719,7 +726,7 @@ static BOOL _isInterceptedSelector(SEL sel)
 {
   ASDisplayNodeAssertMainThread();
 
-  if (!self.asyncDataSource || _pendingReloadData) {
+  if (!self.asyncDataSource || _superIsPendingDataLoad) {
     return; // if the asyncDataSource has become invalid while we are processing, ignore this request to avoid crashes
   }
 
@@ -738,7 +745,7 @@ static BOOL _isInterceptedSelector(SEL sel)
 {
   ASDisplayNodeAssertMainThread();
 
-  if (!self.asyncDataSource || _pendingReloadData) {
+  if (!self.asyncDataSource || _superIsPendingDataLoad) {
     return; // if the asyncDataSource has become invalid while we are processing, ignore this request to avoid crashes
   }
 
@@ -757,7 +764,7 @@ static BOOL _isInterceptedSelector(SEL sel)
 {
   ASDisplayNodeAssertMainThread();
 
-  if (!self.asyncDataSource || _pendingReloadData) {
+  if (!self.asyncDataSource || _superIsPendingDataLoad) {
     return; // if the asyncDataSource has become invalid while we are processing, ignore this request to avoid crashes
   }
 


### PR DESCRIPTION
This resolves #654

We could remove the flag and just call `[self layoutIfNeeded]` immediately after `[super reloadData]`
  - + Reduces complexity of ASCollectionView
  - - Relies on implementation details of `UICollectionView`
  - - Performance cost