### PR TITLE
[ASDisplayNode] Implement recursivelyDetachedFromMainThread to indicate thread affinity state of subtrees.

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -172,6 +172,8 @@ typedef NS_OPTIONS(NSUInteger, ASInterfaceState)
  */
 @property (atomic, readonly, assign, getter=isNodeLoaded) BOOL nodeLoaded;
 
+@property (atomic, readonly, assign, getter=isRecursivelyDetachedFromMainThread) BOOL recursivelyDetachedFromMainThread;
+
 /** 
  * @abstract Returns whether the node rely on a layer instead of a view.
  *

--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -172,6 +172,11 @@ typedef NS_OPTIONS(NSUInteger, ASInterfaceState)
  */
 @property (atomic, readonly, assign, getter=isNodeLoaded) BOOL nodeLoaded;
 
+/**
+ * @abstract Reflects the fact of node and it's subnodes being thread agnostic.
+ *
+ * @return YES if node and it's subnodes hierarchy is safe to manipulate on any thread; NO otherwise.
+ */
 @property (atomic, readonly, assign, getter=isRecursivelyDetachedFromMainThread) BOOL recursivelyDetachedFromMainThread;
 
 /** 

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -1421,7 +1421,7 @@ static NSInteger incrementIfFound(NSInteger i) {
   }
 }
 
-// Check if we still have any detached subnode and
+// Check if we still have any detached subnode and update detachment accordingly
 - (void)__updateMainThreadDetachment {
   BOOL allSubnodesAreDetached = YES;
   for (ASDisplayNode *subnode in _subnodes) {

--- a/AsyncDisplayKit/Details/ASCollectionDataController.mm
+++ b/AsyncDisplayKit/Details/ASCollectionDataController.mm
@@ -49,7 +49,7 @@
     _pendingIndexPaths[kind] = indexPaths;
     
     // Measure loaded nodes before leaving the main thread
-    [self layoutLoadedNodes:nodes ofKind:kind atIndexPaths:indexPaths];
+    [self layoutMainThreadAttachedNodes:nodes ofKind:kind atIndexPaths:indexPaths];
   }
 }
 
@@ -91,7 +91,7 @@
     _pendingIndexPaths[kind] = indexPaths;
     
     // Measure loaded nodes before leaving the main thread
-    [self layoutLoadedNodes:nodes ofKind:kind atIndexPaths:indexPaths];
+    [self layoutMainThreadAttachedNodes:nodes ofKind:kind atIndexPaths:indexPaths];
   }
 }
 
@@ -132,7 +132,7 @@
     _pendingIndexPaths[kind] = indexPaths;
     
     // Measure loaded nodes before leaving the main thread
-    [self layoutLoadedNodes:nodes ofKind:kind atIndexPaths:indexPaths];
+    [self layoutMainThreadAttachedNodes:nodes ofKind:kind atIndexPaths:indexPaths];
   }
 }
 

--- a/AsyncDisplayKit/Details/ASCollectionDataController.mm
+++ b/AsyncDisplayKit/Details/ASCollectionDataController.mm
@@ -47,8 +47,8 @@
     [self _populateSupplementaryNodesOfKind:kind withMutableNodes:nodes mutableIndexPaths:indexPaths];
     _pendingNodes[kind] = nodes;
     _pendingIndexPaths[kind] = indexPaths;
-    
-    // Measure loaded nodes before leaving the main thread
+
+    // Measure main thread attached nodes before leaving the main thread
     [self layoutMainThreadAttachedNodes:nodes ofKind:kind atIndexPaths:indexPaths];
   }
 }
@@ -89,8 +89,8 @@
     [self _populateSupplementaryNodesOfKind:kind withSections:sections mutableNodes:nodes mutableIndexPaths:indexPaths];
     _pendingNodes[kind] = nodes;
     _pendingIndexPaths[kind] = indexPaths;
-    
-    // Measure loaded nodes before leaving the main thread
+
+    // Measure main thread attached nodes before leaving the main thread
     [self layoutMainThreadAttachedNodes:nodes ofKind:kind atIndexPaths:indexPaths];
   }
 }
@@ -131,7 +131,7 @@
     _pendingNodes[kind] = nodes;
     _pendingIndexPaths[kind] = indexPaths;
     
-    // Measure loaded nodes before leaving the main thread
+    // Measure main thread attached nodes before leaving the main thread
     [self layoutMainThreadAttachedNodes:nodes ofKind:kind atIndexPaths:indexPaths];
   }
 }

--- a/AsyncDisplayKit/Details/ASDataController+Subclasses.h
+++ b/AsyncDisplayKit/Details/ASDataController+Subclasses.h
@@ -40,7 +40,7 @@
  * @discussion Once nodes have loaded their views, we can't layout in the background so this is a chance
  * to do so immediately on the main thread.
  */
