### PR TITLE
[ASMapNode] now supports MKMapSnapshotOptions 

### DIFF
--- a/AsyncDisplayKit/ASMapNode.h
+++ b/AsyncDisplayKit/ASMapNode.h
@@ -12,9 +12,9 @@
 @interface ASMapNode : ASImageNode
 
 /**
- The current region of ASMapNode. This can be set at any time and ASMapNode will animate the change. This property may be set from a background thread before the node is loaded, and will automatically be applied to define the region of the static snapshot (if .liveMap = NO) or the internal MKMapView (otherwise).
+ The current options of ASMapNode. This can be set at any time and ASMapNode will animate the change. This property may be set from a background thread before the node is loaded, and will automatically be applied to define the behavior of the static snapshot (if .liveMap = NO) or the internal MKMapView (otherwise).
  */
-@property (nonatomic, assign) MKCoordinateRegion region;
+@property (nonatomic, readwrite) MKMapSnapshotOptions *options;
 
 /**
  This is the MKMapView that is the live map part of ASMapNode. This will be nil if .liveMap = NO. Note, MKMapView is *not* thread-safe.

--- a/AsyncDisplayKit/ASMapNode.h
+++ b/AsyncDisplayKit/ASMapNode.h
@@ -12,9 +12,9 @@
 @interface ASMapNode : ASImageNode
 
 /**
- The current options of ASMapNode. This can be set at any time and ASMapNode will animate the change. This property may be set from a background thread before the node is loaded, and will automatically be applied to define the behavior of the static snapshot (if .liveMap = NO) or the internal MKMapView (otherwise).
+ The current options of ASMapNode. This can be set at any time and ASMapNode will animate the change.<br><br>This property may be set from a background thread before the node is loaded, and will automatically be applied to define the behavior of the static snapshot (if .liveMap = NO) or the internal MKMapView (otherwise).<br><br> Changes to the region and camera options will only be animated when when the liveMap mode is enabled, otherwise these options will be applied statically to the new snapshot. <br><br> The options object is used to specify properties even when the liveMap mode is enabled, allowing seamless transitions between the snapshot and liveMap (as well as back to the snapshot).
  */
-@property (nonatomic, readwrite) MKMapSnapshotOptions *options;
+@property (nonatomic, strong) MKMapSnapshotOptions *options;
 
 /**
  This is the MKMapView that is the live map part of ASMapNode. This will be nil if .liveMap = NO. Note, MKMapView is *not* thread-safe.
@@ -38,7 +38,7 @@
 @property (nonatomic, weak) id <MKMapViewDelegate> mapDelegate;
 
 /**
- * @discussion This method set the annotations of the static map view and also to the live map view. Passing an empty array clears the map of any annotations.
+ * @discussion This method sets the annotations of the static map view and also to the live map view. Passing an empty array clears the map of any annotations.
  * @param annotations An array of objects that conform to the MKAnnotation protocol
  */
 - (void)setAnnotations:(NSArray *)annotations;

--- a/AsyncDisplayKit/ASMapNode.mm
+++ b/AsyncDisplayKit/ASMapNode.mm
@@ -39,11 +39,6 @@
   _needsMapReloadOnBoundsChange = YES;
   _liveMap = NO;
   _centerCoordinateOfMap = kCLLocationCoordinate2DInvalid;
-  
-  _options = [[MKMapSnapshotOptions alloc] init];
-  //Default world-scale view
-  _options.region = MKCoordinateRegionForMapRect(MKMapRectWorld);
-  
   return self;
 }
 
@@ -176,7 +171,9 @@
 - (void)setUpSnapshotter
 {
   ASDisplayNodeAssert(!CGSizeEqualToSize(CGSizeZero, self.calculatedSize), @"self.calculatedSize can not be zero. Make sure that you are setting a preferredFrameSize or wrapping ASMapNode in a ASRatioLayoutSpec or similar.");
-  _options.size = self.calculatedSize;
+  if (!_options) {
+    [self createInitialOptions];
+  }
   _snapshotter = [[MKMapSnapshotter alloc] initWithOptions:_options];
 }
 
@@ -184,6 +181,14 @@
 {
   [_snapshotter cancel];
   _snapshotter = [[MKMapSnapshotter alloc] initWithOptions:_options];
+}
+
+- (void)createInitialOptions
+{
+  _options = [[MKMapSnapshotOptions alloc] init];
+  //Default world-scale view
+  _options.region = MKCoordinateRegionForMapRect(MKMapRectWorld);
+  _options.size = self.calculatedSize;
 }
 
 - (void)applySnapshotOptions
@@ -203,6 +208,9 @@
     __weak ASMapNode *weakSelf = self;
     _mapView = [[MKMapView alloc] initWithFrame:CGRectZero];
     _mapView.delegate = weakSelf.mapDelegate;
+    if (!_options) {
+      [weakSelf createInitialOptions];
+    }
     [weakSelf applySnapshotOptions];
     [_mapView addAnnotations:_annotations];
     [weakSelf setNeedsLayout];


### PR DESCRIPTION
@appleguy this will resolve #988 

Breaking Change:
`region` property has been superseded by `options` which is a MKMapSnapshotOptions object. This allows for more flexibility and customisation. All snapshot options will be applied to the MKMapView when it is activated.

Currently working on an example app and tests to better showcase ASMapNode!