### PR TITLE
Fix an issue, ASNetworkImageNode can't load image from bundle via NSURL.

### DIFF
--- a/AsyncDisplayKit/ASNetworkImageNode.mm
+++ b/AsyncDisplayKit/ASNetworkImageNode.mm
@@ -191,7 +191,7 @@
           _imageLoaded = YES;
 
           if (self.shouldCacheImage) {
-            self.image = [UIImage imageNamed:_URL.path];
+            self.image = [UIImage imageNamed:[_URL.path stringByReplacingOccurrencesOfString:@"/" withString:@""]];
           } else {
             self.image = [UIImage imageWithContentsOfFile:_URL.path];
           }


### PR DESCRIPTION
Issue report and PR.

If only provide a file URL to ASNetworkImageNode.URL, it will not load the bundle image.
But if you deliver an UIImage to ASNetworkImgaeNode, that's not good.
The problem is, imageNode shouldCacheImage default values is true, but [UIImage imageNamed:_URL.path] requires an pure file name without any other characters.
See ASNetworkImageNode.mm:194, that's the issue code. If you use ASNetworkImageNode.mm:195 code, the issue solved.
This issue can be found at [https://github.com/PonyCui/AsyncDisplayKit/tree/ASNetworkImageNode-BundleImageIssue](https://github.com/PonyCui/AsyncDisplayKit/tree/ASNetworkImageNode-BundleImageIssue) branch, examples/ASNetworkImageNode-BundleImageIssue directory.