### PR TITLE
[ASDisplayNode] Allow UIKit / CA Bridged Properties to Always Be Writeable On Background Threads

### DIFF
--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -451,6 +451,10 @@
 		B350625F1B0111800018CF92 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 058D09AF195D04C000B7D73C /* Foundation.framework */; };
 		C78F7E2A1BF7808300CDEAFC /* ASTableNode.m in Sources */ = {isa = PBXBuildFile; fileRef = B0F880591BEAEC7500D17647 /* ASTableNode.m */; };
 		C78F7E2B1BF7809800CDEAFC /* ASTableNode.h in Headers */ = {isa = PBXBuildFile; fileRef = B0F880581BEAEC7500D17647 /* ASTableNode.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CC4CA2D91C2F73AE003D381F /* ASMainQueueTransaction.h in Headers */ = {isa = PBXBuildFile; fileRef = CC4CA2D71C2F73AE003D381F /* ASMainQueueTransaction.h */; };
+		CC4CA2DA1C2F73AE003D381F /* ASMainQueueTransaction.h in Headers */ = {isa = PBXBuildFile; fileRef = CC4CA2D71C2F73AE003D381F /* ASMainQueueTransaction.h */; };
+		CC4CA2DB1C2F73AE003D381F /* ASMainQueueTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = CC4CA2D81C2F73AE003D381F /* ASMainQueueTransaction.m */; };
+		CC4CA2DC1C2F73AE003D381F /* ASMainQueueTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = CC4CA2D81C2F73AE003D381F /* ASMainQueueTransaction.m */; };
 		CC7FD9DE1BB5E962005CCB2B /* ASPhotosFrameworkImageRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = CC7FD9DC1BB5E962005CCB2B /* ASPhotosFrameworkImageRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CC7FD9DF1BB5E962005CCB2B /* ASPhotosFrameworkImageRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = CC7FD9DD1BB5E962005CCB2B /* ASPhotosFrameworkImageRequest.m */; };
 		CC7FD9E11BB5F750005CCB2B /* ASPhotosFrameworkImageRequestTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CC7FD9E01BB5F750005CCB2B /* ASPhotosFrameworkImageRequestTests.m */; };
@@ -751,6 +755,8 @@
 		B0F880591BEAEC7500D17647 /* ASTableNode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASTableNode.m; sourceTree = "<group>"; };
 		B35061DA1B010EDF0018CF92 /* AsyncDisplayKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AsyncDisplayKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B35061DD1B010EDF0018CF92 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = "../AsyncDisplayKit-iOS/Info.plist"; sourceTree = "<group>"; };
+		CC4CA2D71C2F73AE003D381F /* ASMainQueueTransaction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASMainQueueTransaction.h; sourceTree = "<group>"; };
+		CC4CA2D81C2F73AE003D381F /* ASMainQueueTransaction.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASMainQueueTransaction.m; sourceTree = "<group>"; };
 		CC7FD9DC1BB5E962005CCB2B /* ASPhotosFrameworkImageRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASPhotosFrameworkImageRequest.h; sourceTree = "<group>"; };
 		CC7FD9DD1BB5E962005CCB2B /* ASPhotosFrameworkImageRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASPhotosFrameworkImageRequest.m; sourceTree = "<group>"; };
 		CC7FD9E01BB5F750005CCB2B /* ASPhotosFrameworkImageRequestTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASPhotosFrameworkImageRequestTests.m; sourceTree = "<group>"; };
@@ -965,6 +971,7 @@
 				058D0A2D195D057000B7D73C /* ASDisplayLayerTests.m */,
 				058D0A2E195D057000B7D73C /* ASDisplayNodeAppearanceTests.m */,
 				058D0A2F195D057000B7D73C /* ASDisplayNodeTests.m */,
+				CC4CA2D51C2F55F1003D381F /* ASDisplayNodeUIKitPropertiesTests.m */,
 				058D0A30195D057000B7D73C /* ASDisplayNodeTestsHelper.h */,
 				058D0A31195D057000B7D73C /* ASDisplayNodeTestsHelper.m */,
 				052EE0651A159FEF002C6279 /* ASMultiplexImageNodeTests.m */,
