### PR TITLE
[ASDisplayNode] Preserve contents after non-range-managed nodes are removed from superviews or windows.

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -1775,18 +1775,22 @@ static BOOL ShouldUseNewRenderingRange = NO;
     if (newState & ASInterfaceStateFetchData) {
       [self fetchData];
     } else {
-      [self clearFetchedData];
+      if ([self supportsRangeManagedInterfaceState]) {
+        [self clearFetchedData];
+      }
     }
   }
 
   // Entered or exited contents rendering state.
   if ((newState & ASInterfaceStateDisplay) != (oldState & ASInterfaceStateDisplay)) {
-    if (newState & ASInterfaceStateDisplay) {
-      // Once the working window is eliminated (ASRangeHandlerRender), trigger display directly here.
-      [self setDisplaySuspended:NO];
-    } else {
-      [self setDisplaySuspended:YES];
-      [self clearContents];
+    if ([self supportsRangeManagedInterfaceState]) {
+      if (newState & ASInterfaceStateDisplay) {
+        // Once the working window is eliminated (ASRangeHandlerRender), trigger display directly here.
+        [self setDisplaySuspended:NO];
+      } else {
+        [self setDisplaySuspended:YES];
+        [self clearContents];
+      }
     }
   }
 

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -1770,6 +1770,10 @@ static BOOL ShouldUseNewRenderingRange = NO;
     // Trigger asynchronous measurement if it is not already cached or being calculated.
   }
   
+  // For the FetchData and Display ranges, we don't want to call -clear* if not being managed by a range controller.
+  // Otherwise we get flashing behavior from normal UIKit manipulations like navigation controller push / pop.
+  // Still, the interfaceState should be updated to the current state of the node; just don't act on the transition.
+  
   // Entered or exited data loading state.
   if ((newState & ASInterfaceStateFetchData) != (oldState & ASInterfaceStateFetchData)) {
     if (newState & ASInterfaceStateFetchData) {

--- a/AsyncDisplayKitTests/ASDisplayNodeTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeTests.m
@@ -1702,7 +1702,11 @@ static inline BOOL _CGPointEqualToPointWithEpsilon(CGPoint point1, CGPoint point
   XCTAssert(node.interfaceState == ASInterfaceStateInHierarchy);
 
   [node.view removeFromSuperview];
-  XCTAssert(!node.hasFetchedData);
+  // We don't want to call -clearFetchedData on nodes that aren't being managed by a range controller.
+  // Otherwise we get flashing behavior from normal UIKit manipulations like navigation controller push / pop.
+  // Still, the interfaceState should be None to reflect the current state of the node.
+  // We just don't proactively clear contents or fetched data for this state transition.
+  XCTAssert(node.hasFetchedData);
   XCTAssert(node.interfaceState == ASInterfaceStateNone);
 }
 


### PR DESCRIPTION
This behavior changed in 1.9.3 and introduced flickering in some cases.  Preserving the contents is closer to UIKit behavior.

Thank you @tuyuan2012 for reporting this in https://github.com/facebook/AsyncDisplayKit/issues/991, and providing a test project that made it easier to fix in the most correct way!  @Adlai-Holler, heads up regarding this behavior - I think you may have been expecting it to clear the contents here, so make sure your app calls -clearFetchedData and/or -clearContents manually if so.  I am thinking of other ways to refine this behavior in the future, such as suspending updates to interfaceState in certain situations and then un-suspending them to apply a pending state.