### PR TITLE
ASCellNode selected/highlighted properties

### DIFF
--- a/AsyncDisplayKit/ASCellNode.h
+++ b/AsyncDisplayKit/ASCellNode.h
@@ -44,6 +44,16 @@
 @property (nonatomic) UITableViewCellSelectionStyle selectionStyle;
 
 /*
+ * A Boolean value that indicates whether the node is selected.
+ */
+@property (nonatomic, assign) BOOL selected;
+
+/*
+ * A Boolean value that indicates whether the node is highlighted.
+ */
+@property (nonatomic, assign) BOOL highlighted;
+
+/*
  * ASCellNode must forward touch events in order for UITableView and UICollectionView tap handling to work. Overriding
  * these methods (e.g. for highlighting) requires the super method be called.
  */

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -106,6 +106,28 @@ static BOOL _isInterceptedSelector(SEL sel)
 
 @end
 
+#pragma mark -
+#pragma mark ASCellNode<->UICollectionViewCell bridging.
+
+@class _ASCollectionViewCell;
+
+@interface _ASCollectionViewCell : UICollectionViewCell
+@property (nonatomic, weak) ASCellNode *node;
+@end
+
+@implementation _ASCollectionViewCell
+
+- (void)setSelected:(BOOL)selected
+{
+  _node.selected = selected;
+}
+
+- (void)setHighlighted:(BOOL)highlighted
+{
+  _node.highlighted = highlighted;
+}
+
+@end
 
 #pragma mark -
 #pragma mark ASCollectionView.
@@ -204,7 +226,7 @@ static BOOL _isInterceptedSelector(SEL sel)
   
   self.backgroundColor = [UIColor whiteColor];
   
-  [self registerClass:[UICollectionViewCell class] forCellWithReuseIdentifier:@"_ASCollectionViewCell"];
+  [self registerClass:[_ASCollectionViewCell class] forCellWithReuseIdentifier:@"_ASCollectionViewCell"];
   
   return self;
 }
@@ -412,11 +434,12 @@ static BOOL _isInterceptedSelector(SEL sel)
 {
   static NSString *reuseIdentifier = @"_ASCollectionViewCell";
   
-  UICollectionViewCell *cell = [self dequeueReusableCellWithReuseIdentifier:reuseIdentifier forIndexPath:indexPath];
+  _ASCollectionViewCell *cell = [self dequeueReusableCellWithReuseIdentifier:reuseIdentifier forIndexPath:indexPath];
 
   ASCellNode *node = [_dataController nodeAtIndexPath:indexPath];
-  
   [_rangeController configureContentView:cell.contentView forCellNode:node];
+  
+  cell.node = node;
   
   return cell;
 }

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -135,6 +135,15 @@ static BOOL _isInterceptedSelector(SEL sel)
   [super didTransitionToState:state];
 }
 
+- (void)setSelected:(BOOL)selected
+{
+  _node.selected = selected;
+}
+
+- (void)setHighlighted:(BOOL)highlighted {
+  _node.highlighted = highlighted;
+}
+
 @end
 
 

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -140,7 +140,8 @@ static BOOL _isInterceptedSelector(SEL sel)
   _node.selected = selected;
 }
 
-- (void)setHighlighted:(BOOL)highlighted {
+- (void)setHighlighted:(BOOL)highlighted
+{
   _node.highlighted = highlighted;
 }
 


### PR DESCRIPTION
Selected/highlighted properties on ASCellNode can be useful for doing some work when table view cell is selected or highlighted (e.g. change node's background color).