### PR TITLE
Ascii art visual debugging for ASLayoutSpecs

### DIFF
--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -208,6 +208,10 @@
 		6BDC61F61979037800E50D21 /* AsyncDisplayKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BDC61F51978FEA400E50D21 /* AsyncDisplayKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9C49C36F1B853957000B0DD5 /* ASStackLayoutable.h in Headers */ = {isa = PBXBuildFile; fileRef = 9C49C36E1B853957000B0DD5 /* ASStackLayoutable.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9C49C3701B853961000B0DD5 /* ASStackLayoutable.h in Headers */ = {isa = PBXBuildFile; fileRef = 9C49C36E1B853957000B0DD5 /* ASStackLayoutable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9C5586691BD549CB00B50E3A /* ASAsciiArtBoxCreator.h in Headers */ = {isa = PBXBuildFile; fileRef = 9C5586671BD549CB00B50E3A /* ASAsciiArtBoxCreator.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9C55866A1BD549CB00B50E3A /* ASAsciiArtBoxCreator.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C5586681BD549CB00B50E3A /* ASAsciiArtBoxCreator.m */; settings = {ASSET_TAGS = (); }; };
+		9C55866B1BD54A1900B50E3A /* ASAsciiArtBoxCreator.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C5586681BD549CB00B50E3A /* ASAsciiArtBoxCreator.m */; settings = {ASSET_TAGS = (); }; };
+		9C55866C1BD54A3000B50E3A /* ASAsciiArtBoxCreator.h in Headers */ = {isa = PBXBuildFile; fileRef = 9C5586671BD549CB00B50E3A /* ASAsciiArtBoxCreator.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9C5FA3511B8F6ADF00A62714 /* ASLayoutOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 9C5FA34F1B8F6ADF00A62714 /* ASLayoutOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9C5FA3521B8F6ADF00A62714 /* ASLayoutOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 9C5FA34F1B8F6ADF00A62714 /* ASLayoutOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9C5FA3531B8F6ADF00A62714 /* ASLayoutOptions.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9C5FA3501B8F6ADF00A62714 /* ASLayoutOptions.mm */; };
@@ -567,6 +571,8 @@
 		4640521D1A3F83C40061C0BA /* ASLayoutController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASLayoutController.h; sourceTree = "<group>"; };
 		6BDC61F51978FEA400E50D21 /* AsyncDisplayKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AsyncDisplayKit.h; sourceTree = "<group>"; };
 		9C49C36E1B853957000B0DD5 /* ASStackLayoutable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASStackLayoutable.h; path = AsyncDisplayKit/Layout/ASStackLayoutable.h; sourceTree = "<group>"; };
+		9C5586671BD549CB00B50E3A /* ASAsciiArtBoxCreator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASAsciiArtBoxCreator.h; path = AsyncDisplayKit/Layout/ASAsciiArtBoxCreator.h; sourceTree = "<group>"; };
+		9C5586681BD549CB00B50E3A /* ASAsciiArtBoxCreator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ASAsciiArtBoxCreator.m; path = AsyncDisplayKit/Layout/ASAsciiArtBoxCreator.m; sourceTree = "<group>"; };
 		9C5FA34F1B8F6ADF00A62714 /* ASLayoutOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASLayoutOptions.h; path = AsyncDisplayKit/Layout/ASLayoutOptions.h; sourceTree = "<group>"; };
 		9C5FA3501B8F6ADF00A62714 /* ASLayoutOptions.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = ASLayoutOptions.mm; path = AsyncDisplayKit/Layout/ASLayoutOptions.mm; sourceTree = "<group>"; };
 		9C5FA35C1B90C9A500A62714 /* ASLayoutOptionsPrivate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = ASLayoutOptionsPrivate.mm; path = AsyncDisplayKit/Layout/ASLayoutOptionsPrivate.mm; sourceTree = "<group>"; };
@@ -976,6 +982,8 @@
 		AC6456051B0A333200CF11B8 /* Layout */ = {
 			isa = PBXGroup;
 			children = (
+				9C5586671BD549CB00B50E3A /* ASAsciiArtBoxCreator.h */,
+				9C5586681BD549CB00B50E3A /* ASAsciiArtBoxCreator.m */,
 				ACF6ED011B17843500DA7C62 /* ASBackgroundLayoutSpec.h */,
 				ACF6ED021B17843500DA7C62 /* ASBackgroundLayoutSpec.mm */,
 				ACF6ED031B17843500DA7C62 /* ASCenterLayoutSpec.h */,
@@ -1053,6 +1061,7 @@
 				058D0A53195D05DC00B7D73C /* _ASDisplayLayer.h in Headers */,
 				058D0A55195D05DC00B7D73C /* _ASDisplayView.h in Headers */,
 				058D0A74195D05F800B7D73C /* _ASPendingState.h in Headers */,
+				9C5586691BD549CB00B50E3A /* ASAsciiArtBoxCreator.h in Headers */,
 				058D0A76195D05F900B7D73C /* _ASScopeTimer.h in Headers */,
 				205F0E191B37339C007741D0 /* ASAbstractLayoutController.h in Headers */,
 				058D0A82195D060300B7D73C /* ASAssert.h in Headers */,
@@ -1156,6 +1165,7 @@
 				B350620F1B010EFD0018CF92 /* _ASDisplayLayer.h in Headers */,
 				B35062111B010EFD0018CF92 /* _ASDisplayView.h in Headers */,
 				B350624B1B010EFD0018CF92 /* _ASPendingState.h in Headers */,
+				9C55866C1BD54A3000B50E3A /* ASAsciiArtBoxCreator.h in Headers */,
 				B350624D1B010EFD0018CF92 /* _ASScopeTimer.h in Headers */,
 				509E68611B3AEDA0009B9150 /* ASAbstractLayoutController.h in Headers */,
 				B35062571B010F070018CF92 /* ASAssert.h in Headers */,
@@ -1444,6 +1454,7 @@
 				058D0A26195D050800B7D73C /* _ASCoreAnimationExtras.mm in Sources */,
 				058D0A18195D050800B7D73C /* _ASDisplayLayer.mm in Sources */,
 				058D0A19195D050800B7D73C /* _ASDisplayView.mm in Sources */,
+				9C55866A1BD549CB00B50E3A /* ASAsciiArtBoxCreator.m in Sources */,
 				058D0A27195D050800B7D73C /* _ASPendingState.m in Sources */,
 				205F0E1A1B37339C007741D0 /* ASAbstractLayoutController.mm in Sources */,
 				ACF6ED1B1B17843500DA7C62 /* ASBackgroundLayoutSpec.mm in Sources */,
@@ -1554,6 +1565,7 @@
 				B350624A1B010EFD0018CF92 /* _ASCoreAnimationExtras.mm in Sources */,
 				2767E9421BB19BD600EA9B77 /* ASViewController.m in Sources */,
 				B35062101B010EFD0018CF92 /* _ASDisplayLayer.mm in Sources */,
+				9C55866B1BD54A1900B50E3A /* ASAsciiArtBoxCreator.m in Sources */,
 				B35062121B010EFD0018CF92 /* _ASDisplayView.mm in Sources */,
 				B350624C1B010EFD0018CF92 /* _ASPendingState.m in Sources */,
 				509E68621B3AEDA5009B9150 /* ASAbstractLayoutController.mm in Sources */,

--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -48,7 +48,7 @@ typedef void (^ASDisplayNodeDidLoadBlock)(ASDisplayNode *node);
  *
  */
 
-@interface ASDisplayNode : ASDealloc2MainObject <ASLayoutable, ASLayoutableAsciiArtProtocol>
+@interface ASDisplayNode : ASDealloc2MainObject <ASLayoutable>
 
 
 /** @name Initializing a node object */
@@ -657,6 +657,9 @@ typedef void (^ASDisplayNodeDidLoadBlock)(ASDisplayNode *node);
  * @param node The node to be added.
  */
 - (void)addSubnode:(ASDisplayNode *)node;
+@end
+
+@interface ASDisplayNode (Debugging) <ASLayoutableAsciiArtProtocol>
 @end
 
 @interface ASDisplayNode (Deprecated)

--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -519,7 +519,7 @@ typedef void (^ASDisplayNodeDidLoadBlock)(ASDisplayNode *node);
  * Convenience methods for debugging.
  */
 
-@interface ASDisplayNode (Debugging)
+@interface ASDisplayNode (Debugging) <ASLayoutableAsciiArtProtocol>
 
 /**
  * @abstract Return a description of the node hierarchy.
@@ -657,9 +657,6 @@ typedef void (^ASDisplayNodeDidLoadBlock)(ASDisplayNode *node);
  * @param node The node to be added.
  */
 - (void)addSubnode:(ASDisplayNode *)node;
-@end
-
-@interface ASDisplayNode (Debugging) <ASLayoutableAsciiArtProtocol>
 @end
 
 @interface ASDisplayNode (Deprecated)

--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -12,7 +12,7 @@
 #import <AsyncDisplayKit/ASBaseDefines.h>
 #import <AsyncDisplayKit/ASDealloc2MainObject.h>
 #import <AsyncDisplayKit/ASDimension.h>
-
+#import <AsyncDisplayKit/ASAsciiArtBoxCreator.h>
 #import <AsyncDisplayKit/ASLayoutable.h>
 
 @class ASDisplayNode;
@@ -48,7 +48,7 @@ typedef void (^ASDisplayNodeDidLoadBlock)(ASDisplayNode *node);
  *
  */
 
-@interface ASDisplayNode : ASDealloc2MainObject <ASLayoutable>
+@interface ASDisplayNode : ASDealloc2MainObject <ASLayoutable, ASLayoutableAsciiArtProtocol>
 
 
 /** @name Initializing a node object */

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -2074,6 +2074,19 @@ static void _recursivelySetDisplaySuspended(ASDisplayNode *node, CALayer *layer,
   return self;
 }
 
+
+#pragma mark - ASLayoutableAsciiArtProtocol
+
+- (NSString *)asciiArtString
+{
+  return [ASLayoutSpec asciiArtStringForChildren:@[] parentName:[self asciiArtName]];
+}
+
+- (NSString *)asciiArtName
+{
+  return NSStringFromClass([self class]);
+}
+
 @end
 
 @implementation ASDisplayNode (Debugging)

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -2074,19 +2074,6 @@ static void _recursivelySetDisplaySuspended(ASDisplayNode *node, CALayer *layer,
   return self;
 }
 
-
-#pragma mark - ASLayoutableAsciiArtProtocol
-
-- (NSString *)asciiArtString
-{
-  return [ASLayoutSpec asciiArtStringForChildren:@[] parentName:[self asciiArtName]];
-}
-
-- (NSString *)asciiArtName
-{
-  return NSStringFromClass([self class]);
-}
-
 @end
 
 @implementation ASDisplayNode (Debugging)
@@ -2148,6 +2135,18 @@ static void _recursivelySetDisplaySuspended(ASDisplayNode *node, CALayer *layer,
     [subtree appendString:[n _recursiveDescriptionHelperWithIndent:[indent stringByAppendingString:@" | "]]];
   }
   return subtree;
+}
+
+#pragma mark - ASLayoutableAsciiArtProtocol
+
+- (NSString *)asciiArtString
+{
+    return [ASLayoutSpec asciiArtStringForChildren:@[] parentName:[self asciiArtName]];
+}
+
+- (NSString *)asciiArtName
+{
+    return NSStringFromClass([self class]);
 }
 
 @end

--- a/AsyncDisplayKit/Layout/ASAsciiArtBoxCreator.h
+++ b/AsyncDisplayKit/Layout/ASAsciiArtBoxCreator.h
@@ -1,0 +1,59 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <Foundation/Foundation.h>
+
+@protocol ASLayoutableAsciiArtProtocol <NSObject>
+/**
+ *  Returns an ascii-art representation of this object and its children.
+ *  For example, an ASInsetSpec may return something like this:
+ *
+ *   --ASInsetLayoutSpec--
+ *   |     ASTextNode    |
+ *   ---------------------
+ */
+- (NSString *)asciiArtString;
+
+/**
+ *  returns the name of this object that will display in the ascii art. Usually this can
+ *  simply be NSStringFromClass([self class]).
+ */
+- (NSString *)asciiArtName;
+
+@end
+
+/**
+ *  A that takes a parent and its children and renders as ascii art box.
+ */
+@interface ASAsciiArtBoxCreator : NSObject
+
+/**
+ *  Renders an ascii art box with the children aligned horizontally
+ *  Example:
+ *  ------------ASStackLayoutSpec-----------
+ *  |  ASTextNode  ASTextNode  ASTextNode  |
+ *  ----------------------------------------
+ */
++ (NSString *)horizontalBoxStringForChildren:(NSArray<NSString *> *)children parent:(NSString *)parent;
+
+/**
+ *  Renders an ascii art box with the children aligned vertically.
+ *  Example:
+ *   --ASStackLayoutSpec--
+ *   |     ASTextNode    |
+ *   |     ASTextNode    |
+ *   |     ASTextNode    |
+ *   ---------------------
+ */
++ (NSString *)verticalBoxStringForChildren:(NSArray<NSString *> *)children parent:(NSString *)parent;
+
+@end
+
+

--- a/AsyncDisplayKit/Layout/ASAsciiArtBoxCreator.h
+++ b/AsyncDisplayKit/Layout/ASAsciiArtBoxCreator.h
@@ -41,7 +41,7 @@
  *  |  ASTextNode  ASTextNode  ASTextNode  |
  *  ----------------------------------------
  */
-+ (NSString *)horizontalBoxStringForChildren:(NSArray<NSString *> *)children parent:(NSString *)parent;
++ (NSString *)horizontalBoxStringForChildren:(NSArray *)children parent:(NSString *)parent;
 
 /**
  *  Renders an ascii art box with the children aligned vertically.
@@ -52,7 +52,7 @@
  *   |     ASTextNode    |
  *   ---------------------
  */
-+ (NSString *)verticalBoxStringForChildren:(NSArray<NSString *> *)children parent:(NSString *)parent;
++ (NSString *)verticalBoxStringForChildren:(NSArray *)children parent:(NSString *)parent;
 
 @end
 

--- a/AsyncDisplayKit/Layout/ASAsciiArtBoxCreator.m
+++ b/AsyncDisplayKit/Layout/ASAsciiArtBoxCreator.m
@@ -1,0 +1,185 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+@import UIKit;
+#import "ASAsciiArtBoxCreator.h"
+
+static const NSUInteger kDebugBoxPadding = 2;
+
+typedef NS_ENUM(NSUInteger, PIDebugBoxPaddingLocation)
+{
+  PIDebugBoxPaddingLocationFront,
+  PIDebugBoxPaddingLocationEnd,
+  PIDebugBoxPaddingLocationBoth
+};
+
+@interface NSString(PIDebugBox)
+
+@end
+
+@implementation NSString(PIDebugBox)
+
++ (instancetype)debugbox_stringWithString:(NSString *)stringToRepeat repeatedCount:(NSUInteger)repeatCount
+{
+  NSMutableString *string = [[NSMutableString alloc] initWithCapacity:[stringToRepeat length]  * repeatCount];
+  for (NSUInteger index = 0; index < repeatCount; index++) {
+    [string appendString:stringToRepeat];
+  }
+  return [string copy];
+}
+
+- (NSString *)debugbox_stringByAddingPadding:(NSString *)padding count:(NSUInteger)count location:(PIDebugBoxPaddingLocation)location
+{
+  NSString *paddingString = [NSString debugbox_stringWithString:padding repeatedCount:count];
+  switch (location) {
+    case PIDebugBoxPaddingLocationFront:
+      return [NSString stringWithFormat:@"%@%@", paddingString, self];
+    case PIDebugBoxPaddingLocationEnd:
+      return [NSString stringWithFormat:@"%@%@", self, paddingString];
+    case PIDebugBoxPaddingLocationBoth:
+      return [NSString stringWithFormat:@"%@%@%@", paddingString, self, paddingString];
+  }
+  return [self copy];
+}
+
+@end
+
+@implementation ASAsciiArtBoxCreator
+
++ (NSString *)horizontalBoxStringForChildren:(NSArray<NSString *> *)children parent:(NSString *)parent
+{
+  if ([children count] == 0) {
+    return parent;
+  }
+  
+  NSMutableArray<NSArray<NSString *> *> *childrenLines = [NSMutableArray array];
+  
+  // split the children into lines
+  NSUInteger lineCountPerChild = 0;
+  for (NSString *child in children) {
+    NSArray *lines = [child componentsSeparatedByString:@"\n"];
+    lineCountPerChild = MAX(lineCountPerChild, [lines count]);
+  }
+  
+  for (NSString *child in children) {
+    NSMutableArray *lines = [[child componentsSeparatedByString:@"\n"] mutableCopy];
+    NSUInteger topPadding = ceilf((CGFloat)(lineCountPerChild - [lines count])/2.0);
+    NSUInteger bottomPadding = (lineCountPerChild - [lines count])/2.0;
+    NSUInteger lineLength = [lines[0] length];
+    
+    for (NSUInteger index = 0; index < topPadding; index++) {
+      [lines insertObject:[NSString debugbox_stringWithString:@" " repeatedCount:lineLength] atIndex:0];
+    }
+    for (NSUInteger index = 0; index < bottomPadding; index++) {
+      [lines addObject:[NSString debugbox_stringWithString:@" " repeatedCount:lineLength]];
+    }
+    [childrenLines addObject:lines];
+  }
+  
+  NSMutableArray<NSString *> *concatenatedLines = [NSMutableArray array];
+  NSString *padding = [NSString debugbox_stringWithString:@" " repeatedCount:kDebugBoxPadding];
+  for (NSUInteger index = 0; index < lineCountPerChild; index++) {
+    NSMutableString *line = [[NSMutableString alloc] init];
+    [line appendFormat:@"|%@",padding];
+    for (NSArray<NSString *> *childLines in childrenLines) {
+      [line appendFormat:@"%@%@", childLines[index], padding];
+    }
+    [line appendString:@"|"];
+    [concatenatedLines addObject:line];
+  }
+  
+  // surround the lines in a box
+  NSUInteger totalLineLength = [concatenatedLines[0] length];
+  if (totalLineLength < [parent length]) {
+    NSUInteger difference = [parent length] + (2 * kDebugBoxPadding) - totalLineLength;
+    NSUInteger leftPadding = ceilf((CGFloat)difference/2.0);
+    NSUInteger rightPadding = difference/2;
+    
+    NSString *leftString = [@"|" debugbox_stringByAddingPadding:@" " count:leftPadding location:PIDebugBoxPaddingLocationEnd];
+    NSString *rightString = [@"|" debugbox_stringByAddingPadding:@" " count:rightPadding location:PIDebugBoxPaddingLocationFront];
+    
+    NSMutableArray *paddedLines = [NSMutableArray array];
+    for (NSString *line in concatenatedLines) {
+      NSString *paddedLine = [line stringByReplacingOccurrencesOfString:@"|" withString:leftString options:NSCaseInsensitiveSearch range:NSMakeRange(0, 1)];
+      paddedLine = [paddedLine stringByReplacingOccurrencesOfString:@"|" withString:rightString options:NSCaseInsensitiveSearch range:NSMakeRange([paddedLine length] - 1, 1)];
+      [paddedLines addObject:paddedLine];
+    }
+    concatenatedLines = paddedLines;
+    totalLineLength += difference;
+  }
+  concatenatedLines = [self appendTopAndBottomToBoxString:concatenatedLines parent:parent];
+  return [concatenatedLines componentsJoinedByString:@"\n"];
+  
+}
+
++ (NSString *)verticalBoxStringForChildren:(NSArray<NSString *> *)children parent:(NSString *)parent
+{
+  if ([children count] == 0) {
+    return parent;
+  }
+  
+  NSMutableArray<NSString *> *childrenLines = [NSMutableArray array];
+  
+  NSUInteger maxChildLength = 0;
+  for (NSString *child in children) {
+    NSArray *lines = [child componentsSeparatedByString:@"\n"];
+    maxChildLength = MAX(maxChildLength, [lines[0] length]);
+  }
+  
+  NSUInteger rightPadding = 0;
+  NSUInteger leftPadding = 0;
+  
+  if (maxChildLength < [parent length]) {
+    NSUInteger difference = [parent length] + (2 * kDebugBoxPadding) - maxChildLength;
+    leftPadding = ceilf((CGFloat)difference/2.0);
+    rightPadding = difference/2;
+  }
+  
+  NSString *rightPaddingString = [NSString debugbox_stringWithString:@" " repeatedCount:rightPadding + kDebugBoxPadding];
+  NSString *leftPaddingString = [NSString debugbox_stringWithString:@" " repeatedCount:leftPadding + kDebugBoxPadding];
+  
+  for (NSString *child in children) {
+    NSMutableArray *lines = [[child componentsSeparatedByString:@"\n"] mutableCopy];
+    
+    NSUInteger leftLinePadding = ceilf((CGFloat)(maxChildLength - [lines[0] length])/2.0);
+    NSUInteger rightLinePadding = (maxChildLength - [lines[0] length])/2.0;
+    
+    for (NSString *line in lines) {
+      NSString *rightLinePaddingString = [NSString debugbox_stringWithString:@" " repeatedCount:rightLinePadding];
+      rightLinePaddingString = [NSString stringWithFormat:@"%@%@|", rightLinePaddingString, rightPaddingString];
+      
+      NSString *leftLinePaddingString = [NSString debugbox_stringWithString:@" " repeatedCount:leftLinePadding];
+      leftLinePaddingString = [NSString stringWithFormat:@"|%@%@", leftLinePaddingString, leftPaddingString];
+      
+      NSString *paddingLine = [NSString stringWithFormat:@"%@%@%@", leftLinePaddingString, line, rightLinePaddingString];
+      [childrenLines addObject:paddingLine];
+    }
+  }
+  
+  childrenLines = [self appendTopAndBottomToBoxString:childrenLines parent:parent];
+  return [childrenLines componentsJoinedByString:@"\n"];
+}
+
++ (NSMutableArray *)appendTopAndBottomToBoxString:(NSMutableArray<NSString *> *)boxStrings parent:(NSString *)parent
+{
+  NSUInteger totalLineLength = [boxStrings[0] length];
+  [boxStrings addObject:[NSString debugbox_stringWithString:@"-" repeatedCount:totalLineLength]];
+  
+  NSUInteger leftPadding = ceilf(((CGFloat)(totalLineLength - [parent length]))/2.0);
+  NSUInteger rightPadding = (totalLineLength - [parent length])/2;
+  
+  NSString *topLine = [parent debugbox_stringByAddingPadding:@"-" count:leftPadding location:PIDebugBoxPaddingLocationFront];
+  topLine = [topLine debugbox_stringByAddingPadding:@"-" count:rightPadding location:PIDebugBoxPaddingLocationEnd];
+  [boxStrings insertObject:topLine atIndex:0];
+  
+  return boxStrings;
+}
+
+@end

--- a/AsyncDisplayKit/Layout/ASAsciiArtBoxCreator.m
+++ b/AsyncDisplayKit/Layout/ASAsciiArtBoxCreator.m
@@ -53,13 +53,13 @@ typedef NS_ENUM(NSUInteger, PIDebugBoxPaddingLocation)
 
 @implementation ASAsciiArtBoxCreator
 
-+ (NSString *)horizontalBoxStringForChildren:(NSArray<NSString *> *)children parent:(NSString *)parent
++ (NSString *)horizontalBoxStringForChildren:(NSArray *)children parent:(NSString *)parent
 {
   if ([children count] == 0) {
     return parent;
   }
   
-  NSMutableArray<NSArray<NSString *> *> *childrenLines = [NSMutableArray array];
+  NSMutableArray *childrenLines = [NSMutableArray array];
   
   // split the children into lines
   NSUInteger lineCountPerChild = 0;
@@ -83,12 +83,12 @@ typedef NS_ENUM(NSUInteger, PIDebugBoxPaddingLocation)
     [childrenLines addObject:lines];
   }
   
-  NSMutableArray<NSString *> *concatenatedLines = [NSMutableArray array];
+  NSMutableArray *concatenatedLines = [NSMutableArray array];
   NSString *padding = [NSString debugbox_stringWithString:@" " repeatedCount:kDebugBoxPadding];
   for (NSUInteger index = 0; index < lineCountPerChild; index++) {
     NSMutableString *line = [[NSMutableString alloc] init];
     [line appendFormat:@"|%@",padding];
-    for (NSArray<NSString *> *childLines in childrenLines) {
+    for (NSArray *childLines in childrenLines) {
       [line appendFormat:@"%@%@", childLines[index], padding];
     }
     [line appendString:@"|"];
@@ -119,13 +119,13 @@ typedef NS_ENUM(NSUInteger, PIDebugBoxPaddingLocation)
   
 }
 
-+ (NSString *)verticalBoxStringForChildren:(NSArray<NSString *> *)children parent:(NSString *)parent
++ (NSString *)verticalBoxStringForChildren:(NSArray *)children parent:(NSString *)parent
 {
   if ([children count] == 0) {
     return parent;
   }
   
-  NSMutableArray<NSString *> *childrenLines = [NSMutableArray array];
+  NSMutableArray *childrenLines = [NSMutableArray array];
   
   NSUInteger maxChildLength = 0;
   for (NSString *child in children) {
@@ -167,7 +167,7 @@ typedef NS_ENUM(NSUInteger, PIDebugBoxPaddingLocation)
   return [childrenLines componentsJoinedByString:@"\n"];
 }
 
-+ (NSMutableArray *)appendTopAndBottomToBoxString:(NSMutableArray<NSString *> *)boxStrings parent:(NSString *)parent
++ (NSMutableArray *)appendTopAndBottomToBoxString:(NSMutableArray *)boxStrings parent:(NSString *)parent
 {
   NSUInteger totalLineLength = [boxStrings[0] length];
   [boxStrings addObject:[NSString debugbox_stringWithString:@"-" repeatedCount:totalLineLength]];

--- a/AsyncDisplayKit/Layout/ASLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASLayoutSpec.h
@@ -12,7 +12,7 @@
 #import <AsyncDisplayKit/ASAsciiArtBoxCreator.h>
 
 /** A layout spec is an immutable object that describes a layout, loosely inspired by React. */
-@interface ASLayoutSpec : NSObject <ASLayoutable, ASLayoutableAsciiArtProtocol>
+@interface ASLayoutSpec : NSObject <ASLayoutable>
 
 /** 
  * Creation of a layout spec should only happen by a user in layoutSpecThatFits:. During that method, a
@@ -95,7 +95,9 @@
 
 /** Returns all children added to this layout spec. */
 - (NSArray *)children;
+@end
 
+@interface ASLayoutSpec (Debugging) <ASLayoutableAsciiArtProtocol>
 /**
  *  Used by other layout specs to create ascii art debug strings
  */

--- a/AsyncDisplayKit/Layout/ASLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASLayoutSpec.h
@@ -9,9 +9,10 @@
  */
 
 #import <AsyncDisplayKit/ASLayoutable.h>
+#import <AsyncDisplayKit/ASAsciiArtBoxCreator.h>
 
 /** A layout spec is an immutable object that describes a layout, loosely inspired by React. */
-@interface ASLayoutSpec : NSObject <ASLayoutable>
+@interface ASLayoutSpec : NSObject <ASLayoutable, ASLayoutableAsciiArtProtocol>
 
 /** 
  * Creation of a layout spec should only happen by a user in layoutSpecThatFits:. During that method, a
@@ -94,5 +95,11 @@
 
 /** Returns all children added to this layout spec. */
 - (NSArray *)children;
+
+/**
+ *  Used by other layout specs to create ascii art debug strings
+ */
++ (NSString *)asciiArtStringForChildren:(NSArray<id<ASLayoutableAsciiArtProtocol>> *)children parentName:(NSString *)parentName direction:(ASStackLayoutDirection)direction;
++ (NSString *)asciiArtStringForChildren:(NSArray<id<ASLayoutableAsciiArtProtocol>> *)children parentName:(NSString *)parentName;
 
 @end

--- a/AsyncDisplayKit/Layout/ASLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASLayoutSpec.h
@@ -101,7 +101,7 @@
 /**
  *  Used by other layout specs to create ascii art debug strings
  */
-+ (NSString *)asciiArtStringForChildren:(NSArray<id<ASLayoutableAsciiArtProtocol>> *)children parentName:(NSString *)parentName direction:(ASStackLayoutDirection)direction;
-+ (NSString *)asciiArtStringForChildren:(NSArray<id<ASLayoutableAsciiArtProtocol>> *)children parentName:(NSString *)parentName;
++ (NSString *)asciiArtStringForChildren:(NSArray *)children parentName:(NSString *)parentName direction:(ASStackLayoutDirection)direction;
++ (NSString *)asciiArtStringForChildren:(NSArray *)children parentName:(NSString *)parentName;
 
 @end

--- a/AsyncDisplayKit/Layout/ASLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASLayoutSpec.mm
@@ -128,7 +128,7 @@ static NSString * const kDefaultChildrenKey = @"kDefaultChildrenKey";
 
 #pragma mark - ASLayoutableAsciiArtProtocol
 
-+ (NSString *)asciiArtStringForChildren:(NSArray<id<ASLayoutableAsciiArtProtocol>> *)children parentName:(NSString *)parentName direction:(ASStackLayoutDirection)direction
++ (NSString *)asciiArtStringForChildren:(NSArray *)children parentName:(NSString *)parentName direction:(ASStackLayoutDirection)direction
 {
   NSMutableArray *childStrings = [NSMutableArray array];
   for (id<ASLayoutableAsciiArtProtocol> layoutChild in children) {
@@ -143,7 +143,7 @@ static NSString * const kDefaultChildrenKey = @"kDefaultChildrenKey";
   return [ASAsciiArtBoxCreator verticalBoxStringForChildren:childStrings parent:parentName];
 }
 
-+ (NSString *)asciiArtStringForChildren:(NSArray<id<ASLayoutableAsciiArtProtocol>> *)children parentName:(NSString *)parentName
++ (NSString *)asciiArtStringForChildren:(NSArray *)children parentName:(NSString *)parentName
 {
   return [self asciiArtStringForChildren:children parentName:parentName direction:ASStackLayoutDirectionHorizontal];
 }

--- a/AsyncDisplayKit/Layout/ASLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASLayoutSpec.mm
@@ -122,6 +122,10 @@ static NSString * const kDefaultChildrenKey = @"kDefaultChildrenKey";
   return self.layoutChildren[kDefaultChildrenKey];
 }
 
+@end
+
+@implementation ASLayoutSpec (Debugging)
+
 #pragma mark - ASLayoutableAsciiArtProtocol
 
 + (NSString *)asciiArtStringForChildren:(NSArray<id<ASLayoutableAsciiArtProtocol>> *)children parentName:(NSString *)parentName direction:(ASStackLayoutDirection)direction

--- a/AsyncDisplayKit/Layout/ASLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASLayoutSpec.mm
@@ -122,5 +122,36 @@ static NSString * const kDefaultChildrenKey = @"kDefaultChildrenKey";
   return self.layoutChildren[kDefaultChildrenKey];
 }
 
-                     
+#pragma mark - ASLayoutableAsciiArtProtocol
+
++ (NSString *)asciiArtStringForChildren:(NSArray<id<ASLayoutableAsciiArtProtocol>> *)children parentName:(NSString *)parentName direction:(ASStackLayoutDirection)direction
+{
+  NSMutableArray *childStrings = [NSMutableArray array];
+  for (id<ASLayoutableAsciiArtProtocol> layoutChild in children) {
+    NSString *childString = [layoutChild asciiArtString];
+    if (childString) {
+      [childStrings addObject:childString];
+    }
+  }
+  if (direction == ASStackLayoutDirectionHorizontal) {
+    return [ASAsciiArtBoxCreator horizontalBoxStringForChildren:childStrings parent:parentName];
+  }
+  return [ASAsciiArtBoxCreator verticalBoxStringForChildren:childStrings parent:parentName];
+}
+
++ (NSString *)asciiArtStringForChildren:(NSArray<id<ASLayoutableAsciiArtProtocol>> *)children parentName:(NSString *)parentName
+{
+  return [self asciiArtStringForChildren:children parentName:parentName direction:ASStackLayoutDirectionHorizontal];
+}
+
+- (NSString *)asciiArtString
+{
+  return [ASLayoutSpec asciiArtStringForChildren:@[self.child] parentName:[self asciiArtName]];
+}
+
+- (NSString *)asciiArtName
+{
+  return NSStringFromClass([self class]);
+}
+
 @end

--- a/AsyncDisplayKit/Layout/ASOverlayLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASOverlayLayoutSpec.mm
@@ -72,4 +72,11 @@ static NSString * const kOverlayChildKey = @"kOverlayChildKey";
   return nil;
 }
 
+#pragma mark - ASLayoutableAsciiArtProtocol
+
+- (NSString *)debugBoxString
+{
+  return [ASLayoutSpec asciiArtStringForChildren:@[self.overlay, self.child] parentName:[self asciiArtName]];
+}
+
 @end

--- a/AsyncDisplayKit/Layout/ASOverlayLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASOverlayLayoutSpec.mm
@@ -72,6 +72,10 @@ static NSString * const kOverlayChildKey = @"kOverlayChildKey";
   return nil;
 }
 
+@end
+
+@implementation ASOverlayLayoutSpec (Debugging)
+
 #pragma mark - ASLayoutableAsciiArtProtocol
 
 - (NSString *)debugBoxString

--- a/AsyncDisplayKit/Layout/ASRatioLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASRatioLayoutSpec.mm
@@ -86,6 +86,10 @@
   return nil;
 }
 
+@end
+
+@implementation ASRatioLayoutSpec (Debugging)
+
 #pragma mark - ASLayoutableAsciiArtProtocol
 
 - (NSString *)asciiArtName

--- a/AsyncDisplayKit/Layout/ASRatioLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASRatioLayoutSpec.mm
@@ -86,4 +86,11 @@
   return nil;
 }
 
