### PR TITLE
Implicit node hierarchy handling with ASLayouts

### DIFF
--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -475,6 +475,8 @@
 		D785F6621A74327E00291744 /* ASScrollNode.h in Headers */ = {isa = PBXBuildFile; fileRef = D785F6601A74327E00291744 /* ASScrollNode.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D785F6631A74327E00291744 /* ASScrollNode.m in Sources */ = {isa = PBXBuildFile; fileRef = D785F6611A74327E00291744 /* ASScrollNode.m */; };
 		DB7121BCD50849C498C886FB /* libPods-AsyncDisplayKitTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EFA731F0396842FF8AB635EE /* libPods-AsyncDisplayKitTests.a */; };
+		DBC452DB1C5BF64600B16017 /* NSArray+Diffing.h in Headers */ = {isa = PBXBuildFile; fileRef = DBC452D91C5BF64600B16017 /* NSArray+Diffing.h */; };
+		DBC452DC1C5BF64600B16017 /* NSArray+Diffing.m in Sources */ = {isa = PBXBuildFile; fileRef = DBC452DA1C5BF64600B16017 /* NSArray+Diffing.m */; };
 		DE040EF91C2B40AC004692FF /* ASCollectionViewFlowLayoutInspector.h in Headers */ = {isa = PBXBuildFile; fileRef = 251B8EF41BBB3D690087C538 /* ASCollectionViewFlowLayoutInspector.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DE0702FC1C3671E900D7DE62 /* libAsyncDisplayKit.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 058D09AC195D04C000B7D73C /* libAsyncDisplayKit.a */; };
 		DE6EA3221C14000600183B10 /* ASDisplayNode+FrameworkPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = DE6EA3211C14000600183B10 /* ASDisplayNode+FrameworkPrivate.h */; };
@@ -802,6 +804,8 @@
 		D3779BCFF841AD3EB56537ED /* Pods-AsyncDisplayKitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AsyncDisplayKitTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-AsyncDisplayKitTests/Pods-AsyncDisplayKitTests.release.xcconfig"; sourceTree = "<group>"; };
 		D785F6601A74327E00291744 /* ASScrollNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASScrollNode.h; sourceTree = "<group>"; };
 		D785F6611A74327E00291744 /* ASScrollNode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASScrollNode.m; sourceTree = "<group>"; };
+		DBC452D91C5BF64600B16017 /* NSArray+Diffing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSArray+Diffing.h"; sourceTree = "<group>"; };
+		DBC452DA1C5BF64600B16017 /* NSArray+Diffing.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSArray+Diffing.m"; sourceTree = "<group>"; };
 		DE6EA3211C14000600183B10 /* ASDisplayNode+FrameworkPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ASDisplayNode+FrameworkPrivate.h"; sourceTree = "<group>"; };
 		DE8BEABF1C2DF3FC00D57C12 /* ASDelegateProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASDelegateProxy.h; sourceTree = "<group>"; };
 		DE8BEAC01C2DF3FC00D57C12 /* ASDelegateProxy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASDelegateProxy.m; sourceTree = "<group>"; };
@@ -1164,6 +1168,8 @@
 				0442850C1BAA64EC00D16268 /* ASMultidimensionalArrayUtils.mm */,
 				AEB7B0181C5962EA00662EF4 /* ASDefaultPlayButton.h */,
 				AEB7B0191C5962EA00662EF4 /* ASDefaultPlayButton.m */,
+				DBC452D91C5BF64600B16017 /* NSArray+Diffing.h */,
+				DBC452DA1C5BF64600B16017 /* NSArray+Diffing.m */,
 			);
 			path = Private;
 			sourceTree = "<group>";
@@ -1354,6 +1360,7 @@
 				ACF6ED201B17843500DA7C62 /* ASDimension.h in Headers */,
 				058D0A78195D05F900B7D73C /* ASDisplayNode+DebugTiming.h in Headers */,
 				DECBD6E71BE56E1900CF4905 /* ASButtonNode.h in Headers */,
+				DBC452DB1C5BF64600B16017 /* NSArray+Diffing.h in Headers */,
 				058D0A4C195D05CB00B7D73C /* ASDisplayNode+Subclasses.h in Headers */,
 				258FF4271C0D152600A83844 /* ASRangeHandlerVisible.h in Headers */,
 				058D0A4A195D05CB00B7D73C /* ASDisplayNode.h in Headers */,
@@ -1782,6 +1789,7 @@
 				ACF6ED1D1B17843500DA7C62 /* ASCenterLayoutSpec.mm in Sources */,
 				18C2ED801B9B7DE800F627B3 /* ASCollectionNode.mm in Sources */,
 				92DD2FE41BF4B97E0074C9DD /* ASMapNode.mm in Sources */,
