### PR TITLE
New ASDelegateProxy class to unify logic for Table & Collection forwarding.  Fix dealloc-during-animation crash.

### DIFF
--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -461,6 +461,10 @@
 		DE040EF91C2B40AC004692FF /* ASCollectionViewFlowLayoutInspector.h in Headers */ = {isa = PBXBuildFile; fileRef = 251B8EF41BBB3D690087C538 /* ASCollectionViewFlowLayoutInspector.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DE6EA3221C14000600183B10 /* ASDisplayNode+FrameworkPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = DE6EA3211C14000600183B10 /* ASDisplayNode+FrameworkPrivate.h */; };
 		DE6EA3231C14000600183B10 /* ASDisplayNode+FrameworkPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = DE6EA3211C14000600183B10 /* ASDisplayNode+FrameworkPrivate.h */; };
+		DEC447B51C2B9DBC00C8CBD1 /* ASDelegateProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = DEC447B31C2B9DBC00C8CBD1 /* ASDelegateProxy.h */; };
+		DEC447B61C2B9DBC00C8CBD1 /* ASDelegateProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = DEC447B31C2B9DBC00C8CBD1 /* ASDelegateProxy.h */; };
+		DEC447B71C2B9DBC00C8CBD1 /* ASDelegateProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = DEC447B41C2B9DBC00C8CBD1 /* ASDelegateProxy.m */; };
+		DEC447B81C2B9DBC00C8CBD1 /* ASDelegateProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = DEC447B41C2B9DBC00C8CBD1 /* ASDelegateProxy.m */; };
 		DECBD6E71BE56E1900CF4905 /* ASButtonNode.h in Headers */ = {isa = PBXBuildFile; fileRef = DECBD6E51BE56E1900CF4905 /* ASButtonNode.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DECBD6E81BE56E1900CF4905 /* ASButtonNode.h in Headers */ = {isa = PBXBuildFile; fileRef = DECBD6E51BE56E1900CF4905 /* ASButtonNode.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DECBD6E91BE56E1900CF4905 /* ASButtonNode.mm in Sources */ = {isa = PBXBuildFile; fileRef = DECBD6E61BE56E1900CF4905 /* ASButtonNode.mm */; };
@@ -754,6 +758,8 @@
 		D785F6601A74327E00291744 /* ASScrollNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASScrollNode.h; sourceTree = "<group>"; };
 		D785F6611A74327E00291744 /* ASScrollNode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASScrollNode.m; sourceTree = "<group>"; };
 		DE6EA3211C14000600183B10 /* ASDisplayNode+FrameworkPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ASDisplayNode+FrameworkPrivate.h"; sourceTree = "<group>"; };
+		DEC447B31C2B9DBC00C8CBD1 /* ASDelegateProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASDelegateProxy.h; sourceTree = "<group>"; };
+		DEC447B41C2B9DBC00C8CBD1 /* ASDelegateProxy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASDelegateProxy.m; sourceTree = "<group>"; };
 		DECBD6E51BE56E1900CF4905 /* ASButtonNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASButtonNode.h; sourceTree = "<group>"; };
 		DECBD6E61BE56E1900CF4905 /* ASButtonNode.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASButtonNode.mm; sourceTree = "<group>"; };
 		EFA731F0396842FF8AB635EE /* libPods-AsyncDisplayKitTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-AsyncDisplayKitTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1149,6 +1155,8 @@
 		25B171EA1C12242700508A7A /* Data Controller */ = {
 			isa = PBXGroup;
 			children = (
+				DEC447B31C2B9DBC00C8CBD1 /* ASDelegateProxy.h */,
+				DEC447B41C2B9DBC00C8CBD1 /* ASDelegateProxy.m */,
 				251B8EF21BBB3D690087C538 /* ASCollectionDataController.h */,
 				251B8EF31BBB3D690087C538 /* ASCollectionDataController.mm */,
 				464052191A3F83C40061C0BA /* ASDataController.h */,
@@ -1264,6 +1272,7 @@
 				18C2ED7E1B9B7DE800F627B3 /* ASCollectionNode.h in Headers */,
 				257754C01BEE458E00737CA5 /* ASTextNodeWordKerner.h in Headers */,
 				AC3C4A511A1139C100143C57 /* ASCollectionView.h in Headers */,
+				DEC447B51C2B9DBC00C8CBD1 /* ASDelegateProxy.h in Headers */,
 				205F0E1D1B373A2C007741D0 /* ASCollectionViewLayoutController.h in Headers */,
 				AC3C4A541A113EEC00143C57 /* ASCollectionViewProtocols.h in Headers */,
 				058D0A49195D05CB00B7D73C /* ASControlNode+Subclasses.h in Headers */,
@@ -1432,6 +1441,7 @@
 				34EFC7791B701D3600AD841F /* ASLayoutSpecUtilities.h in Headers */,
 				B350625C1B010F070018CF92 /* ASLog.h in Headers */,
 				0442850E1BAA64EC00D16268 /* ASMultidimensionalArrayUtils.h in Headers */,
+				DEC447B61C2B9DBC00C8CBD1 /* ASDelegateProxy.h in Headers */,
 				B35062041B010EFD0018CF92 /* ASMultiplexImageNode.h in Headers */,
 				DECBD6E81BE56E1900CF4905 /* ASButtonNode.h in Headers */,
 				B35062241B010EFD0018CF92 /* ASMutableAttributedStringBuilder.h in Headers */,
@@ -1687,6 +1697,7 @@
 				0549634A1A1EA066000F8E56 /* ASBasicImageDownloader.mm in Sources */,
 				299DA1AA1A828D2900162D41 /* ASBatchContext.mm in Sources */,
 				AC6456091B0A335000CF11B8 /* ASCellNode.m in Sources */,
+				DEC447B71C2B9DBC00C8CBD1 /* ASDelegateProxy.m in Sources */,
 				ACF6ED1D1B17843500DA7C62 /* ASCenterLayoutSpec.mm in Sources */,
 				18C2ED801B9B7DE800F627B3 /* ASCollectionNode.m in Sources */,
 				92DD2FE41BF4B97E0074C9DD /* ASMapNode.mm in Sources */,
@@ -1816,6 +1827,7 @@
 				509E68621B3AEDA5009B9150 /* ASAbstractLayoutController.mm in Sources */,
 				254C6B861BF94F8A003EC431 /* ASTextKitContext.mm in Sources */,
 				34EFC7621B701CA400AD841F /* ASBackgroundLayoutSpec.mm in Sources */,
+				DEC447B81C2B9DBC00C8CBD1 /* ASDelegateProxy.m in Sources */,
 				B35062141B010EFD0018CF92 /* ASBasicImageDownloader.mm in Sources */,
 				B35062161B010EFD0018CF92 /* ASBatchContext.mm in Sources */,
 				AC47D9421B3B891B00AAEE9D /* ASCellNode.m in Sources */,

--- a/AsyncDisplayKit.xcworkspace/contents.xcworkspacedata
+++ b/AsyncDisplayKit.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,12 @@
 <Workspace
    version = "1.0">
    <FileRef
+      location = "group:AsyncDisplayKit/Details/ASDelegateProxy.h">
+   </FileRef>
+   <FileRef
+      location = "group:AsyncDisplayKit/Details/ASDelegateProxy.m">
+   </FileRef>
+   <FileRef
       location = "group:AsyncDisplayKit.xcodeproj">
    </FileRef>
    <FileRef

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -184,10 +184,8 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
 {
   // Sometimes the UIKit classes can call back to their delegate even during deallocation, due to animation completion blocks etc.
   _isDeallocating = YES;
-  NSLog(@"before dealloc - delegate - %@, datasource - %@, proxyDelegate - %@, proxyDatasource - %@", self.asyncDelegate, self.asyncDataSource, _proxyDelegate, _proxyDataSource);
   [self setAsyncDelegate:nil];
   [self setAsyncDataSource:nil];
-  NSLog(@"after dealloc - delegate - %@, datasource - %@, proxyDelegate - %@, proxyDatasource - %@", self.asyncDelegate, self.asyncDataSource, _proxyDelegate, _proxyDataSource);
 }
 
 /**
@@ -269,8 +267,6 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
     _asyncDataSourceImplementsConstrainedSizeForNode = ([_asyncDataSource respondsToSelector:@selector(collectionView:constrainedSizeForNodeAtIndexPath:)] ? 1 : 0);
   }
   
-  NSLog(@"setAsyncDataSource - %@, proxy - %@, deallocating - %d", asyncDataSource, _proxyDataSource, _isDeallocating);
-  
   super.dataSource = (id<UICollectionViewDataSource>)_proxyDataSource;
 }
 
@@ -295,9 +291,7 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
     _proxyDelegate = [[ASCollectionViewProxy alloc] initWithTarget:_asyncDelegate interceptor:self];
     _asyncDelegateImplementsInsetSection = ([_asyncDelegate respondsToSelector:@selector(collectionView:layout:insetForSectionAtIndex:)] ? 1 : 0);
   }
-  
-  NSLog(@"setAsyncDelegate - %@, proxy - %@, deallocating - %d", asyncDelegate, _proxyDelegate, _isDeallocating);
-  
+    
   super.delegate = (id<UICollectionViewDelegate>)_proxyDelegate;
   
   [_layoutInspector didChangeCollectionViewDelegate:asyncDelegate];

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -184,8 +184,10 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
 {
   // Sometimes the UIKit classes can call back to their delegate even during deallocation, due to animation completion blocks etc.
   _isDeallocating = YES;
+  NSLog(@"before dealloc - delegate - %@, datasource - %@, proxyDelegate - %@, proxyDatasource - %@", self.asyncDelegate, self.asyncDataSource, _proxyDelegate, _proxyDataSource);
   [self setAsyncDelegate:nil];
   [self setAsyncDataSource:nil];
+  NSLog(@"after dealloc - delegate - %@, datasource - %@, proxyDelegate - %@, proxyDatasource - %@", self.asyncDelegate, self.asyncDataSource, _proxyDelegate, _proxyDataSource);
 }
 
 /**
@@ -267,6 +269,8 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
     _asyncDataSourceImplementsConstrainedSizeForNode = ([_asyncDataSource respondsToSelector:@selector(collectionView:constrainedSizeForNodeAtIndexPath:)] ? 1 : 0);
   }
   
+  NSLog(@"setAsyncDataSource - %@, proxy - %@, deallocating - %d", asyncDataSource, _proxyDataSource, _isDeallocating);
+  
   super.dataSource = (id<UICollectionViewDataSource>)_proxyDataSource;
 }
 
@@ -291,6 +295,8 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
     _proxyDelegate = [[ASCollectionViewProxy alloc] initWithTarget:_asyncDelegate interceptor:self];
     _asyncDelegateImplementsInsetSection = ([_asyncDelegate respondsToSelector:@selector(collectionView:layout:insetForSectionAtIndex:)] ? 1 : 0);
   }
+  
+  NSLog(@"setAsyncDelegate - %@, proxy - %@, deallocating - %d", asyncDelegate, _proxyDelegate, _isDeallocating);
   
   super.delegate = (id<UICollectionViewDelegate>)_proxyDelegate;
   

--- a/AsyncDisplayKit/Details/ASDelegateProxy.h
+++ b/AsyncDisplayKit/Details/ASDelegateProxy.h
@@ -1,0 +1,51 @@
+/* Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Foundation/Foundation.h>
+
+@class ASDelegateProxy;
+@protocol ASDelegateProxyInterceptor
+@required
+// Called if the target object is discovered to be nil if it had been non-nil at init time.
+// This happens if the object is deallocated, because the proxy must maintain a weak reference to avoid cycles.
+// Though the target object may become nil, the interceptor must not; it is assumed the interceptor owns the proxy.
+- (void)proxyTargetHasDeallocated:(ASDelegateProxy *)proxy;
+@end
+
+/**
+ * Stand-in for delegates like UITableView or UICollectionView's delegate / dataSource.
+ * Any selectors flagged by "interceptsSelector" are routed to the interceptor object and are not delivered to the target.
+ * Everything else leaves AsyncDisplayKit safely and arrives at the original target object.
+ */
+
+@interface ASDelegateProxy : NSProxy
+
+- (instancetype)initWithTarget:(id<NSObject>)target interceptor:(id <ASDelegateProxyInterceptor>)interceptor;
+
+// This method must be overridden by a subclass.
+- (BOOL)interceptsSelector:(SEL)selector;
+
+@end
+
+/**
+ * ASTableView intercepts and/or overrides a few of UITableView's critical data source and delegate methods.
+ *
+ * Any selector included in this function *MUST* be implemented by ASTableView.
+ */
+
+@interface ASTableViewProxy : ASDelegateProxy
+@end
+
+/**
+ * ASCollectionView intercepts and/or overrides a few of UICollectionView's critical data source and delegate methods.
+ *
+ * Any selector included in this function *MUST* be implemented by ASCollectionView.
+ */
+
+@interface ASCollectionViewProxy : ASDelegateProxy
+@end

--- a/AsyncDisplayKit/Details/ASDelegateProxy.m
+++ b/AsyncDisplayKit/Details/ASDelegateProxy.m
@@ -1,0 +1,117 @@
+/* Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "ASDelegateProxy.h"
+#import "ASTableView.h"
+#import "ASCollectionView.h"
+#import "ASAssert.h"
+
+@implementation ASTableViewProxy
+
+- (BOOL)interceptsSelector:(SEL)selector
+{
+  return (
+          // handled by ASTableView node<->cell machinery
+          selector == @selector(tableView:cellForRowAtIndexPath:) ||
+          selector == @selector(tableView:heightForRowAtIndexPath:) ||
+          
+          // handled by ASRangeController
+          selector == @selector(numberOfSectionsInTableView:) ||
+          selector == @selector(tableView:numberOfRowsInSection:) ||
+          
+          // used for ASRangeController visibility updates
+          selector == @selector(tableView:willDisplayCell:forRowAtIndexPath:) ||
+          selector == @selector(tableView:didEndDisplayingCell:forRowAtIndexPath:) ||
+          
+          // used for batch fetching API
+          selector == @selector(scrollViewWillEndDragging:withVelocity:targetContentOffset:)
+          );
+}
+
+@end
+
+@implementation ASCollectionViewProxy
+
+- (BOOL)interceptsSelector:(SEL)selector
+{
+  return (
+          // handled by ASCollectionView node<->cell machinery
+          selector == @selector(collectionView:cellForItemAtIndexPath:) ||
+          selector == @selector(collectionView:layout:sizeForItemAtIndexPath:) ||
+          selector == @selector(collectionView:viewForSupplementaryElementOfKind:atIndexPath:) ||
+          
+          // handled by ASRangeController
+          selector == @selector(numberOfSectionsInCollectionView:) ||
+          selector == @selector(collectionView:numberOfItemsInSection:) ||
+          
+          // used for ASRangeController visibility updates
+          selector == @selector(collectionView:willDisplayCell:forItemAtIndexPath:) ||
+          selector == @selector(collectionView:didEndDisplayingCell:forItemAtIndexPath:) ||
+          
+          // used for batch fetching API
+          selector == @selector(scrollViewWillEndDragging:withVelocity:targetContentOffset:)
+          );
+}
+
+@end
+
+@implementation ASDelegateProxy {
+  id <NSObject> __weak _target;
+  id <ASDelegateProxyInterceptor> __weak _interceptor;
+}
+
+- (instancetype)initWithTarget:(id <NSObject>)target interceptor:(id <ASDelegateProxyInterceptor>)interceptor
+{
+  // -[NSProxy init] is undefined
+  if (!self) {
+    return nil;
+  }
+  
+  ASDisplayNodeAssert(interceptor, @"interceptor must not be nil");
+  
+  _target = target ? : [NSNull null];
+  _interceptor = interceptor;
+  
+  return self;
+}
+
+- (BOOL)respondsToSelector:(SEL)aSelector
+{
+  ASDisplayNodeAssert(_interceptor, @"interceptor must not be nil");
+  
+  if ([self interceptsSelector:aSelector]) {
+    return YES;
+  } else {
+    // Also return NO if _target has become nil due to zeroing weak reference (or placeholder initialization).
+    return [_target respondsToSelector:aSelector];
+  }
+}
+
+- (id)forwardingTargetForSelector:(SEL)aSelector
+{
+  ASDisplayNodeAssert(_interceptor, @"interceptor must not be nil");
+  
+  if ([self interceptsSelector:aSelector]) {
+    return _interceptor;
+  } else {
+    if (_target) {
+      return [_target respondsToSelector:aSelector] ? _target : nil;
+    } else {
+      [_interceptor proxyTargetHasDeallocated:self];
+      return nil;
+    }
+  }
+}
+
+- (BOOL)interceptsSelector:(SEL)selector
+{
+  ASDisplayNodeAssert(NO, @"This method must be overridden by subclasses.");
+  return NO;
+}
+
+@end

--- a/AsyncDisplayKit/Details/ASDelegateProxy.m
+++ b/AsyncDisplayKit/Details/ASDelegateProxy.m
@@ -82,10 +82,8 @@
 
 - (BOOL)respondsToSelector:(SEL)aSelector
 {
-  ASDisplayNodeAssert(_interceptor, @"interceptor must not be nil");
-  
   if ([self interceptsSelector:aSelector]) {
-    return YES;
+    return (_interceptor != nil);
   } else {
     // Also return NO if _target has become nil due to zeroing weak reference (or placeholder initialization).
     return [_target respondsToSelector:aSelector];
@@ -94,8 +92,6 @@
 
 - (id)forwardingTargetForSelector:(SEL)aSelector
 {
-  ASDisplayNodeAssert(_interceptor, @"interceptor must not be nil");
-  
   if ([self interceptsSelector:aSelector]) {
     return _interceptor;
   } else {

--- a/AsyncDisplayKitTests/ASBasicImageDownloaderTests.m
+++ b/AsyncDisplayKitTests/ASBasicImageDownloaderTests.m
@@ -11,45 +11,38 @@
 #import <AsyncDisplayKit/ASBasicImageDownloader.h>
 
 // Z in the name to delay running until after the test instance is operating normally.
-@interface ASZBasicImageDownloaderTests : XCTestCase
+@interface ASBasicImageDownloaderTests : XCTestCase
 
 @end
 
-@implementation ASZBasicImageDownloaderTests
+@implementation ASBasicImageDownloaderTests
 
 - (void)testAsynchronouslyDownloadTheSameURLTwice
 {
     ASBasicImageDownloader *downloader = [ASBasicImageDownloader sharedImageDownloader];
     
     NSURL *URL = [NSURL URLWithString:@"http://wrongPath/wrongResource.png"];
-    
-    dispatch_group_t group = dispatch_group_create();
-    
+  
     __block BOOL firstDone = NO;
     
-    dispatch_group_enter(group);
     [downloader downloadImageWithURL:URL
                        callbackQueue:dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)
                downloadProgressBlock:nil
                           completion:^(CGImageRef image, NSError *error) {
                               firstDone = YES;
-                              dispatch_group_leave(group);
                           }];
     
     __block BOOL secondDone = NO;
     
-    dispatch_group_enter(group);
     [downloader downloadImageWithURL:URL
                        callbackQueue:dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)
                downloadProgressBlock:nil
                           completion:^(CGImageRef image, NSError *error) {
                               secondDone = YES;
-                              dispatch_group_leave(group);
                           }];
-    
-    XCTAssert(0 == dispatch_group_wait(group, dispatch_time(0, 10 * 1000000000)), @"URL loading takes too long");
-    
-    XCTAssert(firstDone && secondDone, @"Not all handlers has been called");
+  
+    sleep(3);
+    XCTAssert(firstDone && secondDone, @"Not all ASBasicImageDownloader completion handlers have been called after 3 seconds");
 }
 
 @end

--- a/examples/ASCollectionView/Sample.xcodeproj/project.pbxproj
+++ b/examples/ASCollectionView/Sample.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		AC3C4A6A1A11F47200143C57 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = AC3C4A691A11F47200143C57 /* ViewController.m */; };
 		AC3C4A8E1A11F80C00143C57 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AC3C4A8D1A11F80C00143C57 /* Images.xcassets */; };
 		FABD6D156A3EB118497E5CE6 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F02BAF78E68BC56FD8C161B7 /* libPods.a */; };
+		FC3FCA801C2B1564009F6D6D /* PresentingViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FC3FCA7F1C2B1564009F6D6D /* PresentingViewController.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -34,6 +35,8 @@
 		AC3C4A8D1A11F80C00143C57 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		CD1ABB23007FEDB31D8C1978 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
 		F02BAF78E68BC56FD8C161B7 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		FC3FCA7E1C2B1564009F6D6D /* PresentingViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PresentingViewController.h; sourceTree = "<group>"; };
+		FC3FCA7F1C2B1564009F6D6D /* PresentingViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PresentingViewController.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -82,6 +85,8 @@
 				AC3C4A661A11F47200143C57 /* AppDelegate.m */,
 				AC3C4A681A11F47200143C57 /* ViewController.h */,
 				AC3C4A691A11F47200143C57 /* ViewController.m */,
+				FC3FCA7E1C2B1564009F6D6D /* PresentingViewController.h */,
+				FC3FCA7F1C2B1564009F6D6D /* PresentingViewController.m */,
 				AC3C4A8D1A11F80C00143C57 /* Images.xcassets */,
 				AC3C4A611A11F47200143C57 /* Supporting Files */,
 				9B92C87F1BC17D3000EE46B2 /* SupplementaryNode.h */,
@@ -125,7 +130,6 @@
 				AC3C4A5B1A11F47200143C57 /* Frameworks */,
 				AC3C4A5C1A11F47200143C57 /* Resources */,
 				A6902C454C7661D0D277AC62 /* Copy Pods Resources */,
-				EC37EEC9933F5786936BFE7C /* Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -196,21 +200,6 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		EC37EEC9933F5786936BFE7C /* Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		F868CFBB21824CC9521B6588 /* Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -236,6 +225,7 @@
 				25FDEC921BF31EE700CEB123 /* ItemNode.m in Sources */,
 				AC3C4A6A1A11F47200143C57 /* ViewController.m in Sources */,
 				9B92C8811BC17D3000EE46B2 /* SupplementaryNode.m in Sources */,
+				FC3FCA801C2B1564009F6D6D /* PresentingViewController.m in Sources */,
 				AC3C4A671A11F47200143C57 /* AppDelegate.m in Sources */,
 				AC3C4A641A11F47200143C57 /* main.m in Sources */,
 			);

