### PR TITLE
Make ASControlState imitate UIControlState

### DIFF
--- a/AsyncDisplayKit/ASButtonNode.mm
+++ b/AsyncDisplayKit/ASButtonNode.mm
@@ -53,23 +53,23 @@
 
 - (void)setEnabled:(BOOL)enabled
 {
-    [super setEnabled:enabled];
-    [self updateImage];
-    [self updateTitle];
+  [super setEnabled:enabled];
+  [self updateImage];
+  [self updateTitle];
 }
 
 - (void)setHighlighted:(BOOL)highlighted
 {
-    [super setHighlighted:highlighted];
-    [self updateImage];
-    [self updateTitle];
+  [super setHighlighted:highlighted];
+  [self updateImage];
+  [self updateTitle];
 }
 
 - (void)setSelected:(BOOL)selected
 {
-    [super setSelected:selected];
-    [self updateImage];
-    [self updateTitle];
+  [super setSelected:selected];
+  [self updateImage];
+  [self updateTitle];
 }
 
 - (void)updateImage

--- a/AsyncDisplayKit/ASButtonNode.mm
+++ b/AsyncDisplayKit/ASButtonNode.mm
@@ -47,16 +47,29 @@
     
     [self addSubnode:_titleNode];
     [self addSubnode:_imageNode];
-    
-    [self addTarget:self action:@selector(controlEventUpdated:) forControlEvents:ASControlNodeEventAllEvents];
   }
   return self;
 }
 
-- (void)controlEventUpdated:(ASControlNode *)node
+- (void)setEnabled:(BOOL)enabled
 {
-  [self updateImage];
-  [self updateTitle];
+    [super setEnabled:enabled];
+    [self updateImage];
+    [self updateTitle];
+}
+
+- (void)setHighlighted:(BOOL)highlighted
+{
+    [super setHighlighted:highlighted];
+    [self updateImage];
+    [self updateTitle];
+}
+
+- (void)setSelected:(BOOL)selected
+{
+    [super setSelected:selected];
+    [self updateImage];
+    [self updateTitle];
 }
 
 - (void)updateImage

--- a/AsyncDisplayKit/ASControlNode.h
+++ b/AsyncDisplayKit/ASControlNode.h
@@ -60,7 +60,7 @@ typedef NS_OPTIONS(NSUInteger, ASControlState) {
   @abstract Indicates whether or not the receiver is highlighted.
   @discussion This is set automatically when the there is a touch inside the control and removed on exit or touch up. This is different from touchInside in that it includes an area around the control, rather than just for touches inside the control.
  */
-@property (nonatomic, readonly, assign, getter=isHighlighted) BOOL highlighted;
+@property (nonatomic, assign, getter=isHighlighted) BOOL highlighted;
 
 /**
  @abstract Indicates whether or not the receiver is highlighted.

--- a/AsyncDisplayKit/ASControlNode.m
+++ b/AsyncDisplayKit/ASControlNode.m
@@ -46,7 +46,6 @@
 }
 
 // Read-write overrides.
-@property (nonatomic, readwrite, assign, getter=isHighlighted) BOOL highlighted;
 @property (nonatomic, readwrite, assign, getter=isTracking) BOOL tracking;
 @property (nonatomic, readwrite, assign, getter=isTouchInside) BOOL touchInside;
 
@@ -186,10 +185,6 @@ void _ASEnumerateControlEventsIncludedInMaskWithBlock(ASControlNodeEvent mask, v
   // Send the appropriate touch-up control event.
   CGRect expandedBounds = CGRectInset(self.view.bounds, kASControlNodeExpandedInset, kASControlNodeExpandedInset);
   BOOL touchUpIsInsideExpandedBounds = CGRectContainsPoint(expandedBounds, touchLocation);
-  
-  if (touchUpIsInsideExpandedBounds) {
-    self.selected = !self.selected;
-  }
 
   [self sendActionsForControlEvents:(touchUpIsInsideExpandedBounds ? ASControlNodeEventTouchUpInside : ASControlNodeEventTouchUpOutside)
                           withEvent:event];


### PR DESCRIPTION
- selected state isn't implicitly controlled by ASControlNode anymore
- highlighted state can be overriden by users
- Decouple ASButtonNode's state from control events

@appleguy @connor