### PR TITLE
[ASTextNode] Optimize handling of constrained size to almost never recreate NSLayoutManager

### DIFF
--- a/AsyncDisplayKit/ASCollectionNode+Beta.h
+++ b/AsyncDisplayKit/ASCollectionNode+Beta.h
@@ -6,6 +6,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#import "ASCollectionNode.h"
 @protocol ASCollectionViewLayoutFacilitatorProtocol;
 
 NS_ASSUME_NONNULL_BEGIN

--- a/AsyncDisplayKit/TextKit/ASTextKitContext.h
+++ b/AsyncDisplayKit/TextKit/ASTextKitContext.h
@@ -30,6 +30,8 @@
                          constrainedSize:(CGSize)constrainedSize
                     layoutManagerFactory:(NSLayoutManager*(*)(void))layoutManagerFactory;
 
+@property (nonatomic, assign, readwrite) CGSize constrainedSize;
+
 /**
  All operations on TextKit values MUST occur within this locked context.  Simultaneous access (even non-mutative) to
  TextKit components may cause crashes.

--- a/AsyncDisplayKit/TextKit/ASTextKitContext.mm
+++ b/AsyncDisplayKit/TextKit/ASTextKitContext.mm
@@ -49,6 +49,16 @@
   return self;
 }
 
+- (CGSize)constrainedSize
+{
+  return _textContainer.size;
+}
+
+- (void)setConstrainedSize:(CGSize)constrainedSize
+{
+  _textContainer.size = constrainedSize;
+}
+
 - (void)performBlockWithLockedTextKitComponents:(void (^)(NSLayoutManager *,
                                                           NSTextStorage *,
                                                           NSTextContainer *))block

--- a/AsyncDisplayKit/TextKit/ASTextKitRenderer.h
+++ b/AsyncDisplayKit/TextKit/ASTextKitRenderer.h
@@ -37,7 +37,6 @@
 
 /**
  Designated Initializer
-dvlkferufedgjnhjjfhldjedlunvtdtv
  @discussion Sizing will occur as a result of initialization, so be careful when/where you use this.
  */
 - (instancetype)initWithTextKitAttributes:(const ASTextKitAttributes &)textComponentAttributes
@@ -51,7 +50,7 @@ dvlkferufedgjnhjjfhldjedlunvtdtv
 
 @property (nonatomic, assign, readonly) ASTextKitAttributes attributes;
 
-@property (nonatomic, assign, readonly) CGSize constrainedSize;
+@property (nonatomic, assign, readwrite) CGSize constrainedSize;
 
 #pragma mark - Drawing
 /*

--- a/AsyncDisplayKit/TextKit/ASTextKitTailTruncater.mm
+++ b/AsyncDisplayKit/TextKit/ASTextKitTailTruncater.mm
@@ -18,7 +18,6 @@
   __weak ASTextKitContext *_context;
   NSAttributedString *_truncationAttributedString;
   NSCharacterSet *_avoidTailTruncationSet;
-  CGSize _constrainedSize;
 }
 @synthesize visibleRanges = _visibleRanges;
 @synthesize truncationStringRect = _truncationStringRect;
@@ -26,13 +25,11 @@
 - (instancetype)initWithContext:(ASTextKitContext *)context
      truncationAttributedString:(NSAttributedString *)truncationAttributedString
          avoidTailTruncationSet:(NSCharacterSet *)avoidTailTruncationSet
-                constrainedSize:(CGSize)constrainedSize
 {
   if (self = [super init]) {
     _context = context;
     _truncationAttributedString = truncationAttributedString;
     _avoidTailTruncationSet = avoidTailTruncationSet;
-    _constrainedSize = constrainedSize;
 
     [self _truncate];
   }

--- a/AsyncDisplayKit/TextKit/ASTextKitTruncating.h
+++ b/AsyncDisplayKit/TextKit/ASTextKitTruncating.h
@@ -31,7 +31,6 @@
  */
 - (instancetype)initWithContext:(ASTextKitContext *)context
      truncationAttributedString:(NSAttributedString *)truncationAttributedString
-         avoidTailTruncationSet:(NSCharacterSet *)avoidTailTruncationSet
-                constrainedSize:(CGSize)constrainedSize;
+         avoidTailTruncationSet:(NSCharacterSet *)avoidTailTruncationSet;
 
 @end

