### PR TITLE
[ASDisplayNode] Add delegate to ASDisplayNode, allowing ASViewController layout

### DIFF
--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -273,6 +273,7 @@
 		92DD2FE81BF4D0A80074C9DD /* ASMapNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 92DD2FE11BF4B97E0074C9DD /* ASMapNode.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		92DD2FE91BF4D4870074C9DD /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 92DD2FE51BF4D05E0074C9DD /* MapKit.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		92DD2FEA1BF4D49B0074C9DD /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 92DD2FE51BF4D05E0074C9DD /* MapKit.framework */; };
+		9B40BB671C4AEAE30074F2FE /* ASDisplayNodeLayoutTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9B40BB661C4AEAE30074F2FE /* ASDisplayNodeLayoutTests.m */; };
 		9B92C8851BC2EB6E00EE46B2 /* ASCollectionDataController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 251B8EF31BBB3D690087C538 /* ASCollectionDataController.mm */; };
 		9B92C8861BC2EB7600EE46B2 /* ASCollectionViewFlowLayoutInspector.m in Sources */ = {isa = PBXBuildFile; fileRef = 251B8EF51BBB3D690087C538 /* ASCollectionViewFlowLayoutInspector.m */; };
 		9C49C36F1B853957000B0DD5 /* ASStackLayoutable.h in Headers */ = {isa = PBXBuildFile; fileRef = 9C49C36E1B853957000B0DD5 /* ASStackLayoutable.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -699,6 +700,7 @@
 		92DD2FE11BF4B97E0074C9DD /* ASMapNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASMapNode.h; sourceTree = "<group>"; };
 		92DD2FE21BF4B97E0074C9DD /* ASMapNode.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASMapNode.mm; sourceTree = "<group>"; };
 		92DD2FE51BF4D05E0074C9DD /* MapKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MapKit.framework; path = System/Library/Frameworks/MapKit.framework; sourceTree = SDKROOT; };
+		9B40BB661C4AEAE30074F2FE /* ASDisplayNodeLayoutTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASDisplayNodeLayoutTests.m; sourceTree = "<group>"; };
 		9C49C36E1B853957000B0DD5 /* ASStackLayoutable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASStackLayoutable.h; path = AsyncDisplayKit/Layout/ASStackLayoutable.h; sourceTree = "<group>"; };
 		9C5586671BD549CB00B50E3A /* ASAsciiArtBoxCreator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASAsciiArtBoxCreator.h; path = AsyncDisplayKit/Layout/ASAsciiArtBoxCreator.h; sourceTree = "<group>"; };
 		9C5586681BD549CB00B50E3A /* ASAsciiArtBoxCreator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ASAsciiArtBoxCreator.m; path = AsyncDisplayKit/Layout/ASAsciiArtBoxCreator.m; sourceTree = "<group>"; };
@@ -966,6 +968,7 @@
 		058D09C5195D04C000B7D73C /* AsyncDisplayKitTests */ = {
 			isa = PBXGroup;
 			children = (
+				9B40BB661C4AEAE30074F2FE /* ASDisplayNodeLayoutTests.m */,
 				057D02C01AC0A66700C7AC3C /* AsyncDisplayKitTestHost */,
 				056D21501ABCEDA1001107EF /* ASSnapshotTestCase.h */,
 				05EA6FE61AC0966E00E35788 /* ASSnapshotTestCase.mm */,
@@ -1828,6 +1831,7 @@
 				ACF6ED611B178DC700DA7C62 /* ASOverlayLayoutSpecSnapshotTests.mm in Sources */,
 				ACF6ED621B178DC700DA7C62 /* ASRatioLayoutSpecSnapshotTests.mm in Sources */,
 				254C6B541BF8FF2A003EC431 /* ASTextKitTests.mm in Sources */,
+				9B40BB671C4AEAE30074F2FE /* ASDisplayNodeLayoutTests.m in Sources */,
 				05EA6FE71AC0966E00E35788 /* ASSnapshotTestCase.mm in Sources */,
 				ACF6ED631B178DC700DA7C62 /* ASStackLayoutSpecSnapshotTests.mm in Sources */,
 				3C9C128519E616EF00E942A0 /* ASTableViewTests.m in Sources */,

--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -214,7 +214,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) ASInterfaceState interfaceState;
 
 /**
- * @abstract The display node's delegate object.
+ * @abstract The display node's delegate for handling interface operations (ie. external layout, layoutSpec definition).
  */
 @property (nonatomic, weak) id<ASDisplayNodeInterfaceDelegate> interfaceDelegate;
 

--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -72,7 +72,7 @@ typedef NS_OPTIONS(NSUInteger, ASInterfaceState)
 
 - (ASLayout * _Nullable)displayNode:(ASDisplayNode * _Nonnull)displayNode layoutThatFits:(ASSizeRange)constrainedSize;
 
-- (ASLayoutSpec * _Nonnull)displayNode:(ASDisplayNode * _Nonnull)displayNode layoutSpecThatFits:(ASSizeRange)constrainedSize;
+- (ASLayoutSpec * _Nullable)displayNode:(ASDisplayNode * _Nonnull)displayNode layoutSpecThatFits:(ASSizeRange)constrainedSize;
 
 @end
 

--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -66,13 +66,13 @@ typedef NS_OPTIONS(NSUInteger, ASInterfaceState)
   ASInterfaceStateInHierarchy   = ASInterfaceStateMeasureLayout | ASInterfaceStateFetchData | ASInterfaceStateDisplay | ASInterfaceStateVisible,
 };
 
-@protocol ASDisplayNodeDelegate <NSObject>
+@protocol ASDisplayNodeInterfaceDelegate <NSObject>
 
 @optional
 
-- (ASLayout *)displayNode:(ASDisplayNode *)displayNode layoutThatFits:(ASSizeRange)constrainedSize;
+- (ASLayout * _Nullable)displayNode:(ASDisplayNode * _Nonnull)displayNode layoutThatFits:(ASSizeRange)constrainedSize;
 
-- (ASLayoutSpec *)displayNode:(ASDisplayNode *)displayNode layoutSpecThatFits:(ASSizeRange)constrainedSize;
+- (ASLayoutSpec * _Nonnull)displayNode:(ASDisplayNode * _Nonnull)displayNode layoutSpecThatFits:(ASSizeRange)constrainedSize;
 
 @end
 
@@ -216,7 +216,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * @abstract The display node's delegate object.
  */
-@property (nonatomic, weak) id<ASDisplayNodeDelegate> delegate;
+@property (nonatomic, weak) id<ASDisplayNodeInterfaceDelegate> interfaceDelegate;
 
 /** @name Managing dimensions */
 

--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -66,6 +66,16 @@ typedef NS_OPTIONS(NSUInteger, ASInterfaceState)
   ASInterfaceStateInHierarchy   = ASInterfaceStateMeasureLayout | ASInterfaceStateFetchData | ASInterfaceStateDisplay | ASInterfaceStateVisible,
 };
 
