### PR TITLE
Provide Basic Interface State Support for Nodes Outside of Cells

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode+Subclasses.h
+++ b/AsyncDisplayKit/ASDisplayNode+Subclasses.h
@@ -366,7 +366,7 @@
 
 
 /**
- * Called just before the view is added to a superview.
+ * Called just before the view is added to a window.
  */
 - (void)willEnterHierarchy ASDISPLAYNODE_REQUIRES_SUPER;
 
@@ -426,9 +426,13 @@
 @end
 
 @interface ASDisplayNode (ASDisplayNodePrivate)
-// This method has proven helpful in a few rare scenarios, similar to a category extension on UIView,
-// but it's considered private API for now and its use should not be encouraged.
-- (ASDisplayNode *)_supernodeWithClass:(Class)supernodeClass;
+/**
+ * This method has proven helpful in a few rare scenarios, similar to a category extension on UIView,
+ * but it's considered private API for now and its use should not be encouraged.
+ * @param checkViewHierarchy If YES, and no supernode can be found, method will walk up from `self.view` to find a supernode.
+ * If YES, this method must be called on the main thread and the node must not be layer-backed.
+ */
+- (ASDisplayNode *)_supernodeWithClass:(Class)supernodeClass checkViewHierarchy:(BOOL)checkViewHierarchy;
 
 // The two methods below will eventually be exposed, but their names are subject to change.
 /**

--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -41,17 +41,31 @@ typedef void (^ASDisplayNodeDidLoadBlock)(ASDisplayNode *node);
 typedef NS_OPTIONS(NSUInteger, ASInterfaceState)
 {
   /** The element is not predicted to be onscreen soon and preloading should not be performed */
-  ASInterfaceStateNone          = 1 << 0,
+  ASInterfaceStateNone          = 0,
   /** The element may be added to a view soon that could become visible.  Measure the layout, including size calculation. */
-  ASInterfaceStateMeasureLayout = 1 << 1,
+  ASInterfaceStateMeasureLayout = 1 << 0,
   /** The element is likely enough to come onscreen that disk and/or network data required for display should be fetched. */
-  ASInterfaceStateFetchData     = 1 << 2,
+  ASInterfaceStateFetchData     = 1 << 1,
   /** The element is very likely to become visible, and concurrent rendering should be executed for any -setNeedsDisplay. */
-  ASInterfaceStateDisplay       = 1 << 3,
+  ASInterfaceStateDisplay       = 1 << 2,
   /** The element is physically onscreen by at least 1 pixel.
    In practice, all other bit fields should also be set when this flag is set. */
-  ASInterfaceStateVisible       = 1 << 4,
+  ASInterfaceStateVisible       = 1 << 3,
 };
+
+/**
+ * Currently we only set `interfaceState` for
+ * nodes contained in table views or collection views.
+ 
+ * Nodes that aren't contained in cells will be in this state when
+ * they are in the view hierarchy, and `ASInterfaceStateNone` when
+ * they aren't.
+ */
+static const ASInterfaceState ASInterfaceStateInHierarchy =
+    ASInterfaceStateMeasureLayout
+  | ASInterfaceStateFetchData
+  | ASInterfaceStateDisplay
+  | ASInterfaceStateVisible;
 
 /**
  * An `ASDisplayNode` is an abstraction over `UIView` and `CALayer` that allows you to perform calculations about a view

--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -51,21 +51,17 @@ typedef NS_OPTIONS(NSUInteger, ASInterfaceState)
   /** The element is physically onscreen by at least 1 pixel.
    In practice, all other bit fields should also be set when this flag is set. */
   ASInterfaceStateVisible       = 1 << 3,
+
+  /**
+   * The node is not contained in a cell but it is in a window.
+   *
+   * Currently we only set `interfaceState` to other values for
+   * nodes contained in table views or collection views.
+   */
+  ASInterfaceStateInHierarchy   = ASInterfaceStateMeasureLayout | ASInterfaceStateFetchData | ASInterfaceStateDisplay | ASInterfaceStateVisible,
 };
 
