### PR TITLE
[ASDisplayNode] Order-of-magnitude speedup in handling of "disable visibility" notifications.

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -1251,6 +1251,19 @@ static NSInteger incrementIfFound(NSInteger i) {
   }
 }
 
+- (BOOL)__visibilityNotificationsDisabled
+{
+  // Currently, this method is only used by the testing infrastructure to verify this internal feature.
+  ASDN::MutexLocker l(_propertyLock);
+  return _flags.visibilityNotificationsDisabled > 0;
+}
+
+- (BOOL)__selfOrParentHasVisibilityNotificationsDisabled
+{
+  ASDN::MutexLocker l(_propertyLock);
+  return (_hierarchyState & ASHierarchyStateTransitioningSupernodes);
+}
+
 - (void)__incrementVisibilityNotificationsDisabled
 {
   ASDN::MutexLocker l(_propertyLock);
@@ -1280,12 +1293,6 @@ static NSInteger incrementIfFound(NSInteger i) {
     // the ASHierarchyState bit cleared (the only value checked when reading this state).
     [self exitHierarchyState:ASHierarchyStateTransitioningSupernodes];
   }
-}
-
-- (BOOL)__selfOrParentHasVisibilityNotificationsDisabled
-{
-  ASDN::MutexLocker l(_propertyLock);
-  return (_hierarchyState & ASHierarchyStateTransitioningSupernodes);
 }
 
 - (void)__enterHierarchy

--- a/AsyncDisplayKit/Details/ASBasicImageDownloader.h
+++ b/AsyncDisplayKit/Details/ASBasicImageDownloader.h
@@ -16,4 +16,7 @@
 
 + (instancetype)sharedImageDownloader;
 
++ (instancetype)new __attribute__((unavailable("+[ASBasicImageDownloader sharedImageDownloader] must be used.")));
+- (instancetype)init __attribute__((unavailable("+[ASBasicImageDownloader sharedImageDownloader] must be used.")));
+
 @end

--- a/AsyncDisplayKit/Details/ASBasicImageDownloader.mm
+++ b/AsyncDisplayKit/Details/ASBasicImageDownloader.mm
@@ -205,14 +205,14 @@ static const char *kContextKey = NSStringFromClass(ASBasicImageDownloaderContext
   static ASBasicImageDownloader *sharedImageDownloader = nil;
   static dispatch_once_t once = 0;
   dispatch_once(&once, ^{
-    sharedImageDownloader = [[ASBasicImageDownloader alloc] init];
+    sharedImageDownloader = [[ASBasicImageDownloader alloc] _init];
   });
   return sharedImageDownloader;
 }
 
 #pragma mark Lifecycle.
 
-- (instancetype)init
+- (instancetype)_init
 {
   if (!(self = [super init]))
     return nil;

--- a/AsyncDisplayKit/Private/ASDisplayNode+DebugTiming.mm
+++ b/AsyncDisplayKit/Private/ASDisplayNode+DebugTiming.mm
@@ -7,11 +7,9 @@
  */
 
 #import "ASDisplayNode+DebugTiming.h"
-
 #import "ASDisplayNodeInternal.h"
 
 @implementation ASDisplayNode (DebugTiming)
-
 
 #if TIME_DISPLAYNODE_OPS
 - (NSTimeInterval)debugTimeToCreateView
@@ -82,7 +80,5 @@
 }
 
 #endif
-
-
 
 @end

--- a/AsyncDisplayKit/Private/ASDisplayNode+FrameworkPrivate.h
+++ b/AsyncDisplayKit/Private/ASDisplayNode+FrameworkPrivate.h
@@ -37,14 +37,17 @@
 typedef NS_OPTIONS(NSUInteger, ASHierarchyState)
 {
   /** The node may or may not have a supernode, but no supernode has a special hierarchy-influencing option enabled. */
-  ASHierarchyStateNormal       = 0,
+  ASHierarchyStateNormal                  = 0,
   /** The node has a supernode with .shouldRasterizeDescendants = YES.
       Note: the root node of the rasterized subtree (the one with the property set on it) will NOT have this state set. */
-  ASHierarchyStateRasterized   = 1 << 0,
+  ASHierarchyStateRasterized              = 1 << 0,
   /** The node or one of its supernodes is managed by a class like ASRangeController.  Most commonly, these nodes are
       ASCellNode objects or a subnode of one, and are used in ASTableView or ASCollectionView.
       These nodes also recieve regular updates to the .interfaceState property with more detailed status information. */
-  ASHierarchyStateRangeManaged = 1 << 1,
+  ASHierarchyStateRangeManaged            = 1 << 1,
+  /** Down-propogated version of _flags.visibilityNotificationsDisabled.  This flag is very rarely set, but by having it
+      locally available to nodes, they do not have to walk up supernodes at the critical points it is checked. */
+  ASHierarchyStateTransitioningSupernodes = 1 << 2
 };
 
 @interface ASDisplayNode () <_ASDisplayLayerDelegate>

