### PR TITLE
Data Controller Batch Change Sorting

### DIFF
--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -374,6 +374,10 @@
 		B350625D1B0111740018CF92 /* Photos.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 051943141A1575670030A7D0 /* Photos.framework */; };
 		B350625E1B0111780018CF92 /* AssetsLibrary.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 051943121A1575630030A7D0 /* AssetsLibrary.framework */; };
 		B350625F1B0111800018CF92 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 058D09AF195D04C000B7D73C /* Foundation.framework */; };
+		CCE3AEC41BBB02DA00AFAB54 /* _ASHierarchyChangeSet.h in Headers */ = {isa = PBXBuildFile; fileRef = CCE3AEC21BBB02DA00AFAB54 /* _ASHierarchyChangeSet.h */; settings = {ASSET_TAGS = (); }; };
+		CCE3AEC51BBB02DA00AFAB54 /* _ASHierarchyChangeSet.h in Headers */ = {isa = PBXBuildFile; fileRef = CCE3AEC21BBB02DA00AFAB54 /* _ASHierarchyChangeSet.h */; settings = {ASSET_TAGS = (); }; };
+		CCE3AEC61BBB02DA00AFAB54 /* _ASHierarchyChangeSet.m in Sources */ = {isa = PBXBuildFile; fileRef = CCE3AEC31BBB02DA00AFAB54 /* _ASHierarchyChangeSet.m */; settings = {ASSET_TAGS = (); }; };
+		CCE3AEC71BBB02DA00AFAB54 /* _ASHierarchyChangeSet.m in Sources */ = {isa = PBXBuildFile; fileRef = CCE3AEC31BBB02DA00AFAB54 /* _ASHierarchyChangeSet.m */; settings = {ASSET_TAGS = (); }; };
 		D785F6621A74327E00291744 /* ASScrollNode.h in Headers */ = {isa = PBXBuildFile; fileRef = D785F6601A74327E00291744 /* ASScrollNode.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D785F6631A74327E00291744 /* ASScrollNode.m in Sources */ = {isa = PBXBuildFile; fileRef = D785F6611A74327E00291744 /* ASScrollNode.m */; };
 		DB7121BCD50849C498C886FB /* libPods-AsyncDisplayKitTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EFA731F0396842FF8AB635EE /* libPods-AsyncDisplayKitTests.a */; };
