### PR TITLE
Clean up syntax and organization of ASRangeController

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.h
+++ b/AsyncDisplayKit/ASCollectionView.h
@@ -416,9 +416,3 @@
 - (CGSize)collectionView:(ASCollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout referenceSizeForFooterInSection:(NSInteger)section;
 
 @end
-
-@interface ASCollectionView (Deprecated)
-
-@property (nonatomic, assign) ASRangeTuningParameters rangeTuningParameters ASDISPLAYNODE_DEPRECATED;
-
-@end

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -130,7 +130,7 @@ static BOOL _isInterceptedSelector(SEL sel)
 #pragma mark -
 #pragma mark ASCollectionView.
 
-@interface ASCollectionView () <ASRangeControllerDelegate, ASDataControllerSource, ASCellNodeLayoutDelegate> {
+@interface ASCollectionView () <ASRangeControllerDataSource, ASRangeControllerDelegate, ASDataControllerSource, ASCellNodeLayoutDelegate> {
   _ASCollectionViewProxy *_proxyDataSource;
   _ASCollectionViewProxy *_proxyDelegate;
 
@@ -199,6 +199,7 @@ static BOOL _isInterceptedSelector(SEL sel)
   _layoutController = [[ASCollectionViewLayoutController alloc] initWithCollectionView:self];
 
   _rangeController = [[ASRangeController alloc] init];
+  _rangeController.dataSource = self;
   _rangeController.delegate = self;
   _rangeController.layoutController = _layoutController;
 
@@ -765,14 +766,35 @@ static BOOL _isInterceptedSelector(SEL sel)
   return [_layoutInspector collectionView:self numberOfSectionsForSupplementaryNodeOfKind:kind];
 }
 
-#pragma mark - ASRangeControllerDelegate.
+#pragma mark - ASRangeControllerDataSource
 
-- (void)rangeControllerBeginUpdates:(ASRangeController *)rangeController {
+- (NSArray *)visibleNodeIndexPathsForRangeController:(ASRangeController *)rangeController
+{
+  ASDisplayNodeAssertMainThread();
+  return [self indexPathsForVisibleItems];
+}
+
+- (CGSize)viewportSizeForRangeController:(ASRangeController *)rangeController
+{
+  ASDisplayNodeAssertMainThread();
+  return self.bounds.size;
+}
+
+- (NSArray *)rangeController:(ASRangeController *)rangeController nodesAtIndexPaths:(NSArray *)indexPaths
+{
+  return [_dataController nodesAtIndexPaths:indexPaths];
+}
+
+#pragma mark - ASRangeControllerDelegate
+
+- (void)didBeginUpdatesInRangeController:(ASRangeController *)rangeController
+{
   ASDisplayNodeAssertMainThread();
   _performingBatchUpdates = YES;
 }
 
-- (void)rangeController:(ASRangeController *)rangeController endUpdatesAnimated:(BOOL)animated completion:(void (^)(BOOL))completion {
+- (void)rangeController:(ASRangeController *)rangeController didEndUpdatesAnimated:(BOOL)animated completion:(void (^)(BOOL))completion
+{
   ASDisplayNodeAssertMainThread();
 
   if (!self.asyncDataSource || _superIsPendingDataLoad) {
@@ -792,23 +814,6 @@ static BOOL _isInterceptedSelector(SEL sel)
 
   [_batchUpdateBlocks removeAllObjects];
   _performingBatchUpdates = NO;
-}
-
-- (NSArray *)rangeControllerVisibleNodeIndexPaths:(ASRangeController *)rangeController
-{
-  ASDisplayNodeAssertMainThread();
-  return [self indexPathsForVisibleItems];
-}
-
-- (CGSize)rangeControllerViewportSize:(ASRangeController *)rangeController
-{
-  ASDisplayNodeAssertMainThread();
-  return self.bounds.size;
-}
-
-- (NSArray *)rangeController:(ASRangeController *)rangeController nodesAtIndexPaths:(NSArray *)indexPaths
-{
-  return [_dataController nodesAtIndexPaths:indexPaths];
 }
 
 - (void)rangeController:(ASRangeController *)rangeController didInsertNodes:(NSArray *)nodes atIndexPaths:(NSArray *)indexPaths withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions

--- a/AsyncDisplayKit/ASTableView.h
+++ b/AsyncDisplayKit/ASTableView.h
@@ -345,9 +345,3 @@
 - (BOOL)shouldBatchFetchForTableView:(ASTableView *)tableView;
 
 @end
-
-@interface ASTableView (Deprecated)
-
-@property (nonatomic, assign) ASRangeTuningParameters rangeTuningParameters ASDISPLAYNODE_DEPRECATED;
-
-@end

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -151,7 +151,7 @@ static BOOL _isInterceptedSelector(SEL sel)
 #pragma mark -
 #pragma mark ASTableView
 
-@interface ASTableView () <ASRangeControllerDelegate, ASDataControllerSource, _ASTableViewCellDelegate, ASCellNodeLayoutDelegate> {
+@interface ASTableView () <ASRangeControllerDataSource, ASRangeControllerDelegate, ASDataControllerSource, _ASTableViewCellDelegate, ASCellNodeLayoutDelegate> {
   _ASTableViewProxy *_proxyDataSource;
   _ASTableViewProxy *_proxyDelegate;
 
@@ -193,6 +193,7 @@ static BOOL _isInterceptedSelector(SEL sel)
   
   _rangeController = [[ASRangeController alloc] init];
   _rangeController.layoutController = _layoutController;
+  _rangeController.dataSource = self;
   _rangeController.delegate = self;
   
   _dataController = [[dataControllerClass alloc] initWithAsyncDataFetching:asyncDataFetching];
@@ -639,11 +640,72 @@ static BOOL _isInterceptedSelector(SEL sel)
   }
 }
 
+#pragma mark - ASRangeControllerDataSource
 
-#pragma mark -
-#pragma mark ASRangeControllerDelegate
+- (NSArray *)visibleNodeIndexPathsForRangeController:(ASRangeController *)rangeController
+{
+  ASDisplayNodeAssertMainThread();
+  
+  NSArray *visibleIndexPaths = self.indexPathsForVisibleRows;
+  
+  if (_pendingVisibleIndexPath) {
+    NSMutableSet *indexPaths = [NSMutableSet setWithArray:self.indexPathsForVisibleRows];
+    
+    BOOL (^isAfter)(NSIndexPath *, NSIndexPath *) = ^BOOL(NSIndexPath *indexPath, NSIndexPath *anchor) {
+      if (!anchor || !indexPath) {
+        return NO;
+      }
+      if (indexPath.section == anchor.section) {
+        return (indexPath.row == anchor.row+1); // assumes that indexes are valid
+        
+      } else if (indexPath.section > anchor.section && indexPath.row == 0) {
+        if (anchor.row != [_dataController numberOfRowsInSection:anchor.section] -1) {
+          return NO;  // anchor is not at the end of the section
+        }
+        
+        NSInteger nextSection = anchor.section+1;
+        while([_dataController numberOfRowsInSection:nextSection] == 0) {
+          ++nextSection;
+        }
+        
+        return indexPath.section == nextSection;
+      }
+      
+      return NO;
+    };
+    
+    BOOL (^isBefore)(NSIndexPath *, NSIndexPath *) = ^BOOL(NSIndexPath *indexPath, NSIndexPath *anchor) {
+      return isAfter(anchor, indexPath);
+    };
+    
+    if ([indexPaths containsObject:_pendingVisibleIndexPath]) {
+      _pendingVisibleIndexPath = nil; // once it has shown up in visibleIndexPaths, we can stop tracking it
+    } else if (!isBefore(_pendingVisibleIndexPath, visibleIndexPaths.firstObject) &&
+               !isAfter(_pendingVisibleIndexPath, visibleIndexPaths.lastObject)) {
+      _pendingVisibleIndexPath = nil; // not contiguous, ignore.
+    } else {
+      [indexPaths addObject:_pendingVisibleIndexPath];
+      visibleIndexPaths = [indexPaths.allObjects sortedArrayUsingSelector:@selector(compare:)];
+    }
+  }
+  
+  return visibleIndexPaths;
+}
 
-- (void)rangeControllerBeginUpdates:(ASRangeController *)rangeController
+- (NSArray *)rangeController:(ASRangeController *)rangeController nodesAtIndexPaths:(NSArray *)indexPaths
+{
+  return [_dataController nodesAtIndexPaths:indexPaths];
+}
+
+- (CGSize)viewportSizeForRangeController:(ASRangeController *)rangeController
+{
+  ASDisplayNodeAssertMainThread();
+  return self.bounds.size;
+}
+
+#pragma mark - ASRangeControllerDelegate
+
+- (void)didBeginUpdatesInRangeController:(ASRangeController *)rangeController
 {
   ASDisplayNodeAssertMainThread();
   LOG(@"--- UITableView beginUpdates");
@@ -659,7 +721,7 @@ static BOOL _isInterceptedSelector(SEL sel)
   }
 }
 
-- (void)rangeController:(ASRangeController *)rangeController endUpdatesAnimated:(BOOL)animated completion:(void (^)(BOOL))completion
+- (void)rangeController:(ASRangeController *)rangeController didEndUpdatesAnimated:(BOOL)animated completion:(void (^)(BOOL))completion
 {
   ASDisplayNodeAssertMainThread();
   LOG(@"--- UITableView endUpdates");
@@ -682,67 +744,6 @@ static BOOL _isInterceptedSelector(SEL sel)
   if (completion) {
     completion(YES);
   }
-}
-
-- (NSArray *)rangeControllerVisibleNodeIndexPaths:(ASRangeController *)rangeController
-{
-  ASDisplayNodeAssertMainThread();
-
-  NSArray *visibleIndexPaths = self.indexPathsForVisibleRows;
-
-  if (_pendingVisibleIndexPath) {
-    NSMutableSet *indexPaths = [NSMutableSet setWithArray:self.indexPathsForVisibleRows];
-
-    BOOL (^isAfter)(NSIndexPath *, NSIndexPath *) = ^BOOL(NSIndexPath *indexPath, NSIndexPath *anchor) {
-      if (!anchor || !indexPath) {
-        return NO;
-      }
-      if (indexPath.section == anchor.section) {
-        return (indexPath.row == anchor.row+1); // assumes that indexes are valid
-
-      } else if (indexPath.section > anchor.section && indexPath.row == 0) {
-        if (anchor.row != [_dataController numberOfRowsInSection:anchor.section] -1) {
-          return NO;  // anchor is not at the end of the section
-        }
-
-        NSInteger nextSection = anchor.section+1;
-        while([_dataController numberOfRowsInSection:nextSection] == 0) {
-          ++nextSection;
-        }
-
-        return indexPath.section == nextSection;
-      }
-
-      return NO;
-    };
-
-    BOOL (^isBefore)(NSIndexPath *, NSIndexPath *) = ^BOOL(NSIndexPath *indexPath, NSIndexPath *anchor) {
-      return isAfter(anchor, indexPath);
-    };
-
-    if ([indexPaths containsObject:_pendingVisibleIndexPath]) {
-      _pendingVisibleIndexPath = nil; // once it has shown up in visibleIndexPaths, we can stop tracking it
-    } else if (!isBefore(_pendingVisibleIndexPath, visibleIndexPaths.firstObject) &&
-               !isAfter(_pendingVisibleIndexPath, visibleIndexPaths.lastObject)) {
-      _pendingVisibleIndexPath = nil; // not contiguous, ignore.
-    } else {
-      [indexPaths addObject:_pendingVisibleIndexPath];
-      visibleIndexPaths = [indexPaths.allObjects sortedArrayUsingSelector:@selector(compare:)];
-    }
-  }
-
-  return visibleIndexPaths;
-}
-
-- (NSArray *)rangeController:(ASRangeController *)rangeController nodesAtIndexPaths:(NSArray *)indexPaths
-{
-  return [_dataController nodesAtIndexPaths:indexPaths];
-}
-
-- (CGSize)rangeControllerViewportSize:(ASRangeController *)rangeController
-{
-  ASDisplayNodeAssertMainThread();
-  return self.bounds.size;
 }
 
 - (void)rangeController:(ASRangeController *)rangeController didInsertNodes:(NSArray *)nodes atIndexPaths:(NSArray *)indexPaths withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -690,7 +690,7 @@ static BOOL _isInterceptedSelector(SEL sel)
 
   NSArray *visibleIndexPaths = self.indexPathsForVisibleRows;
 
-  if ( _pendingVisibleIndexPath ) {
+  if (_pendingVisibleIndexPath) {
     NSMutableSet *indexPaths = [NSMutableSet setWithArray:self.indexPathsForVisibleRows];
 
     BOOL (^isAfter)(NSIndexPath *, NSIndexPath *) = ^BOOL(NSIndexPath *indexPath, NSIndexPath *anchor) {
@@ -720,7 +720,7 @@ static BOOL _isInterceptedSelector(SEL sel)
       return isAfter(anchor, indexPath);
     };
 
-    if ( [indexPaths containsObject:_pendingVisibleIndexPath]) {
+    if ([indexPaths containsObject:_pendingVisibleIndexPath]) {
       _pendingVisibleIndexPath = nil; // once it has shown up in visibleIndexPaths, we can stop tracking it
     } else if (!isBefore(_pendingVisibleIndexPath, visibleIndexPaths.firstObject) &&
                !isAfter(_pendingVisibleIndexPath, visibleIndexPaths.lastObject)) {

--- a/AsyncDisplayKit/Details/ASAbstractLayoutController.h
+++ b/AsyncDisplayKit/Details/ASAbstractLayoutController.h
@@ -15,6 +15,4 @@
 
 - (ASRangeTuningParameters)tuningParametersForRangeType:(ASLayoutRangeType)rangeType;
 
-@property (nonatomic, assign) ASRangeTuningParameters tuningParameters ASDISPLAYNODE_DEPRECATED;
-
 @end

--- a/AsyncDisplayKit/Details/ASAbstractLayoutController.mm
+++ b/AsyncDisplayKit/Details/ASAbstractLayoutController.mm
@@ -52,33 +52,7 @@
   _tuningParameters[rangeType] = tuningParameters;
 }
 
-// Support for the deprecated tuningParameters property
-- (ASRangeTuningParameters)tuningParameters
-{
-  return [self tuningParametersForRangeType:ASLayoutRangeTypeRender];
-}
-
-// Support for the deprecated tuningParameters property
-- (void)setTuningParameters:(ASRangeTuningParameters)tuningParameters
-{
-  [self setTuningParameters:tuningParameters forRangeType:ASLayoutRangeTypeRender];
-}
-
-#pragma mark - Index Path Range Support
-
-// Support for deprecated method
-- (BOOL)shouldUpdateForVisibleIndexPath:(NSArray *)indexPaths viewportSize:(CGSize)viewportSize
-{
-  return [self shouldUpdateForVisibleIndexPaths:indexPaths viewportSize:viewportSize rangeType:ASLayoutRangeTypeRender];
-}
-
-// Support for the deprecated method
-- (NSSet *)indexPathsForScrolling:(ASScrollDirection)scrollDirection viewportSize:(CGSize)viewportSize
-{
-  return [self indexPathsForScrolling:scrollDirection viewportSize:viewportSize rangeType:ASLayoutRangeTypeRender];
-}
-
-#pragma mark - Abstract
+#pragma mark - Abstract Index Path Range Support
 
 - (BOOL)shouldUpdateForVisibleIndexPaths:(NSArray *)indexPaths viewportSize:(CGSize)viewportSize rangeType:(ASLayoutRangeType)rangeType
 {

--- a/AsyncDisplayKit/Details/ASLayoutController.h
+++ b/AsyncDisplayKit/Details/ASLayoutController.h
@@ -12,7 +12,6 @@
 #import <AsyncDisplayKit/ASLayoutRangeType.h>
 #import <AsyncDisplayKit/ASScrollDirection.h>
 
-
 typedef struct {
   CGFloat leadingBufferScreenfuls;
   CGFloat trailingBufferScreenfuls;

--- a/AsyncDisplayKit/Details/ASLayoutController.h
+++ b/AsyncDisplayKit/Details/ASLayoutController.h
@@ -31,12 +31,6 @@ typedef struct {
 
 - (NSSet *)indexPathsForScrolling:(ASScrollDirection)scrollDirection viewportSize:(CGSize)viewportSize rangeType:(ASLayoutRangeType)rangeType;
 
-@property (nonatomic, assign) ASRangeTuningParameters tuningParameters ASDISPLAYNODE_DEPRECATED;
-
-- (BOOL)shouldUpdateForVisibleIndexPath:(NSArray *)indexPath viewportSize:(CGSize)viewportSize ASDISPLAYNODE_DEPRECATED;
-
-- (NSSet *)indexPathsForScrolling:(ASScrollDirection)scrollDirection viewportSize:(CGSize)viewportSize ASDISPLAYNODE_DEPRECATED;
-
 @optional
 
 - (void)insertNodesAtIndexPaths:(NSArray *)indexPaths withSizes:(NSArray *)nodeSizes;

--- a/AsyncDisplayKit/Details/ASRangeController.h
+++ b/AsyncDisplayKit/Details/ASRangeController.h
@@ -13,7 +13,7 @@
 #import <AsyncDisplayKit/ASFlowLayoutController.h>
 #import <AsyncDisplayKit/ASLayoutController.h>
 
-
+@protocol ASRangeControllerDataSource;
 @protocol ASRangeControllerDelegate;
 
 /**
@@ -46,49 +46,43 @@
 - (void)configureContentView:(UIView *)contentView forCellNode:(ASCellNode *)node;
 
 /**
- * Delegate and ultimate data source.  Must not be nil.
+ * 
+ */
+@property (nonatomic, strong) id<ASLayoutController> layoutController;
+
+/**
+ * The underlying data source for the range controller
+ */
+@property (nonatomic, weak) id<ASRangeControllerDataSource> dataSource;
+
+/**
+ * Delegate for handling range controller events. Must not be nil.
  */
 @property (nonatomic, weak) id<ASRangeControllerDelegate> delegate;
 
-@property (nonatomic, strong) id<ASLayoutController> layoutController;
-
 @end
 
-
 /**
- * <ASRangeController> delegate.  For example, <ASTableView>.
+ * Data source for ASRangeController.
+ *
+ * Allows the range controller to perform external queries on the range. 
+ * Ex. range nodes, visible index paths, and viewport size.
  */
-@protocol ASRangeControllerDelegate <NSObject>
+@protocol ASRangeControllerDataSource <NSObject>
 
 /**
  * @param rangeController Sender.
  *
  * @returns an array of index paths corresponding to the nodes currently visible onscreen (i.e., the visible range).
  */
-- (NSArray *)rangeControllerVisibleNodeIndexPaths:(ASRangeController *)rangeController;
+- (NSArray *)visibleNodeIndexPathsForRangeController:(ASRangeController *)rangeController;
 
 /**
  * @param rangeController Sender.
  *
  * @returns the receiver's viewport size (i.e., the screen space occupied by the visible range).
  */
-- (CGSize)rangeControllerViewportSize:(ASRangeController *)rangeController;
-
-/**
- * Begin updates.
- *
- * @param rangeController Sender.
- */
-- (void)rangeControllerBeginUpdates:(ASRangeController *)rangeController;
-
-/**
- * End updates.
- *
- * @param rangeController Sender.
- * @param animated NO if all animations are disabled. YES otherwise.
- * @param completion Completion block.
- */
-- (void)rangeController:(ASRangeController * )rangeController endUpdatesAnimated:(BOOL)animated completion:(void (^)(BOOL))completion;
+- (CGSize)viewportSizeForRangeController:(ASRangeController *)rangeController;
 
 /**
  * Fetch nodes at specific index paths.
@@ -98,6 +92,29 @@
  * @param indexPaths Index paths.
  */
 - (NSArray *)rangeController:(ASRangeController *)rangeController nodesAtIndexPaths:(NSArray *)indexPaths;
+
+@end
+
+/**
+ * Delegate for ASRangeController.
+ */
+@protocol ASRangeControllerDelegate <NSObject>
+
+/**
+ * Begin updates.
+ *
+ * @param rangeController Sender.
+ */
+- (void)didBeginUpdatesInRangeController:(ASRangeController *)rangeController;
+
+/**
+ * End updates.
+ *
+ * @param rangeController Sender.
+ * @param animated NO if all animations are disabled. YES otherwise.
+ * @param completion Completion block.
+ */
+- (void)rangeController:(ASRangeController * )rangeController didEndUpdatesAnimated:(BOOL)animated completion:(void (^)(BOOL))completion;
 
 /**
  * Called for nodes insertion.

--- a/AsyncDisplayKit/Details/ASRangeController.h
+++ b/AsyncDisplayKit/Details/ASRangeController.h
@@ -46,7 +46,10 @@
 - (void)configureContentView:(UIView *)contentView forCellNode:(ASCellNode *)node;
 
 /**
- * 
+ * An object that describes the layout behavior of the ranged component (table view, collection view, etc.)
+ *
+ * Used primarily for providing the current range of index paths and identifying when the
+ * range controller should invalidate its range.
  */
 @property (nonatomic, strong) id<ASLayoutController> layoutController;
 


### PR DESCRIPTION
I'm currently reading through range controller and saw a few things that needed some syntax and organization clean up:

- Removed deprecated layout controller methods that were long longer needed.
  - Now that we're closer to a 2.0, we should start the discussion of removing the remaining deprecated methods that live in ASDisplayNode—there are only three.
- Cleaned up syntax usage in ASRangeController
- Separated data and callback methods into data source and delegate protocols, respectively. It's now a little clearer what data is required for the range controller to work. In the process, I reordered some of the naming of the methods to make them a bit more readable.