@@ -1068,6 +1075,8 @@
 		058D0A01195D050800B7D73C /* Private */ = {
 			isa = PBXGroup;
 			children = (
+				CC4CA2D71C2F73AE003D381F /* ASMainQueueTransaction.h */,
+				CC4CA2D81C2F73AE003D381F /* ASMainQueueTransaction.m */,
 				AC026B6D1BD57DBF00BBC17E /* _ASHierarchyChangeSet.h */,
 				AC026B6E1BD57DBF00BBC17E /* _ASHierarchyChangeSet.m */,
 				9C65A7291BA8EA4D0084DA91 /* ASLayoutOptionsPrivate.h */,
@@ -1306,6 +1315,7 @@
 				ACF6ED221B17843500DA7C62 /* ASInsetLayoutSpec.h in Headers */,
 				ACF6ED4B1B17847A00DA7C62 /* ASInternalHelpers.h in Headers */,
 				ACF6ED241B17843500DA7C62 /* ASLayout.h in Headers */,
+				CC4CA2D91C2F73AE003D381F /* ASMainQueueTransaction.h in Headers */,
 				251B8EFB1BBB3D690087C538 /* ASDataController+Subclasses.h in Headers */,
 				ACF6ED2A1B17843500DA7C62 /* ASLayoutable.h in Headers */,
 				9CDC18CC1B910E12004965E2 /* ASLayoutablePrivate.h in Headers */,
@@ -1443,6 +1453,7 @@
 				0442850E1BAA64EC00D16268 /* ASMultidimensionalArrayUtils.h in Headers */,
 				DE8BEAC21C2DF3FC00D57C12 /* ASDelegateProxy.h in Headers */,
 				B35062041B010EFD0018CF92 /* ASMultiplexImageNode.h in Headers */,
+				CC4CA2DA1C2F73AE003D381F /* ASMainQueueTransaction.h in Headers */,
 				DECBD6E81BE56E1900CF4905 /* ASButtonNode.h in Headers */,
 				B35062241B010EFD0018CF92 /* ASMutableAttributedStringBuilder.h in Headers */,
 				B35062061B010EFD0018CF92 /* ASNetworkImageNode.h in Headers */,
@@ -1763,6 +1774,7 @@
 				ACC945AB1BA9E7C1005E1FB8 /* ASViewController.m in Sources */,
 				B0F8805B1BEAEC7500D17647 /* ASTableNode.m in Sources */,
 				205F0E221B376416007741D0 /* CGRect+ASConvenience.m in Sources */,
+				CC4CA2DB1C2F73AE003D381F /* ASMainQueueTransaction.m in Sources */,
 				257754B21BEE44CD00737CA5 /* ASTextKitShadower.mm in Sources */,
 				058D0A21195D050800B7D73C /* NSMutableAttributedString+TextKitAdditions.m in Sources */,
 				205F0E101B371875007741D0 /* UICollectionViewLayout+ASConvenience.m in Sources */,
@@ -1893,6 +1905,7 @@
 				254C6B8D1BF94F8A003EC431 /* ASEqualityHashHelpers.mm in Sources */,
 				254C6B871BF94F8A003EC431 /* ASTextKitEntityAttribute.m in Sources */,
 				34566CB31BC1213700715E6B /* ASPhotosFrameworkImageRequest.m in Sources */,
+				CC4CA2DC1C2F73AE003D381F /* ASMainQueueTransaction.m in Sources */,
 				254C6B831BF94F8A003EC431 /* ASTextKitCoreTextAdditions.m in Sources */,
 				B350623B1B010EFD0018CF92 /* NSMutableAttributedString+TextKitAdditions.m in Sources */,
 				044284FD1BAA365100D16268 /* UICollectionViewLayout+ASConvenience.m in Sources */,

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -234,6 +234,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   _contentsScaleForDisplay = ASScreenScale();
   _displaySentinel = [[ASSentinel alloc] init];
   _preferredFrameSize = CGSizeZero;
+  _pendingViewState = [_ASPendingState new];
 }
 
 - (id)init
@@ -339,7 +340,6 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   _layer = nil;
 
   [self __setSupernode:nil];
-  _pendingViewState = nil;
   _replaceAsyncSentinel = nil;
 
   _displaySentinel = nil;
@@ -353,11 +353,6 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
 {
   ASDisplayNodeAssertThreadAffinity(self);
   ASDN::MutexLocker l(_propertyLock);
-  
-  if (_flags.layerBacked)
-    _pendingViewState = [_ASPendingState pendingViewStateFromLayer:_layer];
-  else
-    _pendingViewState = [_ASPendingState pendingViewStateFromView:_view];
     
   [_view removeFromSuperview];
   _view = nil;
@@ -2039,15 +2034,6 @@ static BOOL ShouldUseNewRenderingRange = NO;
 
 
 #pragma mark - Pending View State
-- (_ASPendingState *)pendingViewState
-{
-  if (!_pendingViewState) {
-    _pendingViewState = [[_ASPendingState alloc] init];
-    ASDisplayNodeAssertNotNil(_pendingViewState, @"should have created a pendingViewState");
-  }
-
-  return _pendingViewState;
-}
 
 - (void)_applyPendingStateToViewOrLayer
 {
@@ -2063,8 +2049,6 @@ static BOOL ShouldUseNewRenderingRange = NO;
   } else {
     [_pendingViewState applyToView:_view];
   }
-
-  _pendingViewState = nil;
 
   // TODO: move this into real pending state
   if (_flags.displaySuspended) {

--- a/AsyncDisplayKit/Private/ASMainQueueTransaction.h
+++ b/AsyncDisplayKit/Private/ASMainQueueTransaction.h
@@ -1,0 +1,21 @@
+//
+//  ASMainQueueTransaction.h
+//  AsyncDisplayKit
+//
+//  Created by Adlai Holler on 12/26/15.
+//  Copyright © 2015 Facebook. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ASMainQueueTransaction : NSObject
+
++ (void)transactWithBlock:(void(^)())body;
+
++ (void)performOnMainThread:(void(^)())mainThreadWork;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/AsyncDisplayKit/Private/ASMainQueueTransaction.m
+++ b/AsyncDisplayKit/Private/ASMainQueueTransaction.m
@@ -1,0 +1,66 @@
+//
+//  ASMainQueueTransaction.m
+//  AsyncDisplayKit
+//
+//  Created by Adlai Holler on 12/26/15.
+//  Copyright © 2015 Facebook. All rights reserved.
+//
+
+#import "ASMainQueueTransaction.h"
+#import "ASAssert.h"
+
+NSString *ASThreadMainQueueBlocksKey = @"asdk_propertiesTransactions";
+
+@implementation ASMainQueueTransaction
+
++ (void)transactWithBlock:(void (^)())body
+{
+  ASDisplayNodeAssertNotNil(body, @"ASMainQueueTransaction requires a body block.");
+
+  NSMutableDictionary *threadDictionary = NSThread.currentThread.threadDictionary;
+  NSMutableArray *mainQueueBlocks = threadDictionary[ASThreadMainQueueBlocksKey];
+
+  // If we're already collecting main queue blocks, just run the body and return.
+  if (mainQueueBlocks != nil) {
+    body();
+    return;
+  }
+
+  // Create a new batch of main queue blocks and store it in the thread dictionary.
+  mainQueueBlocks = [NSMutableArray new];
+  threadDictionary[ASThreadMainQueueBlocksKey] = mainQueueBlocks;
+
+  // Run the body. Any blocks passed to to `performOnMainThread` during
+  // this invocation will be appended to `mainQueueBlocks`.
+  body();
+
+  [threadDictionary removeObjectForKey:ASThreadMainQueueBlocksKey];
+
+  // If we accumulated any blocks, run them all in one main queue block.
+  if (mainQueueBlocks.count > 0) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      for (dispatch_block_t block in mainQueueBlocks) {
+        block();
+      }
+    });
+  }
+}
+
++ (void)performOnMainThread:(void (^)())mainThreadWork
+{
+  if (NSThread.isMainThread) {
+    mainThreadWork();
+    return;
+  }
+
+  NSMutableDictionary *threadDictionary = NSThread.currentThread.threadDictionary;
+  NSMutableArray *mainQueueBlocks = threadDictionary[ASThreadMainQueueBlocksKey];
+
+  if (mainQueueBlocks == nil) {
+    dispatch_async(dispatch_get_main_queue(), mainThreadWork);
+  } else {
+    [mainQueueBlocks addObject:mainThreadWork];
+  }
+}
+
+@end

