### PR TITLE
Bridge UITableViewCell pointInside to ASNodeCell

### DIFF
--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -75,6 +75,10 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
   _node.highlighted = highlighted;
 }
 
+- (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event {
+    return [_node pointInside:point withEvent:event];
+}
+
 @end
 
 #pragma mark -

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -75,8 +75,9 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
   _node.highlighted = highlighted;
 }
 
-- (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event {
-    return [_node pointInside:point withEvent:event];
+- (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event
+{
+  return [_node pointInside:point withEvent:event];
 }
 
 @end


### PR DESCRIPTION
Allow ASNodeCell to specify pointInside of UITableViewCell.
This is very usefull, if ASNodeCell is presented as bubble aligned to
left or right (like Messages.app) and we need to be able to select row
only if user taps on bubble.