### PR TITLE
Prevent calling unsupported UICollectionViewDelegate methods (supplementary view appearance)

### DIFF
--- a/AsyncDisplayKit/ASCellNode.m
+++ b/AsyncDisplayKit/ASCellNode.m
@@ -63,13 +63,6 @@
   return self;
 }
 
-//- (ASLayoutSpec *)layoutSpecThatFits:(ASSizeRange)constrainedSize
-//{
-//  _viewControllerNode.frame = (CGRect){{0,0}, constrainedSize.max};
-//  NSLog(@"%f %f", constrainedSize.max.width, constrainedSize.max.height);
-//  return [super layoutSpecThatFits:constrainedSize];
-//}
-
 - (void)layout
 {
   [super layout];

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -944,6 +944,16 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   ASDisplayNodeAssert(![self.asyncDataSource respondsToSelector:_cmd], @"%@ is not supported by ASCollectionView - please remove or disable this data source method.", NSStringFromSelector(_cmd));
 }
 
+- (void)collectionView:(UICollectionView *)collectionView willDisplaySupplementaryView:(UICollectionReusableView *)view forElementKind:(NSString *)elementKind atIndexPath:(NSIndexPath *)indexPath
+{
+  ASDisplayNodeAssert(![self.asyncDataSource respondsToSelector:_cmd], @"%@ is not supported by ASCollectionView - please remove or disable this delegate method.", NSStringFromSelector(_cmd));
+}
+
+- (void)collectionView:(UICollectionView *)collectionView didEndDisplayingSupplementaryView:(UICollectionReusableView *)view forElementOfKind:(NSString *)elementKind atIndexPath:(NSIndexPath *)indexPath
+{
+  ASDisplayNodeAssert(![self.asyncDataSource respondsToSelector:_cmd], @"%@ is not supported by ASCollectionView - please remove or disable this delegate method.", NSStringFromSelector(_cmd));
+}
+
 #endif
 
 @end

--- a/AsyncDisplayKit/Details/ASDelegateProxy.m
+++ b/AsyncDisplayKit/Details/ASDelegateProxy.m
@@ -58,7 +58,9 @@
           
           // intercepted due to not being supported by ASCollectionView (prevent bugs caused by usage)
           selector == @selector(collectionView:canMoveItemAtIndexPath:) ||
-          selector == @selector(collectionView:moveItemAtIndexPath:toIndexPath:)
+          selector == @selector(collectionView:moveItemAtIndexPath:toIndexPath:) ||
+          selector == @selector(collectionView:willDisplaySupplementaryView:forElementKind:atIndexPath:) ||
+          selector == @selector(collectionView:didEndDisplayingSupplementaryView:forElementOfKind:atIndexPath:)
           );
 }
 

--- a/examples/CustomCollectionView/Sample/ViewController.m
+++ b/examples/CustomCollectionView/Sample/ViewController.m
@@ -54,7 +54,7 @@ static NSUInteger kNumberOfImages = 14;
   
   _layoutInspector = [[MosaicCollectionViewLayoutInspector alloc] init];
   
-  _collectionView = [[ASCollectionView alloc] initWithFrame:CGRectZero collectionViewLayout:layout asyncDataFetching:YES];
+  _collectionView = [[ASCollectionView alloc] initWithFrame:CGRectZero collectionViewLayout:layout];
   _collectionView.asyncDataSource = self;
   _collectionView.asyncDelegate = self;
   _collectionView.layoutInspector = _layoutInspector;


### PR DESCRIPTION
cc @levi, @stowy maybe we can fix this at some point soon, but for now, away they go - they're not safe to use unless reconciled with the async layout delay.