### PR TITLE
Reduce Reliance on -textNode:shouldHighlightLinkAttribute:value:atPoint:

### DIFF
--- a/AsyncDisplayKit/ASTextNode.h
+++ b/AsyncDisplayKit/ASTextNode.h
@@ -245,7 +245,7 @@ typedef NS_ENUM(NSUInteger, ASTextNodeHighlightStyle) {
  @param attribute The attribute that was tapped. Will not be nil.
  @param value The value of the tapped attribute.
  @param point The point within textNode, in textNode's coordinate system, that was touched to trigger a highlight.
- @discussion If not implemented, the default value is NO.
+ @discussion If not implemented, the default value is YES.
  @return YES if the entity attribute should be a link, NO otherwise.
  */
 - (BOOL)textNode:(ASTextNode *)textNode shouldHighlightLinkAttribute:(NSString *)attribute value:(id)value atPoint:(CGPoint)point;

--- a/AsyncDisplayKit/ASTextNode.mm
+++ b/AsyncDisplayKit/ASTextNode.mm
@@ -394,13 +394,15 @@ static NSString *ASTextNodeTruncationTokenAttributeName = @"ASTextNodeTruncation
   return [self _linkAttributeValueAtPoint:point
                             attributeName:attributeNameOut
                                     range:rangeOut
-            inAdditionalTruncationMessage:NULL];
+            inAdditionalTruncationMessage:NULL
+                          forHighlighting:NO];
 }
 
 - (id)_linkAttributeValueAtPoint:(CGPoint)point
                    attributeName:(out NSString **)attributeNameOut
                            range:(out NSRange *)rangeOut
    inAdditionalTruncationMessage:(out BOOL *)inAdditionalTruncationMessageOut
+                 forHighlighting:(BOOL)highlighting
 {
   ASTextKitRenderer *renderer = [self _renderer];
   NSRange visibleRange = renderer.visibleRanges[0];
@@ -453,10 +455,10 @@ static NSString *ASTextNodeTruncationTokenAttributeName = @"ASTextNodeTruncation
         continue;
       }
 
-      // Check if delegate implements optional method, if not assume NO.
-      // Should the text be highlightable/touchable?
-      if (![_delegate respondsToSelector:@selector(textNode:shouldHighlightLinkAttribute:value:atPoint:)] ||
-          ![_delegate textNode:self shouldHighlightLinkAttribute:name value:value atPoint:point]) {
+      // If highlighting, check with delegate first. If not implemented, assume YES.
+      if (highlighting
+          && [_delegate respondsToSelector:@selector(textNode:shouldHighlightLinkAttribute:value:atPoint:)]
+          && ![_delegate textNode:self shouldHighlightLinkAttribute:name value:value atPoint:point]) {
         value = nil;
         name = nil;
       }
@@ -758,7 +760,8 @@ static NSString *ASTextNodeTruncationTokenAttributeName = @"ASTextNodeTruncation
   id linkAttributeValue = [self _linkAttributeValueAtPoint:point
                                              attributeName:&linkAttributeName
                                                      range:&range
-                             inAdditionalTruncationMessage:&inAdditionalTruncationMessage];
+                             inAdditionalTruncationMessage:&inAdditionalTruncationMessage
+                                           forHighlighting:YES];
 
   NSUInteger lastCharIndex = NSIntegerMax;
   BOOL linkCrossesVisibleRange = (lastCharIndex > range.location) && (lastCharIndex < NSMaxRange(range) - 1);
@@ -787,7 +790,8 @@ static NSString *ASTextNodeTruncationTokenAttributeName = @"ASTextNodeTruncation
   id linkAttributeValue = [self _linkAttributeValueAtPoint:point
                                              attributeName:&linkAttributeName
                                                      range:&range
-                             inAdditionalTruncationMessage:&inAdditionalTruncationMessage];
+                             inAdditionalTruncationMessage:&inAdditionalTruncationMessage
+                                           forHighlighting:YES];
 
   NSUInteger lastCharIndex = NSIntegerMax;
   BOOL linkCrossesVisibleRange = (lastCharIndex > range.location) && (lastCharIndex < NSMaxRange(range) - 1);
@@ -838,7 +842,8 @@ static NSString *ASTextNodeTruncationTokenAttributeName = @"ASTextNodeTruncation
     [self _linkAttributeValueAtPoint:point
                        attributeName:NULL
                                range:&range
-       inAdditionalTruncationMessage:NULL];
+       inAdditionalTruncationMessage:NULL
+                     forHighlighting:YES];
 
     if (!NSEqualRanges(_highlightRange, range)) {
       [self _clearHighlightIfNecessary];


### PR DESCRIPTION
This changes the default value to `YES`, which falls in line with many other `thing:shouldActWithThing:` patterns. Also, the text node no longer consults the delegate when handling external calls to `linkAttributeValueAtPoint:`.

I reckon this could be released immediately. Users who don't implement the method obviously aren't using highlighting.