+#pragma mark - ASLayoutableAsciiArtProtocol
+
+- (NSString *)asciiArtName
+{
+  return [NSString stringWithFormat:@"%@ (%.1f)", NSStringFromClass([self class]), self.ratio];
+}
+
 @end

--- a/AsyncDisplayKit/Layout/ASStackLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASStackLayoutSpec.mm
@@ -135,6 +135,10 @@
                                    sublayouts:sublayouts];
 }
 
+@end
+
+@implementation ASStackLayoutSpec (Debugging)
+
 #pragma mark - ASLayoutableAsciiArtProtocol
 
 - (NSString *)asciiArtString

--- a/AsyncDisplayKit/Layout/ASStackLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASStackLayoutSpec.mm
@@ -135,4 +135,11 @@
                                    sublayouts:sublayouts];
 }
 
+#pragma mark - ASLayoutableAsciiArtProtocol
+
+- (NSString *)asciiArtString
+{
+  return [ASLayoutSpec asciiArtStringForChildren:self.children parentName:[self asciiArtName] direction:self.direction];
+}
+
 @end

--- a/AsyncDisplayKit/Layout/ASStaticLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASStaticLayoutSpec.mm
@@ -84,6 +84,10 @@
   return nil;
 }
 
+@end
+
+@implementation ASStaticLayoutSpec (Debugging)
+
 #pragma mark - ASLayoutableAsciiArtProtocol
 
 - (NSString *)debugBoxString

