### PR TITLE
Reduce Frequency of beginUpdates/endUpdates Due to Node Relayout

### DIFF
--- a/AsyncDisplayKit/ASCellNode.h
+++ b/AsyncDisplayKit/ASCellNode.h
@@ -15,13 +15,13 @@ typedef NSUInteger ASCellNodeAnimation;
 @protocol ASCellNodeLayoutDelegate <NSObject>
 
 /**
- * Notifies the delegate that the specified cell node has done a relayout
- * that resulted in a change of `calculatedSize`.
+ * Notifies the delegate that the specified cell node has done a relayout.
  * The notification is done on main thread.
  *
  * @param node A node informing the delegate about the relayout.
+ * @param sizeChanged `YES` if the node's `calculatedSize` changed during the relayout, `NO` otherwise.
  */
-- (void)nodeDidRelayoutWithSizeChange:(ASCellNode *)node;
+- (void)nodeDidRelayout:(ASCellNode *)node sizeChanged:(BOOL)sizeChanged;
 @end
 
 /**

--- a/AsyncDisplayKit/ASCellNode.h
+++ b/AsyncDisplayKit/ASCellNode.h
@@ -15,12 +15,13 @@ typedef NSUInteger ASCellNodeAnimation;
 @protocol ASCellNodeLayoutDelegate <NSObject>
 
 /**
- * Notifies the delegate that the specified cell node has done a relayout.
+ * Notifies the delegate that the specified cell node has done a relayout
+ * that resulted in a change of `calculatedSize`.
  * The notification is done on main thread.
  *
  * @param node A node informing the delegate about the relayout.
  */
-- (void)nodeDidRelayout:(ASCellNode *)node;
+- (void)nodeDidRelayoutWithSizeChange:(ASCellNode *)node;
 @end
 
 /**

--- a/AsyncDisplayKit/ASCellNode.m
+++ b/AsyncDisplayKit/ASCellNode.m
@@ -53,11 +53,12 @@
 - (void)setNeedsLayout
 {
   ASDisplayNodeAssertThreadAffinity(self);  
+  CGSize oldSize = self.calculatedSize;
   [super setNeedsLayout];
   
-  if (_layoutDelegate != nil) {
+  if (_layoutDelegate != nil && !CGSizeEqualToSize(oldSize, self.calculatedSize)) {
     ASPerformBlockOnMainThread(^{
-      [_layoutDelegate nodeDidRelayout:self];
+      [_layoutDelegate nodeDidRelayoutWithSizeChange:self];
     });
   }
 }

--- a/AsyncDisplayKit/ASCellNode.m
+++ b/AsyncDisplayKit/ASCellNode.m
@@ -55,10 +55,11 @@
   ASDisplayNodeAssertThreadAffinity(self);  
   CGSize oldSize = self.calculatedSize;
   [super setNeedsLayout];
-  
-  if (_layoutDelegate != nil && !CGSizeEqualToSize(oldSize, self.calculatedSize)) {
+
+  if (_layoutDelegate != nil) {
+    BOOL sizeChanged = !CGSizeEqualToSize(oldSize, self.calculatedSize);
     ASPerformBlockOnMainThread(^{
-      [_layoutDelegate nodeDidRelayoutWithSizeChange:self];
+      [_layoutDelegate nodeDidRelayout:self sizeChanged:sizeChanged];
     });
   }
 }

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -155,6 +155,7 @@ static BOOL _isInterceptedSelector(SEL sel)
   BOOL _asyncDelegateImplementsInsetSection;
   BOOL _collectionViewLayoutImplementsInsetSection;
   BOOL _asyncDataSourceImplementsConstrainedSizeForNode;
+  BOOL _queuedNodeSizeUpdate;
 
   ASBatchContext *_batchContext;
   
@@ -912,10 +913,26 @@ static BOOL _isInterceptedSelector(SEL sel)
 
 #pragma mark - ASCellNodeDelegate
 
-- (void)nodeDidRelayout:(ASCellNode *)node
+- (void)nodeDidRelayoutWithSizeChange:(ASCellNode *)node
 {
   ASDisplayNodeAssertMainThread();
-  // Cause UICollectionView to requery for the new height of this node
+
+  if (_queuedNodeSizeUpdate) {
+    return;
+  }
+
+  _queuedNodeSizeUpdate = YES;
+  [self performSelector:@selector(requeryNodeSizes)
+             withObject:nil
+             afterDelay:0
+                inModes:@[ NSRunLoopCommonModes ]];
+}
+
+// Cause UICollectionView to requery for the new size of all nodes
+- (void)requeryNodeSizes
+{
+  _queuedNodeSizeUpdate = NO;
+
   [super performBatchUpdates:^{} completion:nil];
 }
 

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -913,11 +913,11 @@ static BOOL _isInterceptedSelector(SEL sel)
 
 #pragma mark - ASCellNodeDelegate
 
-- (void)nodeDidRelayoutWithSizeChange:(ASCellNode *)node
+- (void)nodeDidRelayout:(ASCellNode *)node sizeChanged:(BOOL)sizeChanged
 {
   ASDisplayNodeAssertMainThread();
 
-  if (_queuedNodeSizeUpdate) {
+  if (!sizeChanged || _queuedNodeSizeUpdate) {
     return;
   }
 

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -910,11 +910,11 @@ static BOOL _isInterceptedSelector(SEL sel)
 
 #pragma mark - ASCellNodeLayoutDelegate
 
-- (void)nodeDidRelayoutWithSizeChange:(ASCellNode *)node
+- (void)nodeDidRelayout:(ASCellNode *)node sizeChanged:(BOOL)sizeChanged
 {
   ASDisplayNodeAssertMainThread();
 
-  if (_queuedNodeHeightUpdate) {
+  if (!sizeChanged || _queuedNodeHeightUpdate) {
     return;
   }
 


### PR DESCRIPTION
@nguyenhuy @appleguy Experimenting with Kittens shows that when you enlarge the image this still correctly updates the table view, but when you swap the image and text it correctly does not bother the table view.

- Change delegate method `nodeDidRelayout:` to `nodeDidRelayoutWithSizeChange:` to filter layouts that don't affect height.
- In `ASTableView`, `ASCollectionView`, enqueue `beginUpdates()/endUpdates()` in the run loop. These calls can be expensive – querying 100 nodes for their heights and enqueuing an animation – so this should be worth the effort.