+@protocol ASDisplayNodeDelegate <NSObject>
+
+@optional
+
+- (ASLayout *)displayNode:(ASDisplayNode *)displayNode layoutThatFits:(ASSizeRange)constrainedSize;
+
+- (ASLayoutSpec *)displayNode:(ASDisplayNode *)displayNode layoutSpecThatFits:(ASSizeRange)constrainedSize;
+
+@end
+
 /**
  * An `ASDisplayNode` is an abstraction over `UIView` and `CALayer` that allows you to perform calculations about a view
  * hierarchy off the main thread, and could do rendering off the main thread as well.
@@ -203,6 +213,10 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, readonly) ASInterfaceState interfaceState;
 
+/**
+ * @abstract The display node's delegate object.
+ */
+@property (nonatomic, weak) id<ASDisplayNodeDelegate> delegate;
 
 /** @name Managing dimensions */
 

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -591,8 +591,8 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   //  - we haven't already
   //  - the constrained size range is different
   if (!_flags.isMeasured || !ASSizeRangeEqualToSizeRange(constrainedSize, _constrainedSize)) {
-    if (_flags.delegateImplementsLayout) {
-      _layout = [self.delegate displayNode:self layoutThatFits:constrainedSize];
+    if (_flags.interfaceDelegateImplementsLayout) {
+      _layout = [self.interfaceDelegate displayNode:self layoutThatFits:constrainedSize];
     }
     
     // When the delegate doesn't handle creating the layout, use the default behavior
@@ -1595,8 +1595,8 @@ static BOOL ShouldUseNewRenderingRange = NO;
   ASLayoutSpec *layoutSpec;
   if (_methodOverrides & ASDisplayNodeMethodOverrideLayoutSpecThatFits) {
     layoutSpec = [self layoutSpecThatFits:constrainedSize];
-  } else if (_flags.delegateImplementsLayoutSpec) {
-    layoutSpec = [self.delegate displayNode:self layoutSpecThatFits:constrainedSize];
+  } else if (_flags.interfaceDelegateImplementsLayoutSpec) {
+    layoutSpec = [self.interfaceDelegate displayNode:self layoutSpecThatFits:constrainedSize];
   }
   
   if (layoutSpec) {
@@ -1957,11 +1957,11 @@ static BOOL ShouldUseNewRenderingRange = NO;
   });
 }
 