+				DBC452DC1C5BF64600B16017 /* NSArray+Diffing.m in Sources */,
 				AC3C4A521A1139C100143C57 /* ASCollectionView.mm in Sources */,
 				205F0E1E1B373A2C007741D0 /* ASCollectionViewLayoutController.mm in Sources */,
 				058D0A13195D050800B7D73C /* ASControlNode.m in Sources */,

--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -478,6 +478,7 @@
 		DBC452DB1C5BF64600B16017 /* NSArray+Diffing.h in Headers */ = {isa = PBXBuildFile; fileRef = DBC452D91C5BF64600B16017 /* NSArray+Diffing.h */; };
 		DBC452DC1C5BF64600B16017 /* NSArray+Diffing.m in Sources */ = {isa = PBXBuildFile; fileRef = DBC452DA1C5BF64600B16017 /* NSArray+Diffing.m */; };
 		DBC452DE1C5C6A6A00B16017 /* ArrayDiffingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DBC452DD1C5C6A6A00B16017 /* ArrayDiffingTests.m */; };
+		DBC453221C5FD97200B16017 /* ASDisplayNodeImplicitHierarchyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DBC453211C5FD97200B16017 /* ASDisplayNodeImplicitHierarchyTests.m */; };
 		DE040EF91C2B40AC004692FF /* ASCollectionViewFlowLayoutInspector.h in Headers */ = {isa = PBXBuildFile; fileRef = 251B8EF41BBB3D690087C538 /* ASCollectionViewFlowLayoutInspector.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DE0702FC1C3671E900D7DE62 /* libAsyncDisplayKit.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 058D09AC195D04C000B7D73C /* libAsyncDisplayKit.a */; };
 		DE6EA3221C14000600183B10 /* ASDisplayNode+FrameworkPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = DE6EA3211C14000600183B10 /* ASDisplayNode+FrameworkPrivate.h */; };
@@ -808,6 +809,7 @@
 		DBC452D91C5BF64600B16017 /* NSArray+Diffing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSArray+Diffing.h"; sourceTree = "<group>"; };
 		DBC452DA1C5BF64600B16017 /* NSArray+Diffing.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSArray+Diffing.m"; sourceTree = "<group>"; };
 		DBC452DD1C5C6A6A00B16017 /* ArrayDiffingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ArrayDiffingTests.m; sourceTree = "<group>"; };
+		DBC453211C5FD97200B16017 /* ASDisplayNodeImplicitHierarchyTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASDisplayNodeImplicitHierarchyTests.m; sourceTree = "<group>"; };
 		DE6EA3211C14000600183B10 /* ASDisplayNode+FrameworkPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ASDisplayNode+FrameworkPrivate.h"; sourceTree = "<group>"; };
 		DE8BEABF1C2DF3FC00D57C12 /* ASDelegateProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASDelegateProxy.h; sourceTree = "<group>"; };
 		DE8BEAC01C2DF3FC00D57C12 /* ASDelegateProxy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASDelegateProxy.m; sourceTree = "<group>"; };
@@ -1006,6 +1008,7 @@
 		058D09C5195D04C000B7D73C /* AsyncDisplayKitTests */ = {
 			isa = PBXGroup;
 			children = (
+				DBC453211C5FD97200B16017 /* ASDisplayNodeImplicitHierarchyTests.m */,
 				DBC452DD1C5C6A6A00B16017 /* ArrayDiffingTests.m */,
 				057D02C01AC0A66700C7AC3C /* AsyncDisplayKitTestHost */,
 				056D21501ABCEDA1001107EF /* ASSnapshotTestCase.h */,
@@ -1901,6 +1904,7 @@
 				254C6B521BF8FE6D003EC431 /* ASTextKitTruncationTests.mm in Sources */,
 				058D0A3D195D057000B7D73C /* ASTextKitCoreTextAdditionsTests.m in Sources */,
 				058D0A40195D057000B7D73C /* ASTextNodeTests.m in Sources */,
+				DBC453221C5FD97200B16017 /* ASDisplayNodeImplicitHierarchyTests.m in Sources */,
 				058D0A41195D057000B7D73C /* ASTextNodeWordKernerTests.mm in Sources */,
 				DBC452DE1C5C6A6A00B16017 /* ArrayDiffingTests.m in Sources */,
 			);

--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -477,6 +477,7 @@
 		DB7121BCD50849C498C886FB /* libPods-AsyncDisplayKitTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EFA731F0396842FF8AB635EE /* libPods-AsyncDisplayKitTests.a */; };
 		DBC452DB1C5BF64600B16017 /* NSArray+Diffing.h in Headers */ = {isa = PBXBuildFile; fileRef = DBC452D91C5BF64600B16017 /* NSArray+Diffing.h */; };
 		DBC452DC1C5BF64600B16017 /* NSArray+Diffing.m in Sources */ = {isa = PBXBuildFile; fileRef = DBC452DA1C5BF64600B16017 /* NSArray+Diffing.m */; };