--- a/AsyncDisplayKit/Private/_ASPendingState.h
+++ b/AsyncDisplayKit/Private/_ASPendingState.h
@@ -20,7 +20,52 @@
  When you want to configure a view from this pending state information, just call -applyToView:
  */
 
-@interface _ASPendingState : NSObject <ASDisplayNodeViewProperties, ASDisplayProperties>
+@interface _ASPendingState : NSObject <ASDisplayNodeViewProperties, ASDisplayProperties> {
+  @package
+
+  UIViewAutoresizing autoresizingMask;
+  unsigned int edgeAntialiasingMask;
+  CGRect frame;   // Frame is only to be used for synchronous views wrapped by nodes (see setFrame:)
+  CGRect bounds;
+  CGColorRef backgroundColor;
+  id contents;
+  CGFloat alpha;
+  CGFloat cornerRadius;
+  UIViewContentMode contentMode;
+  CGPoint anchorPoint;
+  CGPoint position;
+  CGFloat zPosition;
+  CGFloat contentsScale;
+  CATransform3D transform;
+  CATransform3D sublayerTransform;
+  CGColorRef shadowColor;
+  CGFloat shadowOpacity;
+  CGSize shadowOffset;
+  CGFloat shadowRadius;
+  CGFloat borderWidth;
+  CGColorRef borderColor;
+  UIColor *tintColor;
+  BOOL opaque;
+  BOOL allowsEdgeAntialiasing;
+  BOOL autoresizesSubviews;
+  BOOL needsDisplayOnBoundsChange;
+  BOOL hidden;
+  BOOL clipsToBounds;
+  BOOL exclusiveTouch;
+  BOOL userInteractionEnabled;
+  BOOL asyncTransactionContainer;
+  BOOL isAccessibilityElement;
+  NSString *accessibilityLabel;
+  NSString *accessibilityHint;
+  NSString *accessibilityValue;
+  UIAccessibilityTraits accessibilityTraits;
+  CGRect accessibilityFrame;
+  NSString *accessibilityLanguage;
+  BOOL accessibilityElementsHidden;
+  BOOL accessibilityViewIsModal;
+  BOOL shouldGroupAccessibilityChildren;
+  NSString *accessibilityIdentifier;
+}
 
 // Supports all of the properties included in the ASDisplayNodeViewProperties protocol
 

