### PR TITLE
Supplementary nodes must be added to the completed nodes after their measurement completes.

### DIFF
--- a/examples/CustomCollectionView/Sample/ViewController.m
+++ b/examples/CustomCollectionView/Sample/ViewController.m
@@ -101,11 +101,13 @@ static NSUInteger kNumberOfImages = 14;
   return [[SupplementaryNode alloc] initWithText:text];
 }
 
-- (NSInteger)numberOfSectionsInCollectionView:(UICollectionView *)collectionView {
+- (NSInteger)numberOfSectionsInCollectionView:(UICollectionView *)collectionView
+{
   return _sections.count;
 }
 
-- (NSInteger)collectionView:(UICollectionView *)collectionView numberOfItemsInSection:(NSInteger)section {
+- (NSInteger)collectionView:(UICollectionView *)collectionView numberOfItemsInSection:(NSInteger)section
+{
   return [_sections[section] count];
 }
 


### PR DESCRIPTION
This only occurs after reloading individual sections (not inserting them, or reloading everything).

Thank you @wieseljonas for reporting this in https://github.com/facebook/AsyncDisplayKit/issues/986 - and providing a test case modification to CustomCollectionView.  It is the only way I was able to fix this for 1.9.4, and I think this just about wraps up the release.