### PR TITLE
Call UIViewController's designated initializer in ASViewController

### DIFF
--- a/AsyncDisplayKit/ASViewController.m
+++ b/AsyncDisplayKit/ASViewController.m
@@ -20,7 +20,7 @@
 
 - (instancetype)initWithNode:(ASDisplayNode *)node
 {
-  if (!(self = [super init])) {
+  if (!(self = [super initWithNibName:nil bundle:nil])) {
     return nil;
   }
   


### PR DESCRIPTION
ASViewController currently cannot be subclassed in Swift, as the original call to `[super init]` directs to calling the designated initializer of UIViewController `[self initWithNibName:bundle:]`. Because of Swift's initializer inheritance behavior, this designated initializer will not implicitly be available on the subclassed ASViewController without some extra boilerplate. Adding an explicit call to the designated initializer fixes this issue.