### PR TITLE
Fix attribute value setting in testLinkInTextUsesForegroundColor 

### DIFF
--- a/AsyncDisplayKitTests/ASTextKitTests.mm
+++ b/AsyncDisplayKitTests/ASTextKitTests.mm
@@ -148,7 +148,7 @@ static BOOL checkAttributes(const ASTextKitAttributes &attributes, const CGSize 
                                         // so we have to choose a style and color and match it in the text kit version
                                         // for this test
                                         NSUnderlineStyleAttributeName : @(NSUnderlineStyleSingle),
-                                        NSUnderlineColorAttributeName: [UIColor redColor],
+                                        NSUnderlineColorAttributeName: [UIColor blueColor],
                                         };
   NSDictionary *textAttributes = @{NSFontAttributeName : [UIFont systemFontOfSize:12],
                                    };
@@ -165,7 +165,7 @@ static BOOL checkAttributes(const ASTextKitAttributes &attributes, const CGSize 
   
   for (NSString *attributeName in linkTextAttributes.keyEnumerator) {
     [attrStr addAttribute:attributeName
-                    value:linkTextAttributes[NSUnderlineStyleAttributeName]
+                    value:linkTextAttributes[attributeName]
                     range:selectedRange];
   }
   


### PR DESCRIPTION
Fixes a typo when copying the attribute value in testLinkInTextUsesForegroundColor snapshot test and varies underline color to improve the test case. Also verified tests were working by comparing images generated by snapshot. 

<img width="498" alt="screen shot 2016-01-27 at 11 47 04 pm" src="https://cloud.githubusercontent.com/assets/194822/12638344/3918ab50-c551-11e5-8495-a141f05dabff.png">
<img width="433" alt="screen shot 2016-01-27 at 11 46 56 pm" src="https://cloud.githubusercontent.com/assets/194822/12638345/3af1c0ec-c551-11e5-8bdd-79feb009bb0c.png">