-/**
- * Currently we only set `interfaceState` for
- * nodes contained in table views or collection views.
- 
- * Nodes that aren't contained in cells will be in this state when
- * they are in the view hierarchy, and `ASInterfaceStateNone` when
- * they aren't.
- */
-static const ASInterfaceState ASInterfaceStateInHierarchy =
-    ASInterfaceStateMeasureLayout
-  | ASInterfaceStateFetchData
-  | ASInterfaceStateDisplay
-  | ASInterfaceStateVisible;
+
 
 /**
  * An `ASDisplayNode` is an abstraction over `UIView` and `CALayer` that allows you to perform calculations about a view

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -24,6 +24,7 @@
 #import "ASInternalHelpers.h"
 #import "ASLayout.h"
 #import "ASLayoutSpec.h"
+#import "ASCellNode.h"
 
 @interface ASDisplayNode () <UIGestureRecognizerDelegate>
 
@@ -1581,6 +1582,10 @@ void recursivelyEnsureDisplayForLayer(CALayer *layer)
   ASDisplayNodeAssertMainThread();
   ASDisplayNodeAssert(_flags.isEnteringHierarchy, @"You should never call -willEnterHierarchy directly. Appearance is automatically managed by ASDisplayNode");
   ASDisplayNodeAssert(!_flags.isExitingHierarchy, @"ASDisplayNode inconsistency. __enterHierarchy and __exitHierarchy are mutually exclusive");
+
+  if (![self supportsInterfaceState]) {
+    self.interfaceState = ASInterfaceStateInHierarchy;
+  }
 }
 
 - (void)didExitHierarchy
@@ -1588,6 +1593,10 @@ void recursivelyEnsureDisplayForLayer(CALayer *layer)
   ASDisplayNodeAssertMainThread();
   ASDisplayNodeAssert(_flags.isExitingHierarchy, @"You should never call -didExitHierarchy directly. Appearance is automatically managed by ASDisplayNode");
   ASDisplayNodeAssert(!_flags.isEnteringHierarchy, @"ASDisplayNode inconsistency. __enterHierarchy and __exitHierarchy are mutually exclusive");
+  
+  if (![self supportsInterfaceState]) {
+    self.interfaceState = ASInterfaceStateNone;
+  }
 }
 
 - (void)clearContents
@@ -1633,6 +1642,20 @@ void recursivelyEnsureDisplayForLayer(CALayer *layer)
     [subnode recursivelyClearFetchedData];
   }
   [self clearFetchedData];
+}
+
+/**
+ * We currently only set interface state on nodes
+ * in table/collection views. For other nodes, if they are
+ * in the hierarchy we return `Unknown`, otherwise we return `None`.
+ *
+ * TODO: Avoid traversing up node hierarchy due to possible deadlock.
+ * @see https://github.com/facebook/AsyncDisplayKit/issues/900
+ * Possible solution is to push `isInCellNode` state downward on `addSubnode`/`removeFromSupernode`.
+ */
+- (BOOL)supportsInterfaceState {
+  return ([self isKindOfClass:ASCellNode.class]
+      || [self _supernodeWithClass:ASCellNode.class checkViewHierarchy:NO] != nil);
 }
 
 - (ASInterfaceState)interfaceState
@@ -1871,13 +1894,16 @@ void recursivelyEnsureDisplayForLayer(CALayer *layer)
 
 // This method has proved helpful in a few rare scenarios, similar to a category extension on UIView, but assumes knowledge of _ASDisplayView.
 // It's considered private API for now and its use should not be encouraged.
