### PR TITLE
Enable node detection for tableHeaderView and tableFooterView on ASTableView.

### DIFF
--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -532,6 +532,22 @@ static BOOL _isInterceptedSelector(SEL sel)
 #pragma mark -
 #pragma mark Intercepted selectors
 
+- (void)setTableHeaderView:(UIView *)tableHeaderView
+{
+  // Typically the view will be nil before setting it, but reset state if it is being re-hosted.
+  [self.tableHeaderView.asyncdisplaykit_node exitHierarchyState:ASHierarchyStateRangeManaged];
+  [super setTableHeaderView:tableHeaderView];
+  [self.tableHeaderView.asyncdisplaykit_node enterHierarchyState:ASHierarchyStateRangeManaged];
+}
+
+- (void)setTableFooterView:(UIView *)tableFooterView
+{
+  // Typically the view will be nil before setting it, but reset state if it is being re-hosted.
+  [self.tableFooterView.asyncdisplaykit_node exitHierarchyState:ASHierarchyStateRangeManaged];
+  [super setTableFooterView:tableFooterView];
+  [self.tableFooterView.asyncdisplaykit_node enterHierarchyState:ASHierarchyStateRangeManaged];
+}
+
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
 {
   _ASTableViewCell *cell = [self dequeueReusableCellWithIdentifier:kCellReuseIdentifier forIndexPath:indexPath];


### PR DESCRIPTION
Ensure they behave as managed nodes - which prevents them from clearContents-ing
their subnodes when the table reloads, as they will be onscreen as long as the table is.