### PR TITLE
Avoid overwriting areAnimationsEnabled if app changes it again during animation

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -789,26 +789,14 @@ static BOOL _isInterceptedSelector(SEL sel)
     }
     return; // if the asyncDataSource has become invalid while we are processing, ignore this request to avoid crashes
   }
-
-  BOOL animationsEnabled = NO;
-
-  if (!animated) {
-    animationsEnabled = [UIView areAnimationsEnabled];
-    [UIView setAnimationsEnabled:NO];
-  }
-
-  [super performBatchUpdates:^{
-    [_batchUpdateBlocks enumerateObjectsUsingBlock:^(dispatch_block_t block, NSUInteger idx, BOOL *stop) {
-      block();
-    }];
-  } completion:^(BOOL finished) {
-    if (!animated) {
-      [UIView setAnimationsEnabled:animationsEnabled];
-    }
-    if (completion) {
-      completion(finished);
-    }
-  }];
+  
+  ASPerformBlockWithoutAnimation(!animated, ^{
+    [super performBatchUpdates:^{
+      [_batchUpdateBlocks enumerateObjectsUsingBlock:^(dispatch_block_t block, NSUInteger idx, BOOL *stop) {
+        block();
+      }];
+    } completion:completion];
+  });
 
   [_batchUpdateBlocks removeAllObjects];
   _performingBatchUpdates = NO;

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -792,9 +792,9 @@ static BOOL _isInterceptedSelector(SEL sel)
   
   ASPerformBlockWithoutAnimation(!animated, ^{
     [super performBatchUpdates:^{
-      [_batchUpdateBlocks enumerateObjectsUsingBlock:^(dispatch_block_t block, NSUInteger idx, BOOL *stop) {
+      for (dispatch_block_t block in _batchUpdateBlocks) {
         block();
-      }];
+      }
     } completion:completion];
   });
 

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -180,26 +180,6 @@ static BOOL _isInterceptedSelector(SEL sel)
 
 @implementation ASTableView
 
-/**
- @summary Conditionally performs UIView geometry changes in the given block without animation.
- 
- Used primarily to circumvent UITableView forcing insertion animations when explicitly told not to via
- `UITableViewRowAnimationNone`. More info: https://github.com/facebook/AsyncDisplayKit/pull/445
- 
- @param withoutAnimation Set to `YES` to perform given block without animation
- @param block Perform UIView geometry changes within the passed block
- */
-void ASPerformBlockWithoutAnimation(BOOL withoutAnimation, void (^block)()) {
-  if (withoutAnimation) {
-    BOOL animationsEnabled = [UIView areAnimationsEnabled];
-    [UIView setAnimationsEnabled:NO];
-    block();
-    [UIView setAnimationsEnabled:animationsEnabled];
-  } else {
-    block();
-  }
-}
-
 + (Class)dataControllerClass
 {
   return [ASChangeSetDataController class];

--- a/AsyncDisplayKit/Private/ASInternalHelpers.h
+++ b/AsyncDisplayKit/Private/ASInternalHelpers.h
@@ -10,6 +10,7 @@
 
 #include <CoreGraphics/CGBase.h>
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 #import "ASBaseDefines.h"
 
 ASDISPLAYNODE_EXTERN_C_BEGIN
@@ -26,6 +27,23 @@ CGFloat ASCeilPixelValue(CGFloat f);
 CGFloat ASRoundPixelValue(CGFloat f);
 
 ASDISPLAYNODE_EXTERN_C_END
+
+/**
+ @summary Conditionally performs UIView geometry changes in the given block without animation.
+ 
+ Used primarily to circumvent UITableView forcing insertion animations when explicitly told not to via
+ `UITableViewRowAnimationNone`. More info: https://github.com/facebook/AsyncDisplayKit/pull/445
+ 
+ @param withoutAnimation Set to `YES` to perform given block without animation
+ @param block Perform UIView geometry changes within the passed block
+ */
+ASDISPLAYNODE_INLINE void ASPerformBlockWithoutAnimation(BOOL withoutAnimation, void (^block)()) {
+  if (withoutAnimation) {
+    [UIView performWithoutAnimation:block];
+  } else {
+    block();
+  }
+}
 
 @interface NSIndexPath (ASInverseComparison)
 - (NSComparisonResult)asdk_inverseCompare:(NSIndexPath *)otherIndexPath;


### PR DESCRIPTION
We already had this `ASPerformBlockWithoutAnimation` convenience function, so I elevated it from `ASTableView.mm -> ASInternalHelpers.h` and reimplemented it using `performWithoutAnimation`. Now we never call `setAnimationsEnabled:` which should resolve #788 