### PR TITLE
[ASPagerNode] Ensure delegate property can be set before the view is loaded.

### DIFF
--- a/AsyncDisplayKit/ASPagerNode.h
+++ b/AsyncDisplayKit/ASPagerNode.h
@@ -26,13 +26,14 @@
 - (instancetype)initWithFlowLayout:(UICollectionViewFlowLayout *)flowLayout;
 
 // The underlying ASCollectionView object.
-- (ASCollectionView *)collectionView;
+@property (nonatomic, readonly) ASCollectionView *view;
 
 // Delegate is optional, and uses the same protocol as ASCollectionNode.
 // This includes UIScrollViewDelegate as well as most methods from UICollectionViewDelegate, like willDisplay...
-@property (weak, nonatomic) id <ASCollectionDelegate>  delegate;
+@property (nonatomic, weak) id <ASCollectionDelegate> delegate;
 
 // Data Source is required, and uses a different protocol from ASCollectionNode.
+//@property (nonatomic, weak) id <ASPagerNodeDataSource> dataSource;
 - (void)setDataSource:(id <ASPagerNodeDataSource>)dataSource;
 - (id <ASPagerNodeDataSource>)dataSource;
 

--- a/AsyncDisplayKit/ASPagerNode.m
+++ b/AsyncDisplayKit/ASPagerNode.m
@@ -19,7 +19,7 @@
 @end
 
 @implementation ASPagerNode
-@dynamic delegate;
+@dynamic view, delegate, dataSource;
 
 - (instancetype)init
 {
@@ -31,6 +31,12 @@
   return [self initWithFlowLayout:flowLayout];
 }
 
+- (instancetype)initWithCollectionViewLayout:(UICollectionViewLayout *)layout
+{
+  ASDisplayNodeAssert([layout isKindOfClass:[UICollectionViewFlowLayout class]], @"ASPagerNode requires a flow layout.");
+  return [self initWithFlowLayout:(UICollectionViewFlowLayout *)layout];
+}
+
 - (instancetype)initWithFlowLayout:(UICollectionViewFlowLayout *)flowLayout
 {
   self = [super initWithCollectionViewLayout:flowLayout];
@@ -38,11 +44,6 @@
     _flowLayout = flowLayout;
   }
   return self;
-}
-
-- (ASCollectionView *)collectionView
-{
-  return self.view;
 }
 
 - (void)setDataSource:(id <ASPagerNodeDataSource>)pagerDataSource
@@ -69,8 +70,6 @@
   [super didLoad];
   
   ASCollectionView *cv = self.view;
-  cv.asyncDataSource = self;
-  cv.asyncDelegate = self;
   
   cv.pagingEnabled = YES;
   cv.allowsSelection = NO;

--- a/examples/VerticalWithinHorizontalScrolling/Sample/ViewController.m
+++ b/examples/VerticalWithinHorizontalScrolling/Sample/ViewController.m
@@ -10,14 +10,12 @@
  */
 
 #import <AsyncDisplayKit/AsyncDisplayKit.h>
-#import <AsyncDisplayKit/ASAssert.h>
-
 #import "ViewController.h"
 #import "GradientTableNode.h"
 
-@interface ViewController () <ASCollectionViewDataSource, ASCollectionViewDelegate>
+@interface ViewController () <ASPagerNodeDataSource>
 {
-  ASCollectionView *_pagerView;
+  ASPagerNode *_pagerNode;
 }
 
 @end
@@ -31,23 +29,12 @@
 {
   if (!(self = [super init]))
     return nil;
-
-  UICollectionViewFlowLayout *flowLayout = [[UICollectionViewFlowLayout alloc] init];
-  flowLayout.scrollDirection = UICollectionViewScrollDirectionHorizontal;
-//  flowLayout.itemSize = [[UIScreen mainScreen] bounds].size;
-  flowLayout.minimumInteritemSpacing = 0;
-  flowLayout.minimumLineSpacing = 0;
   
-  _pagerView = [[ASCollectionView alloc] initWithCollectionViewLayout:flowLayout];
+  _pagerNode = [[ASPagerNode alloc] init];
+  _pagerNode.dataSource = self;
   
-  ASRangeTuningParameters rangeTuningParameters;
-  rangeTuningParameters.leadingBufferScreenfuls = 1.0;
-  rangeTuningParameters.trailingBufferScreenfuls = 1.0;
-  [_pagerView setTuningParameters:rangeTuningParameters forRangeType:ASLayoutRangeTypeRender];
-  
-  _pagerView.pagingEnabled = YES;
-  _pagerView.asyncDataSource = self;
-  _pagerView.asyncDelegate = self;
+  // Could implement ASCollectionDelegate if we wanted extra callbacks, like from UIScrollView.
+  //_pagerNode.delegate = self;
   
   self.title = @"Paging Table Nodes";
   self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemRedo
@@ -59,20 +46,19 @@
 
 - (void)reloadEverything
 {
-  [_pagerView reloadData];
+  [_pagerNode reloadData];
 }
 
 - (void)viewDidLoad
 {
   [super viewDidLoad];
 
-  [self.view addSubview:_pagerView];
+  [self.view addSubnode:_pagerNode];
 }
 
 - (void)viewWillLayoutSubviews
 {
-  _pagerView.frame = self.view.bounds;
-  _pagerView.contentInset = UIEdgeInsetsZero;
+  _pagerNode.frame = self.view.bounds;
 }
 
 - (BOOL)prefersStatusBarHidden
@@ -81,20 +67,20 @@
 }
 
 #pragma mark -
-#pragma mark ASTableView.
+#pragma mark ASPagerNode.
 
-- (ASCellNode *)collectionView:(ASCollectionView *)collectionView nodeForItemAtIndexPath:(NSIndexPath *)indexPath;
+- (ASCellNode *)pagerNode:(ASPagerNode *)pagerNode nodeAtIndex:(NSInteger)index;
 {
-  CGSize boundsSize = collectionView.bounds.size;
+  CGSize boundsSize = pagerNode.bounds.size;
   CGSize gradientRowSize = CGSizeMake(boundsSize.width, 100);
   GradientTableNode *node = [[GradientTableNode alloc] initWithElementSize:gradientRowSize];
   node.preferredFrameSize = boundsSize;
   return node;
 }
 
-- (NSInteger)collectionView:(UICollectionView *)collectionView numberOfItemsInSection:(NSInteger)section
+- (NSInteger)numberOfPagesInPagerNode:(ASPagerNode *)pagerNode
 {
-  return (section == 0 ? 10 : 0);
+  return 10;
 }
 
 @end


### PR DESCRIPTION
It was being overwritten to be "self", but the final implementation of ASPagerNode turned out to not need any delegate methods.