### PR TITLE
Update ReadMe to include Cocoapods downloads badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![Build Status](https://travis-ci.org/facebook/AsyncDisplayKit.svg)](https://travis-ci.org/facebook/AsyncDisplayKit)
 [![Coverage Status](https://coveralls.io/repos/facebook/AsyncDisplayKit/badge.svg?branch=master)](https://coveralls.io/r/facebook/AsyncDisplayKit?branch=master)
- [![Version](http://img.shields.io/cocoapods/v/AsyncDisplayKit.svg)](http://cocoapods.org/?q=AsyncDisplayKit)
- [![Platform](http://img.shields.io/cocoapods/p/AsyncDisplayKit.svg)]()
- [![License](http://img.shields.io/cocoapods/l/AsyncDisplayKit.svg)](https://github.com/facebook/AsyncDisplayKit/blob/master/LICENSE)
+[![Version](https://img.shields.io/cocoapods/v/AsyncDisplayKit.svg)](http://cocoapods.org/pods/AsyncDisplayKit)
+[![Platform](https://img.shields.io/cocoapods/p/AsyncDisplayKit.svg)]()
+[![License](https://img.shields.io/cocoapods/l/AsyncDisplayKit.svg)](https://github.com/facebook/AsyncDisplayKit/blob/master/LICENSE)
 
 AsyncDisplayKit is an iOS framework that keeps even the most complex user
 interfaces smooth and responsive.  It was originally built to make Facebook's

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Version](https://img.shields.io/cocoapods/v/AsyncDisplayKit.svg)](http://cocoapods.org/pods/AsyncDisplayKit)
 [![Platform](https://img.shields.io/cocoapods/p/AsyncDisplayKit.svg)]()
 [![License](https://img.shields.io/cocoapods/l/AsyncDisplayKit.svg)](https://github.com/facebook/AsyncDisplayKit/blob/master/LICENSE)
+[![Downloads](https://img.shields.io/badge/downloads-%3E120k-green.svg)](http://cocoapods.org/pods/AsyncDisplayKit)
 
 AsyncDisplayKit is an iOS framework that keeps even the most complex user
 interfaces smooth and responsive.  It was originally built to make Facebook's


### PR DESCRIPTION
As specified in #1086. Hey @appleguy Turns out these links have been there all along but were just hidden since they were using http (I think). The img.shields.io is a bit unstable at times but seems to be the best solution so far. Will update in future if better solutions come up!