### PR TITLE
Add a Reset Method to RangeController, Use In reloadData

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -270,6 +270,7 @@ static BOOL _isInterceptedSelector(SEL sel)
   ASDisplayNodeAssert(self.asyncDelegate, @"ASCollectionView's asyncDelegate property must be set.");
   ASPerformBlockOnMainThread(^{
     _superIsPendingDataLoad = YES;
+    [_rangeController reset];
     [super reloadData];
   });
   [_dataController reloadDataWithAnimationOptions:kASCollectionViewAnimationNone completion:completion];
@@ -283,6 +284,7 @@ static BOOL _isInterceptedSelector(SEL sel)
 - (void)reloadDataImmediately
 {
   ASDisplayNodeAssertMainThread();
+  [_rangeController reset];
   [_dataController reloadDataImmediatelyWithAnimationOptions:kASCollectionViewAnimationNone];
   [super reloadData];
 }

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -314,6 +314,7 @@ static BOOL _isInterceptedSelector(SEL sel)
 {
   ASDisplayNodeAssert(self.asyncDelegate, @"ASTableView's asyncDelegate property must be set.");
   ASPerformBlockOnMainThread(^{
+    [_rangeController reset];
     [super reloadData];
   });
   [_dataController reloadDataWithAnimationOptions:UITableViewRowAnimationNone completion:completion];
@@ -327,6 +328,7 @@ static BOOL _isInterceptedSelector(SEL sel)
 - (void)reloadDataImmediately
 {
   ASDisplayNodeAssertMainThread();
+  [_rangeController reset];
   [_dataController reloadDataImmediatelyWithAnimationOptions:UITableViewRowAnimationNone];
   [super reloadData];
 }

--- a/AsyncDisplayKit/Details/ASRangeController.h
+++ b/AsyncDisplayKit/Details/ASRangeController.h
@@ -46,6 +46,11 @@
 - (void)configureContentView:(UIView *)contentView forCellNode:(ASCellNode *)node;
 
 /**
+ * Clear all working ranges. Useful when performing a `reloadData`. Must be called on the main thread.
+ */
+- (void)reset;
+
+/**
  * Delegate and ultimate data source.  Must not be nil.
  */
 @property (nonatomic, weak) id<ASRangeControllerDelegate> delegate;

--- a/AsyncDisplayKit/Details/ASRangeController.mm
+++ b/AsyncDisplayKit/Details/ASRangeController.mm
@@ -153,6 +153,13 @@
   _queuedRangeUpdate = NO;
 }
 
+- (void)reset
+{
+  ASDisplayNodeAssertMainThread();
+  _rangeIsValid = NO;
+  [_rangeTypeIndexPaths removeAllObjects];
+}
+
 - (BOOL)shouldSkipVisibleNodesForRangeType:(ASLayoutRangeType)rangeType
 {
   return rangeType == ASLayoutRangeTypeRender;


### PR DESCRIPTION
Pursuant to #861, here's my attempt at a fix. It resolves the issues I'm having with nodes not always getting `fetchData` post-`reloadData` but I'm hardly an expert on ASRangeController. I threw in the main thread assertion kind of willy-nilly to be honest.