### PR TITLE
[ASTextNode] Prompt creation of truncater object when the context object is accessed.

### DIFF
--- a/AsyncDisplayKit/TextKit/ASTextKitRenderer.mm
+++ b/AsyncDisplayKit/TextKit/ASTextKitRenderer.mm
@@ -88,6 +88,8 @@ static NSCharacterSet *_defaultAvoidTruncationCharacterSet()
                                                    exclusionPaths:attributes.exclusionPaths
                                                   constrainedSize:shadowConstrainedSize
                                              layoutManagerFactory:attributes.layoutManagerFactory];
+
+    [self truncater];
   }
   return _context;
 }


### PR DESCRIPTION
See [comment](https://github.com/facebook/AsyncDisplayKit/commit/99fbc97bdaecd2f99009b9734ba0f8f2b665632b#commitcomment-15649130)


Fixes #865.

attributedString on ASTextNode should be set after all truncationStrings...