### PR TITLE
Fix unusual cell content blanking issue when making existing cells much taller.

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -506,16 +506,6 @@ typedef void (^ASDisplayNodeDidLoadBlock)(ASDisplayNode *node);
  */
 - (CGRect)convertRect:(CGRect)rect fromNode:(ASDisplayNode *)node;
 
-/** @name UIResponder methods */
-
-// By default these fall through to the underlying view, but can be overridden.
-- (BOOL)canBecomeFirstResponder;                                            // default==NO
-- (BOOL)becomeFirstResponder;                                               // default==NO (no-op)
-- (BOOL)canResignFirstResponder;                                            // default==YES
-- (BOOL)resignFirstResponder;                                               // default==NO (no-op)
-- (BOOL)isFirstResponder;
-- (BOOL)canPerformAction:(SEL)action withSender:(id)sender;
-
 @end
 
 
@@ -614,6 +604,15 @@ typedef void (^ASDisplayNodeDidLoadBlock)(ASDisplayNode *node);
 @property (atomic, assign)           CGFloat borderWidth;                   // default=0
 @property (atomic, assign)           CGColorRef borderColor;                // default=opaque rgb black
 
+// UIResponder methods
+// By default these fall through to the underlying view, but can be overridden.
+- (BOOL)canBecomeFirstResponder;                                            // default==NO
+- (BOOL)becomeFirstResponder;                                               // default==NO (no-op)
+- (BOOL)canResignFirstResponder;                                            // default==YES
+- (BOOL)resignFirstResponder;                                               // default==NO (no-op)
+- (BOOL)isFirstResponder;
+- (BOOL)canPerformAction:(SEL)action withSender:(id)sender;
+
 // Accessibility support
 @property (atomic, assign)           BOOL isAccessibilityElement;
 @property (atomic, copy)             NSString *accessibilityLabel;
@@ -646,6 +645,7 @@ typedef void (^ASDisplayNodeDidLoadBlock)(ASDisplayNode *node);
  * @param node The node to be added.
  */
 - (void)addSubnode:(ASDisplayNode *)node;
+- (NSString *)name;
 @end
 
 /** CALayer(AsyncDisplayKit) defines convenience method for adding sub-ASDisplayNode to a CALayer. */
@@ -656,6 +656,7 @@ typedef void (^ASDisplayNodeDidLoadBlock)(ASDisplayNode *node);
  * @param node The node to be added.
  */
 - (void)addSubnode:(ASDisplayNode *)node;
+- (NSString *)name;
 @end
 
 @interface ASDisplayNode (Deprecated)

--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -646,7 +646,6 @@ typedef void (^ASDisplayNodeDidLoadBlock)(ASDisplayNode *node);
  * @param node The node to be added.
  */
 - (void)addSubnode:(ASDisplayNode *)node;
-- (NSString *)name;
 @end
 
 /** CALayer(AsyncDisplayKit) defines convenience method for adding sub-ASDisplayNode to a CALayer. */
@@ -657,7 +656,6 @@ typedef void (^ASDisplayNodeDidLoadBlock)(ASDisplayNode *node);
  * @param node The node to be added.
  */
 - (void)addSubnode:(ASDisplayNode *)node;
-- (NSString *)name;
 @end
 
 @interface ASDisplayNode (Deprecated)

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -2190,11 +2190,6 @@ static const char *ASDisplayNodeAssociatedNodeKey = "ASAssociatedNode";
   }
 }
 
-- (NSString *)name
-{
-  return self.asyncdisplaykit_node.name;
-}
-
 @end
 
 @implementation CALayer (AsyncDisplayKit)
@@ -2202,11 +2197,6 @@ static const char *ASDisplayNodeAssociatedNodeKey = "ASAssociatedNode";
 - (void)addSubnode:(ASDisplayNode *)node
 {
   [self addSublayer:node.layer];
-}
-
-- (NSString *)name
-{
-  return self.asyncdisplaykit_node.name;
 }
 
 @end

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -670,7 +670,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
       [self _addSubnodeViewsAndLayers];
     }
     
-    [self recursivelyDisplayImmediately];
+    [self recursivelyEnsureDisplay];
   }
 }
 
@@ -2043,35 +2043,6 @@ static void _recursivelySetDisplaySuspended(ASDisplayNode *node, CALayer *layer,
 
 }
 
