### PR TITLE
[ASDisplayNode] Automatically find and hook up node hierarchies, even when -addSubview: is used directly.

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -996,13 +996,14 @@ static bool disableNotificationsForMovingBetweenParents(ASDisplayNode *from, ASD
   if (isMovingEquivalentParents) {
     [subnode __incrementVisibilityNotificationsDisabled];
   }
+  
   [subnode removeFromSupernode];
-
+  [oldSubnode removeFromSupernode];
+  
   if (!_subnodes)
     _subnodes = [[NSMutableArray alloc] init];
-
-  [oldSubnode removeFromSupernode];
   [_subnodes insertObject:subnode atIndex:subnodeIndex];
+  [subnode __setSupernode:self];
 
   // Don't bother inserting the view/layer if in a rasterized subtree, because there are no layers in the hierarchy and none of this could possibly work.
   if (!_flags.shouldRasterizeDescendants && [self __shouldLoadViewOrLayer]) {
@@ -1030,8 +1031,6 @@ static bool disableNotificationsForMovingBetweenParents(ASDisplayNode *from, ASD
   if (isMovingEquivalentParents) {
     [subnode __decrementVisibilityNotificationsDisabled];
   }
-
-  [subnode __setSupernode:self];
 }
 
 - (void)replaceSubnode:(ASDisplayNode *)oldSubnode withSubnode:(ASDisplayNode *)replacementSubnode
@@ -1231,7 +1230,7 @@ static NSInteger incrementIfFound(NSInteger i) {
   BOOL shouldRemoveFromSuperviewOrSuperlayer = NO;
   
   if (self.nodeLoaded && _supernode.nodeLoaded) {
-    if (_flags.layerBacked) {
+    if (_flags.layerBacked || _supernode.layerBacked) {
       shouldRemoveFromSuperviewOrSuperlayer = (_layer.superlayer == _supernode.layer);
     } else {
       shouldRemoveFromSuperviewOrSuperlayer = (_view.superview == _supernode.view);

--- a/AsyncDisplayKitTests/ASDisplayNodeTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeTests.m
@@ -1342,9 +1342,12 @@ static inline BOOL _CGPointEqualToPointWithEpsilon(CGPoint point1, CGPoint point
   [parent insertSubnode:c belowSubnode:b];
   XCTAssertEqualObjects(orderStringFromSublayers(parent.layer), @"a,e,d,c,b", @"Didn't match");
 
-  XCTAssertEqual(3u, parent.subnodes.count, @"Should have the right subnode count");
+  XCTAssertEqual(4u, parent.subnodes.count, @"Should have the right subnode count");
   XCTAssertEqual(4u, parent.view.subviews.count, @"Should have the right subview count");
   XCTAssertEqual(5u, parent.layer.sublayers.count, @"Should have the right sublayer count");
+  
+  [e removeFromSuperlayer];
+  XCTAssertEqual(4u, parent.layer.sublayers.count, @"Should have the right sublayer count");
 
   //TODO: assert that things deallocate immediately and don't have latent autoreleases in here
   [parent release];
@@ -1352,6 +1355,7 @@ static inline BOOL _CGPointEqualToPointWithEpsilon(CGPoint point1, CGPoint point
   [b release];
   [c release];
   [d release];
+  [e release];
 }
 
 - (void)testAppleBugInsertSubview
@@ -1415,11 +1419,11 @@ static inline BOOL _CGPointEqualToPointWithEpsilon(CGPoint point1, CGPoint point
   [parent.view insertSubview:d aboveSubview:a.view];
   XCTAssertEqualObjects(orderStringFromSublayers(parent.layer), @"a,d,b", @"Didn't match");
 
-  // (a,e,d,b) => (a,d,>c<,b)
+  // (a,d,b) => (a,d,>c<,b)
   [parent insertSubnode:c belowSubnode:b];
   XCTAssertEqualObjects(orderStringFromSublayers(parent.layer), @"a,d,c,b", @"Didn't match");
 
-  XCTAssertEqual(3u, parent.subnodes.count, @"Should have the right subnode count");
+  XCTAssertEqual(4u, parent.subnodes.count, @"Should have the right subnode count");
   XCTAssertEqual(4u, parent.view.subviews.count, @"Should have the right subview count");
   XCTAssertEqual(4u, parent.layer.sublayers.count, @"Should have the right sublayer count");
 


### PR DESCRIPTION
Improve UIView & CALayer handling of -addSubnode:, and ensure node hierarchies are hooked up even when addSubview: is used directly.

@1nput0utput, could you please test this?  I have already done so with your app and am pretty sure it is the complete fix.  This one was a hell of a hard time to develop.  I tried all combinations of addSubview / addSubnode for both the ingoing and outgoing of the animation (including mismatched ones - going wild over here!)

I did quite a bit of debugging for the flash, but sadly and strangely have not been able to locate it yet.  The contents of the image node is NOT being cleared and the image is NOT re-decoding.  So I think the actual cause is likely that the view controllers are not swapped out in the same runloop or something like that.

Just so you know, the main reason this was so hard is that at the end of the animation you were adding the node back to the KittenNode while the hierarchy that owned the KittenNode (ASTableView etc) itself was not onscreen - its window was considered nil - and so this introduced some trickiness, but I think that is now handled.

I want to make sure the flicker is fixed, but I'm running low on time to debug that specifically.  Could you please take a look at a technique such as marking the other view .hidden or .alpha = 0.0, instead of removing it from the window completely, or at least verify that it is added and in the hierarchy behind the view that is being faded out before the transition starts?