### PR TITLE
Resolve Internal Inconsistency During Updates When Using Stable Range Controller

### DIFF
--- a/AsyncDisplayKit/Details/ASRangeController.mm
+++ b/AsyncDisplayKit/Details/ASRangeController.mm
@@ -156,8 +156,7 @@
       NSSet *indexPaths = [_layoutController indexPathsForScrolling:_scrollDirection rangeType:rangeType];
 
       // Notify to remove indexpaths that are leftover that are not visible or included in the _layoutController calculated paths
-      // This value may be nil for the first call of this method.
-      NSMutableSet *removedIndexPaths = [_rangeTypeIndexPaths[rangeKey] mutableCopy];
+      NSMutableSet *removedIndexPaths = _rangeIsValid ? [_rangeTypeIndexPaths[rangeKey] mutableCopy] : [NSMutableSet set];
       [removedIndexPaths minusSet:indexPaths];
       [removedIndexPaths minusSet:visibleNodePathsSet];
 


### PR DESCRIPTION
This addresses #1028 #1055 #1047 .

The issue seems to be caused by one of the changes in ffcddf3 where we stopped checking if the range was valid before removing nodes from the working range. I just reverted that change exactly as-was and the issue is gone for me.

@appleguy I'm not sure the implications of this change. I suspect it means that under certain conditions, nodes won't be removed from the working range. We may now be throwing the baby out with the bathwater.