### PR TITLE
Demote Photos.framework image request QoS

### DIFF
--- a/AsyncDisplayKit/ASMultiplexImageNode.mm
+++ b/AsyncDisplayKit/ASMultiplexImageNode.mm
@@ -606,6 +606,10 @@ typedef void(^ASMultiplexImageLoadCompletionBlock)(UIImage *image, id imageIdent
       }
     }];
   }];
+  if (AS_AT_LEAST_IOS8) {
+    // If you don't set this, iOS will sometimes infer NSQualityOfServiceUserInteractive and promote the entire queue to that level, damaging system responsiveness
+    newImageRequestOp.qualityOfService = NSQualityOfServiceUserInitiated;
+  }
   _phImageRequestOperation = newImageRequestOp;
   [phImageRequestQueue addOperation:newImageRequestOp];
 }


### PR DESCRIPTION
I found that sometimes iOS was inferring `UserInteractive` for these, which would degrade UIKit performance.