### PR TITLE
ensure all nodes are exited on dealloc

### DIFF
--- a/AsyncDisplayKit/Details/ASRangeHandlerRender.mm
+++ b/AsyncDisplayKit/Details/ASRangeHandlerRender.mm
@@ -11,25 +11,44 @@
 #import "ASDisplayNode.h"
 #import "ASDisplayNode+Subclasses.h"
 #import "ASDisplayNodeInternal.h"
+#import "_ASDisplayView.h"
+
+@interface ASRangeHandlerRender ()
+@property (nonatomic,readonly) UIWindow *workingWindow;
+@end
 
 @implementation ASRangeHandlerRender
 
-+ (UIWindow *)workingWindow
+@synthesize workingWindow = _workingWindow;
+
+- (UIWindow *)workingWindow
 {
   ASDisplayNodeAssertMainThread();
-  
+
   // we add nodes' views to this invisible window to start async rendering
   // TODO: Replace this with directly triggering display https://github.com/facebook/AsyncDisplayKit/issues/315
-  static UIWindow *workingWindow = nil;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    workingWindow = [[UIWindow alloc] initWithFrame:CGRectZero];
-    workingWindow.windowLevel = UIWindowLevelNormal - 1000;
-    workingWindow.userInteractionEnabled = NO;
-    workingWindow.hidden = YES;
-    workingWindow.alpha = 0.0;
-  });
-  return workingWindow;
+
+  if (!_workingWindow) {
+    _workingWindow = [[UIWindow alloc] initWithFrame:CGRectZero];
+    _workingWindow.windowLevel = UIWindowLevelNormal - 1000;
+    _workingWindow.userInteractionEnabled = NO;
+    _workingWindow.hidden = YES;
+    _workingWindow.alpha = 0.0;
+  }
+
+  return _workingWindow;
+}
+
+- (void)dealloc
+{
+  NSArray *views = [self.workingWindow.subviews copy];
+  for(_ASDisplayView *view in views) {
+    if (![view isKindOfClass:[_ASDisplayView class]]) {
+      continue;
+    }
+    ASDisplayNode *node = view.asyncdisplaykit_node;
+    [self node:node exitedRangeOfType:ASLayoutRangeTypeRender];
+  }
 }
 
 - (void)node:(ASDisplayNode *)node enteredRangeOfType:(ASLayoutRangeType)rangeType
@@ -44,7 +63,7 @@
   // Any view-backed nodes will still create their views in order to assemble the layer heirarchy, and they will
   // also assemble a view subtree for the node, but we avoid the much more significant expense triggered by a view
   // being added or removed from an onscreen window (responder chain setup, will/DidMoveToWindow: recursive calls, etc)
-  [[[[self class] workingWindow] layer] addSublayer:node.layer];
+  [[[self workingWindow] layer] addSublayer:node.layer];
 }
 
 - (void)node:(ASDisplayNode *)node exitedRangeOfType:(ASLayoutRangeType)rangeType
@@ -71,7 +90,7 @@
   
   [node recursivelySetDisplaySuspended:YES];
   
-  if (node.layer.superlayer != [[[self class] workingWindow] layer]) {
+  if (node.layer.superlayer != [[self workingWindow] layer]) {
     // In this case, the node has previously passed through the working range (or it is zero), and it has now fallen outside the working range.
     if (![node isLayerBacked]) {
       // If the node is view-backed, we need to make sure to remove the view (which is now present in the containing cell contentsView).


### PR DESCRIPTION
This is a short-term fix for #797 and #791 suggested by @appleguy. I'm using a tweaked build of 1.2.3 and this seems to be working well for me. It clears any ASCellNodes that were in the Render state when the ASRangeController is dealloced (ultimately.) It is still possible for ASCellNodes to "leak" temporarily while the ASRangeController is alive. The good news is that this code will make sure it is cleaned up when the parent ASTable/CollectionView is dealloced.

I haven't tested this on master though (I'm not really set up for that at the moment), can someone give it a spin and make sure it plays well with all the amazing code in 1.9+?