### PR TITLE
Fix crash in ASCII art creator for one-element children arrays.

### DIFF
--- a/AsyncDisplayKit/Layout/ASLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASLayoutSpec.mm
@@ -150,7 +150,8 @@ static NSString * const kDefaultChildrenKey = @"kDefaultChildrenKey";
 
 - (NSString *)asciiArtString
 {
-  return [ASLayoutSpec asciiArtStringForChildren:@[self.child] parentName:[self asciiArtName]];
+  NSArray *children = self.child ? @[self.child] : self.children;
+  return [ASLayoutSpec asciiArtStringForChildren:children parentName:[self asciiArtName]];
 }
 
 - (NSString *)asciiArtName


### PR DESCRIPTION
The API lets people create things with the children array even if they only have one child.