### PR TITLE
[ASDisplayNode] Introduced ASHierarchyState, eliminating upward traversal and locking.

### DIFF
--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -441,6 +441,8 @@
 		D785F6621A74327E00291744 /* ASScrollNode.h in Headers */ = {isa = PBXBuildFile; fileRef = D785F6601A74327E00291744 /* ASScrollNode.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D785F6631A74327E00291744 /* ASScrollNode.m in Sources */ = {isa = PBXBuildFile; fileRef = D785F6611A74327E00291744 /* ASScrollNode.m */; };
 		DB7121BCD50849C498C886FB /* libPods-AsyncDisplayKitTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EFA731F0396842FF8AB635EE /* libPods-AsyncDisplayKitTests.a */; };
+		DE6EA3221C14000600183B10 /* ASDisplayNode+FrameworkPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = DE6EA3211C14000600183B10 /* ASDisplayNode+FrameworkPrivate.h */; };
+		DE6EA3231C14000600183B10 /* ASDisplayNode+FrameworkPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = DE6EA3211C14000600183B10 /* ASDisplayNode+FrameworkPrivate.h */; };
 		DECBD6E71BE56E1900CF4905 /* ASButtonNode.h in Headers */ = {isa = PBXBuildFile; fileRef = DECBD6E51BE56E1900CF4905 /* ASButtonNode.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DECBD6E81BE56E1900CF4905 /* ASButtonNode.h in Headers */ = {isa = PBXBuildFile; fileRef = DECBD6E51BE56E1900CF4905 /* ASButtonNode.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DECBD6E91BE56E1900CF4905 /* ASButtonNode.mm in Sources */ = {isa = PBXBuildFile; fileRef = DECBD6E61BE56E1900CF4905 /* ASButtonNode.mm */; };
@@ -725,6 +727,7 @@
 		D3779BCFF841AD3EB56537ED /* Pods-AsyncDisplayKitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AsyncDisplayKitTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-AsyncDisplayKitTests/Pods-AsyncDisplayKitTests.release.xcconfig"; sourceTree = "<group>"; };
 		D785F6601A74327E00291744 /* ASScrollNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASScrollNode.h; sourceTree = "<group>"; };
 		D785F6611A74327E00291744 /* ASScrollNode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASScrollNode.m; sourceTree = "<group>"; };
+		DE6EA3211C14000600183B10 /* ASDisplayNode+FrameworkPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ASDisplayNode+FrameworkPrivate.h"; sourceTree = "<group>"; };
 		DECBD6E51BE56E1900CF4905 /* ASButtonNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASButtonNode.h; sourceTree = "<group>"; };
 		DECBD6E61BE56E1900CF4905 /* ASButtonNode.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASButtonNode.mm; sourceTree = "<group>"; };
 		EFA731F0396842FF8AB635EE /* libPods-AsyncDisplayKitTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-AsyncDisplayKitTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1045,6 +1048,7 @@
 				058D0A09195D050800B7D73C /* ASDisplayNode+DebugTiming.h */,
 				058D0A0A195D050800B7D73C /* ASDisplayNode+DebugTiming.mm */,
 				058D0A0B195D050800B7D73C /* ASDisplayNode+UIViewBridge.mm */,
+				DE6EA3211C14000600183B10 /* ASDisplayNode+FrameworkPrivate.h */,
 				058D0A0C195D050800B7D73C /* ASDisplayNodeInternal.h */,
 				058D0A0D195D050800B7D73C /* ASImageNode+CGExtras.h */,
 				058D0A0E195D050800B7D73C /* ASImageNode+CGExtras.m */,
@@ -1231,6 +1235,7 @@
 				257754B11BEE44CD00737CA5 /* ASTextKitShadower.h in Headers */,
 				058D0A7B195D05F900B7D73C /* ASDisplayNodeInternal.h in Headers */,
 				0587F9BD1A7309ED00AFF0BA /* ASEditableTextNode.h in Headers */,
+				DE6EA3221C14000600183B10 /* ASDisplayNode+FrameworkPrivate.h in Headers */,
 				1950C4491A3BB5C1005C8279 /* ASEqualityHelpers.h in Headers */,
 				257754A81BEE44CD00737CA5 /* ASTextKitContext.h in Headers */,
 				464052221A3F83C40061C0BA /* ASFlowLayoutController.h in Headers */,
@@ -1340,6 +1345,7 @@
 				254C6B791BF94DF4003EC431 /* ASTextKitEntityAttribute.h in Headers */,
 				509E68631B3AEDB4009B9150 /* ASCollectionViewLayoutController.h in Headers */,
 				B35061F71B010EFD0018CF92 /* ASCollectionViewProtocols.h in Headers */,
+				DE6EA3231C14000600183B10 /* ASDisplayNode+FrameworkPrivate.h in Headers */,
 				B35061FA1B010EFD0018CF92 /* ASControlNode+Subclasses.h in Headers */,
 				B35061F81B010EFD0018CF92 /* ASControlNode.h in Headers */,
 				B35062171B010EFD0018CF92 /* ASDataController.h in Headers */,

--- a/AsyncDisplayKit/ASCellNode.m
+++ b/AsyncDisplayKit/ASCellNode.m
@@ -25,7 +25,7 @@
   if (!(self = [super init]))
     return nil;
 
-  // use UITableViewCell defaults
+  // Use UITableViewCell defaults
   _selectionStyle = UITableViewCellSelectionStyleDefault;
   self.clipsToBounds = YES;
 

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -6,19 +6,16 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import "ASCollectionView.h"
-
 #import "ASAssert.h"
-#import "ASCollectionViewLayoutController.h"
-#import "ASRangeController.h"
-#import "ASCollectionDataController.h"
 #import "ASBatchFetching.h"
-#import "UICollectionViewLayout+ASConvenience.h"
-#import "ASInternalHelpers.h"
+#import "ASCollectionView.h"
+#import "ASCollectionDataController.h"
+#import "ASCollectionViewLayoutController.h"
 #import "ASCollectionViewFlowLayoutInspector.h"
-
-// FIXME: Temporary nonsense import until method names are finalized and exposed
-#import "ASDisplayNode+Subclasses.h"
+#import "ASDisplayNode+FrameworkPrivate.h"
+#import "ASInternalHelpers.h"
+#import "ASRangeController.h"
+#import "UICollectionViewLayout+ASConvenience.h"
 
 static const NSUInteger kASCollectionViewAnimationNone = UITableViewRowAnimationNone;
 static const ASSizeRange kInvalidSizeRange = {CGSizeZero, CGSizeZero};
@@ -661,6 +658,8 @@ static BOOL _isInterceptedSelector(SEL sel)
 - (ASCellNode *)dataController:(ASDataController *)dataController nodeAtIndexPath:(NSIndexPath *)indexPath
 {
   ASCellNode *node = [_asyncDataSource collectionView:self nodeForItemAtIndexPath:indexPath];
+  [node enterHierarchyState:ASHierarchyStateRangeManaged];
+  
   ASDisplayNodeAssert([node isKindOfClass:ASCellNode.class], @"invalid node class, expected ASCellNode");
   if (node.layoutDelegate == nil) {
     node.layoutDelegate = self;

--- a/AsyncDisplayKit/ASDisplayNode+Subclasses.h
+++ b/AsyncDisplayKit/ASDisplayNode+Subclasses.h
@@ -412,9 +412,7 @@
  */
 - (UIImage *)placeholderImage;
 
-
 /** @name Description */
-
 
 /**
  * @abstract Return a description of the node
@@ -422,48 +420,6 @@
  * @discussion The function that gets called for each display node in -recursiveDescription
  */
 - (NSString *)descriptionForRecursiveDescription;
-
-@end
-
-@interface ASDisplayNode (ASDisplayNodePrivate)
-/**
- * This method has proven helpful in a few rare scenarios, similar to a category extension on UIView,
- * but it's considered private API for now and its use should not be encouraged.
- * @param checkViewHierarchy If YES, and no supernode can be found, method will walk up from `self.view` to find a supernode.
- * If YES, this method must be called on the main thread and the node must not be layer-backed.
- */
-- (ASDisplayNode *)_supernodeWithClass:(Class)supernodeClass checkViewHierarchy:(BOOL)checkViewHierarchy;
-
-// The two methods below will eventually be exposed, but their names are subject to change.
-/**
- * @abstract Ensure that all rendering is complete for this node and its descendents.
- *
- * @discussion Calling this method on the main thread after a node is added to the view heirarchy will ensure that
- * placeholder states are never visible to the user.  It is used by ASTableView, ASCollectionView, and ASViewController
- * to implement their respective ".neverShowPlaceholders" option.
- *
- * If all nodes have layer.contents set and/or their layer does not have -needsDisplay set, the method will return immediately.
- *
- * This method is capable of handling a mixed set of nodes, with some not having started display, some in progress on an
- * asynchronous display operation, and some already finished.
- *
- * In order to guarantee against deadlocks, this method should only be called on the main thread.
- * It may block on the private queue, [_ASDisplayLayer displayQueue]
- */
-- (void)recursivelyEnsureDisplay;
-
-/**
- * @abstract Allows a node to bypass all ensureDisplay passes.  Defaults to NO.
- *
- * @discussion Nodes that are expensive to draw and expected to have placeholder even with
- * .neverShowPlaceholders enabled should set this to YES.
- *
- * ASImageNode uses the default of NO, as it is often used for UI images that are expected to synchronize with ensureDisplay.
- *
- * ASNetworkImageNode and ASMultiplexImageNode set this to YES, because they load data from a database or server,
- * and are expected to support a placeholder state given that display is often blocked on slow data fetching.
- */
-@property (nonatomic, assign) BOOL shouldBypassEnsureDisplay;
 
 @end
 

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -1585,7 +1585,7 @@ void recursivelyEnsureDisplayForLayer(CALayer *layer)
   ASDisplayNodeAssert(_flags.isEnteringHierarchy, @"You should never call -willEnterHierarchy directly. Appearance is automatically managed by ASDisplayNode");
   ASDisplayNodeAssert(!_flags.isExitingHierarchy, @"ASDisplayNode inconsistency. __enterHierarchy and __exitHierarchy are mutually exclusive");
 
-  if (![self supportsInterfaceState]) {
+  if (![self supportsRangeManagedInterfaceState]) {
     self.interfaceState = ASInterfaceStateInHierarchy;
   }
 }
@@ -1596,7 +1596,7 @@ void recursivelyEnsureDisplayForLayer(CALayer *layer)
   ASDisplayNodeAssert(_flags.isExitingHierarchy, @"You should never call -didExitHierarchy directly. Appearance is automatically managed by ASDisplayNode");
   ASDisplayNodeAssert(!_flags.isEnteringHierarchy, @"ASDisplayNode inconsistency. __enterHierarchy and __exitHierarchy are mutually exclusive");
   
-  if (![self supportsInterfaceState]) {
+  if (![self supportsRangeManagedInterfaceState]) {
     self.interfaceState = ASInterfaceStateNone;
   }
 }
@@ -1647,18 +1647,12 @@ void recursivelyEnsureDisplayForLayer(CALayer *layer)
 }
 
 /**
- * We currently only set interface state on nodes
- * in table/collection views. For other nodes, if they are
- * in the hierarchy we return `Unknown`, otherwise we return `None`.
- *
- * TODO: Avoid traversing up node hierarchy due to possible deadlock.
- * @see https://github.com/facebook/AsyncDisplayKit/issues/900
- * Possible solution is to push `isInCellNode` state downward on `addSubnode`/`removeFromSupernode`.
+ * We currently only set interface state on nodes in table/collection views. For other nodes, if they are
+ * in the hierarchy we enable all ASInterfaceState types with `ASInterfaceStateInHierarchy`, otherwise `None`.
  */
-- (BOOL)supportsInterfaceState
+- (BOOL)supportsRangeManagedInterfaceState
 {
-  return ([self isKindOfClass:ASCellNode.class]
-      || [self _supernodeWithClass:ASCellNode.class checkViewHierarchy:NO] != nil);
+  return (_hierarchyState & ASHierarchyStateRangeManaged);
 }
 
 - (ASInterfaceState)interfaceState

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -657,6 +657,12 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
         [node __loadNode];
       }
     });
