### PR TITLE
[ASRangeControllerBeta] Scan all nodes after edit operations.

### DIFF
--- a/AsyncDisplayKit/Details/ASRangeControllerBeta.mm
+++ b/AsyncDisplayKit/Details/ASRangeControllerBeta.mm
@@ -134,6 +134,10 @@
   [allIndexPaths unionSet:_allPreviousIndexPaths];
   _allPreviousIndexPaths = allCurrentIndexPaths;
   
+  if (!_rangeIsValid) {
+    [allIndexPaths addObjectsFromArray:ASIndexPathsForMultidimensionalArray(allNodes)];
+  }
+  
   // This array is only used if logging is enabled.
   NSMutableArray<NSIndexPath *> *modifiedIndexPaths = (RangeControllerLoggingEnabled ? [NSMutableArray array] : nil);
   


### PR DESCRIPTION
@knopp, please do take a look!  Is there any more efficient way you can think to do this?  I'm particularly bummed about creating all the index paths - I think we could make an alternate codepath that iterates over the nodes themselves, keeping a local integer of section and item number, doing something like the multidimensional helper function does internally by building up the index path by index - but not having to create a full array of them.  This might not help efficiency much, though it would also eliminate accessing the nodes out of the 2D array.