### PR TITLE
Reduce early creation of views and layers in collection view

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.h
+++ b/AsyncDisplayKit/ASCollectionView.h
@@ -91,6 +91,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, weak) id<ASCollectionViewLayoutInspecting> layoutInspector;
 
 /**
+ * The ASInterfaceState of this collection view.
+ */
+@property (nonatomic, readonly) ASInterfaceState interfaceState;
+
+/**
  *  Perform a batch of updates asynchronously, optionally disabling all animations in the batch. This method must be called from the main thread. 
  *  The asyncDataSource must be updated to reflect the changes before the update block completes.
  *

--- a/AsyncDisplayKit/ASCollectionView.h
+++ b/AsyncDisplayKit/ASCollectionView.h
@@ -91,11 +91,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, weak) id<ASCollectionViewLayoutInspecting> layoutInspector;
 
 /**
- * The ASInterfaceState of this collection view.
- */
-@property (nonatomic, readonly) ASInterfaceState interfaceState;
-
-/**
  *  Perform a batch of updates asynchronously, optionally disabling all animations in the batch. This method must be called from the main thread. 
  *  The asyncDataSource must be updated to reflect the changes before the update block completes.
  *

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -242,19 +242,6 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   return _flowLayoutInspector;
 }
 
-- (ASInterfaceState)interfaceState
-{
-  ASCollectionNode *collectionNode = self.collectionNode;
-  if (collectionNode) {
-    return collectionNode.interfaceState;
-  } else {
-    // Until we can always create an associated ASCollectionNode without a retain cycle,
-    // we might be on our own to try to guess if we're visible.  The node normally
-    // handles this even if it is the root / directly added to the view hierarchy.
-    return (self.window != nil ? ASInterfaceStateVisible : ASInterfaceStateNone);
-  }
-}
-
 #pragma mark -
 #pragma mark Overrides.
 
@@ -841,7 +828,15 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
 
 - (ASInterfaceState)interfaceStateForRangeController:(ASRangeController *)rangeController
 {
-  return self.interfaceState;
+  ASCollectionNode *collectionNode = self.collectionNode;
+  if (collectionNode) {
+    return collectionNode.interfaceState;
+  } else {
+    // Until we can always create an associated ASCollectionNode without a retain cycle,
+    // we might be on our own to try to guess if we're visible.  The node normally
+    // handles this even if it is the root / directly added to the view hierarchy.
+    return (self.window != nil ? ASInterfaceStateVisible : ASInterfaceStateNone);
+  }
 }
 
 - (NSArray *)rangeController:(ASRangeController *)rangeController nodesAtIndexPaths:(NSArray *)indexPaths

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -17,7 +17,6 @@
 #import "ASDisplayNode+FrameworkPrivate.h"
 #import "ASDisplayNode+Beta.h"
 #import "ASInternalHelpers.h"
-#import "ASRangeController.h"
 #import "UICollectionViewLayout+ASConvenience.h"
 #import "_ASDisplayLayer.h"
 
@@ -241,6 +240,19 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
     _flowLayoutInspector = [[ASCollectionViewFlowLayoutInspector alloc] initWithCollectionView:self flowLayout:layout];
   }
   return _flowLayoutInspector;
+}
+
+- (ASInterfaceState)interfaceState
+{
+  ASCollectionNode *collectionNode = self.collectionNode;
+  if (collectionNode) {
+    return collectionNode.interfaceState;
+  } else {
+    // Until we can always create an associated ASCollectionNode without a retain cycle,
+    // we might be on our own to try to guess if we're visible.  The node normally
+    // handles this even if it is the root / directly added to the view hierarchy.
+    return (self.window != nil ? ASInterfaceStateVisible : ASInterfaceStateNone);
+  }
 }
 
 #pragma mark -
@@ -535,16 +547,16 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   ASScrollDirection scrollableDirections = [self scrollableDirections];
   
   if (ASScrollDirectionContainsHorizontalDirection(scrollableDirections)) { // Can scroll horizontally.
-    if (scrollVelocity.x >= 0) {
+    if (scrollVelocity.x > 0) {
       direction |= ASScrollDirectionRight;
-    } else {
+    } else if (scrollVelocity.x < 0) {
       direction |= ASScrollDirectionLeft;
     }
   }
   if (ASScrollDirectionContainsVerticalDirection(scrollableDirections)) { // Can scroll vertically.
-    if (scrollVelocity.y >= 0) {
+    if (scrollVelocity.y > 0) {
       direction |= ASScrollDirectionDown;
-    } else {
+    } else if (scrollVelocity.y < 0) {
       direction |= ASScrollDirectionUp;
     }
   }
@@ -829,15 +841,7 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
 
 - (ASInterfaceState)interfaceStateForRangeController:(ASRangeController *)rangeController
 {
-  ASCollectionNode *collectionNode = self.collectionNode;
-  if (collectionNode) {
-    return self.collectionNode.interfaceState;
-  } else {
-    // Until we can always create an associated ASCollectionNode without a retain cycle,
-    // we might be on our own to try to guess if we're visible.  The node normally
-    // handles this even if it is the root / directly added to the view hierarchy.
-    return (self.window != nil ? ASInterfaceStateVisible : ASInterfaceStateNone);
-  }
+  return self.interfaceState;
 }
 
 - (NSArray *)rangeController:(ASRangeController *)rangeController nodesAtIndexPaths:(NSArray *)indexPaths

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -1585,6 +1585,7 @@ static BOOL ShouldUseNewRenderingRange = YES;
 {
   return ShouldUseNewRenderingRange;
 }
+
 + (void)setShouldUseNewRenderingRange:(BOOL)shouldUseNewRenderingRange
 {
   ShouldUseNewRenderingRange = shouldUseNewRenderingRange;

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -580,7 +580,7 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
   ASScrollDirection direction = ASScrollDirectionNone;
   if (velocity.y > 0) {
     direction = ASScrollDirectionDown;
-  } else {
+  } else if (velocity.y < 0) {
     direction = ASScrollDirectionUp;
   }
   return direction;

--- a/AsyncDisplayKit/Details/ASCollectionViewLayoutController.mm
+++ b/AsyncDisplayKit/Details/ASCollectionViewLayoutController.mm
@@ -14,6 +14,7 @@
 #import "ASCollectionView.h"
 #import "CGRect+ASConvenience.h"
 #import "UICollectionViewLayout+ASConvenience.h"
+#import "ASDisplayNodeExtras.h"
 
 struct ASRangeGeometry {
   CGRect rangeBounds;
@@ -162,6 +163,21 @@ typedef struct ASRangeGeometry ASRangeGeometry;
   }
   
   return CGRectExpandToRangeWithScrollableDirections(rect, tuningParameters, _scrollableDirections, scrollDirection);
+}
+
+- (ASRangeTuningParameters)tuningParametersForRangeType:(ASLayoutRangeType)rangeType
+{
+    BOOL isVisible = ASInterfaceStateIncludesVisible(_collectionView.interfaceState);
+    BOOL isScrolling = (_collectionView.scrollDirection != ASScrollDirectionNone);
+    // When the collecion view is not visible or not scrolling, make display range only as big as visible range.
+    // This reduce early creation of views and layers.
+    if (!isVisible || !isScrolling) {
+        if (rangeType == ASLayoutRangeTypeDisplay) {
+            return [super tuningParametersForRangeType:ASLayoutRangeTypeVisible];
+        }
+    }
+    
+    return [super tuningParametersForRangeType:rangeType];
 }
 
 @end

--- a/AsyncDisplayKit/Details/ASCollectionViewLayoutController.mm
+++ b/AsyncDisplayKit/Details/ASCollectionViewLayoutController.mm
@@ -66,9 +66,9 @@ typedef struct ASRangeGeometry ASRangeGeometry;
   return self;
 }
 
-- (NSSet *)indexPathsForScrolling:(ASScrollDirection)scrollDirection rangeType:(ASLayoutRangeType)rangeType
+- (NSSet *)indexPathsForScrolling:(ASScrollDirection)scrollDirection rangeType:(ASLayoutRangeType)rangeType shouldUseFullRange:(BOOL)shouldUseFullRange
 {
-  ASRangeTuningParameters tuningParameters = [self tuningParametersForRangeType:rangeType];
+  ASRangeTuningParameters tuningParameters = [self tuningParametersForRangeType:rangeType isFullRange:shouldUseFullRange];
   ASRangeGeometry rangeGeometry = [self rangeGeometryWithScrollDirection:scrollDirection tuningParameters:tuningParameters];
   _updateRangeBoundsIndexedByRangeType[rangeType] = rangeGeometry.updateBounds;
   return [self indexPathsForItemsWithinRangeBounds:rangeGeometry.rangeBounds];
@@ -133,9 +133,9 @@ typedef struct ASRangeGeometry ASRangeGeometry;
 
 @implementation ASCollectionViewLayoutControllerBeta
 
-- (NSSet *)indexPathsForScrolling:(ASScrollDirection)scrollDirection rangeType:(ASLayoutRangeType)rangeType
+- (NSSet *)indexPathsForScrolling:(ASScrollDirection)scrollDirection rangeType:(ASLayoutRangeType)rangeType shouldUseFullRange:(BOOL)shouldUseFullRange
 {
-  ASRangeTuningParameters tuningParameters = [self tuningParametersForRangeType:rangeType];
+  ASRangeTuningParameters tuningParameters = [self tuningParametersForRangeType:rangeType isFullRange:shouldUseFullRange];
   CGRect rangeBounds = [self rangeBoundsWithScrollDirection:scrollDirection rangeTuningParameters:tuningParameters];
   return [self indexPathsForItemsWithinRangeBounds:rangeBounds];
 }
@@ -163,21 +163,6 @@ typedef struct ASRangeGeometry ASRangeGeometry;
   }
   
   return CGRectExpandToRangeWithScrollableDirections(rect, tuningParameters, _scrollableDirections, scrollDirection);
-}
-
-- (ASRangeTuningParameters)tuningParametersForRangeType:(ASLayoutRangeType)rangeType
-{
-    BOOL isVisible = ASInterfaceStateIncludesVisible(_collectionView.interfaceState);
-    BOOL isScrolling = (_collectionView.scrollDirection != ASScrollDirectionNone);
-    // When the collecion view is not visible or not scrolling, make display range only as big as visible range.
-    // This reduce early creation of views and layers.
-    if (!isVisible || !isScrolling) {
-        if (rangeType == ASLayoutRangeTypeDisplay) {
-            return [super tuningParametersForRangeType:ASLayoutRangeTypeVisible];
-        }
-    }
-    
-    return [super tuningParametersForRangeType:rangeType];
 }
 
 @end

--- a/AsyncDisplayKit/Details/ASFlowLayoutController.mm
+++ b/AsyncDisplayKit/Details/ASFlowLayoutController.mm
@@ -74,7 +74,7 @@ static const CGFloat kASFlowLayoutControllerRefreshingThreshold = 0.3;
  * IndexPath array for the element in the working range.
  */
 