--- a/examples/ASCollectionView/Sample.xcworkspace/contents.xcworkspacedata
+++ b/examples/ASCollectionView/Sample.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:Sample.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/examples/ASCollectionView/Sample/AppDelegate.h
+++ b/examples/ASCollectionView/Sample/AppDelegate.h
@@ -11,6 +11,8 @@
 
 #import <UIKit/UIKit.h>
 
+#define SIMULATE_WEB_RESPONSE 0
+
 @interface AppDelegate : UIResponder <UIApplicationDelegate>
 
 @property (strong, nonatomic) UIWindow *window;

--- a/examples/ASCollectionView/Sample/AppDelegate.m
+++ b/examples/ASCollectionView/Sample/AppDelegate.m
@@ -11,6 +11,7 @@
 
 #import "AppDelegate.h"
 
+#import "PresentingViewController.h"
 #import "ViewController.h"
 
 @implementation AppDelegate
@@ -31,10 +32,14 @@
 - (void)pushNewViewControllerAnimated:(BOOL)animated
 {
   UINavigationController *navController = (UINavigationController *)self.window.rootViewController;
-  
+
+#if SIMULATE_WEB_RESPONSE
+  UIViewController *viewController = [[PresentingViewController alloc] init];
+#else
   UIViewController *viewController = [[ViewController alloc] init];
   viewController.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@"Push Another Copy" style:UIBarButtonItemStylePlain target:self action:@selector(pushNewViewController)];
