### PR TITLE
[ASTableView] make scrollDirection transform aware in ASCollectionView and ASTableView

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -524,7 +524,9 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   } else {
     scrollVelocity = _deceleratingVelocity;
   }
-  return [self _scrollDirectionForVelocity:scrollVelocity];
+  
+  ASScrollDirection scrollDirection = [self _scrollDirectionForVelocity:scrollVelocity];
+  return ASScrollDirectionApplyTransform(scrollDirection, self.transform);
 }
 
 - (ASScrollDirection)_scrollDirectionForVelocity:(CGPoint)scrollVelocity

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -571,7 +571,8 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
   } else {
     scrollVelocity = _deceleratingVelocity;
   }
-  return [self _scrollDirectionForVelocity:scrollVelocity];
+  ASScrollDirection scrollDirection = [self _scrollDirectionForVelocity:scrollVelocity];
+  return ASScrollDirectionApplyTransform(scrollDirection, self.transform);
 }
 
 - (ASScrollDirection)_scrollDirectionForVelocity:(CGPoint)velocity

--- a/AsyncDisplayKit/Details/ASScrollDirection.h
+++ b/AsyncDisplayKit/Details/ASScrollDirection.h
@@ -10,6 +10,8 @@
 
 #import "ASBaseDefines.h"
 
+#include <CoreGraphics/CGAffineTransform.h>
+
 NS_ASSUME_NONNULL_BEGIN
 
 typedef NS_OPTIONS(NSInteger, ASScrollDirection) {
@@ -32,6 +34,7 @@ BOOL ASScrollDirectionContainsRight(ASScrollDirection scrollDirection);
 BOOL ASScrollDirectionContainsLeft(ASScrollDirection scrollDirection);
 BOOL ASScrollDirectionContainsUp(ASScrollDirection scrollDirection);
 BOOL ASScrollDirectionContainsDown(ASScrollDirection scrollDirection);
+ASScrollDirection ASScrollDirectionApplyTransform(ASScrollDirection scrollDirection, CGAffineTransform transform);
 
 ASDISPLAYNODE_EXTERN_C_END
 

--- a/AsyncDisplayKit/Details/ASScrollDirection.m
+++ b/AsyncDisplayKit/Details/ASScrollDirection.m
@@ -34,3 +34,30 @@ BOOL ASScrollDirectionContainsUp(ASScrollDirection scrollDirection) {
 BOOL ASScrollDirectionContainsDown(ASScrollDirection scrollDirection) {
   return (scrollDirection & ASScrollDirectionDown) != 0;
 }
+
+ASScrollDirection ASScrollDirectionInvertHorizontally(ASScrollDirection scrollDirection) {
+  if (scrollDirection == ASScrollDirectionRight) {
+    return ASScrollDirectionLeft;
+  } else if (scrollDirection == ASScrollDirectionLeft) {
+    return ASScrollDirectionRight;
+  }
+  return scrollDirection;
+}
+
+ASScrollDirection ASScrollDirectionInvertVertically(ASScrollDirection scrollDirection) {
+  if (scrollDirection == ASScrollDirectionUp) {
+    return ASScrollDirectionDown;
+  } else if (scrollDirection == ASScrollDirectionDown) {
+    return ASScrollDirectionUp;
+  }
+  return scrollDirection;
+}
+
+ASScrollDirection ASScrollDirectionApplyTransform(ASScrollDirection scrollDirection, CGAffineTransform transform) {
+  if ((transform.a < 0) && ASScrollDirectionContainsHorizontalDirection(scrollDirection)) {
+    return ASScrollDirectionInvertHorizontally(scrollDirection);
+  } else if ((transform.d < 0) && ASScrollDirectionContainsVerticalDirection(scrollDirection)) {
+    return ASScrollDirectionInvertVertically(scrollDirection);
+  }
+  return scrollDirection;
+}


### PR DESCRIPTION
Addresses Issue #1126 by adding support for batch fetching for ASTableView and ASCollectionViews with inverted transforms by having the scrollDirection take the current transform into account.