### PR TITLE
Fix for behavior difference between CA and UIKit that causes mutation crash.

### DIFF
--- a/AsyncDisplayKit/Details/ASRangeHandlerRender.mm
+++ b/AsyncDisplayKit/Details/ASRangeHandlerRender.mm
@@ -40,7 +40,7 @@
 
 - (void)dealloc
 {
-  for(CALayer *layer in self.workingWindow.layer.sublayers) {
+  for(CALayer *layer in [self.workingWindow.layer.sublayers copy]) {
     ASDisplayNode *node = layer.asyncdisplaykit_node;
     [self node:node exitedRangeOfType:ASLayoutRangeTypeRender];
   }


### PR DESCRIPTION
This was a bug I introduced when porting @eanagel's diff from being view-based to layer-based.

-subviews returns a copy of the array and is actually safe to mutate directly, so I removed the -copy that Ethan had added.  However once I made it -sublayers instead, this was no longer safe.