### PR TITLE
Make textContainerInset configurable for ASEditableTextNode

### DIFF
--- a/AsyncDisplayKit/ASEditableTextNode.h
+++ b/AsyncDisplayKit/ASEditableTextNode.h
@@ -60,6 +60,11 @@
 @property (nonatomic, readonly) UITextInputMode *textInputMode;
 
 /*
+ @abstract The textContainerInset of both the placeholder and typed textView. This value defaults to UIEdgeInsetsZero.
+ */
+@property (nonatomic, readwrite) UIEdgeInsets textContainerInset;
+
+/*
  @abstract The returnKeyType of the keyboard. This value defaults to UIReturnKeyDefault.
  */
 @property (nonatomic, readwrite) UIReturnKeyType returnKeyType;

--- a/AsyncDisplayKit/ASEditableTextNode.mm
+++ b/AsyncDisplayKit/ASEditableTextNode.mm
@@ -78,7 +78,8 @@
   _textKitComponents.layoutManager.delegate = self;
   _wordKerner = [[ASTextNodeWordKerner alloc] init];
   _returnKeyType = UIReturnKeyDefault;
-
+  _textContainerInset = UIEdgeInsetsZero;
+  
   // Create the placeholder scaffolding.
   _placeholderTextKitComponents = [ASTextKitComponents componentsWithAttributedSeedString:nil textContainerSize:CGSizeZero];
   _placeholderTextKitComponents.layoutManager.delegate = self;
@@ -122,7 +123,7 @@
       textView.backgroundColor = nil;
       textView.opaque = NO;
     }
-    textView.textContainerInset = UIEdgeInsetsZero;
+    textView.textContainerInset = self.textContainerInset;
     textView.clipsToBounds = NO; // We don't want selection handles cut off.
   };
 
@@ -173,6 +174,15 @@
     _textKitComponents.textView.backgroundColor = backgroundColor;
   }
   _placeholderTextKitComponents.textView.backgroundColor = backgroundColor;
+}
+
+- (void)setTextContainerInset:(UIEdgeInsets)textContainerInset
+{
+  ASDN::MutexLocker l(_textKitLock);
+
+  _textContainerInset = textContainerInset;
+  _textKitComponents.textView.textContainerInset = textContainerInset;
+  _placeholderTextKitComponents.textView.textContainerInset = textContainerInset;
 }
 
 - (void)setOpaque:(BOOL)opaque


### PR DESCRIPTION
Previously, it was only possible to configure the textContainerInset of the typed textView by accessing the textView property on didLoad. This would cause the placeholder and typed textViews to become desynced however, so in this commit we add the ability to configure both.