### PR TITLE
Placeholder bug

### DIFF
--- a/AsyncDisplayKit.podspec
+++ b/AsyncDisplayKit.podspec
@@ -41,7 +41,7 @@ Pod::Spec.new do |spec|
 
   spec.social_media_url = 'https://twitter.com/fbOpenSource'
   spec.library = 'c++'
-  spec.pod_target_xcconfig = {
+  spec.xcconfig = {
        'CLANG_CXX_LANGUAGE_STANDARD' => 'c++11',
        'CLANG_CXX_LIBRARY' => 'libc++'
   }

--- a/AsyncDisplayKit/ASEditableTextNode.mm
+++ b/AsyncDisplayKit/ASEditableTextNode.mm
@@ -143,6 +143,7 @@
   _textKitComponents.textView.accessibilityHint = _placeholderTextKitComponents.textStorage.string;
   configureTextView(_textKitComponents.textView);
   [self.view addSubview:_textKitComponents.textView];
+  [self _updateDisplayingPlaceholder];
 }
 
 - (CGSize)calculateSizeThatFits:(CGSize)constrainedSize


### PR DESCRIPTION
When setting a default placeholder and an attributedString before `_textKitComponents.textView` was created, the placeholder and the string were both appearing in the text node.

`_updateDisplayingPlaceholder` is called in `setAttributedString`, but since  `_textKitComponents.textView` is nil the placeholder was not hidden. Calling `_updateDisplayingPlaceholder` after `_textKitComponents.textView` loads fixes this.