@@ -619,6 +623,8 @@
 		ACF6ED5B1B178DC700DA7C62 /* ASStackLayoutSpecSnapshotTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASStackLayoutSpecSnapshotTests.mm; sourceTree = "<group>"; };
 		B35061DA1B010EDF0018CF92 /* AsyncDisplayKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AsyncDisplayKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B35061DD1B010EDF0018CF92 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = "../AsyncDisplayKit-iOS/Info.plist"; sourceTree = "<group>"; };
+		CCE3AEC21BBB02DA00AFAB54 /* _ASHierarchyChangeSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _ASHierarchyChangeSet.h; sourceTree = "<group>"; };
+		CCE3AEC31BBB02DA00AFAB54 /* _ASHierarchyChangeSet.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = _ASHierarchyChangeSet.m; sourceTree = "<group>"; };
 		D3779BCFF841AD3EB56537ED /* Pods-AsyncDisplayKitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AsyncDisplayKitTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-AsyncDisplayKitTests/Pods-AsyncDisplayKitTests.release.xcconfig"; sourceTree = "<group>"; };
 		D785F6601A74327E00291744 /* ASScrollNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASScrollNode.h; sourceTree = "<group>"; };
 		D785F6611A74327E00291744 /* ASScrollNode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASScrollNode.m; sourceTree = "<group>"; };
@@ -914,6 +920,8 @@
 		058D0A01195D050800B7D73C /* Private */ = {
 			isa = PBXGroup;
 			children = (
+				CCE3AEC21BBB02DA00AFAB54 /* _ASHierarchyChangeSet.h */,
+				CCE3AEC31BBB02DA00AFAB54 /* _ASHierarchyChangeSet.m */,
 				9C65A7291BA8EA4D0084DA91 /* ASLayoutOptionsPrivate.h */,
 				9C8221931BA237B80037F19A /* ASStackBaselinePositionedLayout.h */,
 				9C8221941BA237B80037F19A /* ASStackBaselinePositionedLayout.mm */,
@@ -1082,6 +1090,7 @@
 				ACF6ED241B17843500DA7C62 /* ASLayout.h in Headers */,
 				ACF6ED2A1B17843500DA7C62 /* ASLayoutable.h in Headers */,
 				9CDC18CC1B910E12004965E2 /* ASLayoutablePrivate.h in Headers */,
+				CCE3AEC41BBB02DA00AFAB54 /* _ASHierarchyChangeSet.h in Headers */,
 				464052241A3F83C40061C0BA /* ASLayoutController.h in Headers */,
 				9C5FA3511B8F6ADF00A62714 /* ASLayoutOptions.h in Headers */,
 				9C65A72A1BA8EA4D0084DA91 /* ASLayoutOptionsPrivate.h in Headers */,
@@ -1184,6 +1193,7 @@
 				34EFC7671B701CD900AD841F /* ASLayout.h in Headers */,
 				34EFC7691B701CE100AD841F /* ASLayoutable.h in Headers */,
 				9CDC18CD1B910E12004965E2 /* ASLayoutablePrivate.h in Headers */,
+				CCE3AEC51BBB02DA00AFAB54 /* _ASHierarchyChangeSet.h in Headers */,
 				B35062201B010EFD0018CF92 /* ASLayoutController.h in Headers */,
 				9C5FA3521B8F6ADF00A62714 /* ASLayoutOptions.h in Headers */,
 				9C65A72B1BA8EA4D0084DA91 /* ASLayoutOptionsPrivate.h in Headers */,
@@ -1453,6 +1463,7 @@
 				0587F9BE1A7309ED00AFF0BA /* ASEditableTextNode.mm in Sources */,
 				464052231A3F83C40061C0BA /* ASFlowLayoutController.mm in Sources */,
 				058D0A1A195D050800B7D73C /* ASHighlightOverlayLayer.mm in Sources */,
+				CCE3AEC61BBB02DA00AFAB54 /* _ASHierarchyChangeSet.m in Sources */,
 				058D0A2B195D050800B7D73C /* ASImageNode+CGExtras.m in Sources */,
 				058D0A16195D050800B7D73C /* ASImageNode.mm in Sources */,
 				430E7C911B4C23F100697A4C /* ASIndexPath.m in Sources */,
@@ -1561,6 +1572,7 @@
 				B35061FF1B010EFD0018CF92 /* ASDisplayNodeExtras.mm in Sources */,
 				B35062011B010EFD0018CF92 /* ASEditableTextNode.mm in Sources */,
 				B350621C1B010EFD0018CF92 /* ASFlowLayoutController.mm in Sources */,
+				CCE3AEC71BBB02DA00AFAB54 /* _ASHierarchyChangeSet.m in Sources */,
 				B350621E1B010EFD0018CF92 /* ASHighlightOverlayLayer.mm in Sources */,
 				B35062541B010EFD0018CF92 /* ASImageNode+CGExtras.m in Sources */,
 				B35062031B010EFD0018CF92 /* ASImageNode.mm in Sources */,

--- a/AsyncDisplayKit/Private/ASInternalHelpers.h
+++ b/AsyncDisplayKit/Private/ASInternalHelpers.h
@@ -26,3 +26,7 @@ CGFloat ASCeilPixelValue(CGFloat f);
 CGFloat ASRoundPixelValue(CGFloat f);
 
 ASDISPLAYNODE_EXTERN_C_END
+
+@interface NSIndexPath (ASInverseComparison)
+- (NSComparisonResult)as_inverseCompare:(NSIndexPath *)otherIndexPath;
+@end

--- a/AsyncDisplayKit/Private/ASInternalHelpers.mm
+++ b/AsyncDisplayKit/Private/ASInternalHelpers.mm
@@ -70,3 +70,12 @@ CGFloat ASRoundPixelValue(CGFloat f)
 {
   return roundf(f * ASScreenScale()) / ASScreenScale();
 }
+
+@implementation NSIndexPath (ASInverseComparison)
+
+- (NSComparisonResult)as_inverseCompare:(NSIndexPath *)otherIndexPath
+{
+  return [otherIndexPath compare:self];
+}
+
+@end

--- a/AsyncDisplayKit/Private/_ASHierarchyChangeSet.h
+++ b/AsyncDisplayKit/Private/_ASHierarchyChangeSet.h
@@ -1,0 +1,72 @@
+//
+//  _ASHierarchyChangeSet.h
+//  AsyncDisplayKit
+//
+//  Created by Adlai Holler on 9/29/15.
+//  Copyright © 2015 Facebook. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "ASDataController.h"
+
+typedef NS_ENUM(NSInteger, _ASHierarchyChangeType) {
+  _ASHierarchyChangeTypeReload,
+  _ASHierarchyChangeTypeDelete,
+  _ASHierarchyChangeTypeInsert
+};
+
+@interface _ASHierarchySectionChange : NSObject
+
+// FIXME: Generalize this to `changeMetadata` dict?
+@property (nonatomic, readonly) ASDataControllerAnimationOptions animationOptions;
+
+@property (nonatomic, strong, readonly) NSIndexSet *indexSet;
+@property (nonatomic, readonly) _ASHierarchyChangeType changeType;
+@end
+
+@interface _ASHierarchyItemChange : NSObject
+@property (nonatomic, readonly) ASDataControllerAnimationOptions animationOptions;
+
+/// Index paths are sorted descending for changeType .Delete, ascending otherwise
+@property (nonatomic, strong, readonly) NSArray *indexPaths;
+@property (nonatomic, readonly) _ASHierarchyChangeType changeType;
+@end
+
+@interface _ASHierarchyChangeSet : NSObject
+
+@property (nonatomic, strong, readonly) NSIndexSet *deletedSections;
+@property (nonatomic, strong, readonly) NSIndexSet *insertedSections;
+@property (nonatomic, strong, readonly) NSIndexSet *reloadedSections;
+@property (nonatomic, strong, readonly) NSArray *insertedItems;
+@property (nonatomic, strong, readonly) NSArray *deletedItems;
+@property (nonatomic, strong, readonly) NSArray *reloadedItems;
+
+@property (nonatomic, readonly) BOOL completed;
+
+/// Call this once the change set has been constructed to prevent future modifications to the changeset. Calling this more than once is a programmer error.
+- (void)markCompleted;
+
+/**
+ @abstract Return sorted changes of the given type, grouped by animation options.
+ 
+ Items deleted from deleted sections are not reported.
+ Items inserted into inserted sections are not reported.
+ Items reloaded in reloaded sections are not reported.
+ 
+ The safe order for processing change groups is:
+ - Reloaded sections & reloaded items
+ - Deleted items, descending order
+ - Deleted sections, descending order
+ - Inserted sections, ascending order
+ - Inserted items, ascending order
+ */
+- (NSArray /*<_ASHierarchySectionChange *>*/ *)sectionChangesOfType:(_ASHierarchyChangeType)changeType;
+- (NSArray /*<_ASHierarchyItemChange *>*/ *)itemChangesOfType:(_ASHierarchyChangeType)changeType;
+
+- (void)deleteSections:(NSIndexSet *)sections animationOptions:(ASDataControllerAnimationOptions)options;
+- (void)insertSections:(NSIndexSet *)sections animationOptions:(ASDataControllerAnimationOptions)options;
+- (void)reloadSections:(NSIndexSet *)sections animationOptions:(ASDataControllerAnimationOptions)options;
+- (void)insertItems:(NSArray *)indexPaths animationOptions:(ASDataControllerAnimationOptions)options;
+- (void)deleteItems:(NSArray *)indexPaths animationOptions:(ASDataControllerAnimationOptions)options;
+- (void)reloadItems:(NSArray *)indexPaths animationOptions:(ASDataControllerAnimationOptions)options;
+@end

--- a/AsyncDisplayKit/Private/_ASHierarchyChangeSet.m
+++ b/AsyncDisplayKit/Private/_ASHierarchyChangeSet.m
@@ -1,0 +1,336 @@
+//
+//  _ASHierarchyChangeSet.m
+//  AsyncDisplayKit
+//
+//  Created by Adlai Holler on 9/29/15.
+//  Copyright © 2015 Facebook. All rights reserved.
+//
+
+#import "_ASHierarchyChangeSet.h"
+#import "ASInternalHelpers.h"
+
+@interface _ASHierarchySectionChange ()
+- (instancetype)initWithChangeType:(_ASHierarchyChangeType)changeType indexSet:(NSIndexSet *)indexSet animationOptions:(ASDataControllerAnimationOptions)animationOptions;
+
+/**
+ On return `changes` is sorted according to the change type with changes coalesced by animationOptions
+ Assumes: `changes` is [_ASHierarchySectionChange] all with the same changeType
+ */
++ (void)sortAndCoalesceChanges:(NSMutableArray *)changes;
+@end
+
+@interface _ASHierarchyItemChange ()
+- (instancetype)initWithChangeType:(_ASHierarchyChangeType)changeType indexPaths:(NSArray *)indexPaths animationOptions:(ASDataControllerAnimationOptions)animationOptions presorted:(BOOL)presorted;
+
+/**
+ On return `changes` is sorted according to the change type with changes coalesced by animationOptions
+ Assumes: `changes` is [_ASHierarchyItemChange] all with the same changeType
+ */
++ (void)sortAndCoalesceChanges:(NSMutableArray *)changes ignoringChangesInSections:(NSIndexSet *)sections;
+@end
+
+@interface _ASHierarchyChangeSet ()
+
+@property (nonatomic, strong, readonly) NSMutableArray *insertItemChanges;
+@property (nonatomic, strong, readonly) NSMutableArray *deleteItemChanges;
+@property (nonatomic, strong, readonly) NSMutableArray *reloadItemChanges;
+@property (nonatomic, strong, readonly) NSMutableArray *insertSectionChanges;
+@property (nonatomic, strong, readonly) NSMutableArray *deleteSectionChanges;
+@property (nonatomic, strong, readonly) NSMutableArray *reloadSectionChanges;
+
+@end
+
+@implementation _ASHierarchyChangeSet {
+  NSMutableIndexSet *_deletedSections;
+  NSMutableIndexSet *_insertedSections;
+  NSMutableIndexSet *_reloadedSections;
+  NSMutableArray *_insertedItems;
+  NSMutableArray *_deletedItems;
+  NSMutableArray *_reloadedItems;
+}
+
+- (instancetype)init
+{
+  self = [super init];
+  if (self) {
+    _deletedSections = [NSMutableIndexSet new];
+    _insertedSections = [NSMutableIndexSet new];
+    _reloadedSections = [NSMutableIndexSet new];
+    
+    _deletedItems = [NSMutableArray new];
+    _insertedItems = [NSMutableArray new];
+    _reloadedItems = [NSMutableArray new];
+    
+    _insertItemChanges = [NSMutableArray new];
+    _deleteItemChanges = [NSMutableArray new];
+    _reloadItemChanges = [NSMutableArray new];
+    _insertSectionChanges = [NSMutableArray new];
+    _deleteSectionChanges = [NSMutableArray new];
+    _reloadSectionChanges = [NSMutableArray new];
+  }
+  return self;
+}
+
+#pragma mark External API
+
+- (void)markCompleted
+{
+  NSAssert(!_completed, @"Attempt to mark already-completed changeset as completed.");
+  _completed = YES;
+  [self _sortAndCoalesceChangeArrays];
+}
+
+- (NSArray *)sectionChangesOfType:(_ASHierarchyChangeType)changeType
+{
+  [self _ensureCompleted];
+  switch (changeType) {
+    case _ASHierarchyChangeTypeInsert:
+      return _insertSectionChanges;
+    case _ASHierarchyChangeTypeReload:
+      return _reloadSectionChanges;
+    case _ASHierarchyChangeTypeDelete:
+      return _deleteSectionChanges;
+    default:
+      NSAssert(NO, @"Request for section changes with invalid type: %lu", changeType);
+  }
+}
+
+- (NSArray *)itemChangesOfType:(_ASHierarchyChangeType)changeType
+{
+  [self _ensureCompleted];
+  switch (changeType) {
+    case _ASHierarchyChangeTypeInsert:
+      return _insertItemChanges;
+    case _ASHierarchyChangeTypeReload:
+      return _reloadItemChanges;
+    case _ASHierarchyChangeTypeDelete:
+      return _deleteItemChanges;
+    default:
+      NSAssert(NO, @"Request for item changes with invalid type: %lu", changeType);
+  }
+}
+
+- (void)deleteItems:(NSArray *)indexPaths animationOptions:(ASDataControllerAnimationOptions)options
+{
+  [self _ensureNotCompleted];
+  _ASHierarchyItemChange *change = [[_ASHierarchyItemChange alloc] initWithChangeType:_ASHierarchyChangeTypeDelete indexPaths:indexPaths animationOptions:options presorted:NO];
+  [_deleteItemChanges addObject:change];
+}
+
+- (void)deleteSections:(NSIndexSet *)sections animationOptions:(ASDataControllerAnimationOptions)options
+{
+  [self _ensureNotCompleted];
+  _ASHierarchySectionChange *change = [[_ASHierarchySectionChange alloc] initWithChangeType:_ASHierarchyChangeTypeDelete indexSet:sections animationOptions:options];
+  [_deleteSectionChanges addObject:change];
+}
+
+- (void)insertItems:(NSArray *)indexPaths animationOptions:(ASDataControllerAnimationOptions)options
+{
+  [self _ensureNotCompleted];
+  _ASHierarchyItemChange *change = [[_ASHierarchyItemChange alloc] initWithChangeType:_ASHierarchyChangeTypeInsert indexPaths:indexPaths animationOptions:options presorted:NO];
+  [_insertItemChanges addObject:change];
+}
+
+- (void)insertSections:(NSIndexSet *)sections animationOptions:(ASDataControllerAnimationOptions)options
+{
+  [self _ensureNotCompleted];
+  _ASHierarchySectionChange *change = [[_ASHierarchySectionChange alloc] initWithChangeType:_ASHierarchyChangeTypeInsert indexSet:sections animationOptions:options];
+  [_insertSectionChanges addObject:change];
+}
+
+- (void)reloadItems:(NSArray *)indexPaths animationOptions:(ASDataControllerAnimationOptions)options
+{
+  [self _ensureNotCompleted];
+  _ASHierarchyItemChange *change = [[_ASHierarchyItemChange alloc] initWithChangeType:_ASHierarchyChangeTypeReload indexPaths:indexPaths animationOptions:options presorted:NO];
+  [_reloadItemChanges addObject:change];
+}
+
+- (void)reloadSections:(NSIndexSet *)sections animationOptions:(ASDataControllerAnimationOptions)options
+{
+  [self _ensureNotCompleted];
+  _ASHierarchySectionChange *change = [[_ASHierarchySectionChange alloc] initWithChangeType:_ASHierarchyChangeTypeReload indexSet:sections animationOptions:options];
+  [_reloadSectionChanges addObject:change];
+}
+
+#pragma mark Private
+
+- (BOOL)_ensureNotCompleted
+{
+  NSAssert(!_completed, @"Attempt to modify completed changeset %@", self);
+  return !_completed;
+}
+
+- (BOOL)_ensureCompleted
+{
+  NSAssert(_completed, @"Attempt to process incomplete changeset %@", self);
+  return _completed;
+}
+
+- (void)_sortAndCoalesceChangeArrays
+{
+  @autoreleasepool {
+    [_ASHierarchySectionChange sortAndCoalesceChanges:_deleteSectionChanges];
+    [_ASHierarchySectionChange sortAndCoalesceChanges:_insertSectionChanges];
+    [_ASHierarchySectionChange sortAndCoalesceChanges:_reloadSectionChanges];
+    [_ASHierarchyItemChange sortAndCoalesceChanges:_deleteItemChanges ignoringChangesInSections:_deletedSections];
+    [_ASHierarchyItemChange sortAndCoalesceChanges:_reloadItemChanges ignoringChangesInSections:_reloadedSections];
+    [_ASHierarchyItemChange sortAndCoalesceChanges:_insertItemChanges ignoringChangesInSections:_insertedSections];
+  }
+}
+
+@end
+
+@implementation _ASHierarchySectionChange
+
+- (instancetype)initWithChangeType:(_ASHierarchyChangeType)changeType indexSet:(NSIndexSet *)indexSet animationOptions:(ASDataControllerAnimationOptions)animationOptions
+{
+  self = [super init];
+  if (self) {
+    _changeType = changeType;
+    _indexSet = indexSet;
+    _animationOptions = animationOptions;
+  }
+  return self;
+}
+
++ (void)sortAndCoalesceChanges:(NSMutableArray *)changes
+{
+  if (changes.count < 1) {
+    return;
+  }
+  
+  _ASHierarchyChangeType type = [changes.firstObject changeType];
+  
+  // Lookup table [Int: AnimationOptions]
+  NSMutableDictionary *animationOptions = [NSMutableDictionary new];
+  
+  // All changed indexes, sorted
+  NSMutableIndexSet *allIndexes = [NSMutableIndexSet new];
+  
+  for (_ASHierarchySectionChange *change in changes) {
+    [change.indexSet enumerateIndexesUsingBlock:^(NSUInteger idx, __unused BOOL *stop) {
+      animationOptions[@(idx)] = @(change.animationOptions);
+    }];
+    [allIndexes addIndexes:change.indexSet];
+  }
+  
+  // Create new changes by grouping sorted changes by animation option
+  NSMutableArray *result = [NSMutableArray new];
+  
+  __block ASDataControllerAnimationOptions currentOptions = 0;
+  __block NSMutableIndexSet *currentIndexes = nil;
+  
+  NSEnumerationOptions options = type == _ASHierarchyChangeTypeDelete ? NSEnumerationReverse : kNilOptions;
+  [allIndexes enumerateIndexesWithOptions:options usingBlock:^(NSUInteger idx, __unused BOOL * stop) {
+    
+    ASDataControllerAnimationOptions options = [animationOptions[@(idx)] integerValue];
+    if (currentIndexes == nil) {
+      // Starting a new group
+      currentIndexes = [NSMutableIndexSet indexSetWithIndex:idx];
+      currentOptions = options;
+    } else if (options == currentOptions) {
+      // Continuing the current group
+      [currentIndexes addIndex:idx];
+    } else {
+      // Ending the current group
+      _ASHierarchySectionChange *change = [[_ASHierarchySectionChange alloc] initWithChangeType:type indexSet:currentIndexes animationOptions:currentOptions];
+      [result addObject:change];
+      currentOptions = 0;
+      currentIndexes = nil;
+    }
+  }];
+  
+  if (currentIndexes != nil) {
+    // Ending the last group
+    _ASHierarchySectionChange *change = [[_ASHierarchySectionChange alloc] initWithChangeType:type indexSet:currentIndexes animationOptions:currentOptions];
+    [result addObject:change];
+    currentOptions = 0;
+    currentIndexes = nil;
+  }
+  [changes setArray:result];
+}
+
+@end
+
+@implementation _ASHierarchyItemChange
+
+- (instancetype)initWithChangeType:(_ASHierarchyChangeType)changeType indexPaths:(NSArray *)indexPaths animationOptions:(ASDataControllerAnimationOptions)animationOptions presorted:(BOOL)presorted
+{
+  self = [super init];
+  if (self) {
+    _changeType = changeType;
+    if (presorted) {
+      _indexPaths = indexPaths;
+    } else {
+      SEL sorting = changeType == _ASHierarchyChangeTypeDelete ? @selector(as_inverseCompare:) : @selector(compare:);
+      _indexPaths = [indexPaths sortedArrayUsingSelector:sorting];
+    }
+    _animationOptions = animationOptions;
+  }
+  return self;
+}
+
++ (void)sortAndCoalesceChanges:(NSMutableArray *)changes ignoringChangesInSections:(NSIndexSet *)sections
+{
+  if (changes.count < 1) {
+    return;
+  }
+  
+  _ASHierarchyChangeType type = [changes.firstObject changeType];
+  
+  // Lookup table [NSIndexPath: AnimationOptions]
+  NSMutableDictionary *animationOptions = [NSMutableDictionary new];
+  
+  // All changed index paths, sorted
+  NSMutableArray *allIndexPaths = [NSMutableArray new];
+  
+  NSPredicate *indexPathInValidSection = [NSPredicate predicateWithBlock:^BOOL(NSIndexPath *indexPath, __unused NSDictionary *_) {
+    return ![sections containsIndex:indexPath.section];
+  }];
+  for (_ASHierarchyItemChange *change in changes) {
+    for (NSIndexPath *indexPath in change.indexPaths) {
+      if ([indexPathInValidSection evaluateWithObject:indexPath]) {
+        animationOptions[indexPath] = @(change.animationOptions);
+        [allIndexPaths addObject:indexPath];
+      }
+    }
+  }
+  
+  SEL sorting = type == _ASHierarchyChangeTypeDelete ? @selector(as_inverseCompare:) : @selector(compare:);
+  [allIndexPaths sortUsingSelector:sorting];
+
+  // Create new changes by grouping sorted changes by animation option
+  NSMutableArray *result = [NSMutableArray new];
+  
+  ASDataControllerAnimationOptions currentOptions = 0;
+  NSMutableArray *currentIndexPaths = nil;
+  
+  for (NSIndexPath *indexPath in allIndexPaths) {
+    ASDataControllerAnimationOptions options = [animationOptions[indexPath] integerValue];
+    if (currentIndexPaths == nil) {
+      // Starting a new group
+      currentIndexPaths = [NSMutableArray arrayWithObject:indexPath];
+      currentOptions = options;
+    } else if (options == currentOptions) {
+      // Continuing the current group
+      [currentIndexPaths addObject:indexPath];
+    } else {
+      // Ending the current group
+      _ASHierarchyItemChange *change = [[_ASHierarchyItemChange alloc] initWithChangeType:type indexPaths:currentIndexPaths animationOptions:currentOptions presorted:YES];
+      [result addObject:change];
+      currentOptions = 0;
+      currentIndexPaths = nil;
+    }
+  }
+  
+  if (currentIndexPaths != nil) {
+    // Ending the last group
+    _ASHierarchyItemChange *change = [[_ASHierarchyItemChange alloc] initWithChangeType:type indexPaths:currentIndexPaths animationOptions:currentOptions presorted:YES];
+    [result addObject:change];
+    currentOptions = 0;
+    currentIndexPaths = nil;
+  }
+  [changes setArray:result];
+}
+
+@end


### PR DESCRIPTION
:warning: Not ready to merge :warning: 

I may be way off in the woods here, so I'm looking for comments on the general direction before I continue to testing and refining. Don't hold back!

- Create a new `_ASHierarchyChangeSet` class that stores and processes changes. The intention here is, you submit your changes with their animation options in arbitrary order, and when you're done it generates sorted changes, coalesced by animationOptions. This way we have the minimum possible number of updates but still in a safe order for use by ASDataController.
- In ASDataController our enqueued edit command blocks are now `(_ASHierarchyChangeSet -> Void)`. During `endUpdates` we create a change set, run all the blocks to load it up with data, then call `markCompleted` so the changeset does its logic, then we do `accessDataSourceWithBlock` and go through the sorted, coalesced changes, applying them using the same code that we USED to use in the edit command block.

I copied & pasted the edit command code pretty directly, so I'm not sure if e.g. we can get rid of some of the `[editTransactionQueue waitUntilAllOperationsAreFinished]` or what the fastest safe behavior we can achieve there is.

@nguyenhuy @appleguy 