### PR TITLE
Fix text truncation

### DIFF
--- a/AsyncDisplayKit/TextKit/ASTextKitRenderer.mm
+++ b/AsyncDisplayKit/TextKit/ASTextKitRenderer.mm
@@ -103,8 +103,6 @@ static NSCharacterSet *_defaultAvoidTruncationCharacterSet()
                                                   constrainedSize:shadowConstrainedSize
                                              layoutManagerFactory:attributes.layoutManagerFactory
                                             layoutManagerDelegate:attributes.layoutManagerDelegate];
-
-    [self truncater];
   }
   return _context;
 }
@@ -138,6 +136,7 @@ static NSCharacterSet *_defaultAvoidTruncationCharacterSet()
 
 - (void)_calculateSize
 {
+  [self truncater];
   if (_attributes.minimumScaleFactor < 1 && _attributes.minimumScaleFactor > 0) {
     [[self fontSizeAdjuster] adjustFontSize];
   }


### PR DESCRIPTION
It seems that text truncation doesn't work if the truncater is initialized after the context is. I previously mentioned a fix in https://github.com/facebook/AsyncDisplayKit/issues/1033 which initialized the truncater in -init, but I think it can be deferred to -_calculateSize.

More background: https://github.com/facebook/AsyncDisplayKit/pull/1110