### PR TITLE
[_ASAsyncTransaction] implement operation priority

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -67,6 +67,11 @@ typedef NS_OPTIONS(NSUInteger, ASInterfaceState)
 };
 
 /**
+ * Default drawing priority for display node
+ */
+extern NSUInteger const ASDefaultDrawingPriority;
+
+/**
  * An `ASDisplayNode` is an abstraction over `UIView` and `CALayer` that allows you to perform calculations about a view
  * hierarchy off the main thread, and could do rendering off the main thread as well.
  *
@@ -475,6 +480,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, assign) NSTimeInterval placeholderFadeDuration;
 
+/**
+ * @abstract Determines drawing priority of the node. Nodes with higher priority will be drawn earlier.
+ *
+ * @discussion Defaults to ASDefaultDrawingPriority. There may be multiple drawing threads, and some of them may
+ * decide to perform operations in queued order (regardless of drawingPriority)
+ */
+@property (nonatomic, assign) NSUInteger drawingPriority;
 
 /** @name Hit Testing */
 

--- a/AsyncDisplayKit/Details/Transactions/_ASAsyncTransaction.h
+++ b/AsyncDisplayKit/Details/Transactions/_ASAsyncTransaction.h
@@ -29,6 +29,8 @@ typedef NS_ENUM(NSUInteger, ASAsyncTransactionState) {
   ASAsyncTransactionStateComplete
 };
 
