### PR TITLE
Don't Set Cell Node Frames During Measure

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -423,7 +423,12 @@ static BOOL _isInterceptedSelector(SEL sel)
 
 - (CGSize)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout sizeForItemAtIndexPath:(NSIndexPath *)indexPath
 {
-  return [[_dataController nodeAtIndexPath:indexPath] calculatedSize];
+  ASCellNode *node = [_dataController nodeAtIndexPath:indexPath];
+  CGSize size = node.calculatedSize;
+  if (!CGSizeEqualToSize(size, node.frame.size)) {
+    node.frame = CGRectMake(0, 0, size.width, size.height);
+  }
+  return size;
 }
 
 - (NSInteger)numberOfSectionsInCollectionView:(UICollectionView *)collectionView

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -537,7 +537,12 @@ void ASPerformBlockWithoutAnimation(BOOL withoutAnimation, void (^block)()) {
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath
 {
   ASCellNode *node = [_dataController nodeAtIndexPath:indexPath];
-  return node.calculatedSize.height;
+  CGSize size = node.calculatedSize;
+  // Update node's frame to ensure it will fill its cell.
+  if (!CGSizeEqualToSize(node.frame.size, size)) {
+    node.frame = CGRectMake(0, 0, size.width, size.height);
+  }
+  return size.height;
 }
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView
@@ -881,8 +886,7 @@ void ASPerformBlockWithoutAnimation(BOOL withoutAnimation, void (^block)()) {
     // Also, in many cases, some nodes may not need to be re-measured at all, such as when user enters and then immediately leaves editing mode.
     // To avoid premature optimization and making such assumption, as well as to keep ASTableView simple, re-measurement is strictly done on main.
     [self beginUpdates];
-    CGSize calculatedSize = [[node measureWithSizeRange:constrainedSize] size];
-    node.frame = CGRectMake(0, 0, calculatedSize.width, calculatedSize.height);
+    [node measureWithSizeRange:constrainedSize];
     [self endUpdates];
   }
 }

--- a/AsyncDisplayKit/Details/ASDataController.mm
+++ b/AsyncDisplayKit/Details/ASDataController.mm
@@ -118,7 +118,6 @@ static void *kASSizingQueueContext = &kASSizingQueueContext;
         ASCellNode *node = nodes[k];
         ASSizeRange constrainedSize = nodeBoundSizes[k];
         [node measureWithSizeRange:constrainedSize];
-        node.frame = CGRectMake(0, 0, node.calculatedSize.width, node.calculatedSize.height);
       }
     });
   }
@@ -579,7 +578,6 @@ static void *kASSizingQueueContext = &kASSizingQueueContext;
             NSIndexPath *indexPath = [NSIndexPath indexPathForRow:rowIndex inSection:sectionIndex];
             ASSizeRange constrainedSize = [_dataSource dataController:self constrainedSizeForNodeAtIndexPath:indexPath];
             [node measureWithSizeRange:constrainedSize];
-            node.frame = CGRectMake(0.0f, 0.0f, node.calculatedSize.width, node.calculatedSize.height);
           }];
         }];
       }];


### PR DESCRIPTION
Small change, but in a delicate part of the framework.

This behavior confused me when I first dug into the framework, and now that I'm currently adding another point where we measure nodes, I think it's worth it to separate out what's essential to this measurement pass rather than duplicate the frame-setting.