-- (void)setDelegate:(id<ASDisplayNodeDelegate>)delegate
+- (void)setInterfaceDelegate:(id<ASDisplayNodeInterfaceDelegate>)interfaceDelegate
 {
-  _delegate = delegate;
-  _flags.delegateImplementsLayout = [delegate respondsToSelector:@selector(displayNode:layoutThatFits:)] ? 1 : 0;
-  _flags.delegateImplementsLayoutSpec = [delegate respondsToSelector:@selector(displayNode:layoutSpecThatFits:)] ? 1 : 0;
+  _interfaceDelegate = interfaceDelegate;
+  _flags.interfaceDelegateImplementsLayout = [interfaceDelegate respondsToSelector:@selector(displayNode:layoutThatFits:)] ? 1 : 0;
+  _flags.interfaceDelegateImplementsLayoutSpec = [interfaceDelegate respondsToSelector:@selector(displayNode:layoutSpecThatFits:)] ? 1 : 0;
 }
 
 - (void)layout

--- a/AsyncDisplayKit/ASEditableTextNode.h
+++ b/AsyncDisplayKit/ASEditableTextNode.h
@@ -19,7 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ASEditableTextNode : ASDisplayNode
 
 // @abstract The text node's delegate, which must conform to the <ASEditableTextNodeDelegate> protocol.
-@property (nonatomic, weak) id <ASEditableTextNodeDelegate, ASDisplayNodeDelegate> delegate;
+@property (nonatomic, readwrite, weak) id <ASEditableTextNodeDelegate> delegate;
 
 #pragma mark - Configuration
 

--- a/AsyncDisplayKit/ASEditableTextNode.h
+++ b/AsyncDisplayKit/ASEditableTextNode.h
@@ -19,7 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ASEditableTextNode : ASDisplayNode
 
 // @abstract The text node's delegate, which must conform to the <ASEditableTextNodeDelegate> protocol.
-@property (nonatomic, readwrite, weak) id <ASEditableTextNodeDelegate> delegate;
+@property (nonatomic, weak) id <ASEditableTextNodeDelegate, ASDisplayNodeDelegate> delegate;
 
 #pragma mark - Configuration
 

--- a/AsyncDisplayKit/ASViewController.h
+++ b/AsyncDisplayKit/ASViewController.h
@@ -24,12 +24,10 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, readonly) ASInterfaceState interfaceState;
 
-
 // AsyncDisplayKit 2.0 BETA: This property is still being tested, but it allows
 // blocking as a view controller becomes visible to ensure no placeholders flash onscreen.
 // Refer to examples/SynchronousConcurrency, AsyncViewController.m
 @property (nonatomic, assign) BOOL neverShowPlaceholders;
