### PR TITLE
Allow User to Move While Touching Link As Long As They Stay In Range

### DIFF
--- a/AsyncDisplayKit/ASTextNode.mm
+++ b/AsyncDisplayKit/ASTextNode.mm
@@ -831,15 +831,18 @@ static NSString *ASTextNodeTruncationTokenAttributeName = @"ASTextNodeTruncation
 {
   [super touchesMoved:touches withEvent:event];
 
-  CGPoint point = [[touches anyObject] locationInView:self.view];
-  NSRange range = NSMakeRange(0, 0);
-  [self _linkAttributeValueAtPoint:point
-                     attributeName:NULL
-                             range:&range
-     inAdditionalTruncationMessage:NULL];
+  // If touch has moved out of the current highlight range, clear the highlight.
+  if (_highlightRange.length > 0) {
+    NSRange range = NSMakeRange(0, 0);
+    CGPoint point = [[touches anyObject] locationInView:self.view];
+    [self _linkAttributeValueAtPoint:point
+                       attributeName:NULL
+                               range:&range
+       inAdditionalTruncationMessage:NULL];
 
-  if (!NSEqualRanges(_highlightRange, range)) {
-    [self _clearHighlightIfNecessary];
+    if (!NSEqualRanges(_highlightRange, range)) {
+      [self _clearHighlightIfNecessary];
+    }
   }
 }
 

--- a/AsyncDisplayKit/ASTextNode.mm
+++ b/AsyncDisplayKit/ASTextNode.mm
@@ -778,11 +778,7 @@ static NSString *ASTextNodeTruncationTokenAttributeName = @"ASTextNodeTruncation
 
   ASDisplayNodeAssertMainThread();
 
-  UITouch *touch = [touches anyObject];
-
-  UIView *view = touch.view;
-  CGPoint point = [touch locationInView:view];
-  point = [self.view convertPoint:point fromView:view];
+  CGPoint point = [[touches anyObject] locationInView:self.view];
 
   NSRange range = NSMakeRange(0, 0);
   NSString *linkAttributeName = nil;
@@ -835,7 +831,16 @@ static NSString *ASTextNodeTruncationTokenAttributeName = @"ASTextNodeTruncation
 {
   [super touchesMoved:touches withEvent:event];
 
-  [self _clearHighlightIfNecessary];
+  CGPoint point = [[touches anyObject] locationInView:self.view];
+  NSRange range = NSMakeRange(0, 0);
+  [self _linkAttributeValueAtPoint:point
+                     attributeName:NULL
+                             range:&range
+     inAdditionalTruncationMessage:NULL];
+
+  if (!NSEqualRanges(_highlightRange, range)) {
+    [self _clearHighlightIfNecessary];
+  }
 }
 
 - (void)_handleLongPress:(UILongPressGestureRecognizer *)longPressRecognizer


### PR DESCRIPTION
Before we were canceling the highlight as soon as we got `touchesMoved:` but some of our users are sloppy organic humanoids, and they couldn't figure out why taps weren't working. :smiley: 