-- (BOOL)canBecomeFirstResponder {
-    return NO;
-}
-
-- (BOOL)canResignFirstResponder {
-    return YES;
-}
-
-- (BOOL)isFirstResponder {
-    ASDisplayNodeAssertMainThread();
-    return _view != nil && [_view isFirstResponder];
-}
-
-// Note: this implicitly loads the view if it hasn't been loaded yet.
-- (BOOL)becomeFirstResponder {
-    ASDisplayNodeAssertMainThread();
-    return !self.layerBacked && [self canBecomeFirstResponder] && [self.view becomeFirstResponder];
-}
-
-- (BOOL)resignFirstResponder {
-    ASDisplayNodeAssertMainThread();
-    return !self.layerBacked && [self canResignFirstResponder] && [_view resignFirstResponder];
-}
-
-- (BOOL)canPerformAction:(SEL)action withSender:(id)sender {
-    ASDisplayNodeAssertMainThread();
-    return !self.layerBacked && [self.view canPerformAction:action withSender:sender];
-}
-
 - (id<ASLayoutable>)finalLayoutable
 {
   return self;
@@ -2081,8 +2052,6 @@ static void _recursivelySetDisplaySuspended(ASDisplayNode *node, CALayer *layer,
 
 @implementation ASDisplayNode (Debugging)
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wobjc-protocol-method-implementation"
 - (NSString *)description
 {
   if (self.name) {
@@ -2091,7 +2060,6 @@ static void _recursivelySetDisplaySuspended(ASDisplayNode *node, CALayer *layer,
     return [super description];
   }
 }
-#pragma clang diagnostic pop
 
 - (NSString *)debugDescription
 {
@@ -2190,6 +2158,11 @@ static const char *ASDisplayNodeAssociatedNodeKey = "ASAssociatedNode";
   }
 }
 
+- (NSString *)name
+{
+  return self.asyncdisplaykit_node.name;
+}
+
 @end
 
 @implementation CALayer (AsyncDisplayKit)
@@ -2197,6 +2170,11 @@ static const char *ASDisplayNodeAssociatedNodeKey = "ASAssociatedNode";
 - (void)addSubnode:(ASDisplayNode *)node
 {
   [self addSublayer:node.layer];
+}
+
+- (NSString *)name
+{
+  return self.asyncdisplaykit_node.name;
 }
 
 @end

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -670,7 +670,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
       [self _addSubnodeViewsAndLayers];
     }
     
-    [self recursivelyEnsureDisplay];
+    [self recursivelyDisplayImmediately];
   }
 }
 

--- a/AsyncDisplayKit/Details/ASRangeHandlerRender.mm
+++ b/AsyncDisplayKit/Details/ASRangeHandlerRender.mm
@@ -37,6 +37,12 @@
   ASDisplayNodeAssertMainThread();
   ASDisplayNodeAssert(rangeType == ASLayoutRangeTypeRender, @"Render delegate should not handle other ranges");
 
+  // If a node had previously been onscreen but now is only in the working range,
+  // ensure its view is not orphaned in a UITableViewCell in the reuse pool.
+  if (![node isLayerBacked] && node.view.superview) {
+    [node.view removeFromSuperview];
+  }
+  
   [node recursivelySetDisplaySuspended:NO];
 
   // Add the node's layer to an off-screen window to trigger display and mark its contents as non-volatile.

--- a/AsyncDisplayKit/Private/ASDisplayNode+UIViewBridge.mm
+++ b/AsyncDisplayKit/Private/ASDisplayNode+UIViewBridge.mm
@@ -67,6 +67,41 @@
  */
 @implementation ASDisplayNode (UIViewBridge)
 
+- (BOOL)canBecomeFirstResponder
+{
+  return NO;
+}
+
+- (BOOL)canResignFirstResponder
+{
+  return YES;
+}
+
+- (BOOL)isFirstResponder
+{
+  ASDisplayNodeAssertMainThread();
+  return _view != nil && [_view isFirstResponder];
+}
+
+// Note: this implicitly loads the view if it hasn't been loaded yet.
+- (BOOL)becomeFirstResponder
+{
+  ASDisplayNodeAssertMainThread();
+  return !self.layerBacked && [self canBecomeFirstResponder] && [self.view becomeFirstResponder];
+}
+
+- (BOOL)resignFirstResponder
+{
+  ASDisplayNodeAssertMainThread();
+  return !self.layerBacked && [self canResignFirstResponder] && [_view resignFirstResponder];
+}
+
+- (BOOL)canPerformAction:(SEL)action withSender:(id)sender
+{
+  ASDisplayNodeAssertMainThread();
+  return !self.layerBacked && [self.view canPerformAction:action withSender:sender];
+}
+
 - (CGFloat)alpha
 {
   _bridge_prologue;

--- a/AsyncDisplayKit/Private/_ASHierarchyChangeSet.m
+++ b/AsyncDisplayKit/Private/_ASHierarchyChangeSet.m
@@ -91,7 +91,7 @@
     case _ASHierarchyChangeTypeDelete:
       return _deleteSectionChanges;
     default:
-      NSAssert(NO, @"Request for section changes with invalid type: %lu", changeType);
+      NSAssert(NO, @"Request for section changes with invalid type: %lu", (long)changeType);
   }
 }
 
@@ -106,7 +106,7 @@
     case _ASHierarchyChangeTypeDelete:
       return _deleteItemChanges;
     default:
-      NSAssert(NO, @"Request for item changes with invalid type: %lu", changeType);
+      NSAssert(NO, @"Request for item changes with invalid type: %lu", (long)changeType);
   }
 }
 


### PR DESCRIPTION
This resolves #815.  It also removes the -name property from CALayer and UIView categories, which is at far too high risk of a namespace collision and provides very little value (sorry, yes, totally unrelated change).