### PR TITLE
[Critical] Don't Cancel Image Downloads in ASMultiplexImageNode.clearContents

### DIFF
--- a/AsyncDisplayKit/ASMultiplexImageNode.mm
+++ b/AsyncDisplayKit/ASMultiplexImageNode.mm
@@ -176,17 +176,13 @@ typedef void(^ASMultiplexImageLoadCompletionBlock)(UIImage *image, id imageIdent
 }
 
 #pragma mark - ASDisplayNode Overrides
+
 - (void)clearContents
 {
   [super clearContents]; // This actually clears the contents, so we need to do this first for our displayedImageIdentifier to be meaningful.
   [self _setDisplayedImageIdentifier:nil withImage:nil];
 
-  [_phImageRequestOperation cancel];
-  
-  if (_downloadIdentifier) {
-    [_downloader cancelImageDownloadForIdentifier:_downloadIdentifier];
-    _downloadIdentifier = nil;
-  }
+  // NOTE: We intentionally do not cancel image downloads until `clearFetchedData`.
 }
 
 - (void)clearFetchedData


### PR DESCRIPTION
Before this PR, if the node leaves the render range, but stays in the preload range, its image download will be canceled and another won't be enqueued so the user may see a lower-quality image or no image.