### PR TITLE
Recursive node thread affinity property

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -172,6 +172,8 @@ typedef NS_OPTIONS(NSUInteger, ASInterfaceState)
  */
 @property (atomic, readonly, assign, getter=isNodeLoaded) BOOL nodeLoaded;
 
+@property (atomic, readonly, assign, getter=isRecursivelyDetachedFromMainThread) BOOL recursivelyDetachedFromMainThread;
+
 /** 
  * @abstract Returns whether the node rely on a layer instead of a view.
  *

--- a/AsyncDisplayKit/Details/ASCollectionDataController.mm
+++ b/AsyncDisplayKit/Details/ASCollectionDataController.mm
@@ -49,7 +49,7 @@
     _pendingIndexPaths[kind] = indexPaths;
     
     // Measure loaded nodes before leaving the main thread
-    [self layoutLoadedNodes:nodes ofKind:kind atIndexPaths:indexPaths];
+    [self layoutMainThreadAttachedNodes:nodes ofKind:kind atIndexPaths:indexPaths];
   }
 }
 
@@ -91,7 +91,7 @@
     _pendingIndexPaths[kind] = indexPaths;
     
     // Measure loaded nodes before leaving the main thread
-    [self layoutLoadedNodes:nodes ofKind:kind atIndexPaths:indexPaths];
+    [self layoutMainThreadAttachedNodes:nodes ofKind:kind atIndexPaths:indexPaths];
   }
 }
 
@@ -132,7 +132,7 @@
     _pendingIndexPaths[kind] = indexPaths;
     
     // Measure loaded nodes before leaving the main thread
-    [self layoutLoadedNodes:nodes ofKind:kind atIndexPaths:indexPaths];
+    [self layoutMainThreadAttachedNodes:nodes ofKind:kind atIndexPaths:indexPaths];
   }
 }
 

--- a/AsyncDisplayKit/Details/ASDataController+Subclasses.h
+++ b/AsyncDisplayKit/Details/ASDataController+Subclasses.h
@@ -40,7 +40,7 @@
  * @discussion Once nodes have loaded their views, we can't layout in the background so this is a chance
  * to do so immediately on the main thread.
  */
-- (void)layoutLoadedNodes:(NSArray *)nodes ofKind:(NSString *)kind atIndexPaths:(NSArray *)indexPaths;
+- (void)layoutMainThreadAttachedNodes:(NSArray *)nodes ofKind:(NSString *)kind atIndexPaths:(NSArray *)indexPaths;
 
 /**
  * Provides the size range for a specific node during the layout process.

--- a/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
+++ b/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
@@ -82,6 +82,7 @@ typedef NS_OPTIONS(NSUInteger, ASDisplayNodeMethodOverrides)
     unsigned shouldRasterizeDescendants:1;
     unsigned shouldBypassEnsureDisplay:1;
     unsigned displaySuspended:1;
+    unsigned isRecursivelyDetachedFromMainThread:1;
 
     // whether custom drawing is enabled
     unsigned implementsDrawRect:1;
@@ -131,6 +132,8 @@ typedef NS_OPTIONS(NSUInteger, ASDisplayNodeMethodOverrides)
 
 // Changed before calling willEnterHierarchy / didExitHierarchy.
 @property (nonatomic, readwrite, assign, getter = isInHierarchy) BOOL inHierarchy;
+
+@property (atomic, readwrite, assign, getter=isRecursivelyDetachedFromMainThread) BOOL recursivelyDetachedFromMainThread;
 
 // Private API for helper functions / unit tests.  Use ASDisplayNodeDisableHierarchyNotifications() to control this.
 - (BOOL)__visibilityNotificationsDisabled;

--- a/AsyncDisplayKitTests/ASDisplayNodeTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeTests.m
@@ -1068,6 +1068,33 @@ static inline BOOL _CGPointEqualToPointWithEpsilon(CGPoint point1, CGPoint point
   XCTAssertTrue(didDealloc, @"unexpected node lifetime");
 }
 
+- (void)testAttachedNodeEnteringLeavingHierarchy {
+  ASDisplayNode *parent = [[ASDisplayNode alloc] init];
+  XCTAssertTrue(parent.isRecursivelyDetachedFromMainThread);
+
+  ASDisplayNode *subnode = [[ASDisplayNode alloc] init];
+  [subnode view];
+  XCTAssertFalse(subnode.isRecursivelyDetachedFromMainThread);
+
+  [parent addSubnode:subnode];
+  XCTAssertFalse(parent.isRecursivelyDetachedFromMainThread);
+
+  [subnode removeFromSupernode];
+  XCTAssertTrue(parent.isRecursivelyDetachedFromMainThread);
+}
+
+- (void)testAttachingSubnode {
+  ASDisplayNode *parent = [[ASDisplayNode alloc] init];
+  ASDisplayNode *subnode1 = [[ASDisplayNode alloc] init];
+  ASDisplayNode *subnode2 = [[ASDisplayNode alloc] init];
+  [parent addSubnode:subnode1];
+  [subnode1 addSubnode:subnode2];
+
+  XCTAssertTrue(parent.isRecursivelyDetachedFromMainThread);
+  [subnode2 view];
+  XCTAssertFalse(parent.isRecursivelyDetachedFromMainThread);
+}
+
 - (void)testSubnodes
 {
   ASDisplayNode *parent = [[ASDisplayNode alloc] init];


### PR DESCRIPTION
**Totally WIP**
I've started to mock new property, as discussed in #927, but i'm running in issues, trying to run tests locally. Suddenly `_layer.asyncdisplaykit_node = self;` inside `- (void)_loadViewOrLayerIsLayerBacked:(BOOL)isLayerBacked` crashes with unrecognized selector error. 

Do you have any clues on sources of this issue?