+extern NSUInteger const ASDefaultTransactionPriority;
+
 /**
  @summary ASAsyncTransaction provides lightweight transaction semantics for asynchronous operations.
 
@@ -95,6 +97,25 @@ typedef NS_ENUM(NSUInteger, ASAsyncTransactionState) {
                    completion:(asyncdisplaykit_async_transaction_operation_completion_block_t)completion;
 
 /**
+ @summary Adds a synchronous operation to the transaction.  The execution block will be executed immediately.
+ 
+ @desc The block will be executed on the specified queue and is expected to complete synchronously.  The async
+ transaction will wait for all operations to execute on their appropriate queues, so the blocks may still be executing
+ async if they are running on a concurrent queue, even though the work for this block is synchronous.
+ 
+ @param block The execution block that will be executed on a background queue.  This is where the expensive work goes.
+ @param priority Execution priority; Tasks with higher priority will be executed sooner
+ @param queue The dispatch queue on which to execute the block.
+ @param completion The completion block that will be executed with the output of the execution block when all of the
+ operations in the transaction are completed. Executed and released on callbackQueue.
+ */
+- (void)addOperationWithBlock:(asyncdisplaykit_async_transaction_operation_block_t)block
+                     priority:(NSUInteger)priority
+                        queue:(dispatch_queue_t)queue
+                   completion:(asyncdisplaykit_async_transaction_operation_completion_block_t)completion;
+
+
+/**
  @summary Adds an async operation to the transaction.  The execution block will be executed immediately.
 
  @desc The block will be executed on the specified queue and is expected to complete asynchronously.  The block will be
@@ -111,6 +132,27 @@ typedef NS_ENUM(NSUInteger, ASAsyncTransactionState) {
 - (void)addAsyncOperationWithBlock:(asyncdisplaykit_async_transaction_async_operation_block_t)block
                              queue:(dispatch_queue_t)queue
                         completion:(asyncdisplaykit_async_transaction_operation_completion_block_t)completion;
+
+/**
+ @summary Adds an async operation to the transaction.  The execution block will be executed immediately.
+ 
+ @desc The block will be executed on the specified queue and is expected to complete asynchronously.  The block will be
+ supplied with a completion block that can be executed once its async operation is completed.  This is useful for
+ network downloads and other operations that have an async API.
+ 
+ WARNING: Consumers MUST call the completeOperationBlock passed into the work block, or objects will be leaked!
+ 
+ @param block The execution block that will be executed on a background queue.  This is where the expensive work goes.
+ @param priority Execution priority; Tasks with higher priority will be executed sooner
+ @param queue The dispatch queue on which to execute the block.
+ @param completion The completion block that will be executed with the output of the execution block when all of the
+ operations in the transaction are completed. Executed and released on callbackQueue.
+ */
+- (void)addAsyncOperationWithBlock:(asyncdisplaykit_async_transaction_async_operation_block_t)block
+                          priority:(NSUInteger)priority
+                             queue:(dispatch_queue_t)queue
+                        completion:(asyncdisplaykit_async_transaction_operation_completion_block_t)completion;
+
 
 
 /**

--- a/AsyncDisplayKit/Details/Transactions/_ASAsyncTransaction.mm
+++ b/AsyncDisplayKit/Details/Transactions/_ASAsyncTransaction.mm
@@ -163,16 +163,11 @@ void ASAsyncTransactionQueue::GroupImpl::schedule(dispatch_queue_t queue, dispat
   
   ++_pendingOperations; // enter group
   
-  NSUInteger maxThreads = [NSProcessInfo processInfo].activeProcessorCount;
-  if (maxThreads < 2) { // it is reasonable to have at least two working threads, also
-    maxThreads = 2;     // [_ASDisplayLayerTests testTransaction] requires at least two threads
-  }
+  NSUInteger maxThreads = [NSProcessInfo processInfo].activeProcessorCount * 2;
 
-#if 0
-  // Bit questionable - we can give main thread more CPU time during tracking;
-  if (maxThreads > 1 && [[NSRunLoop mainRunLoop].currentMode isEqualToString:UITrackingRunLoopMode])
+  // Bit questionable maybe - we can give main thread more CPU time during tracking;
+  if ([[NSRunLoop mainRunLoop].currentMode isEqualToString:UITrackingRunLoopMode])
     --maxThreads;
-#endif
   
   if (entry._threadCount < maxThreads) { // we need to spawn another thread
 

--- a/AsyncDisplayKit/Private/ASDisplayNode+AsyncDisplay.mm
+++ b/AsyncDisplayKit/Private/ASDisplayNode+AsyncDisplay.mm
@@ -358,7 +358,7 @@ static void __ASDisplayLayerDecrementConcurrentDisplayCount(BOOL displayIsAsync,
     
     // Adding this displayBlock operation to the transaction will start it IMMEDIATELY.
     // The only function of the transaction commit is to gate the calling of the completionBlock.
-    [transaction addOperationWithBlock:displayBlock queue:[_ASDisplayLayer displayQueue] completion:completionBlock];
+    [transaction addOperationWithBlock:displayBlock priority:self.drawingPriority queue:[_ASDisplayLayer displayQueue] completion:completionBlock];
   } else {
     UIImage *contents = (UIImage *)displayBlock();
     completionBlock(contents, NO);

--- a/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
+++ b/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
@@ -84,6 +84,7 @@ typedef NS_OPTIONS(NSUInteger, ASDisplayNodeMethodOverrides)
     unsigned shouldRasterizeDescendants:1;
     unsigned shouldBypassEnsureDisplay:1;
     unsigned displaySuspended:1;
+    unsigned hasCustomDrawingPriority:1;
 
     // whether custom drawing is enabled
     unsigned implementsDrawRect:1;


### PR DESCRIPTION
Something to consider.

Two commits here. One somewhat unrelated tweaks number of threads. Just `activeProcessorCount` does indeed seem to be a bit conservative. New code does `activeProcessorCount * 2` and decreases the result by 1 when tracking.

Second implements prioritization of transaction operations. Priority is a number, operations with higher priority are more likely to get executed sooner. Some details:

* one (first) processing threads executes all operation in queue order; This is to ensure that even lower priority operations will not be completely ignored; Subsequent threads execute higher priority operations first
* scheduling and retrieving scheduled operations is done in constant time (in practice; corner cases where no two operations have same priority, would be log(n), but that's extremely unlikely to happen)
* Node drawing priority can be specified by the `drawingPriority` property. The assumption is that most nodes would stick to default priority, so instead of field a flag and associated object is used for nodes with custom priority.

This all seems to help quite a lot in our case, where we strongly prefer labels to be rendered during scrolling to thumbnails, which can now be easily achieved by
```
imageNode.drawingPriority = ASDefaultDrawingPriority - 1;
```
It doesn't make much difference on iPad Air 2, but does on iPad 3. :)