### PR TITLE
Remove SpinLock to ensure it doesn't get used in new code.

### DIFF
--- a/AsyncDisplayKit/Details/ASThread.h
+++ b/AsyncDisplayKit/Details/ASThread.h
@@ -195,39 +195,6 @@ namespace ASDN {
   typedef Locker<StaticMutex> StaticMutexLocker;
   typedef Unlocker<StaticMutex> StaticMutexUnlocker;
 
-  struct SpinLock
-  {
-    SpinLock &operator= (bool value) {
-      _l = value ? ~0 : 0; return *this;
-    }
-
-    SpinLock() { _l = OS_SPINLOCK_INIT; }
-    SpinLock(const SpinLock&) = delete;
-    SpinLock &operator=(const SpinLock&) = delete;
-
-    bool try_lock () {
-      return OSSpinLockTry (&_l);
-    }
-
-    void lock () {
-      OSSpinLockLock(&_l);
-    }
-
-    void unlock () {
-      OSSpinLockUnlock(&_l);
-    }
-
-    OSSpinLock *spinlock () {
-      return &_l;
-    }
-
-  private:
-    OSSpinLock _l;
-  };
-
-  typedef Locker<SpinLock> SpinLocker;
-  typedef Unlocker<SpinLock> SpinUnlocker;
-
   struct Condition
   {
     Condition () {


### PR DESCRIPTION
Looks like not only are spin locks dumb, they're also dangerous!

Recently big time Apple engineers have said spin locks are illegal on iOS. So for the sake of cleanliness, I think we should remove the corresponding class.

Source: http://mjtsai.com/blog/2015/12/16/osspinlock-is-unsafe/