### PR TITLE
[critical] Fix Table View Updating Errors

### DIFF
--- a/AsyncDisplayKit/Private/_ASHierarchyChangeSet.h
+++ b/AsyncDisplayKit/Private/_ASHierarchyChangeSet.h
@@ -34,6 +34,21 @@ typedef NS_ENUM(NSInteger, _ASHierarchyChangeType) {
 
 @interface _ASHierarchyChangeSet : NSObject
 
+/// @precondition The change set must be completed.
+@property (nonatomic, strong, readonly) NSIndexSet *deletedSections;
+/// @precondition The change set must be completed.
+@property (nonatomic, strong, readonly) NSIndexSet *insertedSections;
+/// @precondition The change set must be completed.
+@property (nonatomic, strong, readonly) NSIndexSet *reloadedSections;
+
+/**
+ Get the section index after the update for the given section before the update.
+ 
+ @precondition The change set must be completed.
+ @returns The new section index, or NSNotFound if the given section was deleted.
+ */
+- (NSInteger)newSectionForOldSection:(NSInteger)oldSection;
+
 @property (nonatomic, readonly) BOOL completed;
 
 /// Call this once the change set has been constructed to prevent future modifications to the changeset. Calling this more than once is a programmer error.

--- a/AsyncDisplayKit/Private/_ASHierarchyChangeSet.h
+++ b/AsyncDisplayKit/Private/_ASHierarchyChangeSet.h
@@ -34,13 +34,6 @@ typedef NS_ENUM(NSInteger, _ASHierarchyChangeType) {
 
 @interface _ASHierarchyChangeSet : NSObject
 
-@property (nonatomic, strong, readonly) NSIndexSet *deletedSections;
-@property (nonatomic, strong, readonly) NSIndexSet *insertedSections;
-@property (nonatomic, strong, readonly) NSIndexSet *reloadedSections;
-@property (nonatomic, strong, readonly) NSArray *insertedItems;
-@property (nonatomic, strong, readonly) NSArray *deletedItems;
-@property (nonatomic, strong, readonly) NSArray *reloadedItems;
-
 @property (nonatomic, readonly) BOOL completed;
 
 /// Call this once the change set has been constructed to prevent future modifications to the changeset. Calling this more than once is a programmer error.

--- a/AsyncDisplayKit/Private/_ASHierarchyChangeSet.m
+++ b/AsyncDisplayKit/Private/_ASHierarchyChangeSet.m
@@ -241,7 +241,7 @@
   NSMutableArray *result = [NSMutableArray new];
   
   __block ASDataControllerAnimationOptions currentOptions = 0;
-  __block NSMutableIndexSet *currentIndexes = [NSMutableIndexSet indexSet];
+  NSMutableIndexSet *currentIndexes = [NSMutableIndexSet indexSet];
 
   NSEnumerationOptions options = type == _ASHierarchyChangeTypeDelete ? NSEnumerationReverse : kNilOptions;
 

--- a/AsyncDisplayKit/Private/_ASHierarchyChangeSet.m
+++ b/AsyncDisplayKit/Private/_ASHierarchyChangeSet.m
@@ -219,9 +219,11 @@
   
   __block ASDataControllerAnimationOptions currentOptions = 0;
   __block NSMutableIndexSet *currentIndexes = nil;
-  NSUInteger lastIndex = allIndexes.lastIndex;
-  
-  NSEnumerationOptions options = type == _ASHierarchyChangeTypeDelete ? NSEnumerationReverse : kNilOptions;
+
+  BOOL reverse = (type == _ASHierarchyChangeTypeDelete);
+  NSEnumerationOptions options = reverse ? NSEnumerationReverse : kNilOptions;
+  NSUInteger endIndex = reverse ? allIndexes.firstIndex : allIndexes.lastIndex;
+
   [allIndexes enumerateIndexesWithOptions:options usingBlock:^(NSUInteger idx, __unused BOOL * stop) {
     ASDataControllerAnimationOptions options = [animationOptions[@(idx)] integerValue];
     BOOL endingCurrentGroup = NO;
@@ -237,7 +239,7 @@
       endingCurrentGroup = YES;
     }
     
-    BOOL endingLastGroup = (currentIndexes != nil && lastIndex == idx);
+    BOOL endingLastGroup = (currentIndexes != nil && endIndex == idx);
     
     if (endingCurrentGroup || endingLastGroup) {
       _ASHierarchySectionChange *change = [[_ASHierarchySectionChange alloc] initWithChangeType:type indexSet:currentIndexes animationOptions:currentOptions];

--- a/AsyncDisplayKit/Private/_ASHierarchyChangeSet.m
+++ b/AsyncDisplayKit/Private/_ASHierarchyChangeSet.m
@@ -217,7 +217,7 @@
   // Create new changes by grouping sorted changes by animation option
   NSMutableArray *result = [NSMutableArray new];
   
-  __block ASDataControllerAnimationOptions currentOptions = NSUIntegerMax;
+  __block ASDataControllerAnimationOptions currentOptions = 0;
   __block NSMutableIndexSet *currentIndexes = [NSMutableIndexSet indexSet];
 
   NSEnumerationOptions options = type == _ASHierarchyChangeTypeDelete ? NSEnumerationReverse : kNilOptions;


### PR DESCRIPTION
This resolves #869. @appleguy

See below. ~~The diff is hard-to-read since I reordered lines, but all that is different is when we enumerate changes in reverse (for deletes) our "end index" is actually the _first_ index in the set, not the last index.~~