### PR TITLE
Make ASTextNode Ignore Setting Text to Nil When Text Is Already Empty

### DIFF
--- a/AsyncDisplayKit/ASTextNode.mm
+++ b/AsyncDisplayKit/ASTextNode.mm
@@ -336,12 +336,12 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
 
 - (void)setAttributedString:(NSAttributedString *)attributedString
 {
-  if (ASObjectIsEqual(attributedString, _attributedString)) {
-    return;
-  }
-
   if (attributedString == nil) {
     attributedString = [[NSAttributedString alloc] initWithString:@"" attributes:nil];
+  }
+
+  if (ASObjectIsEqual(attributedString, _attributedString)) {
+    return;
   }
 
   _attributedString = ASCleanseAttributedStringOfCoreTextAttributes(attributedString);


### PR DESCRIPTION
This is a small fix where we coalesce the nil before checking equality so that the text node will correctly ignore setting the text to nil when it is already at "". 

A bigger change would be to make ASTextNode's nullability consistent. Currently it defaults to nil at initialization, and then if you set it to nil any time after that it gets set to "". I don't know much about the our TextKit setup so I didn't want to pull that thread in this PR.