--- a/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
+++ b/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
@@ -135,6 +135,7 @@ typedef NS_OPTIONS(NSUInteger, ASDisplayNodeMethodOverrides)
 
 // Private API for helper functions / unit tests.  Use ASDisplayNodeDisableHierarchyNotifications() to control this.
 - (BOOL)__visibilityNotificationsDisabled;
+- (BOOL)__selfOrParentHasVisibilityNotificationsDisabled;
 - (void)__incrementVisibilityNotificationsDisabled;
 - (void)__decrementVisibilityNotificationsDisabled;
 

--- a/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
+++ b/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
@@ -105,7 +105,6 @@ typedef NS_OPTIONS(NSUInteger, ASDisplayNodeMethodOverrides)
   NSTimeInterval _debugTimeToAddSubnodeViews;
   NSTimeInterval _debugTimeForDidLoad;
 #endif
-
 }
 
 + (void)scheduleNodeForDisplay:(ASDisplayNode *)node;

--- a/AsyncDisplayKitTests/ASBasicImageDownloaderTests.m
+++ b/AsyncDisplayKitTests/ASBasicImageDownloaderTests.m
@@ -16,8 +16,9 @@
 
 @implementation ASBasicImageDownloaderTests
 
-- (void)testAsynchronouslyDownloadTheSameURLTwice {
-    ASBasicImageDownloader *downloader = [ASBasicImageDownloader new];
+- (void)testAsynchronouslyDownloadTheSameURLTwice
+{
+    ASBasicImageDownloader *downloader = [ASBasicImageDownloader sharedImageDownloader];
     
     NSURL *URL = [NSURL URLWithString:@"http://wrongPath/wrongResource.png"];
     

--- a/AsyncDisplayKitTests/ASDisplayNodeAppearanceTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeAppearanceTests.m
@@ -49,6 +49,7 @@ static dispatch_block_t modifyMethodByAddingPrologueBlockAndReturnCleanupBlock(C
 
 @interface ASDisplayNode (PrivateStuffSoWeDontPullInCPPInternalH)
 - (BOOL)__visibilityNotificationsDisabled;
+- (BOOL)__selfOrParentHasVisibilityNotificationsDisabled;
 - (id)initWithViewClass:(Class)viewClass;
 - (id)initWithLayerClass:(Class)layerClass;
 @end
@@ -360,6 +361,7 @@ static UIView *viewWithName(NSString *name) {
   }
   if (useManualDisable) {
     XCTAssertTrue([child __visibilityNotificationsDisabled], @"Should not have re-enabled yet");
+    XCTAssertTrue([child __selfOrParentHasVisibilityNotificationsDisabled], @"Should not have re-enabled yet");
     ASDisplayNodeEnableHierarchyNotifications(child);
   }
 
@@ -377,6 +379,7 @@ static UIView *viewWithName(NSString *name) {
   }
   if (useManualDisable) {
     XCTAssertTrue([child __visibilityNotificationsDisabled], @"Should not have re-enabled yet");
+    XCTAssertTrue([child __selfOrParentHasVisibilityNotificationsDisabled], @"Should not have re-enabled yet");
     ASDisplayNodeEnableHierarchyNotifications(child);
   }
 
@@ -390,6 +393,7 @@ static UIView *viewWithName(NSString *name) {
 
   // Make sure that we don't leave these unbalanced
   XCTAssertFalse([child __visibilityNotificationsDisabled], @"Unbalanced visibility notifications calls");
+  XCTAssertFalse([child __selfOrParentHasVisibilityNotificationsDisabled], @"Should not have re-enabled yet");
 
   [window release];
 }


### PR DESCRIPTION
Before, it was expensive to check this value, even though it was rarely set.
Now the cost is moved to setting the value, and is made very cheap to check with _hierarchyState.