### PR TITLE
Remove CALayer and UIView implementations of "name" property.

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -685,7 +685,6 @@ typedef NS_OPTIONS(NSUInteger, ASInterfaceState)
  * @param node The node to be added.
  */
 - (void)addSubnode:(ASDisplayNode *)node;
-- (NSString *)name;
 @end
 
 /** CALayer(AsyncDisplayKit) defines convenience method for adding sub-ASDisplayNode to a CALayer. */
@@ -696,7 +695,6 @@ typedef NS_OPTIONS(NSUInteger, ASInterfaceState)
  * @param node The node to be added.
  */
 - (void)addSubnode:(ASDisplayNode *)node;
-- (NSString *)name;
 @end
 
 @interface ASDisplayNode (Deprecated)

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -2279,11 +2279,6 @@ static const char *ASDisplayNodeAssociatedNodeKey = "ASAssociatedNode";
   }
 }
 
-- (NSString *)name
-{
-  return self.asyncdisplaykit_node.name;
-}
-
 @end
 
 @implementation CALayer (AsyncDisplayKit)
@@ -2291,11 +2286,6 @@ static const char *ASDisplayNodeAssociatedNodeKey = "ASAssociatedNode";
 - (void)addSubnode:(ASDisplayNode *)node
 {
   [self addSublayer:node.layer];
-}
-
-- (NSString *)name
-{
-  return self.asyncdisplaykit_node.name;
 }
 
 @end

--- a/AsyncDisplayKitTests/ASDisplayNodeTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeTests.m
@@ -36,11 +36,11 @@ static CALayer *layerWithName(NSString *name) {
 }
 
 static NSString *orderStringFromSublayers(CALayer *l) {
-  return [[l.sublayers valueForKey:@"name"] componentsJoinedByString:@","];
+  return [[[l.sublayers valueForKey:@"asyncdisplaykit_node"] valueForKey:@"name"] componentsJoinedByString:@","];
 }
 
 static NSString *orderStringFromSubviews(UIView *v) {
-  return [[v.subviews valueForKey:@"name"] componentsJoinedByString:@","];
+  return [[[v.subviews valueForKey:@"asyncdisplaykit_node"] valueForKey:@"name"] componentsJoinedByString:@","];
 }
 
 static NSString *orderStringFromSubnodes(ASDisplayNode *n) {


### PR DESCRIPTION
This avoids CoreAnimation from capturing the name from a background thread deep within the internals
of AVPlayerLayer, which commits transactions off the main thread.  If the main thread is also accessing
properties that require the lock, in very specific app architectures relying on AVPlayerLayer, this
can cause a deadlock.

The "name" property is primarily used by ASDK's unit test infrastructure, so I'm leaving it in place for
that purpose - and it may still be used for debugging, if someone wants to set it.  It will remain
possible to get the node from a layer or view with asyncdisplaykit_node, and access name from there.