### PR TITLE
Static layout bug?

### DIFF
--- a/AsyncDisplayKit/Layout/ASStaticLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASStaticLayoutSpec.mm
@@ -58,18 +58,14 @@
     [sublayouts addObject:sublayout];
   }
   
-  if (isnan(size.width) || size.width >= FLT_MAX - FLT_EPSILON) {
-    size.width = constrainedSize.min.width;
-    for (ASLayout *sublayout in sublayouts) {
-      size.width = MAX(size.width, sublayout.position.x + sublayout.size.width);
-    }
+  size.width = constrainedSize.min.width;
+  for (ASLayout *sublayout in sublayouts) {
+    size.width = MAX(size.width, sublayout.position.x + sublayout.size.width);
   }
 
-  if (isnan(size.height) || size.height >= FLT_MAX - FLT_EPSILON) {
-    size.height = constrainedSize.min.height;
-    for (ASLayout *sublayout in sublayouts) {
-      size.height = MAX(size.height, sublayout.position.y + sublayout.size.height);
-    }
+  size.height = constrainedSize.min.height;
+  for (ASLayout *sublayout in sublayouts) {
+    size.height = MAX(size.height, sublayout.position.y + sublayout.size.height);
   }
 
   return [ASLayout layoutWithLayoutableObject:self


### PR DESCRIPTION
I noticed when creating a static layout that the sizeRange of the children was being ignored. The case was:

I had an image as a child of a static layout
The image was set to have an exact range of 90x90
When the static layout was measured, the constrained size came in as 375xInf (the width of the containing node and unbounded)
The static layout computed its final size as 375x90

According to the comments in component kit's header file the static layout  "[c]omputes a size that is the union of all childrens' frames." It appeared that we are only doing that in the unbounded direction. My fix is to do it in both directions.

@nguyenhuy Please take a look and let me know what you think.