-
 
 /**
  * The constrained size used to measure the backing node.
@@ -39,6 +37,10 @@ NS_ASSUME_NONNULL_BEGIN
  * backing node.
  */
 - (ASSizeRange)nodeConstrainedSize;
+
+- (ASLayout *)layoutThatFits:(ASSizeRange)constrainedSize;
+
+- (ASLayoutSpec *)layoutSpecThatFits:(ASSizeRange)constrainedSize;
 
 @end
 

--- a/AsyncDisplayKit/ASViewController.m
+++ b/AsyncDisplayKit/ASViewController.m
@@ -11,7 +11,7 @@
 #import "ASDimension.h"
 #import "ASDisplayNode+FrameworkPrivate.h"
 
-@interface ASViewController () <ASDisplayNodeDelegate> {
+@interface ASViewController () <ASDisplayNodeInterfaceDelegate> {
   BOOL _ensureDisplayed;
 }
 
@@ -40,7 +40,7 @@
   ASDisplayNodeAssertNotNil(node, @"Node must not be nil");
   ASDisplayNodeAssertTrue(!node.layerBacked);
   _node = node;
-  node.delegate = self;
+  node.interfaceDelegate = self;
   
   return self;
 }

--- a/AsyncDisplayKit/ASViewController.m
+++ b/AsyncDisplayKit/ASViewController.m
@@ -11,10 +11,13 @@
 #import "ASDimension.h"
 #import "ASDisplayNode+FrameworkPrivate.h"
 
