### PR TITLE
Revert "[ASCellNode] Forward pointInside to node implementation from UITableViewCell."

### DIFF
--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -76,11 +76,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
   _node.highlighted = highlighted;
 }
 
-- (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event
-{
-  return [_node pointInside:point withEvent:event];
-}
-
 @end
 
 #pragma mark -


### PR DESCRIPTION
Reverts facebook/AsyncDisplayKit#1008 -- cc @yury 

I want to make sure this is supported for all ASCellNodes before it is delivered in a production release.  I investigated supporting it in ASCollectionView and ran into some concerns with how the frames are set on the node (they are not necessarily equal to the size of the item cell, yet are at a 0, 0 position that can't be controlled by the engineer).  This could cause regressions for some apps where the touch target becomes smaller than they desire / currently experience.

I think the right fix for this could be to use ASControlNode or similar inside the ASCellNode, rather than relying on the UITableView or UICollectionView tap delegate methods responding only to an area that is smaller than the UIKit component actually is.  That said, I'm still open to doing this, but it needs to be approached holistically by making sure it works reliably for all the ASCellNode use cases.