### PR TITLE
expose beginUpdates and endUpdates

### DIFF
--- a/AsyncDisplayKit/ASCollectionNode+Beta.h
+++ b/AsyncDisplayKit/ASCollectionNode+Beta.h
@@ -14,6 +14,8 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ASCollectionNode (Beta)
 
 - (instancetype)initWithFrame:(CGRect)frame collectionViewLayout:(UICollectionViewLayout *)layout layoutFacilitator:(nullable id<ASCollectionViewLayoutFacilitatorProtocol>)layoutFacilitator;
+- (void)beginUpdates;
+- (void)endUpdatesAnimated:(BOOL)animated;
 
 @end
 

--- a/AsyncDisplayKit/ASCollectionNode.mm
+++ b/AsyncDisplayKit/ASCollectionNode.mm
@@ -189,12 +189,12 @@
 
 - (void)beginUpdates
 {
-    [self.view.dataController beginUpdates];
+  [self.view.dataController beginUpdates];
 }
 
 - (void)endUpdatesAnimated:(BOOL)animated
 {
-    [self.view.dataController endUpdatesAnimated:animated completion:nil];
+  [self.view.dataController endUpdatesAnimated:animated completion:nil];
 }
 
 #pragma mark - ASCollectionView Forwards

--- a/AsyncDisplayKit/ASCollectionNode.mm
+++ b/AsyncDisplayKit/ASCollectionNode.mm
@@ -187,6 +187,16 @@
   [self.view clearFetchedData];
 }
 
+- (void)beginUpdates
+{
+    [self.view.dataController beginUpdates];
+}
+
+- (void)endUpdatesAnimated:(BOOL)animated
+{
+    [self.view.dataController endUpdatesAnimated:animated completion:nil];
+}
+
 #pragma mark - ASCollectionView Forwards
 
 - (ASRangeTuningParameters)tuningParametersForRangeType:(ASLayoutRangeType)rangeType

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -396,6 +396,11 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
 
 #pragma mark Assertions.
 
+- (ASDataController *)dataController
+{
+    return _dataController;
+}
+
 - (void)performBatchAnimated:(BOOL)animated updates:(void (^)())updates completion:(void (^)(BOOL))completion
 {
   ASDisplayNodeAssertMainThread();

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -876,13 +876,13 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   }
   
   if (_performingBatchUpdates) {
-    [_layoutFacilitator collectionViewBatchingCellEditsAtIndexPaths:indexPaths];
+    [_layoutFacilitator collectionViewWillEditCellsAtIndexPaths:indexPaths batched:YES];
     [_batchUpdateBlocks addObject:^{
       [super insertItemsAtIndexPaths:indexPaths];
     }];
   } else {
+    [_layoutFacilitator collectionViewWillEditCellsAtIndexPaths:indexPaths batched:NO];
     [UIView performWithoutAnimation:^{
-      [_layoutFacilitator collectionViewEditingCellsAtIndexPaths:indexPaths];
       [super insertItemsAtIndexPaths:indexPaths];
     }];
   }
@@ -891,19 +891,18 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
 - (void)rangeController:(ASRangeController *)rangeController didDeleteNodes:(NSArray *)nodes atIndexPaths:(NSArray *)indexPaths withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions
 {
   ASDisplayNodeAssertMainThread();
-  [_layoutFacilitator collectionViewEditingCellsAtIndexPaths:indexPaths];
   if (!self.asyncDataSource || _superIsPendingDataLoad) {
     return; // if the asyncDataSource has become invalid while we are processing, ignore this request to avoid crashes
   }
   
   if (_performingBatchUpdates) {
-    [_layoutFacilitator collectionViewBatchingCellEditsAtIndexPaths:indexPaths];
+    [_layoutFacilitator collectionViewWillEditCellsAtIndexPaths:indexPaths batched:YES];
     [_batchUpdateBlocks addObject:^{
       [super deleteItemsAtIndexPaths:indexPaths];
     }];
   } else {
+    [_layoutFacilitator collectionViewWillEditCellsAtIndexPaths:indexPaths batched:NO];
     [UIView performWithoutAnimation:^{
-      [_layoutFacilitator collectionViewEditingCellsAtIndexPaths:indexPaths];
       [super deleteItemsAtIndexPaths:indexPaths];
     }];
   }
@@ -917,13 +916,13 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   }
   
   if (_performingBatchUpdates) {
-    [_layoutFacilitator collectionViewBatchingSectionEditsAtIndexes:indexSet];
+    [_layoutFacilitator collectionViewWillEditSectionsAtIndexSet:indexSet batched:YES];
     [_batchUpdateBlocks addObject:^{
       [super insertSections:indexSet];
     }];
   } else {
+    [_layoutFacilitator collectionViewWillEditSectionsAtIndexSet:indexSet batched:NO];
     [UIView performWithoutAnimation:^{
-      [_layoutFacilitator collectionViewEditingSectionsAtIndexSet:indexSet];
       [super insertSections:indexSet];
     }];
   }