-- (ASDisplayNode *)_supernodeWithClass:(Class)supernodeClass
+- (ASDisplayNode *)_supernodeWithClass:(Class)supernodeClass checkViewHierarchy:(BOOL)checkViewHierarchy
 {
   ASDisplayNode *supernode = self.supernode;
   while (supernode) {
     if ([supernode isKindOfClass:supernodeClass])
       return supernode;
     supernode = supernode.supernode;
+  }
+  if (!checkViewHierarchy) {
+    return nil;
   }
 
   UIView *view = self.view.superview;

--- a/AsyncDisplayKitTests/ASDisplayNodeTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeTests.m
@@ -15,6 +15,7 @@
 #import "ASDisplayNode+Subclasses.h"
 #import "ASDisplayNodeTestsHelper.h"
 #import "UIView+ASConvenience.h"
+#import "ASCellNode.h"
 
 // Conveniences for making nodes named a certain way
 #define DeclareNodeNamed(n) ASDisplayNode *n = [[ASDisplayNode alloc] init]; n.name = @#n
@@ -76,11 +77,15 @@ for (ASDisplayNode *n in @[ nodes ]) {\
 + (dispatch_queue_t)asyncSizingQueue;
 - (id)initWithViewClass:(Class)viewClass;
 - (id)initWithLayerClass:(Class)layerClass;
+
+// FIXME: Importing ASDisplayNodeInternal.h causes a heap of problems.
+- (void)enterInterfaceState:(ASInterfaceState)interfaceState;
 @end
 
 @interface ASTestDisplayNode : ASDisplayNode
 @property (atomic, copy) void (^willDeallocBlock)(ASTestDisplayNode *node);
 @property (atomic, copy) CGSize(^calculateSizeBlock)(ASTestDisplayNode *node, CGSize size);
+@property (atomic) BOOL hasFetchedData;
 @end
 
 @interface ASTestResponderNode : ASTestDisplayNode
@@ -91,6 +96,18 @@ for (ASDisplayNode *n in @[ nodes ]) {\
 - (CGSize)calculateSizeThatFits:(CGSize)constrainedSize
 {
   return _calculateSizeBlock ? _calculateSizeBlock(self, constrainedSize) : CGSizeZero;
+}
+
+- (void)fetchData
+{
+  [super fetchData];
+  self.hasFetchedData = YES;
+}
+
+- (void)clearFetchedData
+{
+  [super clearFetchedData];
+  self.hasFetchedData = NO;
 }
 
 - (void)dealloc
@@ -1661,6 +1678,48 @@ static inline BOOL _CGPointEqualToPointWithEpsilon(CGPoint point1, CGPoint point
 - (void)testBackgroundColorOpaqueRelationshipNoLayer
 {
   [self checkBackgroundColorOpaqueRelationshipWithViewLoaded:NO layerBacked:YES];
+}
+
+// Check that nodes who have no cell node (no range controller)
+// do get their `fetchData` called, and they do report
+// the fetch data interface state.
+- (void)testInterfaceStateForNonCellNode
+{
+  ASTestWindow *window = [ASTestWindow new];
+  ASTestDisplayNode *node = [ASTestDisplayNode new];
+  XCTAssert(node.interfaceState == ASInterfaceStateNone);
+  XCTAssert(!node.hasFetchedData);
+
+  [window addSubview:node.view];
+  XCTAssert(node.hasFetchedData);
+  XCTAssert(node.interfaceState == ASInterfaceStateInHierarchy);
+
+  [node.view removeFromSuperview];
+  XCTAssert(node.hasFetchedData);
+  XCTAssert(node.interfaceState == ASInterfaceStateNone);
+}
+
+// Check that nodes who have no cell node (no range controller)
+// do get their `fetchData` called, and they do report
+// the fetch data interface state.
+- (void)testInterfaceStateForCellNode
+{
+    ASCellNode *cellNode = [ASCellNode new];
+    ASTestDisplayNode *node = [ASTestDisplayNode new];
+    XCTAssert(node.interfaceState == ASInterfaceStateNone);
+    XCTAssert(!node.hasFetchedData);
+
+    // Simulate range handler updating cell node.
+    [cellNode addSubnode:node];
+    [cellNode enterInterfaceState:ASInterfaceStateFetchData];
+    XCTAssert(node.hasFetchedData);
+    XCTAssert(node.interfaceState == ASInterfaceStateFetchData);
+
+    // If the node goes into a view it should not adopt the `InHierarchy` state.
+    ASTestWindow *window = [ASTestWindow new];
+    [window addSubview:cellNode.view];
+    XCTAssert(node.hasFetchedData);
+    XCTAssert(node.interfaceState == ASInterfaceStateFetchData);
 }
 
 - (void)testInitWithViewClass

--- a/AsyncDisplayKitTests/ASDisplayNodeTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeTests.m
@@ -1695,7 +1695,7 @@ static inline BOOL _CGPointEqualToPointWithEpsilon(CGPoint point1, CGPoint point
   XCTAssert(node.interfaceState == ASInterfaceStateInHierarchy);
 
   [node.view removeFromSuperview];
-  XCTAssert(node.hasFetchedData);
+  XCTAssert(!node.hasFetchedData);
   XCTAssert(node.interfaceState == ASInterfaceStateNone);
 }
 


### PR DESCRIPTION
This resolves #897. I added two test cases, and also posted a toy project https://github.com/Adlai-Holler/ASDKPlainNodeTest.

##### Changes

- Add new interface state `ASInterfaceStateInHierarchy` that unites all others. This is the interface state for non cell-hosted nodes that are in the window hierarchy. I don't like the name – I considered `Unknown` but that seems like none more than all, and I considered `All` but that's not very informative.

##### Questions

- What's the safest way to push the `inCellNode`ness down the hierarchy? It's sort of unsafe to walk up the node hierarchy to check during `willEnterHierarchy` and `didExitHierarchy`
- I added `checkViewHierarchy:` param to `_supernodeWithClass` but honestly I wish I had just removed that behavior altogether. We don't call `_supernodeWithClass` anywhere in our code. But I wanted to ask because I haven't thought through the possible benefits of walking up the view hierarchy.

@appleguy What do you think? 
