### PR TITLE
Fixes to baseline stack alignment

### DIFF
--- a/AsyncDisplayKit/ASTextNode.mm
+++ b/AsyncDisplayKit/ASTextNode.mm
@@ -17,6 +17,7 @@
 #import <AsyncDisplayKit/ASTextNodeTextKitHelpers.h>
 #import <AsyncDisplayKit/ASDisplayNodeExtras.h>
 
+#import "ASInternalHelpers.h"
 #import "ASTextNodeRenderer.h"
 #import "ASTextNodeShadower.h"
 #import "ASEqualityHelpers.h"
@@ -344,6 +345,12 @@ static NSString *ASTextNodeTruncationTokenAttributeName = @"ASTextNodeTruncation
       self.isAccessibilityElement = YES;
     }
   });
+  
+  if (attributedString.length > 0) {
+    CGFloat screenScale = ASScreenScale();
+    self.ascender = round([[attributedString attribute:NSFontAttributeName atIndex:0 effectiveRange:NULL] ascender] * screenScale)/screenScale;
+    self.descender = round([[attributedString attribute:NSFontAttributeName atIndex:attributedString.length - 1 effectiveRange:NULL] descender] * screenScale)/screenScale;
+  }
 }
 
 #pragma mark - Text Layout

--- a/AsyncDisplayKit/Layout/ASStackLayoutDefines.h
+++ b/AsyncDisplayKit/Layout/ASStackLayoutDefines.h
@@ -45,9 +45,9 @@ typedef NS_ENUM(NSUInteger, ASStackLayoutAlignItems) {
   ASStackLayoutAlignItemsCenter,
   /** Expand children to fill cross axis */
   ASStackLayoutAlignItemsStretch,
-  /** Children align to their first baseline. Only available for horizontal stack nodes */
+  /** Children align to their first baseline. Only available for horizontal stack spec */
   ASStackLayoutAlignItemsBaselineFirst,
-  /** Children align to their last baseline. Only available for horizontal stack nodes */
+  /** Children align to their last baseline. Only available for horizontal stack spec */
   ASStackLayoutAlignItemsBaselineLast,
 };
 
@@ -66,8 +66,4 @@ typedef NS_ENUM(NSUInteger, ASStackLayoutAlignSelf) {
   ASStackLayoutAlignSelfCenter,
   /** Expand to fill cross axis */
   ASStackLayoutAlignSelfStretch,
-  /** Children align to their first baseline. Only available for horizontal stack nodes */
-  ASStackLayoutAlignSelfBaselineFirst,
-  /** Children align to their last baseline. Only available for horizontal stack nodes */
-  ASStackLayoutAlignSelfBaselineLast,
 };

--- a/AsyncDisplayKit/Private/ASStackLayoutSpecUtilities.h
+++ b/AsyncDisplayKit/Private/ASStackLayoutSpecUtilities.h
@@ -63,10 +63,6 @@ inline ASStackLayoutAlignItems alignment(ASStackLayoutAlignSelf childAlignment, 
       return ASStackLayoutAlignItemsStart;
     case ASStackLayoutAlignSelfStretch:
       return ASStackLayoutAlignItemsStretch;
-    case ASStackLayoutAlignSelfBaselineFirst:
-      return ASStackLayoutAlignItemsBaselineFirst;
-    case ASStackLayoutAlignSelfBaselineLast:
-      return ASStackLayoutAlignItemsBaselineLast;
     case ASStackLayoutAlignSelfAuto:
     default:
       return stackAlignment;


### PR DESCRIPTION
1) Set the ascender/descender of an ASTextNode when the attributeString is set. Previously ascender/descender were only being computed in `setValuesFromLayoutable` and only when the attribute string was not nil. May make sense to remove the computation from `setValuesFromLayoutable` entirely.
2) Remove ability to allow different children of a stack spec to aling to different baselines. This wasn't working before and I'm not convinced it is possible to do properly/useful enough to invest the time.
3) Have all stack spec run `ASStackBaselinePositionedLayout::compute` to compute the stack's ascender and descender. Even if the stack isn't aligning its children to a baseline, the stack itself may be a child of another stack that IS aligning to a baseline.