-
+#endif
+  
   [navController pushViewController:viewController animated:animated];
 }
 

--- a/examples/ASCollectionView/Sample/PresentingViewController.h
+++ b/examples/ASCollectionView/Sample/PresentingViewController.h
@@ -1,0 +1,13 @@
+//
+//  PresentingViewController.h
+//  Sample
+//
+//  Created by Tom King on 12/23/15.
+//  Copyright © 2015 Facebook. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface PresentingViewController : UIViewController
+
+@end

--- a/examples/ASCollectionView/Sample/PresentingViewController.m
+++ b/examples/ASCollectionView/Sample/PresentingViewController.m
@@ -1,0 +1,30 @@
+//
+//  PresentingViewController.m
+//  Sample
+//
+//  Created by Tom King on 12/23/15.
+//  Copyright © 2015 Facebook. All rights reserved.
+//
+
+#import "PresentingViewController.h"
+#import "ViewController.h"
+
+@interface PresentingViewController ()
+
+@end
+
+@implementation PresentingViewController
+
+- (void)viewDidLoad
+{
+  [super viewDidLoad];
+  self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@"Push Details" style:UIBarButtonItemStylePlain target:self action:@selector(pushNewViewController)];
+}
+
+- (void)pushNewViewController
+{
+  ViewController *controller = [[ViewController alloc] init];
+  [self.navigationController pushViewController:controller animated:true];
+}
+
+@end


### PR DESCRIPTION
In addition to being a nice cleanly refactoring, this should resolve the task from @tomizimobile - https://github.com/facebook/AsyncDisplayKit/issues/982

It also supersedes / integrates the work from @RuiAAPeres to ensure that both ASTableView and ASCollectionView can run without any delegate set on them, since those protocols are technically optional (though very commonly used).  That is to say, this diff replaces https://github.com/facebook/AsyncDisplayKit/pull/960