### PR TITLE
[ASButtonNode] Add support for backgroundImage.  Extend & simplify API with separate title and color.

### DIFF
--- a/AsyncDisplayKit/ASButtonNode.h
+++ b/AsyncDisplayKit/ASButtonNode.h
@@ -47,7 +47,7 @@
 - (NSAttributedString * _Nullable)attributedTitleForState:(ASControlState)state;
 
 /**
- *  Sets the styled title to use for the specified state.
+ *  Sets the styled title to use for the specified state. This will reset styled title previously set with -setTitle:withFont:withColor:forState.
  *
  *  @param title The styled text string to use for the title.
  *  @param state The state that uses the specified title. The possible values are described in ASControlState.
@@ -55,7 +55,7 @@
 - (void)setAttributedTitle:(nullable NSAttributedString *)title forState:(ASControlState)state;
 
 /**
- *  Sets the title to use for the specified state.
+ *  Sets the title to use for the specified state. This will reset styled title previously set with -setAttributedTitle:forState.
  *
  *  @param title The styled text string to use for the title.
  *  @param font The font to use for the title.

--- a/AsyncDisplayKit/ASButtonNode.h
+++ b/AsyncDisplayKit/ASButtonNode.h
@@ -11,8 +11,9 @@
 
 @interface ASButtonNode : ASControlNode
 
-@property (nonatomic, readonly) ASTextNode *titleNode;
-@property (nonatomic, readonly) ASImageNode *imageNode;
+@property (nonatomic, readonly) ASTextNode  * _Nonnull titleNode;
+@property (nonatomic, readonly) ASImageNode * _Nonnull imageNode;
+@property (nonatomic, readonly) ASImageNode * _Nonnull backgroundImageNode;
 
 /**
  Spacing between image and title. Defaults to 8.0.
@@ -36,11 +37,66 @@
  */
 @property (nonatomic, assign) ASVerticalAlignment contentVerticalAlignment;
 
+/**
+ *  Returns the styled title associated with the specified state.
+ *
+ *  @param state The state that uses the styled title. The possible values are described in ASControlState.
+ *
+ *  @return The title for the specified state.
+ */
+- (NSAttributedString * _Nullable)attributedTitleForState:(ASControlState)state;
 
-- (NSAttributedString *)attributedTitleForState:(ASControlState)state;
-- (void)setAttributedTitle:(NSAttributedString *)title forState:(ASControlState)state;
+/**
+ *  Sets the styled title to use for the specified state.
+ *
+ *  @param title The styled text string to use for the title.
+ *  @param state The state that uses the specified title. The possible values are described in ASControlState.
+ */
+- (void)setAttributedTitle:(nullable NSAttributedString *)title forState:(ASControlState)state;
 
-- (UIImage *)imageForState:(ASControlState)state;
-- (void)setImage:(UIImage *)image forState:(ASControlState)state;
+/**
+ *  Sets the title to use for the specified state.
+ *
+ *  @param title The styled text string to use for the title.
+ *  @param font The font to use for the title.
+ *  @param color The color to use for the title.
+ *  @param state The state that uses the specified title. The possible values are described in ASControlState.
+ */
+- (void)setTitle:(nonnull NSString *)title withFont:(nullable UIFont *)font withColor:(nullable UIColor *)color forState:(ASControlState)state;
+
+/**
+ *  Returns the image used for a button state.
+ *
+ *  @param state The state that uses the image. Possible values are described in ASControlState.
+ *
+ *  @return The image used for the specified state.
+ */
+- (UIImage * _Nullable)imageForState:(ASControlState)state;
+
+/**
+ *  Sets the image to use for the specified state.
+ *
+ *  @param image The image to use for the specified state.
+ *  @param state The state that uses the specified title. The values are described in ASControlState.
+ */
+- (void)setImage:(nullable UIImage *)image forState:(ASControlState)state;
+
+/**
+ *  Sets the background image to use for the specified state.
+ *
+ *  @param image The image to use for the specified state.
+ *  @param state The state that uses the specified title. The values are described in ASControlState.
+ */
+- (void)setBackgroundImage:(nullable UIImage *)image forState:(ASControlState)state;
+
+
+/**
+ *  Returns the background image used for a button state.
+ *
+ *  @param state The state that uses the image. Possible values are described in ASControlState.
+ *
+ *  @return The background image used for the specified state.
+ */
+- (UIImage * _Nullable)backgroundImageForState:(ASControlState)state;
 
 @end

--- a/AsyncDisplayKit/ASButtonNode.mm
+++ b/AsyncDisplayKit/ASButtonNode.mm
@@ -48,7 +48,12 @@
     _titleNode = [[ASTextNode alloc] init];
     _imageNode = [[ASImageNode alloc] init];
     _backgroundImageNode = [[ASImageNode alloc] init];
+    [_backgroundImageNode setContentMode:UIViewContentModeScaleToFill];
     
+    [_titleNode setLayerBacked:YES];
+    [_imageNode setLayerBacked:YES];
+    [_backgroundImageNode setLayerBacked:YES];
+      
     _contentHorizontalAlignment = ASAlignmentMiddle;
     _contentVerticalAlignment = ASAlignmentCenter;
     
@@ -57,6 +62,12 @@
     [self addSubnode:_imageNode];
   }
   return self;
+}
+
+- (void)setLayerBacked:(BOOL)layerBacked
+{
+  ASDisplayNodeAssert(!layerBacked, @"ASButtonNode must not be layer backed!");
+  [super setLayerBacked:layerBacked];
 }
 
 - (void)setEnabled:(BOOL)enabled


### PR DESCRIPTION
Align the ASButtonNode API with that of UIButton. These new methods will ease the pain of creating NSAttributedString when you only really want is set a title or a colour on ASButtonNode.