@@ -937,13 +936,13 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   }
   
   if (_performingBatchUpdates) {
-    [_layoutFacilitator collectionViewBatchingSectionEditsAtIndexes:indexSet];
+    [_layoutFacilitator collectionViewWillEditSectionsAtIndexSet:indexSet batched:YES];
     [_batchUpdateBlocks addObject:^{
       [super deleteSections:indexSet];
     }];
   } else {
+    [_layoutFacilitator collectionViewWillEditSectionsAtIndexSet:indexSet batched:NO];
     [UIView performWithoutAnimation:^{
-      [_layoutFacilitator collectionViewEditingSectionsAtIndexSet:indexSet];
       [super deleteSections:indexSet];
     }];
   }

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -398,7 +398,7 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
 
 - (ASDataController *)dataController
 {
-    return _dataController;
+  return _dataController;
 }
 
 - (void)performBatchAnimated:(BOOL)animated updates:(void (^)())updates completion:(void (^)(BOOL))completion
@@ -856,6 +856,7 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   }
   
   ASPerformBlockWithoutAnimation(!animated, ^{
+    [_layoutFacilitator collectionViewWillPerformBatchUpdates];
     [super performBatchUpdates:^{
       for (dispatch_block_t block in _batchUpdateBlocks) {
         block();
@@ -870,17 +871,18 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
 - (void)rangeController:(ASRangeController *)rangeController didInsertNodes:(NSArray *)nodes atIndexPaths:(NSArray *)indexPaths withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions
 {
   ASDisplayNodeAssertMainThread();
-  [_layoutFacilitator collectionViewEditingCellsAtIndexPaths:indexPaths];
   if (!self.asyncDataSource || _superIsPendingDataLoad) {
     return; // if the asyncDataSource has become invalid while we are processing, ignore this request to avoid crashes
   }
   
   if (_performingBatchUpdates) {
+    [_layoutFacilitator collectionViewBatchingCellEditsAtIndexPaths:indexPaths];
     [_batchUpdateBlocks addObject:^{
       [super insertItemsAtIndexPaths:indexPaths];
     }];
   } else {
     [UIView performWithoutAnimation:^{
+      [_layoutFacilitator collectionViewEditingCellsAtIndexPaths:indexPaths];
       [super insertItemsAtIndexPaths:indexPaths];
     }];
   }
@@ -895,11 +897,13 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   }
   
   if (_performingBatchUpdates) {
+    [_layoutFacilitator collectionViewBatchingCellEditsAtIndexPaths:indexPaths];
     [_batchUpdateBlocks addObject:^{
       [super deleteItemsAtIndexPaths:indexPaths];
     }];
   } else {
     [UIView performWithoutAnimation:^{
+      [_layoutFacilitator collectionViewEditingCellsAtIndexPaths:indexPaths];
       [super deleteItemsAtIndexPaths:indexPaths];
     }];
   }
@@ -908,17 +912,18 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
 - (void)rangeController:(ASRangeController *)rangeController didInsertSectionsAtIndexSet:(NSIndexSet *)indexSet withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions
 {
   ASDisplayNodeAssertMainThread();
-  [_layoutFacilitator collectionViewEditingSectionsAtIndexSet:indexSet];
   if (!self.asyncDataSource || _superIsPendingDataLoad) {
     return; // if the asyncDataSource has become invalid while we are processing, ignore this request to avoid crashes
   }
   
   if (_performingBatchUpdates) {
+    [_layoutFacilitator collectionViewBatchingSectionEditsAtIndexes:indexSet];
     [_batchUpdateBlocks addObject:^{
       [super insertSections:indexSet];
     }];
   } else {
     [UIView performWithoutAnimation:^{
+      [_layoutFacilitator collectionViewEditingSectionsAtIndexSet:indexSet];
       [super insertSections:indexSet];
     }];
   }
@@ -927,17 +932,18 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
 - (void)rangeController:(ASRangeController *)rangeController didDeleteSectionsAtIndexSet:(NSIndexSet *)indexSet withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions
 {
   ASDisplayNodeAssertMainThread();
-  [_layoutFacilitator collectionViewEditingSectionsAtIndexSet:indexSet];
   if (!self.asyncDataSource || _superIsPendingDataLoad) {
     return; // if the asyncDataSource has become invalid while we are processing, ignore this request to avoid crashes
   }
   
   if (_performingBatchUpdates) {
+    [_layoutFacilitator collectionViewBatchingSectionEditsAtIndexes:indexSet];
     [_batchUpdateBlocks addObject:^{
       [super deleteSections:indexSet];
     }];
   } else {
     [UIView performWithoutAnimation:^{
+      [_layoutFacilitator collectionViewEditingSectionsAtIndexSet:indexSet];
       [super deleteSections:indexSet];
     }];
   }

--- a/AsyncDisplayKit/ASCollectionViewLayoutFacilitatorProtocol.h
+++ b/AsyncDisplayKit/ASCollectionViewLayoutFacilitatorProtocol.h
@@ -25,6 +25,27 @@
  */
 - (void)collectionViewEditingSectionsAtIndexSet:(NSIndexSet *)indexes;
 
+/**
+ * Inform that the collectionView is adding some cell updates into a batch,
+ * and will perform these batch updates at a later point
+ *
+ * NOTE: used in combination with -collectionViewWillPerformBatchUpdates
+ */
+- (void)collectionViewBatchingCellEditsAtIndexPaths:(NSArray *)indexPaths;
+
+/**
+ * Inform that the collectionView is adding some section updates into a batch, 
+ * and will perform these batch updates at a later point
+ *
+ * NOTE: used in combination with -collectionViewWillPerformBatchUpdates
+ */
+- (void)collectionViewBatchingSectionEditsAtIndexes:(NSIndexSet *)indexes;
+
+/**
+ * Informs the delegate that the collectionView is about to call performBatchUpdates
+ */
+- (void)collectionViewWillPerformBatchUpdates;
+
 @end
 
 #endif /* ASCollectionViewLayoutFacilitatorProtocol_h */

--- a/AsyncDisplayKit/ASCollectionViewLayoutFacilitatorProtocol.h
+++ b/AsyncDisplayKit/ASCollectionViewLayoutFacilitatorProtocol.h
@@ -17,29 +17,23 @@
 
 /**
  * Inform that the collectionView is editing the cells at a list of indexPaths
+ *
+ * @param indexPaths, an array of NSIndexPath objects of cells being/will be edited.
+ * @param isBatched, indicates whether the editing operation will be batched by the collectionView
+ *
+ * NOTE: when isBatched, used in combination with -collectionViewWillPerformBatchUpdates
  */
-- (void)collectionViewEditingCellsAtIndexPaths:(NSArray *)indexPaths;
+- (void)collectionViewWillEditCellsAtIndexPaths:(NSArray *)indexPaths batched:(BOOL)isBatched;
 
 /**
  * Inform that the collectionView is editing the sections at a set of indexes
- */
-- (void)collectionViewEditingSectionsAtIndexSet:(NSIndexSet *)indexes;
-
-/**
- * Inform that the collectionView is adding some cell updates into a batch,
- * and will perform these batch updates at a later point
  *
- * NOTE: used in combination with -collectionViewWillPerformBatchUpdates
- */
-- (void)collectionViewBatchingCellEditsAtIndexPaths:(NSArray *)indexPaths;
-
-/**
- * Inform that the collectionView is adding some section updates into a batch, 
- * and will perform these batch updates at a later point
+ * @param indexes, an NSIndexSet of section indexes being/will be edited.
+ * @param isBatched, indicates whether the editing operation will be batched by the collectionView
  *
- * NOTE: used in combination with -collectionViewWillPerformBatchUpdates
+ * NOTE: when isBatched, used in combination with -collectionViewWillPerformBatchUpdates
  */
-- (void)collectionViewBatchingSectionEditsAtIndexes:(NSIndexSet *)indexes;
+- (void)collectionViewWillEditSectionsAtIndexSet:(NSIndexSet *)indexes batched:(BOOL)batched;
 
 /**
  * Informs the delegate that the collectionView is about to call performBatchUpdates

--- a/AsyncDisplayKit/Details/ASCollectionInternal.h
+++ b/AsyncDisplayKit/Details/ASCollectionInternal.h
@@ -8,11 +8,13 @@
 
 #import "ASCollectionView.h"
 #import "ASCollectionNode.h"
+#import "ASDataController.h"
 #import "ASRangeController.h"
 
 @interface ASCollectionView ()
 - (instancetype)_initWithFrame:(CGRect)frame collectionViewLayout:(UICollectionViewLayout *)layout layoutFacilitator:(id<ASCollectionViewLayoutFacilitatorProtocol>)layoutFacilitator ownedByNode:(BOOL)ownedByNode;
 
+@property (nonatomic, strong, readonly) ASDataController *dataController;
 @property (nonatomic, weak, readwrite) ASCollectionNode *collectionNode;
 @property (nonatomic, strong, readonly) ASRangeController *rangeController;
 @end

--- a/AsyncDisplayKit/Details/ASCollectionInternal.h
+++ b/AsyncDisplayKit/Details/ASCollectionInternal.h
@@ -14,7 +14,7 @@
 @interface ASCollectionView ()
 - (instancetype)_initWithFrame:(CGRect)frame collectionViewLayout:(UICollectionViewLayout *)layout layoutFacilitator:(id<ASCollectionViewLayoutFacilitatorProtocol>)layoutFacilitator ownedByNode:(BOOL)ownedByNode;
 
-@property (nonatomic, strong, readonly) ASDataController *dataController;
 @property (nonatomic, weak, readwrite) ASCollectionNode *collectionNode;
+@property (nonatomic, strong, readonly) ASDataController *dataController;
 @property (nonatomic, strong, readonly) ASRangeController *rangeController;
 @end


### PR DESCRIPTION
so when someone is trying to insert/delete/update cells/sections at the same time can batch them in an easy fashion:
```
[self.collectionNode beginUpdates]
updates()
[self.collectionNode endUpdatesAnimated:NO];
```

@appleguy @levi 