-@implementation ASViewController
-{
+@interface ASViewController () <ASDisplayNodeDelegate> {
   BOOL _ensureDisplayed;
 }
+
+@end
+
+@implementation ASViewController
 
 - (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
 {
@@ -37,6 +40,7 @@
   ASDisplayNodeAssertNotNil(node, @"Node must not be nil");
   ASDisplayNodeAssertTrue(!node.layerBacked);
   _node = node;
+  node.delegate = self;
   
   return self;
 }
@@ -80,6 +84,28 @@
 - (ASInterfaceState)interfaceState
 {
   return _node.interfaceState;
+}
+
+- (ASLayout *)layoutThatFits:(ASSizeRange)constrainedSize
+{
+  return nil;
+}
+
+- (ASLayoutSpec *)layoutSpecThatFits:(ASSizeRange)constrainedSize
+{
+  return nil;
+}
+
+#pragma mark - ASDisplayNodeDelegate
+
+- (ASLayout *)displayNode:(ASDisplayNode *)displayNode layoutThatFits:(ASSizeRange)constrainedSize
+{
+  return [self layoutThatFits:constrainedSize];
+}
+
+- (ASLayoutSpec *)displayNode:(ASDisplayNode *)displayNode layoutSpecThatFits:(ASSizeRange)constrainedSize
+{
+  return [self layoutSpecThatFits:constrainedSize];
 }
 
 @end

--- a/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
+++ b/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
@@ -89,6 +89,10 @@ typedef NS_OPTIONS(NSUInteger, ASDisplayNodeMethodOverrides)
     unsigned implementsDrawRect:1;
     unsigned implementsImageDisplay:1;
     unsigned implementsDrawParameters:1;
+    
+    // delegate implementations
+    unsigned delegateImplementsLayout:1;
+    unsigned delegateImplementsLayoutSpec:1;
 
     // internal state
     unsigned isMeasured:1;

--- a/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
+++ b/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
@@ -90,9 +90,9 @@ typedef NS_OPTIONS(NSUInteger, ASDisplayNodeMethodOverrides)
     unsigned implementsImageDisplay:1;
     unsigned implementsDrawParameters:1;
     
-    // delegate implementations
-    unsigned delegateImplementsLayout:1;
-    unsigned delegateImplementsLayoutSpec:1;
+    // interface delegate implementations
+    unsigned interfaceDelegateImplementsLayout:1;
+    unsigned interfaceDelegateImplementsLayoutSpec:1;
 
     // internal state
     unsigned isMeasured:1;

--- a/AsyncDisplayKitTests/ASDisplayNodeLayoutTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeLayoutTests.m
@@ -1,0 +1,91 @@
+//
+//  ASDisplayNodeLayoutTests.m
+//  AsyncDisplayKit
+//
+//  Created by Levi McCallum on 1/16/16.
+//  Copyright © 2016 Facebook. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+#import <AsyncDisplayKit/AsyncDisplayKit.h>
+
+@interface _ASInterfaceHelper : NSObject <ASDisplayNodeInterfaceDelegate>
+
+@property (copy, nonatomic, nullable) ASLayout * _Nullable (^layoutThatFits)(ASSizeRange constrainedSize);
+@property (copy, nonatomic, nullable) ASLayoutSpec * _Nullable (^layoutSpecThatFits)(ASSizeRange constrainedSize);
+
+@end
+
+@implementation _ASInterfaceHelper
+
+- (ASLayout * _Nullable)displayNode:(ASDisplayNode * _Nonnull)displayNode layoutThatFits:(ASSizeRange)constrainedSize
+{
+  return self.layoutThatFits ? self.layoutThatFits(constrainedSize) : nil;
+}
+
+- (ASLayoutSpec * _Nullable)displayNode:(ASDisplayNode * _Nonnull)displayNode layoutSpecThatFits:(ASSizeRange)constrainedSize
+{
+  return self.layoutSpecThatFits ? self.layoutSpecThatFits(constrainedSize) : nil;
+}
+
+@end
+
+@interface ASDisplayNodeLayoutTests : XCTestCase
+
+@property (strong, nonatomic, nonnull) _ASInterfaceHelper *interfaceHelper;
+
+@end
+
+@implementation ASDisplayNodeLayoutTests
+
+- (void)setUp {
+  [super setUp];
+  self.interfaceHelper = [[_ASInterfaceHelper alloc] init];
+}
+
+- (void)tearDown {
+  [super tearDown];
+}
+
+- (void)testLayoutFromInterfaceDelegate
+{
+  ASDisplayNode *node = [[ASDisplayNode alloc] init];
+  node.interfaceDelegate = self.interfaceHelper;
+  self.interfaceHelper.layoutThatFits = ^ ASLayout * _Nullable (ASSizeRange constrainedSize) {
+    return [ASLayout layoutWithLayoutableObject:node size:constrainedSize.max];
+  };
+  [node measureWithSizeRange:ASSizeRangeMake(CGSizeMake(1000.0, 1000.0), CGSizeMake(1000.0, 1000.0))];
+  XCTAssertEqual(node.calculatedSize.height, 1000.0, @"should equal the calculated height of the layout spec");
+  XCTAssertEqual(node.calculatedSize.width, 1000.0, @"should equal the calculated width of the layout spec");
+}
+
+- (void)testLayoutSpecFromInterfaceDelegate
+{
+  self.interfaceHelper.layoutSpecThatFits = ^ ASLayoutSpec * _Nullable (ASSizeRange constrainedSize) {
+    return [[ASStaticLayoutSpec alloc] init];
+  };
+  ASDisplayNode *node = [[ASDisplayNode alloc] init];
+  node.interfaceDelegate = self.interfaceHelper;
+  [node measureWithSizeRange:ASSizeRangeMake(CGSizeMake(1000.0, 1000.0), CGSizeMake(1000.0, 1000.0))];
+  XCTAssertEqual(node.calculatedSize.height, 1000.0, @"should equal the calculated height of the layout spec");
+  XCTAssertEqual(node.calculatedSize.width, 1000.0, @"should equal the calculated width of the layout spec");
+}
+
+- (void)testLayoutFromInterfaceDelegateOverride
+{
+  ASDisplayNode *node = [[ASDisplayNode alloc] init];
+  node.interfaceDelegate = self.interfaceHelper;
+  XCTestExpectation *expectation = [self expectationWithDescription:@"should default to the layout implementation when both are implemented"];
+  self.interfaceHelper.layoutThatFits = ^ ASLayout * _Nullable (ASSizeRange constrainedSize) {
+    [expectation fulfill];
+    return [ASLayout layoutWithLayoutableObject:node size:constrainedSize.max];
+  };
+  self.interfaceHelper.layoutSpecThatFits = ^ ASLayoutSpec * _Nullable (ASSizeRange constrainedSize) {
+    return [[ASStaticLayoutSpec alloc] init];
+  };
+  [node measureWithSizeRange:ASSizeRangeMake(CGSizeMake(1000.0, 1000.0), CGSizeMake(1000.0, 1000.0))];
+  [self waitForExpectationsWithTimeout:10.0 handler:nil];
+}
+
+@end

--- a/examples/SynchronousConcurrency/Sample.xcodeproj/project.pbxproj
+++ b/examples/SynchronousConcurrency/Sample.xcodeproj/project.pbxproj
@@ -11,7 +11,7 @@
 		05E2128719D4DB510098F589 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 05E2128619D4DB510098F589 /* main.m */; };
 		05E2128A19D4DB510098F589 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 05E2128919D4DB510098F589 /* AppDelegate.m */; };
 		05E2128D19D4DB510098F589 /* AsyncTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 05E2128C19D4DB510098F589 /* AsyncTableViewController.m */; };
