### PR TITLE
[ASTextKitRenderer] Potential fix headIndent attribute not being accounted for by the shadower.

### DIFF
--- a/AsyncDisplayKit/TextKit/ASTextKitRenderer.mm
+++ b/AsyncDisplayKit/TextKit/ASTextKitRenderer.mm
@@ -111,7 +111,7 @@ static NSCharacterSet *_defaultAvoidTruncationCharacterSet()
   // to make sure our width calculations aren't being offset by glyphs going beyond the constrained rect.
   boundingRect = CGRectIntersection(boundingRect, {.size = constrainedRect.size});
 
-  _calculatedSize = [_shadower outsetSizeWithInsetSize:boundingRect.size];
+  _calculatedSize = [_shadower outsetSizeWithInsetSize:CGSizeMake(boundingRect.size.width + boundingRect.origin.x, boundingRect.size.height + boundingRect.origin.y)];
 }
 
 - (CGSize)size


### PR DESCRIPTION
Hey @appleguy This is to fix the bug specified in #1076. I'm not entirely sure this is the correct place in the stack to fix this issue. The issue stems from the fact that the `headIndent` property of NSAttributedString actually alters the origin of the boundRect rather than just increase it's size. This bug fix address this by incorporating the origin offset into the final size calculation.

The `tailIndent` property seems to break things even more, that can be fix in a future diff (haven't got to the bottom of that)