+    if (!shouldRasterize) {
+      // At this point all of our subnodes have their layers or views recreated, but we haven't added
+      // them to ours yet.  This is because our node is already loaded, and the above recursion
+      // is only performed on our subnodes -- not self.
+      [self _addSubnodeViewsAndLayers];
+    }
     
     if (self.interfaceState & ASInterfaceStateVisible) {
       // TODO: Change this to recursivelyEnsureDisplay - but need a variant that does not skip
@@ -1735,6 +1741,9 @@ void recursivelyEnsureDisplayForLayer(CALayer *layer)
 
 - (void)enterInterfaceState:(ASInterfaceState)interfaceState
 {
+  if (interfaceState == ASInterfaceStateNone) {
+    return; // This method is a no-op with a 0-bitfield argument, so don't bother recursing.
+  }
   ASDisplayNodePerformBlockOnEveryNode(nil, self, ^(ASDisplayNode *node) {
     node.interfaceState |= interfaceState;
   });
@@ -1742,6 +1751,9 @@ void recursivelyEnsureDisplayForLayer(CALayer *layer)
 
 - (void)exitInterfaceState:(ASInterfaceState)interfaceState
 {
+  if (interfaceState == ASInterfaceStateNone) {
+    return; // This method is a no-op with a 0-bitfield argument, so don't bother recursing.
+  }
   ASDisplayNodePerformBlockOnEveryNode(nil, self, ^(ASDisplayNode *node) {
     node.interfaceState &= (~interfaceState);
   });
@@ -1769,6 +1781,9 @@ void recursivelyEnsureDisplayForLayer(CALayer *layer)
 
 - (void)enterHierarchyState:(ASHierarchyState)hierarchyState
 {
+  if (hierarchyState == ASHierarchyStateNormal) {
+    return; // This method is a no-op with a 0-bitfield argument, so don't bother recursing.
+  }
   ASDisplayNodePerformBlockOnEveryNode(nil, self, ^(ASDisplayNode *node) {
     node.hierarchyState |= hierarchyState;
   });
@@ -1776,6 +1791,9 @@ void recursivelyEnsureDisplayForLayer(CALayer *layer)
 
 - (void)exitHierarchyState:(ASHierarchyState)hierarchyState
 {
+  if (hierarchyState == ASHierarchyStateNormal) {
+    return; // This method is a no-op with a 0-bitfield argument, so don't bother recursing.
+  }
   ASDisplayNodePerformBlockOnEveryNode(nil, self, ^(ASDisplayNode *node) {
     node.hierarchyState &= (~hierarchyState);
   });

--- a/AsyncDisplayKit/ASDisplayNodeExtras.h
+++ b/AsyncDisplayKit/ASDisplayNodeExtras.h
@@ -38,6 +38,12 @@ extern ASDisplayNode *ASDisplayNodeUltimateParentOfNode(ASDisplayNode *node);
 extern void ASDisplayNodePerformBlockOnEveryNode(CALayer *layer, ASDisplayNode *node, void(^block)(ASDisplayNode *node));
 
 /**
+ Identical to ASDisplayNodePerformBlockOnEveryNode, except it does not run the block on the
+ node provided directly to the function call - only on all descendants.
+ */
+extern void ASDisplayNodePerformBlockOnEverySubnode(ASDisplayNode *node, void(^block)(ASDisplayNode *node));
+
+/**
  Given a display node, traverses up the layer tree hierarchy, returning the first display node that passes block.
  */
 extern id ASDisplayNodeFind(ASDisplayNode *node, BOOL (^block)(ASDisplayNode *node));

--- a/AsyncDisplayKit/ASDisplayNodeExtras.mm
+++ b/AsyncDisplayKit/ASDisplayNodeExtras.mm
@@ -7,8 +7,8 @@
  */
 
 #import "ASDisplayNodeExtras.h"
-
 #import "ASDisplayNodeInternal.h"
+#import "ASDisplayNode+FrameworkPrivate.h"
 
 extern ASDisplayNode *ASLayerToDisplayNode(CALayer *layer)
 {
@@ -43,6 +43,13 @@ extern void ASDisplayNodePerformBlockOnEveryNode(CALayer *layer, ASDisplayNode *
     for (ASDisplayNode *subnode in [node subnodes]) {
       ASDisplayNodePerformBlockOnEveryNode(nil, subnode, block);
     }
+  }
+}
+
+extern void ASDisplayNodePerformBlockOnEverySubnode(ASDisplayNode *node, void(^block)(ASDisplayNode *node))
+{
+  for (ASDisplayNode *subnode in node.subnodes) {
+    ASDisplayNodePerformBlockOnEveryNode(nil, subnode, block);
   }
 }
 

--- a/AsyncDisplayKit/ASMultiplexImageNode.mm
+++ b/AsyncDisplayKit/ASMultiplexImageNode.mm
@@ -17,6 +17,7 @@
 #import "ASAvailability.h"
 #import "ASBaseDefines.h"
 #import "ASDisplayNode+Subclasses.h"
+#import "ASDisplayNode+FrameworkPrivate.h"
 #import "ASLog.h"
 #import "ASPhotosFrameworkImageRequest.h"
 #import "ASEqualityHelpers.h"

--- a/AsyncDisplayKit/ASNetworkImageNode.mm
+++ b/AsyncDisplayKit/ASNetworkImageNode.mm
@@ -10,8 +10,9 @@
 
 #import "ASBasicImageDownloader.h"
 #import "ASDisplayNode+Subclasses.h"
-#import "ASThread.h"
+#import "ASDisplayNode+FrameworkPrivate.h"
 #import "ASEqualityHelpers.h"
+#import "ASThread.h"
 
 @interface ASNetworkImageNode ()
 {
@@ -30,9 +31,7 @@
 
   BOOL _imageLoaded;
 }
-
 @end
-
 
 @implementation ASNetworkImageNode
 

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -10,16 +10,14 @@
 #import "ASTableViewInternal.h"
 
 #import "ASAssert.h"
+#import "ASBatchFetching.h"
 #import "ASChangeSetDataController.h"
 #import "ASCollectionViewLayoutController.h"
-#import "ASLayoutController.h"
-#import "ASRangeController.h"
-#import "ASBatchFetching.h"
+#import "ASDisplayNode+FrameworkPrivate.h"
 #import "ASInternalHelpers.h"
 #import "ASLayout.h"
-
-// FIXME: Temporary nonsense import until method names are finalized and exposed
-#import "ASDisplayNode+Subclasses.h"
+#import "ASLayoutController.h"
+#import "ASRangeController.h"
 
 static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
 
@@ -829,6 +827,8 @@ static BOOL _isInterceptedSelector(SEL sel)
 - (ASCellNode *)dataController:(ASDataController *)dataController nodeAtIndexPath:(NSIndexPath *)indexPath
 {
   ASCellNode *node = [_asyncDataSource tableView:self nodeForRowAtIndexPath:indexPath];
+  [node enterHierarchyState:ASHierarchyStateRangeManaged];
+  
   ASDisplayNodeAssert([node isKindOfClass:ASCellNode.class], @"invalid node class, expected ASCellNode");
   if (node.layoutDelegate == nil) {
     node.layoutDelegate = self;

--- a/AsyncDisplayKit/ASViewController.m
+++ b/AsyncDisplayKit/ASViewController.m
@@ -9,9 +9,7 @@
 #import "ASViewController.h"
 #import "ASAssert.h"
 #import "ASDimension.h"
-
-// FIXME: Temporary nonsense import until method names are finalized and exposed
-#import "ASDisplayNode+Subclasses.h"
+#import "ASDisplayNode+FrameworkPrivate.h"
 
 @implementation ASViewController
 {

--- a/AsyncDisplayKit/Details/ASRangeHandlerPreload.mm
+++ b/AsyncDisplayKit/Details/ASRangeHandlerPreload.mm
@@ -8,7 +8,7 @@
 
 #import "ASRangeHandlerPreload.h"
 #import "ASDisplayNode.h"
-#import "ASDisplayNodeInternal.h"
+#import "ASDisplayNode+FrameworkPrivate.h"
 
 @implementation ASRangeHandlerPreload
 

--- a/AsyncDisplayKit/Details/ASRangeHandlerRender.mm
+++ b/AsyncDisplayKit/Details/ASRangeHandlerRender.mm
@@ -10,7 +10,7 @@
 
 #import "ASDisplayNode.h"
 #import "ASDisplayNode+Subclasses.h"
-#import "ASDisplayNodeInternal.h"
+#import "ASDisplayNode+FrameworkPrivate.h"
 
 @interface ASRangeHandlerRender ()
 @property (nonatomic,readonly) UIWindow *workingWindow;

--- a/AsyncDisplayKit/Details/ASRangeHandlerVisible.mm
+++ b/AsyncDisplayKit/Details/ASRangeHandlerVisible.mm
@@ -8,7 +8,7 @@
 
 #import "ASRangeHandlerVisible.h"
 #import "ASDisplayNode.h"
-#import "ASDisplayNodeInternal.h"
+#import "ASDisplayNode+FrameworkPrivate.h"
 
 @implementation ASRangeHandlerVisible
 

--- a/AsyncDisplayKit/Details/_ASDisplayLayer.mm
+++ b/AsyncDisplayKit/Details/_ASDisplayLayer.mm
@@ -14,6 +14,7 @@
 #import "ASAssert.h"
 #import "ASDisplayNode.h"
 #import "ASDisplayNodeInternal.h"
+#import "ASDisplayNode+FrameworkPrivate.h"
 
 @implementation _ASDisplayLayer
 {

--- a/AsyncDisplayKit/Details/_ASDisplayView.mm
+++ b/AsyncDisplayKit/Details/_ASDisplayView.mm
@@ -15,6 +15,7 @@
 #import "ASAssert.h"
 #import "ASDisplayNodeExtras.h"
 #import "ASDisplayNodeInternal.h"
+#import "ASDisplayNode+FrameworkPrivate.h"
 #import "ASDisplayNode+Subclasses.h"
 
 @interface _ASDisplayView ()

--- a/AsyncDisplayKit/Private/ASDisplayNode+AsyncDisplay.mm
+++ b/AsyncDisplayKit/Private/ASDisplayNode+AsyncDisplay.mm
@@ -87,7 +87,7 @@ static void __ASDisplayLayerDecrementConcurrentDisplayCount(BOOL displayIsAsync,
     
   BOOL rasterizingFromAscendent = (_hierarchyState & ASHierarchyStateRasterized);
 
-  // if super node is rasterizing descendents, subnodes will not have had layout calls becase they don't have layers
+  // if super node is rasterizing descendents, subnodes will not have had layout calls because they don't have layers
   if (rasterizingFromAscendent) {
     [self __layout];
   }

--- a/AsyncDisplayKit/Private/ASDisplayNode+AsyncDisplay.mm
+++ b/AsyncDisplayKit/Private/ASDisplayNode+AsyncDisplay.mm
@@ -10,6 +10,7 @@
 #import "_ASAsyncTransaction.h"
 #import "ASAssert.h"
 #import "ASDisplayNodeInternal.h"
+#import "ASDisplayNode+FrameworkPrivate.h"
 
 @implementation ASDisplayNode (AsyncDisplay)
 
@@ -84,7 +85,7 @@ static void __ASDisplayLayerDecrementConcurrentDisplayCount(BOOL displayIsAsync,
     return;
   }
     
-  BOOL rasterizingFromAscendent = [self __rasterizedContainerNode] != nil;
+  BOOL rasterizingFromAscendent = (_hierarchyState & ASHierarchyStateRasterized);
 
   // if super node is rasterizing descendents, subnodes will not have had layout calls becase they don't have layers
   if (rasterizingFromAscendent) {
@@ -178,7 +179,7 @@ static void __ASDisplayLayerDecrementConcurrentDisplayCount(BOOL displayIsAsync,
 
   asyncdisplaykit_async_transaction_operation_block_t displayBlock = nil;
 
-  ASDisplayNodeAssert(rasterizing || ![self __rasterizedContainerNode], @"Rasterized descendants should never display unless being drawn into the rasterized container.");
+  ASDisplayNodeAssert(rasterizing || !(_hierarchyState & ASHierarchyStateRasterized), @"Rasterized descendants should never display unless being drawn into the rasterized container.");
 
   if (!rasterizing && self.shouldRasterizeDescendants) {
     CGRect bounds = self.bounds;
@@ -296,7 +297,7 @@ static void __ASDisplayLayerDecrementConcurrentDisplayCount(BOOL displayIsAsync,
 
   ASDN::MutexLocker l(_propertyLock);
 
-  if ([self __rasterizedContainerNode]) {
+  if (_hierarchyState & ASHierarchyStateRasterized) {
     return;
   }
 

--- a/AsyncDisplayKit/Private/ASDisplayNode+FrameworkPrivate.h
+++ b/AsyncDisplayKit/Private/ASDisplayNode+FrameworkPrivate.h
@@ -1,0 +1,109 @@
+/* Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+//
+// The following methods are ONLY for use by _ASDisplayLayer, _ASDisplayView, and ASDisplayNode.
+// These methods must never be called or overridden by other classes.
+//
+
+#import "_ASDisplayLayer.h"
+#import "_AS-objc-internal.h"
+#import "ASDisplayNodeExtraIvars.h"
+#import "ASDisplayNode.h"
+#import "ASSentinel.h"
+#import "ASThread.h"
+#import "ASLayoutOptions.h"
+
+/**
+ Hierarchy state is propogated from nodes to all of their children when certain behaviors are required from the subtree.
+ Examples include rasterization and external driving of the .interfaceState property.
+ By passing this information explicitly, performance is optimized by avoiding iteration up the supernode chain.
+ Lastly, this avoidance of supernode traversal protects against the possibility of deadlocks when a supernode is
+ simultaneously attempting to materialize views / layers for its subtree (as many related methods require property locking)
+ 
+ Note: as the hierarchy deepens, more state properties may be enabled.  However, state properties may never be disabled /
+ cancelled below the point they are enabled.  They continue to the leaves of the hierarchy.
+ */
+
+typedef NS_OPTIONS(NSUInteger, ASHierarchyState)
+{
+  /** The node may or may not have a supernode, but no supernode has a special hierarchy-influencing option enabled. */
+  ASHierarchyStateNormal       = 0,
+  /** The node has a supernode with .shouldRasterizeDescendants = YES.
+      Note: the root node of the rasterized subtree (the one with the property set on it) will NOT have this state set. */
+  ASHierarchyStateRasterized   = 1 << 0,
+  /** The node or one of its supernodes is managed by a class like ASRangeController.  Most commonly, these nodes are
+      ASCellNode objects or a subnode of one, and are used in ASTableView or ASCollectionView.
+      These nodes also recieve regular updates to the .interfaceState property with more detailed status information. */
+  ASHierarchyStateRangeManaged = 1 << 1,
+};
+
+@interface ASDisplayNode () <_ASDisplayLayerDelegate>
+{
+@protected
+  ASInterfaceState _interfaceState;
+  ASHierarchyState _hierarchyState;
+}
+
+// These methods are recursive, and either union or remove the provided interfaceState to all sub-elements.
+- (void)enterInterfaceState:(ASInterfaceState)interfaceState;
+- (void)exitInterfaceState:(ASInterfaceState)interfaceState;
+
+// These methods are recursive, and either union or remove the provided hierarchyState to all sub-elements.
+- (void)enterHierarchyState:(ASHierarchyState)hierarchyState;
+- (void)exitHierarchyState:(ASHierarchyState)hierarchyState;
+
+/**
+ * @abstract Returns the Hierarchy State of the node.
+ *
+ * @return The current ASHierarchyState of the node, indicating whether it is rasterized or managed by a range controller.
+ *
+ * @see ASInterfaceState
+ */
+@property (nonatomic, readwrite) ASHierarchyState hierarchyState;
+
+// The two methods below will eventually be exposed, but their names are subject to change.
+/**
+ * @abstract Ensure that all rendering is complete for this node and its descendents.
+ *
+ * @discussion Calling this method on the main thread after a node is added to the view heirarchy will ensure that
+ * placeholder states are never visible to the user.  It is used by ASTableView, ASCollectionView, and ASViewController
+ * to implement their respective ".neverShowPlaceholders" option.
+ *
+ * If all nodes have layer.contents set and/or their layer does not have -needsDisplay set, the method will return immediately.
+ *
+ * This method is capable of handling a mixed set of nodes, with some not having started display, some in progress on an
+ * asynchronous display operation, and some already finished.
+ *
+ * In order to guarantee against deadlocks, this method should only be called on the main thread.
+ * It may block on the private queue, [_ASDisplayLayer displayQueue]
+ */
+- (void)recursivelyEnsureDisplay;
+
+/**
+ * @abstract Allows a node to bypass all ensureDisplay passes.  Defaults to NO.
+ *
+ * @discussion Nodes that are expensive to draw and expected to have placeholder even with
+ * .neverShowPlaceholders enabled should set this to YES.
+ *
+ * ASImageNode uses the default of NO, as it is often used for UI images that are expected to synchronize with ensureDisplay.
+ *
+ * ASNetworkImageNode and ASMultiplexImageNode set this to YES, because they load data from a database or server,
+ * and are expected to support a placeholder state given that display is often blocked on slow data fetching.
+ */
+@property (nonatomic, assign) BOOL shouldBypassEnsureDisplay;
+
+@end
+
+@interface UIView (ASDisplayNodeInternal)
+@property (nonatomic, assign, readwrite) ASDisplayNode *asyncdisplaykit_node;
+@end
+
+@interface CALayer (ASDisplayNodeInternal)
+@property (nonatomic, assign, readwrite) ASDisplayNode *asyncdisplaykit_node;
+@end

--- a/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
+++ b/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
@@ -22,13 +22,14 @@
 BOOL ASDisplayNodeSubclassOverridesSelector(Class subclass, SEL selector);
 void ASDisplayNodeRespectThreadAffinityOfNode(ASDisplayNode *node, void (^block)());
 
-typedef NS_OPTIONS(NSUInteger, ASDisplayNodeMethodOverrides) {
-  ASDisplayNodeMethodOverrideNone = 0,
-  ASDisplayNodeMethodOverrideTouchesBegan          = 1 << 0,
-  ASDisplayNodeMethodOverrideTouchesCancelled      = 1 << 1,
-  ASDisplayNodeMethodOverrideTouchesEnded          = 1 << 2,
-  ASDisplayNodeMethodOverrideTouchesMoved          = 1 << 3,
-  ASDisplayNodeMethodOverrideLayoutSpecThatFits    = 1 << 4
+typedef NS_OPTIONS(NSUInteger, ASDisplayNodeMethodOverrides)
+{
+  ASDisplayNodeMethodOverrideNone               = 0,
+  ASDisplayNodeMethodOverrideTouchesBegan       = 1 << 0,
+  ASDisplayNodeMethodOverrideTouchesCancelled   = 1 << 1,
+  ASDisplayNodeMethodOverrideTouchesEnded       = 1 << 2,
+  ASDisplayNodeMethodOverrideTouchesMoved       = 1 << 3,
+  ASDisplayNodeMethodOverrideLayoutSpecThatFits = 1 << 4
 };
 
 @class _ASPendingState;
@@ -73,8 +74,6 @@ typedef NS_OPTIONS(NSUInteger, ASDisplayNodeMethodOverrides) {
 
   _ASPendingState *_pendingViewState;
   
-  ASInterfaceState _interfaceState;
-
   struct ASDisplayNodeFlags {
     // public properties
     unsigned synchronous:1;
@@ -118,9 +117,6 @@ typedef NS_OPTIONS(NSUInteger, ASDisplayNodeMethodOverrides) {
 // Bitmask to check which methods an object overrides.
 @property (nonatomic, assign, readonly) ASDisplayNodeMethodOverrides methodOverrides;
 
-// These methods are recursive, and either union or remove the provided interfaceState to all sub-elements.
-- (void)enterInterfaceState:(ASInterfaceState)interfaceState;
-- (void)exitInterfaceState:(ASInterfaceState)interfaceState;
 
 // Swizzle to extend the builtin functionality with custom logic
 - (BOOL)__shouldLoadViewOrLayer;
@@ -149,9 +145,6 @@ typedef NS_OPTIONS(NSUInteger, ASDisplayNodeMethodOverrides) {
 // Display the node's view/layer immediately on the current thread, bypassing the background thread rendering. Will be deprecated.
 - (void)displayImmediately;
 
-// Returns the ancestor node that rasterizes descendants, or nil if none.
-- (ASDisplayNode *)__rasterizedContainerNode;
-
 // Alternative initialiser for backing with a custom view class.  Supports asynchronous display with _ASDisplayView subclasses.
 - (id)initWithViewClass:(Class)viewClass;
 
@@ -160,12 +153,12 @@ typedef NS_OPTIONS(NSUInteger, ASDisplayNodeMethodOverrides) {
 
 @property (nonatomic, assign) CGFloat contentsScaleForDisplay;
 
-@end
+/**
+ * This method has proven helpful in a few rare scenarios, similar to a category extension on UIView,
+ * but it's considered private API for now and its use should not be encouraged.
+ * @param checkViewHierarchy If YES, and no supernode can be found, method will walk up from `self.view` to find a supernode.
+ * If YES, this method must be called on the main thread and the node must not be layer-backed.
+ */
+- (ASDisplayNode *)_supernodeWithClass:(Class)supernodeClass checkViewHierarchy:(BOOL)checkViewHierarchy;
 
-@interface UIView (ASDisplayNodeInternal)
-@property (nonatomic, assign, readwrite) ASDisplayNode *asyncdisplaykit_node;
-@end
-
-@interface CALayer (ASDisplayNodeInternal)
-@property (nonatomic, assign, readwrite) ASDisplayNode *asyncdisplaykit_node;
 @end

--- a/AsyncDisplayKit/TextKit/ASTextNodeWordKerner.m
+++ b/AsyncDisplayKit/TextKit/ASTextNodeWordKerner.m
@@ -68,7 +68,7 @@
 {
   // If it's a space character and we have custom word kerning, use the whitespace action control character.
   if ([layoutManager.textStorage.string characterAtIndex:characterIndex] == ' ')
-    return NSControlCharacterWhitespaceAction;
+    return NSControlCharacterActionWhitespace;
 
   return defaultAction;
 }

--- a/AsyncDisplayKit/TextKit/ASTextNodeWordKerner.m
+++ b/AsyncDisplayKit/TextKit/ASTextNodeWordKerner.m
@@ -68,7 +68,7 @@
 {
   // If it's a space character and we have custom word kerning, use the whitespace action control character.
   if ([layoutManager.textStorage.string characterAtIndex:characterIndex] == ' ')
-    return NSControlCharacterActionWhitespace;
+    return NSControlCharacterWhitespaceAction;
 
   return defaultAction;
 }

--- a/AsyncDisplayKitTests/ASDisplayNodeTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeTests.m
@@ -1719,7 +1719,7 @@ static inline BOOL _CGPointEqualToPointWithEpsilon(CGPoint point1, CGPoint point
     ASTestWindow *window = [ASTestWindow new];
     [window addSubview:cellNode.view];
     XCTAssert(node.hasFetchedData);
-    XCTAssert(node.interfaceState == ASInterfaceStateFetchData);
+    XCTAssert(node.interfaceState == ASInterfaceStateInHierarchy);
 }
 
 - (void)testInitWithViewClass

--- a/AsyncDisplayKitTests/ASSnapshotTestCase.mm
+++ b/AsyncDisplayKitTests/ASSnapshotTestCase.mm
@@ -7,6 +7,7 @@
  */
 
 #import "ASSnapshotTestCase.h"
+#import "ASDisplayNode+FrameworkPrivate.h"
 #import "ASDisplayNodeInternal.h"
 
 @implementation ASSnapshotTestCase
@@ -46,6 +47,7 @@
 
 + (void)hackilySynchronouslyRecursivelyRenderNode:(ASDisplayNode *)node
 {
+// TODO: Reconfigure this to be able to use [node recursivelyEnsureDisplay];
   [self _recursivelySetDisplaysAsynchronously:NO forNode:node];
   [self _recursivelyLayoutAndDisplayNode:node];
 }


### PR DESCRIPTION

This fixes the recently-reported deadlock, at least to the extent of my testing so far (100% repro with @Adlai-Holler 's test app before, 0% after).

It also adds a new header, ASDisplayNode+FrameworkPrivate.h, to avoid over-usage of *Internal and *+Subclasses.  I cleaned up several such usages.  Having wanted to do this for quite some time, I'm pretty happy to have the file established and know there is more cathartic refactoring to come!

ASHierarchyState itself is obviously similar to ASInterfaceState, but currently has only two state types and does /not/ currently perform operations when the state changes.  Instead, the state is checked by several key codepaths.  I would like to consider expanding this in the future to integrate things like isInHierarchy, and possibly finer-grained definitions of that such as "in window" vs "in subtree / any hierarchy".  Would love ideas both on the current behavior and future possibilities for refactoring + unification around a feature such as this.

The main thing remaining to do here is implement some tests, especially including the combination of the Rasterization and RangeManaged options in the same tree, with runtime enabling + disabling of Rasterization at different levels of the hierarchy.  Should also test that RangeManaged is not set on an ASCellNode used in isolation, but is in both ASTableView and ASCollectionView.  If anyone wants to give this a shot, please do - we need improved test harnesses too, and it may be necessary to do that to get strong coverage of this particular set of behaviors.

I'd love to have a couple community reviewers on this diff before landing it, so please comment!  At the same time, I want to land it quickly and get some testing from at least one or two users who have seen the deadlock.  Lastly, I need to ship this with 1.9.3 by end-of-day tomorrow (Sunday) or I will fall behind during the week.