### PR TITLE
Ensure data consistency between ASDataController and its delegate while executing update transactions

### DIFF
--- a/AsyncDisplayKit/Details/ASDataController.mm
+++ b/AsyncDisplayKit/Details/ASDataController.mm
@@ -24,7 +24,8 @@ const static NSUInteger kASDataControllerSizingCountPerProcessor = 5;
 static void *kASSizingQueueContext = &kASSizingQueueContext;
 
 @interface ASDataController () {
-  NSMutableArray *_completedNodes;            // Main thread only.  External data access can immediately query this.
+  NSMutableArray *_externalCompletedNodes;    // Main thread only.  External data access can immediately query this if available.
+  NSMutableArray *_completedNodes;            // Main thread only.  External data access can immediately query this if _externalCompletedNodes is unavailable.
   NSMutableArray *_editingNodes;              // Modified on _editingTransactionQueue only.  Updates propogated to _completedNodes.
   
   NSMutableArray *_pendingEditCommandBlocks;  // To be run on the main thread.  Handles begin/endUpdates tracking.
@@ -38,6 +39,9 @@ static void *kASSizingQueueContext = &kASSizingQueueContext;
 }
 
 @property (atomic, assign) NSUInteger batchUpdateCounter;
+
+/// Returns nodes that can be queried externally. _externalCompletedNodes is used if available, _completedNodes otherwise.
+- (NSMutableArray *)externalCompletedNodes;
 
 @end
 
