### PR TITLE
[ASTextNode] Fix out-of-bounds error when truncation string is longer than the original string.

### DIFF
--- a/AsyncDisplayKit/ASTextNode.mm
+++ b/AsyncDisplayKit/ASTextNode.mm
@@ -479,6 +479,7 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
   ASTextKitRenderer *renderer = [self _renderer];
   NSRange visibleRange = renderer.visibleRanges[0];
   NSAttributedString *attributedString = _attributedString;
+  NSRange clampedRange = NSIntersectionRange(visibleRange, NSMakeRange(0, attributedString.length));
 
   // Check in a 9-point region around the actual touch point so we make sure
   // we get the best attribute for the touch.
@@ -519,7 +520,7 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
 
     for (NSString *attributeName in _linkAttributeNames) {
       NSRange range;
-      id value = [attributedString attribute:attributeName atIndex:characterIndex longestEffectiveRange:&range inRange:visibleRange];
+      id value = [attributedString attribute:attributeName atIndex:characterIndex longestEffectiveRange:&range inRange:clampedRange];
       NSString *name = attributeName;
 
       if (value == nil || name == nil) {


### PR DESCRIPTION
Actually it is possible that truncated string is longer then original
string.

For example, original string:

```
hello
this is
very long
message here
and there
```

with maximumNumberOfLines=4, truncationAttributedString = ' ...' and
additionalTruncationMessage = 'read more'

will give

```
hello
this is
very long
message here ... read more
```

So `[attributedString attribute:attributeName atIndex:characterIndex
longestEffectiveRange:&range inRange:visibleRange]` will crash.