-		18748FDB1BB727B20053A9C1 /* AsyncViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 18748FDA1BB727B20053A9C1 /* AsyncViewController.m */; settings = {ASSET_TAGS = (); }; };
+		18748FDB1BB727B20053A9C1 /* AsyncViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 18748FDA1BB727B20053A9C1 /* AsyncViewController.m */; };
 		18C2ED861B9B8CE700F627B3 /* RandomCoreGraphicsNode.m in Sources */ = {isa = PBXBuildFile; fileRef = 18C2ED851B9B8CE700F627B3 /* RandomCoreGraphicsNode.m */; };
 		3EC0CDCBA10D483D9F386E5E /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D24B17D1E4A4E7A9566C5E9 /* libPods.a */; };
 		6C2C82AC19EE274300767484 /* Default-667h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6C2C82AA19EE274300767484 /* Default-667h@2x.png */; };
@@ -144,7 +144,7 @@
 		05E2127919D4DB510098F589 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0600;
+				LastUpgradeCheck = 0720;
 				ORGANIZATIONNAME = Facebook;
 				TargetAttributes = {
 					05E2128019D4DB510098F589 = {
@@ -252,6 +252,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -316,6 +317,7 @@
 				INFOPLIST_FILE = Sample/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.facebook.AsyncDisplayKit.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -329,6 +331,7 @@
 				INFOPLIST_FILE = Sample/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.facebook.AsyncDisplayKit.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/examples/SynchronousConcurrency/Sample.xcodeproj/xcshareddata/xcschemes/Sample.xcscheme
+++ b/examples/SynchronousConcurrency/Sample.xcodeproj/xcshareddata/xcschemes/Sample.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0620"
+   LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -23,10 +23,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
       <MacroExpansion>
@@ -38,15 +38,18 @@
             ReferencedContainer = "container:Sample.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
@@ -62,10 +65,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/examples/SynchronousConcurrency/Sample.xcworkspace/contents.xcworkspacedata
+++ b/examples/SynchronousConcurrency/Sample.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:Sample.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/examples/SynchronousConcurrency/Sample/AsyncViewController.m
+++ b/examples/SynchronousConcurrency/Sample/AsyncViewController.m
@@ -9,13 +9,21 @@
 #import "AsyncViewController.h"
 #import "RandomCoreGraphicsNode.h"
 
-@implementation AsyncViewController
+@implementation AsyncViewController {
+  ASTextNode *_textNode;
+}
 
 - (instancetype)init
 {
   if (!(self = [super initWithNode:[[RandomCoreGraphicsNode alloc] init]])) {
     return nil;
   }
+  
+  _textNode = [[ASTextNode alloc] init];
+  _textNode.placeholderEnabled = NO;
+  _textNode.attributedString = [[NSAttributedString alloc] initWithString:@"Hello, ASDK!"
+                                                               attributes:[self _textStyle]];
+  [self.node addSubnode:_textNode];
 
   self.neverShowPlaceholders = YES;
   self.tabBarItem = [[UITabBarItem alloc] initWithTabBarSystemItem:UITabBarSystemItemFavorites tag:0];
@@ -32,6 +40,23 @@
 {
   [self.node recursivelyClearContents];
   [super viewDidDisappear:animated];
+}
+
+- (ASLayoutSpec *)layoutSpecThatFits:(ASSizeRange)constrainedSize
+{
+  return [ASCenterLayoutSpec centerLayoutSpecWithCenteringOptions:ASCenterLayoutSpecCenteringXY sizingOptions:ASCenterLayoutSpecSizingOptionDefault child:_textNode];
+}
+
+- (NSDictionary *)_textStyle
+{
+  UIFont *font = [UIFont fontWithName:@"HelveticaNeue" size:36.0f];
+  
+  NSMutableParagraphStyle *style = [[NSParagraphStyle defaultParagraphStyle] mutableCopy];
+  style.paragraphSpacing = 0.5 * font.lineHeight;
+  style.hyphenationFactor = 1.0;
+  
+  return @{ NSFontAttributeName: font,
+            NSParagraphStyleAttributeName: style };
 }
 
 @end

--- a/examples/SynchronousConcurrency/Sample/Info.plist
+++ b/examples/SynchronousConcurrency/Sample/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.facebook.AsyncDisplayKit.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/examples/SynchronousConcurrency/Sample/RandomCoreGraphicsNode.h
+++ b/examples/SynchronousConcurrency/Sample/RandomCoreGraphicsNode.h
@@ -9,8 +9,5 @@
 #import <AsyncDisplayKit/AsyncDisplayKit.h>
 
 @interface RandomCoreGraphicsNode : ASCellNode
-{
-  ASTextNode *_textNode;
-}
 
 @end

--- a/examples/SynchronousConcurrency/Sample/RandomCoreGraphicsNode.m
+++ b/examples/SynchronousConcurrency/Sample/RandomCoreGraphicsNode.m
@@ -46,48 +46,4 @@
   return [self description];
 }
 
-- (NSDictionary *)textStyle
-{
-  UIFont *font = [UIFont fontWithName:@"HelveticaNeue" size:36.0f];
-  
-  NSMutableParagraphStyle *style = [[NSParagraphStyle defaultParagraphStyle] mutableCopy];
-  style.paragraphSpacing = 0.5 * font.lineHeight;
-  style.hyphenationFactor = 1.0;
-  
-  return @{ NSFontAttributeName: font,
-            NSParagraphStyleAttributeName: style };
-}
-
-- (instancetype)init
-{
-  if (!(self = [super init])) {
-    return nil;
-  }
-  
-  _textNode = [[ASTextNode alloc] init];
-  _textNode.placeholderEnabled = NO;
-  _textNode.attributedString = [[NSAttributedString alloc] initWithString:@"Hello, ASDK!"
-                                                               attributes:[self textStyle]];
-  [self addSubnode:_textNode];
-  
-  return self;
-}
-
-- (CGSize)calculateSizeThatFits:(CGSize)constrainedSize
-{
-  [_textNode measure:constrainedSize];
-  return CGSizeMake(constrainedSize.width, 100);
-}
-
-- (void)layout
-{
-  CGSize boundsSize = self.bounds.size;
-  CGSize textSize = _textNode.calculatedSize;
-  CGRect textRect = CGRectMake(roundf((boundsSize.width - textSize.width) / 2.0),
-                               roundf((boundsSize.height - textSize.height) / 2.0),
-                               textSize.width,
-                               textSize.height);
-  _textNode.frame = textRect;
-}
-
 @end


### PR DESCRIPTION
Sketching out an initial direction of exposing layout and layout spec definition in an ASViewController. Introduced a `delegate` property on ASDisplayNode that allows external layout calculation, similar to the CALayer delegate design.

Note that this is currently not building, as we have a delegate property on a few display node subclasses which will need to inherit `ASDisplayNodeDelegate`. I wanted to put this up for feedback/discussion before I head too far down the road of bringing the other classes up to speed. Moreover, would like to include a few unit tests for this patch.

Fixes #969.