### PR TITLE
Fix table view tests

### DIFF
--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -880,7 +880,7 @@ void ASPerformBlockWithoutAnimation(BOOL withoutAnimation, void (^block)()) {
   // Normally the content view width equals to the constrained size width (which equals to the table view width).
   // If there is a mismatch between these values, for example after the table view entered or left editing mode,
   // content view width is preferred and used to re-measure the cell node.
-  if (contentViewWidth != constrainedSize.max.width) {
+  if (!_ignoreNodesConstrainedWidthChange && contentViewWidth != constrainedSize.max.width) {
     constrainedSize.min.width = contentViewWidth;
     constrainedSize.max.width = contentViewWidth;
 

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -169,8 +169,8 @@ static BOOL _isInterceptedSelector(SEL sel)
   NSIndexPath *_contentOffsetAdjustmentTopVisibleRow;
   CGFloat _contentOffsetAdjustment;
 
-  CGFloat _maxWidthForNodesConstrainedSize;
-  BOOL _ignoreMaxWidthChange;
+  CGFloat _nodesConstrainedWidth;
+  BOOL _ignoreNodesConstrainedWidthChange;
 }
 
 @property (atomic, assign) BOOL asyncDataSourceLocked;
@@ -224,10 +224,10 @@ void ASPerformBlockWithoutAnimation(BOOL withoutAnimation, void (^block)()) {
 
   _automaticallyAdjustsContentOffset = NO;
   
-  _maxWidthForNodesConstrainedSize = self.bounds.size.width;
+  _nodesConstrainedWidth = self.bounds.size.width;
   // If the initial size is 0, expect a size change very soon which is part of the initial configuration
   // and should not trigger a relayout.
-  _ignoreMaxWidthChange = (_maxWidthForNodesConstrainedSize == 0);
+  _ignoreNodesConstrainedWidthChange = (_nodesConstrainedWidth == 0);
 }
 
 - (instancetype)initWithFrame:(CGRect)frame style:(UITableViewStyle)style
@@ -396,13 +396,13 @@ void ASPerformBlockWithoutAnimation(BOOL withoutAnimation, void (^block)()) {
 
 - (void)layoutSubviews
 {
-  if (_maxWidthForNodesConstrainedSize != self.bounds.size.width) {
-    _maxWidthForNodesConstrainedSize = self.bounds.size.width;
+  if (_nodesConstrainedWidth != self.bounds.size.width) {
+    _nodesConstrainedWidth = self.bounds.size.width;
 
     // First width change occurs during initial configuration. An expensive relayout pass is unnecessary at that time
     // and should be avoided, assuming that the initial data loading automatically runs shortly afterward.
-    if (_ignoreMaxWidthChange) {
-      _ignoreMaxWidthChange = NO;
+    if (_ignoreNodesConstrainedWidthChange) {
+      _ignoreNodesConstrainedWidthChange = NO;
     } else {
       [self beginUpdates];
       [_dataController relayoutAllNodes];
@@ -828,8 +828,8 @@ void ASPerformBlockWithoutAnimation(BOOL withoutAnimation, void (^block)()) {
 
 - (ASSizeRange)dataController:(ASDataController *)dataController constrainedSizeForNodeAtIndexPath:(NSIndexPath *)indexPath
 {
-  return ASSizeRangeMake(CGSizeMake(_maxWidthForNodesConstrainedSize, 0),
-                         CGSizeMake(_maxWidthForNodesConstrainedSize, FLT_MAX));
+  return ASSizeRangeMake(CGSizeMake(_nodesConstrainedWidth, 0),
+                         CGSizeMake(_nodesConstrainedWidth, FLT_MAX));
 }
 
 - (void)dataControllerLockDataSource


### PR DESCRIPTION
There is a bug in ASTableView that causes unnecessary relayout when the table view width is zero initially. This PR includes the fix for this bug and some minor refactorings.

#758, #753

