### PR TITLE
fix overflow issues with ASEditableTextNode's textView

### DIFF
--- a/AsyncDisplayKit/ASEditableTextNode.mm
+++ b/AsyncDisplayKit/ASEditableTextNode.mm
@@ -124,7 +124,6 @@
       textView.opaque = NO;
     }
     textView.textContainerInset = self.textContainerInset;
-    textView.clipsToBounds = NO; // We don't want selection handles cut off.
   };
 
   // Create and configure the placeholder text view.


### PR DESCRIPTION
Setting clipBounds = NO causes UITextView to overflow in iOS9 (works fine however in iOS8), so we fix by removing this config.

Addressing the deleted comment:
1. From my tests, selection handle doesn't clip anymore in iOS9+ and iOS8.4 simulator
2. If there is clipping of the handle in any case, we recently made the textView inset configurable which should address the problem by providing a way to give the handle room to breathe.

before:
![simulator screen shot dec 11 2015 7 00 48 pm](https://cloud.githubusercontent.com/assets/194822/11759858/d9ed2782-a039-11e5-8a7c-e46cf863be57.png)

after: (more than three lines, the extra lines are clipped)
![simulator screen shot dec 11 2015 6 53 46 pm](https://cloud.githubusercontent.com/assets/194822/11759862/e9d182d8-a039-11e5-9f08-fed4851f0a63.png)

This should also fix the placeholder text overflowing which has been reported by @steveram