+		DBC452DE1C5C6A6A00B16017 /* ArrayDiffingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DBC452DD1C5C6A6A00B16017 /* ArrayDiffingTests.m */; };
 		DE040EF91C2B40AC004692FF /* ASCollectionViewFlowLayoutInspector.h in Headers */ = {isa = PBXBuildFile; fileRef = 251B8EF41BBB3D690087C538 /* ASCollectionViewFlowLayoutInspector.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DE0702FC1C3671E900D7DE62 /* libAsyncDisplayKit.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 058D09AC195D04C000B7D73C /* libAsyncDisplayKit.a */; };
 		DE6EA3221C14000600183B10 /* ASDisplayNode+FrameworkPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = DE6EA3211C14000600183B10 /* ASDisplayNode+FrameworkPrivate.h */; };
@@ -806,6 +807,7 @@
 		D785F6611A74327E00291744 /* ASScrollNode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASScrollNode.m; sourceTree = "<group>"; };
 		DBC452D91C5BF64600B16017 /* NSArray+Diffing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSArray+Diffing.h"; sourceTree = "<group>"; };
 		DBC452DA1C5BF64600B16017 /* NSArray+Diffing.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSArray+Diffing.m"; sourceTree = "<group>"; };
+		DBC452DD1C5C6A6A00B16017 /* ArrayDiffingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ArrayDiffingTests.m; sourceTree = "<group>"; };
 		DE6EA3211C14000600183B10 /* ASDisplayNode+FrameworkPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ASDisplayNode+FrameworkPrivate.h"; sourceTree = "<group>"; };
 		DE8BEABF1C2DF3FC00D57C12 /* ASDelegateProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASDelegateProxy.h; sourceTree = "<group>"; };
 		DE8BEAC01C2DF3FC00D57C12 /* ASDelegateProxy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASDelegateProxy.m; sourceTree = "<group>"; };
@@ -1004,6 +1006,7 @@
 		058D09C5195D04C000B7D73C /* AsyncDisplayKitTests */ = {
 			isa = PBXGroup;
 			children = (
+				DBC452DD1C5C6A6A00B16017 /* ArrayDiffingTests.m */,
 				057D02C01AC0A66700C7AC3C /* AsyncDisplayKitTestHost */,
 				056D21501ABCEDA1001107EF /* ASSnapshotTestCase.h */,
 				05EA6FE61AC0966E00E35788 /* ASSnapshotTestCase.mm */,
@@ -1899,6 +1902,7 @@
 				058D0A3D195D057000B7D73C /* ASTextKitCoreTextAdditionsTests.m in Sources */,
 				058D0A40195D057000B7D73C /* ASTextNodeTests.m in Sources */,
 				058D0A41195D057000B7D73C /* ASTextNodeWordKernerTests.mm in Sources */,
+				DBC452DE1C5C6A6A00B16017 /* ArrayDiffingTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AsyncDisplayKit/ASDisplayNode+Beta.h
+++ b/AsyncDisplayKit/ASDisplayNode+Beta.h
@@ -11,6 +11,9 @@
 + (BOOL)shouldUseNewRenderingRange;
 + (void)setShouldUseNewRenderingRange:(BOOL)shouldUseNewRenderingRange;
 
++ (BOOL)usesImplicitHierarchyManagement;
++ (void)setUsesImplicitHierarchyManagement:(BOOL)enabled;
+
 /** @name Layout */
 
 

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -597,13 +597,8 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
 
 - (ASLayout *)measureWithSizeRange:(ASSizeRange)constrainedSize
 {
-  ASDN::MutexLocker l(_propertyLock);
-  return [self __measureWithSizeRange:constrainedSize];
-}
-
-- (ASLayout *)__measureWithSizeRange:(ASSizeRange)constrainedSize
-{
   ASDisplayNodeAssertThreadAffinity(self);
+  ASDN::MutexLocker l(_propertyLock);
 
   if (![self __shouldSize])
     return nil;

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -64,7 +64,7 @@ NSInteger const ASDefaultDrawingPriority = ASDefaultTransactionPriority;
 
 BOOL ASDisplayNodeSubclassOverridesSelector(Class subclass, SEL selector)
 {
-    return ASSubclassOverridesSelector([ASDisplayNode class], subclass, selector);
+  return ASSubclassOverridesSelector([ASDisplayNode class], subclass, selector);
 }
 
 void ASDisplayNodeRespectThreadAffinityOfNode(ASDisplayNode *node, void (^block)())

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -639,7 +639,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   }
   
   if (_placeholderLayer) {
-    [self setupPlaceholderLayerContents];
+    [self _setupPlaceholderLayerContents];
   }
 }
 
@@ -2035,14 +2035,14 @@ static BOOL ShouldUseNewRenderingRange = YES;
   if (_placeholderImage && _placeholderLayer && self.layer.contents == nil) {
     [CATransaction begin];
     [CATransaction setDisableActions:YES];
-    [self setupPlaceholderLayerContents];
+    [self _setupPlaceholderLayerContents];
     _placeholderLayer.opacity = 1.0;
     [CATransaction commit];
     [self.layer addSublayer:_placeholderLayer];
   }
 }
 
