### PR TITLE
ASButtonNode content alignement properties

### DIFF
--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -1523,7 +1523,7 @@
 				058D09B9195D04C000B7D73C /* Frameworks */,
 				058D09BA195D04C000B7D73C /* Resources */,
 				3B9D88CDF51B429C8409E4B6 /* Copy Pods Resources */,
-				1B86F48711505F91D5FEF571 /* Embed Pods Frameworks */,
+				5ADEA7587189397768F2B36C /* Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1666,6 +1666,21 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-AsyncDisplayKitTests/Pods-AsyncDisplayKitTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		5ADEA7587189397768F2B36C /* Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-AsyncDisplayKitTests/Pods-AsyncDisplayKitTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/AsyncDisplayKit/ASButtonNode.h
+++ b/AsyncDisplayKit/ASButtonNode.h
@@ -31,6 +31,17 @@ typedef enum : NSUInteger {
  */
 @property (nonatomic, assign) BOOL laysOutHorizontally;
 
+/** Horizontally align content(text or image).
+ Defaults to ASAlignmentMiddle.
+ */
+@property (nonatomic, assign) ASHorizontalAlignment contentHorizontalAlignment;
+
+/** Vertically align content(text or image).
+ Defaults to ASAlignmentCenter.
+ */
+@property (nonatomic, assign) ASVerticalAlignment contentVerticalAlignment;
+
+
 - (NSAttributedString *)attributedTitleForState:(ASButtonState)state;
 - (void)setAttributedTitle:(NSAttributedString *)title forState:(ASButtonState)state;
 

--- a/AsyncDisplayKit/ASButtonNode.h
+++ b/AsyncDisplayKit/ASButtonNode.h
@@ -31,12 +31,12 @@ typedef enum : NSUInteger {
  */
 @property (nonatomic, assign) BOOL laysOutHorizontally;
 
-/** Horizontally align content(text or image).
+/** Horizontally align content (text or image).
  Defaults to ASAlignmentMiddle.
  */
 @property (nonatomic, assign) ASHorizontalAlignment contentHorizontalAlignment;
 
-/** Vertically align content(text or image).
+/** Vertically align content (text or image).
  Defaults to ASAlignmentCenter.
  */
 @property (nonatomic, assign) ASVerticalAlignment contentVerticalAlignment;

--- a/AsyncDisplayKit/ASButtonNode.mm
+++ b/AsyncDisplayKit/ASButtonNode.mm
@@ -39,6 +39,9 @@
     _titleNode = [[ASTextNode alloc] init];
     _imageNode = [[ASImageNode alloc] init];
     
+    _contentHorizontalAlignment = ASAlignmentMiddle;
+    _contentVerticalAlignment = ASAlignmentCenter;
+    
     [self addSubnode:_titleNode];
     [self addSubnode:_imageNode];
     
@@ -195,8 +198,8 @@
   ASStackLayoutSpec *stack = [[ASStackLayoutSpec alloc] init];
   stack.direction = self.laysOutHorizontally ? ASStackLayoutDirectionHorizontal : ASStackLayoutDirectionVertical;
   stack.spacing = self.contentSpacing;
-  stack.horizontalAlignment = self.contentHorizontalAlignment ? self.contentHorizontalAlignment : ASAlignmentMiddle;
-  stack.verticalAlignment = self.contentVerticalAlignment ? self.contentVerticalAlignment  : ASAlignmentCenter;
+  stack.horizontalAlignment = _contentHorizontalAlignment;
+  stack.verticalAlignment = _contentVerticalAlignment;
   
   NSMutableArray *children = [[NSMutableArray alloc] initWithCapacity:2];
   if (self.imageNode.image) {

--- a/AsyncDisplayKit/ASButtonNode.mm
+++ b/AsyncDisplayKit/ASButtonNode.mm
@@ -195,8 +195,8 @@
   ASStackLayoutSpec *stack = [[ASStackLayoutSpec alloc] init];
   stack.direction = self.laysOutHorizontally ? ASStackLayoutDirectionHorizontal : ASStackLayoutDirectionVertical;
   stack.spacing = self.contentSpacing;
-  stack.justifyContent = ASStackLayoutJustifyContentCenter;
-  stack.alignItems = ASStackLayoutAlignItemsCenter;
+  stack.horizontalAlignment = self.contentHorizontalAlignment ? self.contentHorizontalAlignment : ASAlignmentMiddle;
+  stack.verticalAlignment = self.contentVerticalAlignment ? self.contentVerticalAlignment  : ASAlignmentCenter;
   
   NSMutableArray *children = [[NSMutableArray alloc] initWithCapacity:2];
   if (self.imageNode.image) {


### PR DESCRIPTION
@appleguy This small change allows content alignment like in the UIButton. The reason I had initially implemented this was to align 4 ASButtonNodes with flexBasis set with ASRelativeDimension(type: .Percent, value: 0.25). I simply wanted the ability to align ASButtonNode's content to make my whole view look good. I will create another PR for other behaviours I have in my app.
 
<img width="377" alt="screen shot 2015-12-20 at 9 36 10 pm" src="https://cloud.githubusercontent.com/assets/823899/11922135/d0ca31e8-a761-11e5-8e5d-da9d86838218.png">