--- a/AsyncDisplayKit/Layout/ASStaticLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASStaticLayoutSpec.mm
@@ -84,4 +84,11 @@
   return nil;
 }
 
+#pragma mark - ASLayoutableAsciiArtProtocol
+
+- (NSString *)debugBoxString
+{
+  return [ASLayoutSpec asciiArtStringForChildren:self.children parentName:[self asciiArtName]];
+}
+
 @end


### PR DESCRIPTION
Created a class called `ASAsciiArtBoxCreator` that, given a parent name and an array of string representations of the children, will create an ascii representation of the parent. 

Objects that want to be rendered in ascii art should implement the `ASLayoutableAsciiArtProtocol` protocol. The two methods are:
```
- (NSString *)asciiArtString;
- (NSString *)asciiArtName;
```

I have updated `ASDisplayNode` and `ASLayoutSpec` so that they conform to this new protocol. If you are working on a layout, you can put a breakpoint at the end of `- (ASLayoutSpec *)layoutSpecThatFits:(ASSizeRange)constrainedSize` and type `po [layoutSpec asciiArtString]` to see a visual representation of your layout.

For example, this is what the layout for `KittenNode` looks like:
```
(lldb) po [insetSpec asciiArtString]
-------------ASInsetLayoutSpec------------
|  ----------ASStackLayoutSpec---------  |
|  |  ASNetworkImageNode  ASTextNode  |  |
|  ------------------------------------  |
------------------------------------------
```

Here is an example of a more complicated example:
```
---------------------ASStackLayoutSpec-----------------------
|               -----ASStackLayoutSpec------                | 
|               |  --ASInsetLayoutSpec--   |                | 
|               |  |     ASTextNode    |   |                | 
|               |  ---------------------   |                | 
|               |  --ASInsetLayoutSpec--   |                | 
|  ASImageNode  |  |     ASTextNode    |   |  ASButtonNode  | 
|               |  ---------------------   |                | 
|               |  --ASInsetLayoutSpec--|  |                | 
|               |  |    ASStackNode     |  |                | 
|               |  ----------------------  |                | 
|               ----------------------------                | 
------------------------------------------------------------- 
```