-- (void)setupPlaceholderLayerContents
+- (void)_setupPlaceholderLayerContents
 {
   BOOL stretchable = !UIEdgeInsetsEqualToEdgeInsets(_placeholderImage.capInsets, UIEdgeInsetsZero);
   if (stretchable) {

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -21,6 +21,7 @@
 #import "_ASCoreAnimationExtras.h"
 #import "ASDisplayNodeExtras.h"
 #import "ASEqualityHelpers.h"
+#import "NSArray+Diffing.h"
 
 #import "ASInternalHelpers.h"
 #import "ASLayout.h"

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -1606,7 +1606,8 @@ static BOOL ShouldUseNewRenderingRange = YES;
       layout = [ASLayout layoutWithLayoutableObject:self size:layout.size sublayouts:@[layout]];
     }
     return [layout flattenedLayoutUsingPredicateBlock:^BOOL(ASLayout *evaluatedLayout) {
-      return [_subnodes containsObject:evaluatedLayout.layoutableObject];
+      return ASObjectIsEqual(layout, evaluatedLayout) == NO &&
+             [evaluatedLayout.layoutableObject isKindOfClass:[ASDisplayNode class]];
     }];
   } else {
     // If neither -layoutSpecThatFits: nor -calculateSizeThatFits: is overridden by subclassses, preferredFrameSize should be used,

--- a/AsyncDisplayKit/Layout/ASLayout.mm
+++ b/AsyncDisplayKit/Layout/ASLayout.mm
@@ -12,7 +12,7 @@
 #import "ASAssert.h"
 #import "ASLayoutSpecUtilities.h"
 #import "ASInternalHelpers.h"
-#import <stack>
+#import <queue>
 
 CGPoint const CGPointNull = {NAN, NAN};
 
@@ -71,14 +71,14 @@ extern BOOL CGPointIsNull(CGPoint point)
     BOOL visited;
   };
   
-  // Stack of Contexts, used to keep track of sublayouts while traversing this layout in a DFS fashion.
-  std::stack<Context> stack;
-  stack.push({self, CGPointMake(0, 0), NO});
+  // Stack of Contexts, used to keep track of sublayouts while traversing this layout in a BFS fashion.
+  std::queue<Context> queue;
+  queue.push({self, CGPointMake(0, 0), NO});
   
-  while (!stack.empty()) {
-    Context &context = stack.top();
+  while (!queue.empty()) {
+    Context &context = queue.front();
     if (context.visited) {
-      stack.pop();
+      queue.pop();
     } else {
       context.visited = YES;
       
@@ -90,7 +90,7 @@ extern BOOL CGPointIsNull(CGPoint point)
       }
       
       for (ASLayout *sublayout in context.layout.sublayouts) {
-        stack.push({sublayout, context.absolutePosition + sublayout.position, NO});
+        queue.push({sublayout, context.absolutePosition + sublayout.position, NO});
       }
     }
   }

--- a/AsyncDisplayKit/Layout/ASLayout.mm
+++ b/AsyncDisplayKit/Layout/ASLayout.mm
@@ -94,7 +94,7 @@ extern BOOL CGPointIsNull(CGPoint point)
       }
     }
   }
-  
+
   return [ASLayout layoutWithLayoutableObject:_layoutableObject size:_size sublayouts:flattenedSublayouts];
 }
 

--- a/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
+++ b/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
@@ -131,9 +131,7 @@ typedef NS_OPTIONS(NSUInteger, ASDisplayNodeMethodOverrides)
 - (BOOL)__shouldLoadViewOrLayer;
 - (BOOL)__shouldSize;
 
-// Core implementation of -measureWithSizeRange:. Must be called with _propertyLock held.
-- (ASLayout *)__measureWithSizeRange:(ASSizeRange)constrainedSize;
-
+// Invoked by a call to setNeedsLayout to the underlying view
 - (void)__setNeedsLayout;
 - (void)__layout;
 - (void)__setSupernode:(ASDisplayNode *)supernode;

--- a/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
+++ b/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
@@ -59,6 +59,8 @@ typedef NS_OPTIONS(NSUInteger, ASDisplayNodeMethodOverrides)
   ASSizeRange _constrainedSize;
   UIEdgeInsets _hitTestSlop;
   NSMutableArray *_subnodes;
+  NSArray<ASDisplayNode *> *_insertedSubnodes;
+  NSArray<ASDisplayNode *> *_deletedSubnodes;
 
   ASDisplayNodeViewBlock _viewBlock;
   ASDisplayNodeLayerBlock _layerBlock;
@@ -131,8 +133,11 @@ typedef NS_OPTIONS(NSUInteger, ASDisplayNodeMethodOverrides)
 - (BOOL)__shouldLoadViewOrLayer;
 - (BOOL)__shouldSize;
 
