### PR TITLE
Update interface of ASViewController to use lightweight generics. 

### DIFF
--- a/AsyncDisplayKit/ASViewController.h
+++ b/AsyncDisplayKit/ASViewController.h
@@ -11,11 +11,11 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface ASViewController : UIViewController
+@interface ASViewController<__covariant DisplayNodeType : ASDisplayNode *> : UIViewController
 
-- (instancetype)initWithNode:(ASDisplayNode *)node NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithNode:(DisplayNodeType)node NS_DESIGNATED_INITIALIZER;
 
-@property (nonatomic, strong, readonly) ASDisplayNode *node;
+@property (nonatomic, strong, readonly) DisplayNodeType node;
 
 /**
  * @abstract Passthrough property to the the .interfaceState of the node.


### PR DESCRIPTION
This pull request allows subclasses of `ASViewController` to specify the type of `ASDisplayNode` it
contains which allows for stronger type-checking and auto-completion against
the specified display node type.

Example Subclass Declaration:
```
@interface MyASViewController : ASViewController<MyASDisplayNodeSubclass *>
@end
```