### PR TITLE
[ASLayout, ASTextNode] Create -calculatedLayoutDidChange and use it in text node.

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode+Subclasses.h
+++ b/AsyncDisplayKit/ASDisplayNode+Subclasses.h
@@ -91,6 +91,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)layoutDidFinish;
 
+/**
+ * @abstract Called on a background thread if !isNodeLoaded - called on the main thread if isNodeLoaded.
+ *
+ * @discussion When the .calculatedLayout property is set to a new ASLayout (directly from -calculateLayoutThatFits: or
+ * calculated via use of -layoutSpecThatFits:), subclasses may inspect it here.
+ */
+- (void)calculatedLayoutDidChange;
 
 /** @name Layout calculation */
 

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -594,6 +594,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
     _layout = [self calculateLayoutThatFits:constrainedSize];
     _constrainedSize = constrainedSize;
     _flags.isMeasured = YES;
+    [self calculatedLayoutDidChange];
   }
 
   ASDisplayNodeAssertTrue(_layout.layoutableObject == self);
@@ -613,6 +614,10 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   }
 
   return _layout;
+}
+
+- (void)calculatedLayoutDidChange
+{
 }
 
 - (BOOL)displaysAsynchronously


### PR DESCRIPTION
This allows the change in size for the NSTextContainer to occur off the main thread, whenever that size change is necessary.  Then the text relayout can occur earlier, during the process of computing ASLayoutSpecs.