-// Invoked by a call to setNeedsLayout to the underlying view
+/**
+ Invoked by a call to setNeedsLayout to the underlying view
+ */
 - (void)__setNeedsLayout;
+
 - (void)__layout;
 - (void)__setSupernode:(ASDisplayNode *)supernode;
 

--- a/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
+++ b/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
@@ -35,6 +35,7 @@ typedef NS_OPTIONS(NSUInteger, ASDisplayNodeMethodOverrides)
 };
 
 @class _ASPendingState;
+@class _ASDisplayNodePosition;
 
 // Allow 2^n increments of begin disabling hierarchy notifications
 #define VISIBILITY_NOTIFICATIONS_DISABLED_BITS 4
@@ -59,8 +60,12 @@ typedef NS_OPTIONS(NSUInteger, ASDisplayNodeMethodOverrides)
   ASSizeRange _constrainedSize;
   UIEdgeInsets _hitTestSlop;
   NSMutableArray *_subnodes;
-  NSArray<ASDisplayNode *> *_insertedSubnodes;
-  NSArray<ASDisplayNode *> *_deletedSubnodes;
+
+  // Subnodes implicitly managed by layout changes
+  NSMutableArray<ASDisplayNode *> *_managedSubnodes;
+  
+  NSArray<_ASDisplayNodePosition *> *_insertedSubnodes;
+  NSArray<_ASDisplayNodePosition *> *_deletedSubnodes;
 
   ASDisplayNodeViewBlock _viewBlock;
   ASDisplayNodeLayerBlock _layerBlock;

--- a/AsyncDisplayKit/Private/NSArray+Diffing.h
+++ b/AsyncDisplayKit/Private/NSArray+Diffing.h
@@ -11,8 +11,19 @@
 @interface NSArray (Diffing)
 
 /**
- * Uses a bottom-up memoized longest common subsequence solution to identify differences. Runs in O(mn) complexity.
+ * @abstract Compares two arrays, providing the insertion and deletion indexes needed to transform into the target array.
+ * @discussion This compares the equality of each object with `isEqual:`.
+ * This diffing algorithm uses a bottom-up memoized longest common subsequence solution to identify differences.
+ * It runs in O(mn) complexity.
  */
 - (void)asdk_diffWithArray:(NSArray *)array insertions:(NSIndexSet **)insertions deletions:(NSIndexSet **)deletions;
+
+/**
+ * @abstract Compares two arrays, providing the insertion and deletion indexes needed to transform into the target array.
+ * @discussion The `compareBlock` is used to identify the equality of the objects within the arrays.
+ * This diffing algorithm uses a bottom-up memoized longest common subsequence solution to identify differences.
+ * It runs in O(mn) complexity.
+ */
+- (void)asdk_diffWithArray:(NSArray *)array insertions:(NSIndexSet **)insertions deletions:(NSIndexSet **)deletions compareBlock:(BOOL (^)(id lhs, id rhs))comparison;
 
 @end

--- a/AsyncDisplayKit/Private/NSArray+Diffing.h
+++ b/AsyncDisplayKit/Private/NSArray+Diffing.h
@@ -13,6 +13,6 @@
 /**
  * Uses a bottom-up memoized longest common subsequence solution to identify differences. Runs in O(mn) complexity.
  */
-- (void)asdk_diffWithArray:(NSArray *)array insertions:(NSMutableIndexSet **)insertions deletions:(NSMutableIndexSet **)deletions;
+- (void)asdk_diffWithArray:(NSArray *)array insertions:(NSIndexSet **)insertions deletions:(NSIndexSet **)deletions;
 
 @end

--- a/AsyncDisplayKit/Private/NSArray+Diffing.h
+++ b/AsyncDisplayKit/Private/NSArray+Diffing.h
@@ -1,0 +1,18 @@
+//
+//  NSArray+Diffing.h
+//  AsyncDisplayKit
+//
+//  Created by Levi McCallum on 1/29/16.
+//  Copyright © 2016 Facebook. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSArray (Diffing)
+
+/**
+ * Uses a bottom-up memoized longest common subsequence solution to identify differences. Runs in O(mn) complexity.
+ */
+- (void)asdk_diffWithArray:(NSArray *)array insertions:(NSMutableIndexSet **)insertions deletions:(NSMutableIndexSet **)deletions;
+
+@end

--- a/AsyncDisplayKit/Private/NSArray+Diffing.m
+++ b/AsyncDisplayKit/Private/NSArray+Diffing.m
@@ -10,28 +10,32 @@
 
 @implementation NSArray (Diffing)
 
