### PR TITLE
Improve ASMapNode to get ready for 2.0

### DIFF
--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -517,7 +517,7 @@
 		057D02C51AC0A66700C7AC3C /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		057D02C61AC0A66700C7AC3C /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
 		0587F9BB1A7309ED00AFF0BA /* ASEditableTextNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASEditableTextNode.h; sourceTree = "<group>"; };
-		0587F9BC1A7309ED00AFF0BA /* ASEditableTextNode.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; lineEnding = 0; path = ASEditableTextNode.mm; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
+		0587F9BC1A7309ED00AFF0BA /* ASEditableTextNode.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; lineEnding = 0; path = ASEditableTextNode.mm; sourceTree = "<group>"; };
 		058D09AC195D04C000B7D73C /* libAsyncDisplayKit.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libAsyncDisplayKit.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		058D09AF195D04C000B7D73C /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		058D09B3195D04C000B7D73C /* AsyncDisplayKit-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "AsyncDisplayKit-Prefix.pch"; sourceTree = "<group>"; };

--- a/AsyncDisplayKit/ASMapNode.h
+++ b/AsyncDisplayKit/ASMapNode.h
@@ -11,7 +11,7 @@
 
 @interface ASMapNode : ASImageNode
 
-- (instancetype)initWithCoordinate:(CLLocationCoordinate2D)coordinate NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithRegion:(MKCoordinateRegion)region NS_DESIGNATED_INITIALIZER;
 
 /**
  This is the MKMapView that is the live map part of ASMapNode. This will be nil if .liveMap = NO. Note, MKMapView is *not* thread-safe.

--- a/AsyncDisplayKit/ASMapNode.h
+++ b/AsyncDisplayKit/ASMapNode.h
@@ -11,7 +11,10 @@
 
 @interface ASMapNode : ASImageNode
 
-- (instancetype)initWithRegion:(MKCoordinateRegion)region NS_DESIGNATED_INITIALIZER;
+/**
+ The current region of ASMapNode. This can be set at any time and ASMapNode will animate the change.
+ */
+@property (nonatomic, assign) MKCoordinateRegion region;
 
 /**
  This is the MKMapView that is the live map part of ASMapNode. This will be nil if .liveMap = NO. Note, MKMapView is *not* thread-safe.

--- a/AsyncDisplayKit/ASMapNode.mm
+++ b/AsyncDisplayKit/ASMapNode.mm
@@ -36,11 +36,11 @@
   }
   self.backgroundColor = ASDisplayNodeDefaultPlaceholderColor();
   self.clipsToBounds = YES;
-
+  
   _needsMapReloadOnBoundsChange = YES;
   _liveMap = NO;
   _centerCoordinateOfMap = kCLLocationCoordinate2DInvalid;
-
+  
   _options = [[MKMapSnapshotOptions alloc] init];
   _options.region = region;
   
@@ -49,29 +49,28 @@
 
 - (void)didLoad
 {
-    [super didLoad];
-    if (self.isLiveMap && !_mapNode) {
-        self.userInteractionEnabled = YES;
-        [self addLiveMap];
-    }
+  [super didLoad];
+  if (self.isLiveMap && !_mapNode) {
+    self.userInteractionEnabled = YES;
+    [self addLiveMap];
+  }
 }
 
 - (void)fetchData
 {
-    [super fetchData];
-    if (_liveMap && !_mapNode) {
-        [self addLiveMap];
-    }
-    else {
-        [self setUpSnapshotter];
-        [self takeSnapshot];
-    }
+  [super fetchData];
+  if (_liveMap && !_mapNode) {
+    [self addLiveMap];
+  } else {
+    [self setUpSnapshotter];
+    [self takeSnapshot];
+  }
 }
 
 - (void)clearFetchedData
 {
-    [super clearFetchedData];
-    [self removeLiveMap];
+  [super clearFetchedData];
+  [self removeLiveMap];
 }
 
 #pragma mark - Settings
@@ -148,11 +147,11 @@
 
 - (void)setUpSnapshotter
 {
-    if (!_snapshotter) {
-        ASDisplayNodeAssert(!CGSizeEqualToSize(CGSizeZero, self.calculatedSize), @"self.calculatedSize can not be zero. Make sure that you are setting a preferredFrameSize or wrapping ASMapNode in a ASRatioLayoutSpec or similar.");
-        _options.size = self.calculatedSize;
-        _snapshotter = [[MKMapSnapshotter alloc] initWithOptions:_options];
-    }
+  if (!_snapshotter) {
+    ASDisplayNodeAssert(!CGSizeEqualToSize(CGSizeZero, self.calculatedSize), @"self.calculatedSize can not be zero. Make sure that you are setting a preferredFrameSize or wrapping ASMapNode in a ASRatioLayoutSpec or similar.");
+    _options.size = self.calculatedSize;
+    _snapshotter = [[MKMapSnapshotter alloc] initWithOptions:_options];
+  }
 }
 
 - (void)resetSnapshotter
@@ -195,16 +194,16 @@
 
 - (void)setAnnotations:(NSArray *)annotations
 {
-    ASDN::MutexLocker l(_propertyLock);
-    _annotations = [annotations copy];
-    if (annotations.count != _annotations.count) {
-        // Redraw
-        [self setNeedsDisplay];
-        if (_mapView) {
-            [_mapView removeAnnotations:_mapView.annotations];
-            [_mapView addAnnotations:annotations];
-        }
+  ASDN::MutexLocker l(_propertyLock);
+  _annotations = [annotations copy];
+  if (annotations.count != _annotations.count) {
+    // Redraw
+    [self setNeedsDisplay];
+    if (_mapView) {
+      [_mapView removeAnnotations:_mapView.annotations];
+      [_mapView addAnnotations:annotations];
     }
+  }
 }
 
 
@@ -215,13 +214,12 @@
   [super layout];
   if (_mapView) {
     _mapView.frame = CGRectMake(0.0f, 0.0f, self.calculatedSize.width, self.calculatedSize.height);
-  }
-  else {
+  } else {
     // If our bounds.size is different from our current snapshot size, then let's request a new image from MKMapSnapshotter.
     if (!CGSizeEqualToSize(_options.size, self.bounds.size) && _needsMapReloadOnBoundsChange) {
-        _options.size = self.bounds.size;
-        [self resetSnapshotter];
-        [self takeSnapshot];
+      _options.size = self.bounds.size;
+      [self resetSnapshotter];
+      [self takeSnapshot];
     }
   }
 }


### PR DESCRIPTION
Hey @appleguy, here are changes based on your latest feedback
Notable changes:
- Changed init method to `-initWithRegion:` instead of `initWithCoordinate:`
- You can now call setLiveMap before ASMapNode has been loaded to start off with a live map view.
- Smaller syntax changes and clean up.

Just had a thought though, would it be useful for people to be able to change the region after the initialisation of ASMapNode, should we provide a method for this?