--- a/AsyncDisplayKit/Private/_ASPendingState.m
+++ b/AsyncDisplayKit/Private/_ASPendingState.m
@@ -14,48 +14,13 @@
 
 @implementation _ASPendingState
 {
-  @package //Expose all ivars for ASDisplayNode to bypass getters for efficiency
-
-  UIViewAutoresizing autoresizingMask;
-  unsigned int edgeAntialiasingMask;
-  CGRect frame;   // Frame is only to be used for synchronous views wrapped by nodes (see setFrame:)
-  CGRect bounds;
-  CGColorRef backgroundColor;
-  id contents;
-  CGFloat alpha;
-  CGFloat cornerRadius;
-  UIViewContentMode contentMode;
-  CGPoint anchorPoint;
-  CGPoint position;
-  CGFloat zPosition;
-  CGFloat contentsScale;
-  CATransform3D transform;
-  CATransform3D sublayerTransform;
-  CGColorRef shadowColor;
-  CGFloat shadowOpacity;
-  CGSize shadowOffset;
-  CGFloat shadowRadius;
-  CGFloat borderWidth;
-  CGColorRef borderColor;
-  BOOL asyncTransactionContainer;
-  BOOL isAccessibilityElement;
-  NSString *accessibilityLabel;
-  NSString *accessibilityHint;
-  NSString *accessibilityValue;
-  UIAccessibilityTraits accessibilityTraits;
-  CGRect accessibilityFrame;
-  NSString *accessibilityLanguage;
-  BOOL accessibilityElementsHidden;
-  BOOL accessibilityViewIsModal;
-  BOOL shouldGroupAccessibilityChildren;
-  NSString *accessibilityIdentifier;
 
   struct {
     // Properties
     int needsDisplay:1;
     int needsLayout:1;
 
-    // Flags indicating that a given property should be applied to the view at creation
+    // Flags indicating that a given property should be applied to the view
     int setClipsToBounds:1;
     int setOpaque:1;
     int setNeedsDisplayOnBoundsChange:1;

--- a/AsyncDisplayKitTests/ASDisplayNodeTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeTests.m
@@ -1839,4 +1839,16 @@ static bool stringContainsPointer(NSString *description, const void *p) {
   XCTAssert(node.bounds.size.height == 8, @"Wrong ASDisplayNode.bounds.size.height");
 }
 
+#pragma mark UIKit Properties Threading
+
+- (void)testThatSettingAUIKitPropertyInTheBackgroundCausesItToBeSetOnMain
+{
+  ASDisplayNode *node = [[ASDisplayNode alloc] init];
+  [node view];
+  dispatch_sync(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+    node.alpha = 0;
+  });
+  // FIXME: Flesh out this test.
+}
+
 @end


### PR DESCRIPTION
@appleguy This is a first-pass implementation, I'm not satisfied with it for a number of reasons, and I don't expect to merge it. But this will get the ball rolling and hopefully expose important questions. 

The major problems I have with this branch are:
- If the user directly sets properties on the underlying view, we won't find out about it. If they read the corresponding node property, we'll return the old value. This is a tough problem, because we HAVE to buffer property values outside the view to make them readable from any thread. I can't see any solution to this except swizzling the UIKit setters :scream:.
- Order-of-operations is not preserved. If you're in the middle of buffering main-queue commands on thread A and you set a property to X, and then on thread B (while not in a transaction) you set it to Y, and then A flushes the main queue command buffer, the property will get set to X when it should be Y. What's worse, the pending-state value and the view-value will be out-of-sync. This one shouldn't be hard to solve – we should always store the pending value in the pending state, and then always flush THAT rather than just enqueuing individual property sets.
- Related to above, hard to debug since we don't explicitly track the pending state of a node (in fact, such a state barely exists).

For the next pass here's the plan:
- Construct a "weak set" using a weak-to-strong-objects NSMapTable that goes `ASDisplayNode : [NSNull null]`. 
- Create a singleton that has a weak set of nodes that have pending state. When you set a bridged node property off-main on a loaded node, if the pending state was previously empty, we add this node into that set. 
- For setting 
- For the flush, the singleton just calls `applyToView:` or `applyToLayer:` on all the dirty nodes' pending states.
- For transactionalization, I think all we need is to ensure that there are no open transactions when the flush happens, right?
 - Let's say we have four background threads A, B, C, and D:
  - Thread A opens a transaction and starts setting some properties.
  - Thread B opens a transaction and starts setting some properties.
  - Thread C sets a property outside any transaction.
  - Thread A's transaction ends.
  - Thread B's transaction ends.
  - We notice there are no transactions and no flush enqueued. Enqueue a flush on the main thread.
  - Thread D opens a transaction.
  - Main thread: it's time to flush. Lock the singleton (@appleguy dangerous?). But oh! There's an open transaction. Reject flush.
  - Thread D closes its transaction.
  - We notice there are no transactions and no flush enqueued. Enqueue a flush on the main thread.
  - Main thread: it's time to flush. Lock the singleton, confirm no open transactions, let's do this. Apply all pending states to nodes in weak set, empty the set, unlock the singleton.
 - Would it be valuable to have an option to tell the singleton "flush everything NOW" on the main thread? 
I think this would be doable if we accept that the flush may get rejected. Maybe something like `flushChangesWithCompletion:^{}`, so we can wait for any open transactions to end?

Maybe I'm making this way more complicated than it needs to be. 