### PR TITLE
Bring reloadData optimizations back

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -948,10 +948,12 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   
   if (_performingBatchUpdates) {
     [_batchUpdateBlocks addObject:^{
+      _superIsPendingDataLoad = YES;
       [super reloadData];
     }];
   } else {
     [UIView performWithoutAnimation:^{
+      _superIsPendingDataLoad = YES;
       [super reloadData];
     }];
   }

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -250,7 +250,7 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
     _superIsPendingDataLoad = YES;
     [super reloadData];
   });
-  [_dataController reloadDataWithAnimationOptions:kASCollectionViewAnimationNone completion:completion];
+  [_dataController reloadDataWithCompletion:completion];
 }
 
 - (void)reloadData
@@ -262,7 +262,7 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
 {
   ASDisplayNodeAssertMainThread();
   _superIsPendingDataLoad = YES;
-  [_dataController reloadDataImmediatelyWithAnimationOptions:kASCollectionViewAnimationNone];
+  [_dataController reloadDataImmediately];
   [super reloadData];
 }
 
@@ -934,6 +934,25 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   } else {
     [UIView performWithoutAnimation:^{
       [super deleteSections:indexSet];
+    }];
+  }
+}
+
+- (void)rangeControllerDidReloadData:(ASRangeController *)rangeController
+{
+  ASDisplayNodeAssertMainThread();
+  
+  if (!self.asyncDataSource || _superIsPendingDataLoad) {
+    return; // if the asyncDataSource has become invalid while we are processing, ignore this request to avoid crashes
+  }
+  
+  if (_performingBatchUpdates) {
+    [_batchUpdateBlocks addObject:^{
+      [super reloadData];
+    }];
+  } else {
+    [UIView performWithoutAnimation:^{
+      [super reloadData];
     }];
   }
 }

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -298,10 +298,7 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
 
 - (void)reloadDataWithCompletion:(void (^)())completion
 {
-  ASPerformBlockOnMainThread(^{
-    [super reloadData];
-  });
-  [_dataController reloadDataWithAnimationOptions:UITableViewRowAnimationNone completion:completion];
+  [_dataController reloadDataWithCompletion:completion];
 }
 
 - (void)reloadData
@@ -312,8 +309,7 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
 - (void)reloadDataImmediately
 {
   ASDisplayNodeAssertMainThread();
-  [_dataController reloadDataImmediatelyWithAnimationOptions:UITableViewRowAnimationNone];
-  [super reloadData];
+  [_dataController reloadDataImmediately];
 }
 
 - (void)setTuningParameters:(ASRangeTuningParameters)tuningParameters forRangeType:(ASLayoutRangeType)rangeType
@@ -843,6 +839,18 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
   ASPerformBlockWithoutAnimation(preventAnimation, ^{
     [super deleteSections:indexSet withRowAnimation:(UITableViewRowAnimation)animationOptions];
   });
+}
+
+- (void)rangeControllerDidReloadData:(ASRangeController *)rangeController
+{
+  ASDisplayNodeAssertMainThread();
+  LOG(@"UITableView reloadData");
+  
+  if (!self.asyncDataSource) {
+    return; // if the asyncDataSource has become invalid while we are processing, ignore this request to avoid crashes
+  }
+
+  [super reloadData];
 }
 
 #pragma mark - ASDataControllerDelegate

--- a/AsyncDisplayKit/Details/ASDataController.h
+++ b/AsyncDisplayKit/Details/ASDataController.h
@@ -94,6 +94,11 @@ FOUNDATION_EXPORT NSString * const ASDataControllerRowNodeKind;
  */
 - (void)dataController:(ASDataController *)dataController didDeleteSectionsAtIndexSet:(NSIndexSet *)indexSet withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions;
 
+/**
+ Called for data reload.
+ */
+- (void)dataControllerDidReloadData:(ASDataController *)dataController;
+
 @end
 
 /**
@@ -170,9 +175,9 @@ FOUNDATION_EXPORT NSString * const ASDataControllerRowNodeKind;
 
 - (void)moveRowAtIndexPath:(NSIndexPath *)indexPath toIndexPath:(NSIndexPath *)newIndexPath withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions;
 
-- (void)reloadDataWithAnimationOptions:(ASDataControllerAnimationOptions)animationOptions completion:(void (^ _Nullable)())completion;
+- (void)reloadDataWithCompletion:(void (^ _Nullable)())completion;
 
-- (void)reloadDataImmediatelyWithAnimationOptions:(ASDataControllerAnimationOptions)animationOptions;
+- (void)reloadDataImmediately;
 
 /** @name Data Querying */
 

--- a/AsyncDisplayKit/Details/ASRangeController.h
+++ b/AsyncDisplayKit/Details/ASRangeController.h
@@ -190,6 +190,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)rangeController:(ASRangeController *)rangeController didDeleteSectionsAtIndexSet:(NSIndexSet *)indexSet withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions;
 
+/**
+ * Called for data reload.
+ *
+ * @param rangeController Sender.
+ */
+- (void)rangeControllerDidReloadData:(ASRangeController *)rangeController;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/AsyncDisplayKit/Details/ASRangeController.mm
+++ b/AsyncDisplayKit/Details/ASRangeController.mm
@@ -276,4 +276,17 @@
   });
 }
 
+- (void)dataControllerDidReloadData:(ASDataController *)dataController
+{
+  ASPerformBlockOnMainThread(^{
+    _rangeIsValid = NO;
+    
+    // When reload data we need to make sure that _rangeTypeIndexPaths is cleared as well,
+    // otherwise _updateVisibleNodeIndexPaths may try to retrieve nodes from dataSource that aren't there anymore
+    [_rangeTypeIndexPaths removeAllObjects];
+    
+    [_delegate rangeControllerDidReloadData:self];
+  });
+}
+
 @end

--- a/AsyncDisplayKit/Details/ASRangeControllerBeta.mm
+++ b/AsyncDisplayKit/Details/ASRangeControllerBeta.mm
@@ -288,4 +288,12 @@
   });
 }
 
+- (void)dataControllerDidReloadData:(ASDataController *)dataController
+{
+  ASPerformBlockOnMainThread(^{
+    _rangeIsValid = NO;
+    [_delegate rangeControllerDidReloadData:self];
+  });
+}
+
 @end


### PR DESCRIPTION
The ASCollectionView data inconsistency crash introduced by #1093 occurs because I didn't apply the same workaround added in #672. With the root cause discovered, I'd like to bring that PR back. When time permits, I will write a unit test to make sure this kind of crash won't happen again.