### PR TITLE
Fix truncation calculation in ASTextNode by removing layoutManager.usesFontLeading = YES in renderer context

### DIFF
--- a/AsyncDisplayKit/TextKit/ASTextKitContext.mm
+++ b/AsyncDisplayKit/TextKit/ASTextKitContext.mm
@@ -36,7 +36,7 @@
     // Create the TextKit component stack with our default configuration.
     _textStorage = (attributedString ? [[NSTextStorage alloc] initWithAttributedString:attributedString] : [[NSTextStorage alloc] init]);
     _layoutManager = layoutManagerFactory ? layoutManagerFactory() : [[NSLayoutManager alloc] init];
-    _layoutManager.usesFontLeading = NO;
+    _layoutManager.usesFontLeading = YES;
     [_textStorage addLayoutManager:_layoutManager];
     _textContainer = [[NSTextContainer alloc] initWithSize:constrainedSize];
     // We want the text laid out up to the very edges of the container.

--- a/AsyncDisplayKitTests/ASTextKitTests.mm
+++ b/AsyncDisplayKitTests/ASTextKitTests.mm
@@ -26,7 +26,7 @@ static UITextView *UITextViewWithAttributes(const ASTextKitAttributes &attribute
   textView.textContainer.lineFragmentPadding = 0.f;
   textView.textContainer.maximumNumberOfLines = attributes.maximumNumberOfLines;
   textView.textContainerInset = UIEdgeInsetsZero;
-  textView.layoutManager.usesFontLeading = NO;
+  textView.layoutManager.usesFontLeading = YES;
   textView.attributedText = attributes.attributedString;
   return textView;
 }


### PR DESCRIPTION
After debugging #930 it was discovered that increasing the constrainedSize height slightly for ASTextKitRenderer's ASTextKitContext enabled it to truncate on the correct line rather than line N - 1.

After digging some more, found that `ASTextKitContext`'s `_layoutManager`'s `usesFontLeading` was set to NO. However we are using customized font leading in our project (though I'm not sure about `ASTextNode` in general),  so this resulted in a discrepancy between the calculated shrunk size of the text node and the layout+truncation calculation.

I suspect it should be okay to remove overriding of usesFontLeading since apple docs state that the default is YES. I also think it is better to customize via the `layoutManagerFactory` parameter in `ASTextKitContext`'s init method if `usesFontLeading` needs to be set to NO rather than overriding it for all cases.

Regardless, `removing usesFontLeading = NO` fixed #930 for me:
 
Before:
![simulator screen shot dec 12 2015 8 16 48 pm](https://cloud.githubusercontent.com/assets/194822/11765465/a6d5b3b2-a10d-11e5-81fc-50cd4cc58054.png)

After:
![simulator screen shot dec 12 2015 7 58 44 pm](https://cloud.githubusercontent.com/assets/194822/11765466/ac4e874c-a10d-11e5-9f1e-68735954ccde.png)