-- (void)layoutLoadedNodes:(NSArray *)nodes ofKind:(NSString *)kind atIndexPaths:(NSArray *)indexPaths;
+- (void)layoutMainThreadAttachedNodes:(NSArray *)nodes ofKind:(NSString *)kind atIndexPaths:(NSArray *)indexPaths;
 
 /**
  * Provides the size range for a specific node during the layout process.

--- a/AsyncDisplayKit/Details/ASDataController+Subclasses.h
+++ b/AsyncDisplayKit/Details/ASDataController+Subclasses.h
@@ -35,9 +35,9 @@
 - (void)batchLayoutNodes:(NSArray *)nodes ofKind:(NSString *)kind atIndexPaths:(NSArray *)indexPaths completion:(void (^)(NSArray *nodes, NSArray *indexPaths))completionBlock;
 
 /*
- * Perform measurement and layout of loaded nodes on the main thread, skipping unloaded nodes.
+ * Perform measurement and layout of affined nodes on the main thread, skipping thread agnostic nodes.
  *
- * @discussion Once nodes have loaded their views, we can't layout in the background so this is a chance
+ * @discussion Once nodes or any subnodes have loaded their views, we can't layout in the background so this is a chance
  * to do so immediately on the main thread.
  */
 - (void)layoutMainThreadAttachedNodes:(NSArray *)nodes ofKind:(NSString *)kind atIndexPaths:(NSArray *)indexPaths;

