### PR TITLE
Use long-form view block initializer for better Swift support

### DIFF
--- a/AsyncDisplayKit/ASScrollNode.m
+++ b/AsyncDisplayKit/ASScrollNode.m
@@ -28,7 +28,7 @@
 {
   return [super initWithViewBlock:^UIView *{
     return [[ASScrollView alloc] init];
-  }];
+  } didLoadBlock:nil];
 }
 
 @end


### PR DESCRIPTION
Because of Swift's initializer inheritance behavior, calling the `initWithViewBlock:` convenience initializer causes a runtime error. This is easily remedied by using the long-form designated initializer but `ASScrollNode` uses the convenience initializer within the framework. This change allows `master` to work better with Swift.