### PR TITLE
Do not round when resolving relative dimensions

### DIFF
--- a/AsyncDisplayKit/Layout/ASDimension.mm
+++ b/AsyncDisplayKit/Layout/ASDimension.mm
@@ -57,7 +57,7 @@ CGFloat ASRelativeDimensionResolve(ASRelativeDimension dimension, CGFloat parent
     case ASRelativeDimensionTypePoints:
       return dimension.value;
     case ASRelativeDimensionTypePercent:
-      return round(dimension.value * parent);
+      return dimension.value * parent;
   }
 }
 


### PR DESCRIPTION
When laying out a node I got to a state where the constrained width was min 132.22222pts and max width was 100%. When resolving the relative size to pts it rounded to 132pt. This caused an assert in ASSizeRangeMake because the min width (132.222pt) was bigger than the max width (132pt)