### PR TITLE
Fix simple issue with ASTableViewStressTest, make Table / Collection handle changes to dataSource / delegate.

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -234,7 +234,8 @@ static BOOL _isInterceptedSelector(SEL sel)
 
 - (void)setDataSource:(id<UICollectionViewDataSource>)dataSource
 {
-  ASDisplayNodeAssert(NO, @"ASCollectionView uses asyncDataSource, not UICollectionView's dataSource property.");
+  // UIKit can internally generate a call to this method upon changing the asyncDataSource; only assert for non-nil.
+  ASDisplayNodeAssert(dataSource == nil, @"ASCollectionView uses asyncDataSource, not UICollectionView's dataSource property.");
 }
 
 - (void)setDelegate:(id<UICollectionViewDelegate>)delegate

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -259,7 +259,8 @@ void ASPerformBlockWithoutAnimation(BOOL withoutAnimation, void (^block)()) {
 
 - (void)setDataSource:(id<UITableViewDataSource>)dataSource
 {
-  ASDisplayNodeAssert(NO, @"ASTableView uses asyncDataSource, not UITableView's dataSource property.");
+  // UIKit can internally generate a call to this method upon changing the asyncDataSource; only assert for non-nil.
+  ASDisplayNodeAssert(dataSource == nil, @"ASTableView uses asyncDataSource, not UITableView's dataSource property.");
 }
 
 - (void)setDelegate:(id<UITableViewDelegate>)delegate

--- a/examples/ASTableViewStressTest/Sample/ViewController.m
+++ b/examples/ASTableViewStressTest/Sample/ViewController.m
@@ -100,9 +100,6 @@
 
 - (void)thrashTableView
 {
-  _tableView.asyncDelegate = self;
-  _tableView.asyncDataSource = self;
-  
   [_tableView reloadData];
   
   NSArray *indexPathsAddedAndRemoved = nil;


### PR DESCRIPTION
This should address #612.  The stress test completes successfully; this issue prevented it from starting.