### PR TITLE
Fix ASTableViewCell's node selected/highlighted property

### DIFF
--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -136,12 +136,12 @@ static BOOL _isInterceptedSelector(SEL sel)
   [super didTransitionToState:state];
 }
 
-- (void)setSelected:(BOOL)selected
+- (void)setSelected:(BOOL)selected animated:(BOOL)animated
 {
   _node.selected = selected;
 }
 
-- (void)setHighlighted:(BOOL)highlighted
+- (void)setHighlighted:(BOOL)highlighted animated:(BOOL)animated
 {
   _node.highlighted = highlighted;
 }


### PR DESCRIPTION
When user highlight/select cell, ```- (void)setSelected:(BOOL)selected animated:(BOOL)animated``` and ```- (void)setHighlighted:(BOOL)highlighted animated:(BOOL)animated``` are fired instead of ```- (void)setSelected:(BOOL)selected``` and ```- (void)setHighlighted:(BOOL)highlighted```