--- a/AsyncDisplayKitTests/ASTextKitTruncationTests.mm
+++ b/AsyncDisplayKitTests/ASTextKitTruncationTests.mm
@@ -50,8 +50,7 @@
   }];
   ASTextKitTailTruncater *tailTruncater = [[ASTextKitTailTruncater alloc] initWithContext:context
                                                                truncationAttributedString:nil
-                                                                   avoidTailTruncationSet:nil
-                                                                          constrainedSize:constrainedSize];
+                                                                   avoidTailTruncationSet:nil];
   XCTAssert(NSEqualRanges(textKitVisibleRange, tailTruncater.visibleRanges[0]));
 }
 
@@ -67,8 +66,7 @@
                                                             layoutManagerFactory:nil];
   ASTextKitTailTruncater *tailTruncater = [[ASTextKitTailTruncater alloc] initWithContext:context
                                                                truncationAttributedString:[self _simpleTruncationAttributedString]
-                                                                   avoidTailTruncationSet:[NSCharacterSet characterSetWithCharactersInString:@""]
-                                                                          constrainedSize:constrainedSize];
+                                                                   avoidTailTruncationSet:[NSCharacterSet characterSetWithCharactersInString:@""]];
   __block NSString *drawnString;
   [context performBlockWithLockedTextKitComponents:^(NSLayoutManager *layoutManager, NSTextStorage *textStorage, NSTextContainer *textContainer) {
     drawnString = textStorage.string;
@@ -90,8 +88,7 @@
                                                             layoutManagerFactory:nil];
   ASTextKitTailTruncater *tailTruncater = [[ASTextKitTailTruncater alloc] initWithContext:context
                                                                truncationAttributedString:[self _simpleTruncationAttributedString]
-                                                                   avoidTailTruncationSet:[NSCharacterSet characterSetWithCharactersInString:@"."]
-                                                                          constrainedSize:constrainedSize];
+                                                                   avoidTailTruncationSet:[NSCharacterSet characterSetWithCharactersInString:@"."]];
   (void)tailTruncater;
   __block NSString *drawnString;
   [context performBlockWithLockedTextKitComponents:^(NSLayoutManager *layoutManager, NSTextStorage *textStorage, NSTextContainer *textContainer) {
@@ -114,8 +111,7 @@
                                                             layoutManagerFactory:nil];
   ASTextKitTailTruncater *tailTruncater = [[ASTextKitTailTruncater alloc] initWithContext:context
                                                                truncationAttributedString:[self _simpleTruncationAttributedString]
-                                                                   avoidTailTruncationSet:[NSCharacterSet characterSetWithCharactersInString:@"."]
-                                                                          constrainedSize:constrainedSize];
+                                                                   avoidTailTruncationSet:[NSCharacterSet characterSetWithCharactersInString:@"."]];
   // So Xcode doesn't yell at me for an unused var...
   (void)tailTruncater;
   __block NSString *drawnString;
@@ -139,8 +135,7 @@
                                                             layoutManagerFactory:nil];
   XCTAssertNoThrow([[ASTextKitTailTruncater alloc] initWithContext:context
                                         truncationAttributedString:[self _simpleTruncationAttributedString]
-                                            avoidTailTruncationSet:[NSCharacterSet characterSetWithCharactersInString:@"."]
-                                                   constrainedSize:constrainedSize]);
+                                            avoidTailTruncationSet:[NSCharacterSet characterSetWithCharactersInString:@"."]]);
 }
 
 @end


### PR DESCRIPTION
This also fixes three fairly subtle but serious bugs: #1076, #1046 and #1031.

cc @aaronschubert0 - note I ended up tracing a logic flaw to the most recent patch in this area (#1079), which altered the inset handling with the shadower.  I'm still glad you put up this change because it did very clearly appear to improve the behavior, but worsened other situations, like the centering case.  

@nvh - you'd be the most valuable tester, although I confirmed both types of clipping miscalculations very strategically recreated in your awesome sample app appear fully corrected.

@yxztj - I actually was using your sample app for the majority of the time it took me to carefully understand and adjust this code.

@bsmith11, @timominous, @AttilaTheFun, @nguyenhuy, @1nput0utput, @stowy, @lappp9, @RCacheaux, @samhsiung, @binl, @rcancro - Please join us in testing!

I'm excited that I feel confident working in this part of the codebase; it's probably one of the few scary corners remaining to be confronted.  One of the primary needs now is a big expansion in automated performance and logic testing...

The overall code quality and engineering style in the framework, to me, feels awesome. I'm glad to be working on continuing to do industry-first things as a community together!