-- (NSSet *)indexPathsForScrolling:(ASScrollDirection)scrollDirection rangeType:(ASLayoutRangeType)rangeType
+- (NSSet *)indexPathsForScrolling:(ASScrollDirection)scrollDirection rangeType:(ASLayoutRangeType)rangeType shouldUseFullRange:(BOOL)shouldUseFullRange
 {
   CGFloat viewportScreenMetric;
   ASScrollDirection leadingDirection;
@@ -92,7 +92,7 @@ static const CGFloat kASFlowLayoutControllerRefreshingThreshold = 0.3;
     leadingDirection = ASScrollDirectionUp;
   }
 
-  ASRangeTuningParameters tuningParameters = [self tuningParametersForRangeType:rangeType];
+  ASRangeTuningParameters tuningParameters = [self tuningParametersForRangeType:rangeType isFullRange:shouldUseFullRange];
   CGFloat backScreens = scrollDirection == leadingDirection ? tuningParameters.leadingBufferScreenfuls : tuningParameters.trailingBufferScreenfuls;
   CGFloat frontScreens = scrollDirection == leadingDirection ? tuningParameters.trailingBufferScreenfuls : tuningParameters.leadingBufferScreenfuls;
 

--- a/AsyncDisplayKit/Details/ASLayoutController.h
+++ b/AsyncDisplayKit/Details/ASLayoutController.h
@@ -25,17 +25,22 @@ typedef struct {
 
 /**
  * Tuning parameters for the range.
- *
- * Defaults to a trailing buffer of one screenful and a leading buffer of two screenfuls.
  */
 - (void)setTuningParameters:(ASRangeTuningParameters)tuningParameters forRangeType:(ASLayoutRangeType)rangeType;
 
 - (ASRangeTuningParameters)tuningParametersForRangeType:(ASLayoutRangeType)rangeType;
 
+- (void)setMinimumTuningParameters:(ASRangeTuningParameters)minimumTuningParameters forRangeType:(ASLayoutRangeType)rangeType;
+
+- (ASRangeTuningParameters)minimumTuningParametersForRangeType:(ASLayoutRangeType)rangeType;
+
+- (ASRangeTuningParameters)tuningParametersForRangeType:(ASLayoutRangeType)rangeType isFullRange:(BOOL)isFullRange;
+
 // FIXME: This method can be removed once ASRangeControllerBeta becomes the main version.
+// TODO: Now that it is the main version, can we remove this now?
 - (BOOL)shouldUpdateForVisibleIndexPaths:(NSArray<NSIndexPath *> *)indexPaths rangeType:(ASLayoutRangeType)rangeType;
 
-- (NSSet *)indexPathsForScrolling:(ASScrollDirection)scrollDirection rangeType:(ASLayoutRangeType)rangeType;
+- (NSSet *)indexPathsForScrolling:(ASScrollDirection)scrollDirection rangeType:(ASLayoutRangeType)rangeType shouldUseFullRange:(BOOL)shouldUseFullRange;
 
 @optional
 

--- a/AsyncDisplayKit/Details/ASRangeController.mm
+++ b/AsyncDisplayKit/Details/ASRangeController.mm
@@ -153,7 +153,7 @@
     id<ASRangeHandler> rangeHandler = _rangeTypeHandlers[rangeKey];
 
     if (!_rangeIsValid || [_layoutController shouldUpdateForVisibleIndexPaths:visibleNodePaths rangeType:rangeType]) {
-      NSSet *indexPaths = [_layoutController indexPathsForScrolling:_scrollDirection rangeType:rangeType];
+      NSSet *indexPaths = [_layoutController indexPathsForScrolling:_scrollDirection rangeType:rangeType shouldUseFullRange:YES];
 
       // Notify to remove indexpaths that are leftover that are not visible or included in the _layoutController calculated paths
       NSMutableSet *removedIndexPaths = _rangeIsValid ? [_rangeTypeIndexPaths[rangeKey] mutableCopy] : [NSMutableSet set];

--- a/AsyncDisplayKit/Private/ASInternalHelpers.mm
+++ b/AsyncDisplayKit/Private/ASInternalHelpers.mm
@@ -68,7 +68,6 @@ void ASPerformBlockOnBackgroundThread(void (^block)())
   }
 }
 
-
 CGFloat ASScreenScale()
 {
   static CGFloat _scale;


### PR DESCRIPTION
by avoiding pre-rendering when it is not visible or not scrolling.

Two things to consider:
- [x] Make render/display range a bit bigger than visible range, so it feels better when user starts scrolling. The difficult thing is to figure out a good value here.
- [x] If user comes back to the collection view after leaving it for a while (magic words: open close-up and go back to feed), scroll direction is none (again), causing the render range to shrink. This *may* cause some hard earned views to be released. I need to spend more time investigating this theory though.