-- (void)asdk_diffWithArray:(NSArray *)array insertions:(NSMutableIndexSet **)insertions deletions:(NSMutableIndexSet **)deletions
+- (void)asdk_diffWithArray:(NSArray *)array insertions:(NSIndexSet **)insertions deletions:(NSIndexSet **)deletions
 {
   NSIndexSet *commonIndexes = [self _asdk_commonIndexesWithArray:array];
   
   if (insertions) {
     NSArray *commonObjects = [self objectsAtIndexes:commonIndexes];
+    NSMutableIndexSet *insertionIndexes = [NSMutableIndexSet indexSet];
     for (NSInteger i = 0, j = 0; i < commonObjects.count || j < array.count;) {
       if (i < commonObjects.count && j < array.count && [commonObjects[i] isEqual:array[j]]) {
         i++; j++;
       } else {
-        [*insertions addIndex:j];
+        [insertionIndexes addIndex:j];
         j++;
       }
     }
+    *insertions = insertionIndexes;
   }
   
   if (deletions) {
+    NSMutableIndexSet *deletionIndexes = [NSMutableIndexSet indexSet];
     for (NSInteger i = 0; i < self.count; i++) {
       if (![commonIndexes containsIndex:i]) {
-        [*deletions addIndex:i];
+        [deletionIndexes addIndex:i];
       }
     }
+    *deletions = deletionIndexes;
   }
 }
 

