### PR TITLE
adds convenience methods to return a vertical and horizontal stack spec

### DIFF
--- a/AsyncDisplayKit/Layout/ASStackLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASStackLayoutSpec.h
@@ -57,4 +57,14 @@
  */
 + (instancetype)stackLayoutSpecWithDirection:(ASStackLayoutDirection)direction spacing:(CGFloat)spacing justifyContent:(ASStackLayoutJustifyContent)justifyContent alignItems:(ASStackLayoutAlignItems)alignItems children:(NSArray *)children;
 
+/**
+ * @return A stack layout spec with direction of ASStackLayoutDirectionVertical
+ **/
++ (instancetype)verticalStackLayoutSpec;
+
+/**
+ * @return A stack layout spec with direction of ASStackLayoutDirectionHorizontal
+ **/
++ (instancetype)horizontalStackLayoutSpec;
+
 @end

--- a/AsyncDisplayKit/Layout/ASStackLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASStackLayoutSpec.mm
@@ -38,6 +38,20 @@
   return [[self alloc] initWithDirection:direction spacing:spacing justifyContent:justifyContent alignItems:alignItems children:children];
 }
 
++ (instancetype)verticalStackLayoutSpec
+{
+  ASStackLayoutSpec *stackLayoutSpec = [[self alloc] init];
+  stackLayoutSpec.direction = ASStackLayoutDirectionVertical;
+  return stackLayoutSpec;
+}
+
++ (instancetype)horizontalStackLayoutSpec
+{
+  ASStackLayoutSpec *stackLayoutSpec = [[self alloc] init];
+  stackLayoutSpec.direction = ASStackLayoutDirectionHorizontal;
+  return stackLayoutSpec;
+}
+
 - (instancetype)initWithDirection:(ASStackLayoutDirection)direction spacing:(CGFloat)spacing justifyContent:(ASStackLayoutJustifyContent)justifyContent alignItems:(ASStackLayoutAlignItems)alignItems children:(NSArray *)children
 {
   if (!(self = [super init])) {


### PR DESCRIPTION
It felt cumbersome to repeatedly specify the direction of an ASStackLayoutSpec so I thought it'd be nice to provide these convenience classes. I also ran into cases where I named an ASStackLayoutSpec as a verticalStack or horizontalStack but forgot to set it's direction causing me to waste time debugging.