--- a/AsyncDisplayKit/Details/ASDataController.mm
+++ b/AsyncDisplayKit/Details/ASDataController.mm
@@ -174,8 +174,8 @@ static void *kASSizingQueueContext = &kASSizingQueueContext;
     dispatch_group_async(layoutGroup, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
       for (NSUInteger k = j; k < j + batchCount; k++) {
         ASCellNode *node = nodes[k];
-        // Only measure nodes whose views aren't loaded, since we're in the background.
-        // We should already have measured loaded nodes before we left the main thread, using layoutMainThreadAttachedNodes:ofKind:atIndexPaths:
+        // Only measure nodes with thread affinity, since we're in the background.
+        // We should already have measured affined nodes before we left the main thread, using layoutMainThreadAttachedNodes:ofKind:atIndexPaths:
         if (node.isRecursivelyDetachedFromMainThread) {
           [self _layoutNode:node withConstrainedSize:nodeBoundSizes[k]];
         }

--- a/AsyncDisplayKit/Details/ASDataController.mm
+++ b/AsyncDisplayKit/Details/ASDataController.mm
@@ -166,7 +166,7 @@ static void *kASSizingQueueContext = &kASSizingQueueContext;
     
     for (NSUInteger k = j; k < j + batchCount; k++) {
       ASCellNode *node = nodes[k];
-      if (!node.isRecursivelyDetachedFromMainThread) {
+      if (node.isRecursivelyDetachedFromMainThread) {
         nodeBoundSizes[k] = [self constrainedSizeForNodeOfKind:kind atIndexPath:indexPaths[k]];
       }
     }

--- a/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
+++ b/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
@@ -82,6 +82,7 @@ typedef NS_OPTIONS(NSUInteger, ASDisplayNodeMethodOverrides)
     unsigned shouldRasterizeDescendants:1;
     unsigned shouldBypassEnsureDisplay:1;
     unsigned displaySuspended:1;
+    unsigned isRecursivelyDetachedFromMainThread:1;
 
     // whether custom drawing is enabled
     unsigned implementsDrawRect:1;
@@ -131,6 +132,8 @@ typedef NS_OPTIONS(NSUInteger, ASDisplayNodeMethodOverrides)
 
 // Changed before calling willEnterHierarchy / didExitHierarchy.
 @property (nonatomic, readwrite, assign, getter = isInHierarchy) BOOL inHierarchy;
+
+@property (atomic, readwrite, assign, getter=isRecursivelyDetachedFromMainThread) BOOL recursivelyDetachedFromMainThread;
 
 // Private API for helper functions / unit tests.  Use ASDisplayNodeDisableHierarchyNotifications() to control this.
 - (BOOL)__visibilityNotificationsDisabled;

--- a/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
+++ b/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
@@ -133,6 +133,7 @@ typedef NS_OPTIONS(NSUInteger, ASDisplayNodeMethodOverrides)
 // Changed before calling willEnterHierarchy / didExitHierarchy.
 @property (nonatomic, readwrite, assign, getter = isInHierarchy) BOOL inHierarchy;
 
+// Used to track the fact of being thread agnostic over subnodes hierarchy
 @property (atomic, readwrite, assign, getter=isRecursivelyDetachedFromMainThread) BOOL recursivelyDetachedFromMainThread;
 
 // Private API for helper functions / unit tests.  Use ASDisplayNodeDisableHierarchyNotifications() to control this.

--- a/AsyncDisplayKitTests/ASDisplayNodeTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeTests.m
@@ -1068,6 +1068,33 @@ static inline BOOL _CGPointEqualToPointWithEpsilon(CGPoint point1, CGPoint point
   XCTAssertTrue(didDealloc, @"unexpected node lifetime");
 }
 
+- (void)testAttachedNodeEnteringLeavingHierarchy {
+  ASDisplayNode *parent = [[ASDisplayNode alloc] init];
+  XCTAssertTrue(parent.isRecursivelyDetachedFromMainThread);
+
+  ASDisplayNode *subnode = [[ASDisplayNode alloc] init];
+  [subnode view];
+  XCTAssertFalse(subnode.isRecursivelyDetachedFromMainThread);
+
+  [parent addSubnode:subnode];
+  XCTAssertFalse(parent.isRecursivelyDetachedFromMainThread);
+
+  [subnode removeFromSupernode];
+  XCTAssertTrue(parent.isRecursivelyDetachedFromMainThread);
+}
+
+- (void)testAttachingSubnode {
+  ASDisplayNode *parent = [[ASDisplayNode alloc] init];
+  ASDisplayNode *subnode1 = [[ASDisplayNode alloc] init];
+  ASDisplayNode *subnode2 = [[ASDisplayNode alloc] init];
+  [parent addSubnode:subnode1];
+  [subnode1 addSubnode:subnode2];
+
+  XCTAssertTrue(parent.isRecursivelyDetachedFromMainThread);
+  [subnode2 view];
+  XCTAssertFalse(parent.isRecursivelyDetachedFromMainThread);
+}
+
 - (void)testSubnodes
 {
   ASDisplayNode *parent = [[ASDisplayNode alloc] init];


### PR DESCRIPTION
I've approached this problem as discussed in #927. 

New property used in data controller to ensure that faced hierarchy of nodes is available to measure on background thread. Effectively `recursivelyDetachedFromMainThread` is opposite of `isNodeLoaded` calculated over hierarchy, but it never becomes detached again after node unloaded, following comment on `view` and `layer` properties.