--- a/AsyncDisplayKit/Private/NSArray+Diffing.m
+++ b/AsyncDisplayKit/Private/NSArray+Diffing.m
@@ -12,13 +12,20 @@
 
 - (void)asdk_diffWithArray:(NSArray *)array insertions:(NSIndexSet **)insertions deletions:(NSIndexSet **)deletions
 {
-  NSIndexSet *commonIndexes = [self _asdk_commonIndexesWithArray:array];
+  [self asdk_diffWithArray:array insertions:insertions deletions:deletions compareBlock:^BOOL(id lhs, id rhs) {
+    return [lhs isEqual:rhs];
+  }];
+}
+
+- (void)asdk_diffWithArray:(NSArray *)array insertions:(NSIndexSet **)insertions deletions:(NSIndexSet **)deletions compareBlock:(BOOL (^)(id lhs, id rhs))comparison
+{
+  NSIndexSet *commonIndexes = [self _asdk_commonIndexesWithArray:array compareBlock:comparison];
   
   if (insertions) {
     NSArray *commonObjects = [self objectsAtIndexes:commonIndexes];
     NSMutableIndexSet *insertionIndexes = [NSMutableIndexSet indexSet];
     for (NSInteger i = 0, j = 0; i < commonObjects.count || j < array.count;) {
-      if (i < commonObjects.count && j < array.count && [commonObjects[i] isEqual:array[j]]) {
+      if (i < commonObjects.count && j < array.count && comparison(commonObjects[i], array[j])) {
         i++; j++;
       } else {
         [insertionIndexes addIndex:j];
@@ -39,7 +46,7 @@
   }
 }
 
-- (NSIndexSet *)_asdk_commonIndexesWithArray:(NSArray *)array
+- (NSIndexSet *)_asdk_commonIndexesWithArray:(NSArray *)array compareBlock:(BOOL (^)(id lhs, id rhs))comparison
 {
   NSInteger lengths[self.count+1][array.count+1];
   for (NSInteger i = self.count; i >= 0; i--) {
@@ -56,7 +63,7 @@
   
   NSMutableIndexSet *common = [NSMutableIndexSet indexSet];
   for (NSInteger i = 0, j = 0; i < self.count && j < array.count;) {
-    if ([self[i] isEqual:array[j]]) {
+    if (comparison(self[i], array[j])) {
       [common addIndex:i];
       i++; j++;
     } else if (lengths[i+1][j] >= lengths[i][j+1]) {

--- a/AsyncDisplayKitTests/ASDisplayNodeImplicitHierarchyTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeImplicitHierarchyTests.m
@@ -11,19 +11,35 @@
 #import "ASDisplayNode.h"
 #import "ASDisplayNode+Beta.h"
 #import "ASDisplayNode+Subclasses.h"
+
 #import "ASStaticLayoutSpec.h"
+#import "ASStackLayoutSpec.h"
 
 @interface ASSpecTestDisplayNode : ASDisplayNode
 
-@property (copy, nonatomic) ASLayoutSpec * (^layoutSpecBlock)(ASSizeRange constrainedSize);
+@property (copy, nonatomic) ASLayoutSpec * (^layoutSpecBlock)(ASSizeRange constrainedSize, NSNumber *layoutState);
+
+/**
+ Simple state identifier to allow control of current spec inside of the layoutSpecBlock
+ */
+@property (strong, nonatomic) NSNumber *layoutState;
 
 @end
 
 @implementation ASSpecTestDisplayNode
 
+- (instancetype)init
+{
+  self = [super init];
+  if (self) {
+    _layoutState = @1;
+  }
+  return self;
+}
+
 - (ASLayoutSpec *)layoutSpecThatFits:(ASSizeRange)constrainedSize
 {
-  return self.layoutSpecBlock(constrainedSize);
+  return self.layoutSpecBlock(constrainedSize, _layoutState);
 }
 
 @end
@@ -49,18 +65,65 @@
   XCTAssert([ASDisplayNode usesImplicitHierarchyManagement]);
 }
 
-- (void)testInitialNodeInsertion
+- (void)testInitialNodeInsertionWithOrdering
 {
   ASDisplayNode *node1 = [[ASDisplayNode alloc] init];
   ASDisplayNode *node2 = [[ASDisplayNode alloc] init];
+  ASDisplayNode *node3 = [[ASDisplayNode alloc] init];
+  ASDisplayNode *node4 = [[ASDisplayNode alloc] init];
+  ASDisplayNode *node5 = [[ASDisplayNode alloc] init];
+
   ASSpecTestDisplayNode *node = [[ASSpecTestDisplayNode alloc] init];
-  node.layoutSpecBlock = ^(ASSizeRange constrainedSize){
-    return [ASStaticLayoutSpec staticLayoutSpecWithChildren:@[node1, node2]];
+  node.layoutSpecBlock = ^(ASSizeRange constrainedSize, NSNumber *layoutState) {
+    ASStaticLayoutSpec *staticLayout = [ASStaticLayoutSpec staticLayoutSpecWithChildren:@[node4]];
+    
+    ASStackLayoutSpec *stack1 = [[ASStackLayoutSpec alloc] init];
+    [stack1 setChildren:@[node1, node2]];
+
+    ASStackLayoutSpec *stack2 = [[ASStackLayoutSpec alloc] init];
+    [stack2 setChildren:@[node3, staticLayout]];
+    
+    return [ASStaticLayoutSpec staticLayoutSpecWithChildren:@[stack1, stack2, node5]];
   };
+  [node measureWithSizeRange:ASSizeRangeMake(CGSizeZero, CGSizeZero)];
+  [node layout]; // Layout immediately
+  XCTAssertEqual(node.subnodes[0], node5);
+  XCTAssertEqual(node.subnodes[1], node1);
+  XCTAssertEqual(node.subnodes[2], node2);
+  XCTAssertEqual(node.subnodes[3], node3);
+  XCTAssertEqual(node.subnodes[4], node4);
+}
+
+- (void)testCalculatedLayoutHierarchyTransitions
+{
+  ASDisplayNode *node1 = [[ASDisplayNode alloc] init];
+  ASDisplayNode *node2 = [[ASDisplayNode alloc] init];
+  ASDisplayNode *node3 = [[ASDisplayNode alloc] init];
+  
+  ASSpecTestDisplayNode *node = [[ASSpecTestDisplayNode alloc] init];
+  node.layoutSpecBlock = ^(ASSizeRange constrainedSize, NSNumber *layoutState){
+    if ([layoutState isEqualToNumber:@1]) {
+      return [ASStaticLayoutSpec staticLayoutSpecWithChildren:@[node1, node2]];
+    } else {
+      ASStackLayoutSpec *stackLayout = [[ASStackLayoutSpec alloc] init];
+      [stackLayout setChildren:@[node3, node2]];
+      return [ASStaticLayoutSpec staticLayoutSpecWithChildren:@[node1, stackLayout]];
+    }
+  };
+  
   [node measureWithSizeRange:ASSizeRangeMake(CGSizeZero, CGSizeZero)];
   [node layout]; // Layout immediately
   XCTAssertEqual(node.subnodes[0], node1);
   XCTAssertEqual(node.subnodes[1], node2);
+  
+  node.layoutState = @2;
+  [node invalidateCalculatedLayout]; // TODO(levi): Look into a way where measureWithSizeRange resizes when a new hierarchy is introduced but the size has not changed
+  [node measureWithSizeRange:ASSizeRangeMake(CGSizeZero, CGSizeZero)];
+  [node layout]; // Layout immediately
+
+  XCTAssertEqual(node.subnodes[0], node1);
+  XCTAssertEqual(node.subnodes[1], node3);
+  XCTAssertEqual(node.subnodes[2], node2);
 }
 
 @end

--- a/AsyncDisplayKitTests/ASDisplayNodeImplicitHierarchyTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeImplicitHierarchyTests.m
@@ -1,0 +1,66 @@
+//
+//  ASDisplayNodeImplicitHierarchyTests.m
+//  AsyncDisplayKit
+//
+//  Created by Levi McCallum on 2/1/16.
+//  Copyright © 2016 Facebook. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "ASDisplayNode.h"
+#import "ASDisplayNode+Beta.h"
+#import "ASDisplayNode+Subclasses.h"
+#import "ASStaticLayoutSpec.h"
+
+@interface ASSpecTestDisplayNode : ASDisplayNode
+
+@property (copy, nonatomic) ASLayoutSpec * (^layoutSpecBlock)(ASSizeRange constrainedSize);
+
+@end
+
+@implementation ASSpecTestDisplayNode
+
+- (ASLayoutSpec *)layoutSpecThatFits:(ASSizeRange)constrainedSize
+{
+  return self.layoutSpecBlock(constrainedSize);
+}
+
+@end
+
+@interface ASDisplayNodeImplicitHierarchyTests : XCTestCase
+
+@end
+
+@implementation ASDisplayNodeImplicitHierarchyTests
+
+- (void)setUp {
+  [super setUp];
+  [ASDisplayNode setUsesImplicitHierarchyManagement:YES];
+}
+
+- (void)tearDown {
+  [ASDisplayNode setUsesImplicitHierarchyManagement:NO];
+  [super tearDown];
+}
+
+- (void)testFeatureFlag
+{
+  XCTAssert([ASDisplayNode usesImplicitHierarchyManagement]);
+}
+
+- (void)testInitialNodeInsertion
+{
+  ASDisplayNode *node1 = [[ASDisplayNode alloc] init];
+  ASDisplayNode *node2 = [[ASDisplayNode alloc] init];
+  ASSpecTestDisplayNode *node = [[ASSpecTestDisplayNode alloc] init];
+  node.layoutSpecBlock = ^(ASSizeRange constrainedSize){
+    return [ASStaticLayoutSpec staticLayoutSpecWithChildren:@[node1, node2]];
+  };
+  [node measureWithSizeRange:ASSizeRangeMake(CGSizeZero, CGSizeZero)];
+  [node layout]; // Layout immediately
+  XCTAssertEqual(node.subnodes[0], node1);
+  XCTAssertEqual(node.subnodes[1], node2);
+}
+
+@end

--- a/AsyncDisplayKitTests/ArrayDiffingTests.m
+++ b/AsyncDisplayKitTests/ArrayDiffingTests.m
@@ -57,8 +57,7 @@
   ];
   
   for (NSArray *test in tests) {
-    NSMutableIndexSet *insertions = [NSMutableIndexSet indexSet];
-    NSMutableIndexSet *deletions = [NSMutableIndexSet indexSet];
+    NSIndexSet *insertions, *deletions;
     [test[0] asdk_diffWithArray:test[1] insertions:&insertions deletions:&deletions];
     for (NSNumber *index in (NSArray *)test[2]) {
       XCTAssert([insertions containsIndex:[index integerValue]]);

--- a/AsyncDisplayKitTests/ArrayDiffingTests.m
+++ b/AsyncDisplayKitTests/ArrayDiffingTests.m
@@ -1,0 +1,72 @@
+//
+//  ArrayDiffingTests.m
+//  AsyncDisplayKit
+//
+//  Created by Levi McCallum on 1/29/16.
+//  Copyright © 2016 Facebook. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "NSArray+Diffing.h"
+
+@interface ArrayDiffingTests : XCTestCase
+
+@end
+
+@implementation ArrayDiffingTests
+
+- (void)testDiffing {
+  NSArray<NSArray *> *tests = @[
+      @[
+        @[@"bob", @"alice", @"dave"],
+        @[@"bob", @"alice", @"dave", @"gary"],
+        @[@3],
+        @[],
+      ],
+      @[
+        @[@"bob", @"alice", @"dave"],
+        @[@"bob", @"gary", @"alice", @"dave"],
+        @[@1],
+        @[],
+      ],
+      @[
+        @[@"bob", @"alice", @"dave"],
+        @[@"bob", @"alice"],
+        @[],
+        @[@2],
+      ],
+      @[
+        @[@"bob", @"alice", @"dave"],
+        @[],
+        @[],
+        @[@0, @1, @2],
+      ],
+      @[
+        @[@"bob", @"alice", @"dave"],
+        @[@"gary", @"alice", @"dave", @"jack"],
+        @[@0, @3],
+        @[@0],
+      ],
+      @[
+        @[@"bob", @"alice", @"dave", @"judy", @"lynda", @"tony"],
+        @[@"gary", @"bob", @"suzy", @"tony"],
+        @[@0, @2],
+        @[@1, @2, @3, @4],
+      ],
+  ];
+  
+  for (NSArray *test in tests) {
+    NSMutableIndexSet *insertions = [NSMutableIndexSet indexSet];
+    NSMutableIndexSet *deletions = [NSMutableIndexSet indexSet];
+    [test[0] asdk_diffWithArray:test[1] insertions:&insertions deletions:&deletions];
+    for (NSNumber *index in (NSArray *)test[2]) {
+      XCTAssert([insertions containsIndex:[index integerValue]]);
+    }
+    for (NSNumber *index in (NSArray *)test[3]) {
+      XCTAssert([deletions containsIndex:[index integerValue]]);
+    }
+  }
+}
+
+@end


### PR DESCRIPTION
- [x] Perform layout flattening in hierarchy order
- [x] Create diff between new and old computed layout for subnode insertion/deletion operations
- [x] Insert subnodes when layout is first computed
- [x] Perform in-order insertion/deletion subnode operations when changing calculated layouts
- [ ] Support manually-managed subnodes that are not affected by the implicit management
- [ ] Ensure that node ordering is preserved on complex hierarchy changes
- [ ] Perform and expose insertion/deletion operations in `layout` in a way that can eventually be converted into an animation step  