### PR TITLE
Improve cell node layout delegate

### DIFF
--- a/AsyncDisplayKit/ASCellNode.h
+++ b/AsyncDisplayKit/ASCellNode.h
@@ -82,7 +82,7 @@ typedef NSUInteger ASCellNodeAnimation;
 - (void)touchesCancelled:(NSSet *)touches withEvent:(UIEvent *)event ASDISPLAYNODE_REQUIRES_SUPER;
 
 /**
- * Marks the node as needing layout. Convenience for use whether the view / layer is loaded or not. Safe to call from a background thread.
+ * Marks the node as needing layout. Convenience for use whether the view / layer is loaded or not.
  *
  * If this node was measured, calling this method triggers an internal relayout: the calculated layout is invalidated,
  * and the supernode is notified or (if this node is the root one) a full measurement pass is executed using the old constrained size.

--- a/AsyncDisplayKit/ASCellNode.h
+++ b/AsyncDisplayKit/ASCellNode.h
@@ -19,10 +19,8 @@ typedef NSUInteger ASCellNodeAnimation;
  * The notification is done on main thread.
  *
  * @param node A node informing the delegate about the relayout.
- *
- * @param suggestedAnimation A constant indicates how the delegate should animate. See UITableViewRowAnimation.
  */
-- (void)node:(ASCellNode *)node didRelayoutWithSuggestedAnimation:(ASCellNodeAnimation)animation;
+- (void)nodeDidRelayout:(ASCellNode *)node;
 @end
 
 /**
@@ -73,13 +71,6 @@ typedef NSUInteger ASCellNodeAnimation;
  * A delegate to be notified (on main thread) after a relayout.
  */
 @property (nonatomic, weak) id<ASCellNodeLayoutDelegate> layoutDelegate;
-
-/*
- * A constant that is passed to the delegate to indicate how a relayout is to be animated.
- * 
- * @see UITableViewRowAnimation
- */
-@property (nonatomic, assign) ASCellNodeAnimation relayoutAnimation;
 
 /*
  * ASCellNode must forward touch events in order for UITableView and UICollectionView tap handling to work. Overriding

--- a/AsyncDisplayKit/ASCellNode.m
+++ b/AsyncDisplayKit/ASCellNode.m
@@ -28,7 +28,6 @@
   // use UITableViewCell defaults
   _selectionStyle = UITableViewCellSelectionStyleDefault;
   self.clipsToBounds = YES;
-  _relayoutAnimation = UITableViewRowAnimationAutomatic;
 
   return self;
 }
@@ -58,7 +57,7 @@
   
   if (_layoutDelegate != nil) {
     ASPerformBlockOnMainThread(^{
-      [_layoutDelegate node:self didRelayoutWithSuggestedAnimation:_relayoutAnimation];
+      [_layoutDelegate nodeDidRelayout:self];
     });
   }
 }

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -889,13 +889,11 @@ static BOOL _isInterceptedSelector(SEL sel)
 
 #pragma mark - ASCellNodeDelegate
 
-- (void)node:(ASCellNode *)node didRelayoutWithSuggestedAnimation:(ASCellNodeAnimation)animation
+- (void)nodeDidRelayout:(ASCellNode *)node
 {
   ASDisplayNodeAssertMainThread();
-  NSIndexPath *indexPath = [self indexPathForNode:node];
-  if (indexPath != nil) {
-    [super reloadItemsAtIndexPaths:@[indexPath]];
-  }
+  // Cause UICollectionView to requery for the new height of this node
+  [super performBatchUpdates:^{} completion:nil];
 }
 
 @end

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -655,7 +655,9 @@ static BOOL _isInterceptedSelector(SEL sel)
 {
   ASCellNode *node = [_asyncDataSource collectionView:self nodeForItemAtIndexPath:indexPath];
   ASDisplayNodeAssert([node isKindOfClass:ASCellNode.class], @"invalid node class, expected ASCellNode");
-  node.layoutDelegate = self;
+  if (node.layoutDelegate == nil) {
+    node.layoutDelegate = self;
+  }
   return node;
 }
 

--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -559,6 +559,9 @@ typedef void (^ASDisplayNodeDidLoadBlock)(ASDisplayNode *node);
  * 
  * If this node was measured, calling this method triggers an internal relayout: the calculated layout is invalidated,
  * and the supernode is notified or (if this node is the root one) a full measurement pass is executed using the old constrained size.
+ *
+ * Note: ASCellNode has special behavior in that calling this method will automatically notify 
+ * the containing ASTableView / ASCollectionView that the cell should be resized, if necessary.
  */
 - (void)setNeedsLayout;
 

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -820,7 +820,9 @@ static BOOL _isInterceptedSelector(SEL sel)
 {
   ASCellNode *node = [_asyncDataSource tableView:self nodeForRowAtIndexPath:indexPath];
   ASDisplayNodeAssert([node isKindOfClass:ASCellNode.class], @"invalid node class, expected ASCellNode");
-  node.layoutDelegate = self;
+  if (node.layoutDelegate == nil) {
+    node.layoutDelegate = self;
+  }
   return node;
 }
 

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -895,15 +895,14 @@ static BOOL _isInterceptedSelector(SEL sel)
   }
 }
 
-#pragma mark - ASCellNodeDelegate
+#pragma mark - ASCellNodeLayoutDelegate
 
-- (void)node:(ASCellNode *)node didRelayoutWithSuggestedAnimation:(ASCellNodeAnimation)animation
+- (void)nodeDidRelayout:(ASCellNode *)node
 {
   ASDisplayNodeAssertMainThread();
-  NSIndexPath *indexPath = [self indexPathForNode:node];
-  if (indexPath != nil) {
-    [super reloadRowsAtIndexPaths:@[indexPath] withRowAnimation:(UITableViewRowAnimation)animation];
-  }
+  // Cause UITableView to requery for the new height of this node
+  [super beginUpdates];
+  [super endUpdates];
 }
 
 @end

--- a/examples/Kittens/Sample/KittenNode.mm
+++ b/examples/Kittens/Sample/KittenNode.mm
@@ -191,7 +191,17 @@ static const CGFloat kInnerPadding = 10.0f;
 - (void)toggleNodesSwap
 {
   _swappedTextAndImage = !_swappedTextAndImage;
-  [self setNeedsLayout];
+  
+  [UIView animateWithDuration:0.15 animations:^{
+    self.alpha = 0;
+  } completion:^(BOOL finished) {
+    [self setNeedsLayout];
+    [self.view layoutIfNeeded];
+    
+    [UIView animateWithDuration:0.15 animations:^{
+      self.alpha = 1;
+    }];
+  }];
 }
 
 @end


### PR DESCRIPTION
- Instead of reloading, layout delegates (i.e ASTableView and ASCollectionView) trigger an empty update transaction after a cell relayout (fix #808).
- Since delegates don't animate layout changes anymore, revert the animation example in KittenNode.
- Only set a default layout delegate to ASCellNode if it is not provided by the async data source. This allow developers to set their own delegate.
- Address comments in #793.