@@ -347,6 +351,10 @@ static void *kASSizingQueueContext = &kASSizingQueueContext;
 
     [_editingTransactionQueue addOperationWithBlock:^{
       ASDisplayNodePerformBlockOnMainThread(^{
+        // Deep copy _completedNodes to _externalCompletedNodes.
+        // Any external queries from now on will be done on _externalCompletedNodes, to guarantee data consistency with the delegate.
+        _externalCompletedNodes = (NSMutableArray *)ASMultidimensionalArrayDeepMutableCopy(_completedNodes);
+
         LOG(@"endUpdatesWithCompletion - begin updates call to delegate");
         [_delegate dataControllerBeginUpdates:self];
       });
@@ -363,6 +371,9 @@ static void *kASSizingQueueContext = &kASSizingQueueContext;
     
     [_editingTransactionQueue addOperationWithBlock:^{
       ASDisplayNodePerformBlockOnMainThread(^{
+        // Now that the transaction is done, _completedNodes can be accessed externally again.
+        _externalCompletedNodes = nil;
+        
         LOG(@"endUpdatesWithCompletion - calling delegate end");
         [_delegate dataController:self endUpdatesAnimated:animated completion:completion];
       });
@@ -617,28 +628,31 @@ static void *kASSizingQueueContext = &kASSizingQueueContext;
 - (NSUInteger)numberOfSections
 {
   ASDisplayNodeAssertMainThread();
-  return [_completedNodes count];
+  return [[self externalCompletedNodes] count];
 }
 
 - (NSUInteger)numberOfRowsInSection:(NSUInteger)section
 {
   ASDisplayNodeAssertMainThread();
-  return [_completedNodes[section] count];
+  return [[self externalCompletedNodes][section] count];
 }
 
 - (ASCellNode *)nodeAtIndexPath:(NSIndexPath *)indexPath
 {
   ASDisplayNodeAssertMainThread();
-  return _completedNodes[indexPath.section][indexPath.row];
+  return [self externalCompletedNodes][indexPath.section][indexPath.row];
 }
 
 - (NSIndexPath *)indexPathForNode:(ASCellNode *)cellNode;
 {
   ASDisplayNodeAssertMainThread();
 
+  NSArray *nodes = [self externalCompletedNodes];
+  NSUInteger numberOfNodes = nodes.count;
+  
   // Loop through each section to look for the cellNode
-  for (NSUInteger i = 0; i < [_completedNodes count]; i++) {
-    NSArray *sectionNodes = _completedNodes[i];
+  for (NSUInteger i = 0; i < numberOfNodes; i++) {
+    NSArray *sectionNodes = nodes[i];
     NSUInteger cellIndex = [sectionNodes indexOfObjectIdenticalTo:cellNode];
     if (cellIndex != NSNotFound) {
       return [NSIndexPath indexPathForRow:cellIndex inSection:i];
@@ -651,13 +665,18 @@ static void *kASSizingQueueContext = &kASSizingQueueContext;
 - (NSArray *)nodesAtIndexPaths:(NSArray *)indexPaths
 {
   ASDisplayNodeAssertMainThread();
-  return ASFindElementsInMultidimensionalArrayAtIndexPaths(_completedNodes, [indexPaths sortedArrayUsingSelector:@selector(compare:)]);
+  return ASFindElementsInMultidimensionalArrayAtIndexPaths([self externalCompletedNodes], [indexPaths sortedArrayUsingSelector:@selector(compare:)]);
 }
 
 - (NSArray *)completedNodes
 {
   ASDisplayNodeAssertMainThread();
-  return _completedNodes;
+  return [self externalCompletedNodes];
+}
+
+- (NSMutableArray *)externalCompletedNodes
+{
+  return _externalCompletedNodes != nil ? _externalCompletedNodes : _completedNodes;
 }
 
 #pragma mark - Dealloc

--- a/AsyncDisplayKit/Details/ASDataController.mm
+++ b/AsyncDisplayKit/Details/ASDataController.mm
@@ -40,9 +40,6 @@ static void *kASSizingQueueContext = &kASSizingQueueContext;
 
 @property (atomic, assign) NSUInteger batchUpdateCounter;
 
-/// Returns nodes that can be queried externally. _externalCompletedNodes is used if available, _completedNodes otherwise.
-- (NSMutableArray *)externalCompletedNodes;
-
 @end
 
 @implementation ASDataController
@@ -628,26 +625,26 @@ static void *kASSizingQueueContext = &kASSizingQueueContext;
 - (NSUInteger)numberOfSections
 {
   ASDisplayNodeAssertMainThread();
-  return [[self externalCompletedNodes] count];
+  return [[self completedNodes] count];
 }
 
 - (NSUInteger)numberOfRowsInSection:(NSUInteger)section
 {
   ASDisplayNodeAssertMainThread();
-  return [[self externalCompletedNodes][section] count];
+  return [[self completedNodes][section] count];
 }
 
 - (ASCellNode *)nodeAtIndexPath:(NSIndexPath *)indexPath
 {
   ASDisplayNodeAssertMainThread();
-  return [self externalCompletedNodes][indexPath.section][indexPath.row];
+  return [self completedNodes][indexPath.section][indexPath.row];
 }
 
 - (NSIndexPath *)indexPathForNode:(ASCellNode *)cellNode;
 {
   ASDisplayNodeAssertMainThread();
 
-  NSArray *nodes = [self externalCompletedNodes];
+  NSArray *nodes = [self completedNodes];
   NSUInteger numberOfNodes = nodes.count;
   
   // Loop through each section to look for the cellNode
@@ -665,17 +662,13 @@ static void *kASSizingQueueContext = &kASSizingQueueContext;
 - (NSArray *)nodesAtIndexPaths:(NSArray *)indexPaths
 {
   ASDisplayNodeAssertMainThread();
-  return ASFindElementsInMultidimensionalArrayAtIndexPaths([self externalCompletedNodes], [indexPaths sortedArrayUsingSelector:@selector(compare:)]);
+  return ASFindElementsInMultidimensionalArrayAtIndexPaths((NSMutableArray *)[self completedNodes], [indexPaths sortedArrayUsingSelector:@selector(compare:)]);
 }
 
+/// Returns nodes that can be queried externally. _externalCompletedNodes is used if available, _completedNodes otherwise.
 - (NSArray *)completedNodes
 {
   ASDisplayNodeAssertMainThread();
-  return [self externalCompletedNodes];
-}
-
-- (NSMutableArray *)externalCompletedNodes
-{
   return _externalCompletedNodes != nil ? _externalCompletedNodes : _completedNodes;
 }
 


### PR DESCRIPTION
My attempt to fix #619. The idea is to capture ASDataController's _completedNodes and use that cache for any external queries until a current update transaction finishes.

Let me know what you think on this diff. If we don't want to cater ASDataController to work with UITableView and UICollectionView specific behaviours, I can simply make a wrapper/subclass that sits between UITableView/UICollectionView and ASDataController. It can intercept transaction calls as well as external data queries, and ensures data consistency using the same technique here.

I tested this diff by abusing Kitten sample with a bunch of insertions, deletions and device rotations. Really appreciate if @eanagel, @ryanfitz, @Adlai-Holler and @smyrgl can help me to test as well.

I have another diff that tries to fix the issue by calling beginUpdates, edit command blocks and endUpdates in a single run loop. That diff is more complex and doesn't cover all the edge cases:
- It has to catch and queue all delegating blocks, then executes them on main thread. 
- It doesn't handle the case when data is accessed externally after some edit commands finished,  but before the (single) beginUpdates/endUpdates run loop is executed. It crashes because _completedNodes was modified and is different from what the table view/collection view expects.