### PR TITLE
[WIP] call uitableview/collectionview reload methods when reloading sections

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -922,6 +922,26 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   }
 }
 
+- (void)rangeController:(ASRangeController *)rangeController didReloadNodes:(NSArray *)nodes atIndexPaths:(NSArray *)indexPaths withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions
+{
+    ASDisplayNodeAssertMainThread();
+    if (!self.asyncDataSource || _superIsPendingDataLoad) {
+        return; // if the asyncDataSource has become invalid while we are processing, ignore this request to avoid crashes
+    }
+
+    if (_performingBatchUpdates) {
+        [_layoutFacilitator collectionViewWillEditCellsAtIndexPaths:indexPaths batched:YES];
+        [_batchUpdateBlocks addObject:^{
+            [super reloadItemsAtIndexPaths:indexPaths];
+        }];
+    } else {
+        [_layoutFacilitator collectionViewWillEditCellsAtIndexPaths:indexPaths batched:NO];
+        [UIView performWithoutAnimation:^{
+            [super reloadItemsAtIndexPaths:indexPaths];
+        }];
+    }
+}
+
 - (void)rangeController:(ASRangeController *)rangeController didInsertSectionsAtIndexSet:(NSIndexSet *)indexSet withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions
 {
   ASDisplayNodeAssertMainThread();

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -831,6 +831,25 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
   }
 }
 
+- (void)rangeController:(ASRangeController *)rangeController didReloadNodes:(NSArray *)nodes atIndexPaths:(NSArray *)indexPaths withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions
+{
+  ASDisplayNodeAssertMainThread();
+  LOG(@"UITableView reloadRows:%ld rows", indexPaths.count);
+
+  if (!self.asyncDataSource) {
+    return; // if the asyncDataSource has become invalid while we are processing, ignore this request to avoid crashes
+  }
+
+  BOOL preventAnimation = animationOptions == UITableViewRowAnimationNone;
+  ASPerformBlockWithoutAnimation(preventAnimation, ^{
+    [super reloadRowsAtIndexPaths:indexPaths withRowAnimation:(UITableViewRowAnimation)animationOptions];
+  });
+
+  if (_automaticallyAdjustsContentOffset) {
+    [self adjustContentOffsetWithNodes:nodes atIndexPaths:indexPaths inserting:YES];
+  }
+}
+
 - (void)rangeController:(ASRangeController *)rangeController didInsertSectionsAtIndexSet:(NSIndexSet *)indexSet withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions
 {
   ASDisplayNodeAssertMainThread();

--- a/AsyncDisplayKit/Details/ASDataController.h
+++ b/AsyncDisplayKit/Details/ASDataController.h
@@ -85,6 +85,11 @@ FOUNDATION_EXPORT NSString * const ASDataControllerRowNodeKind;
 - (void)dataController:(ASDataController *)dataController didDeleteNodes:(NSArray<ASCellNode *> *)nodes atIndexPaths:(NSArray<NSIndexPath *> *)indexPaths withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions;
 
 /**
+ Called for reload of elements.
+ */
+- (void)dataController:(ASDataController *)dataController didReloadNodes:(NSArray<ASCellNode *> *)nodes atIndexPaths:(NSArray<NSIndexPath *> *)indexPaths withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions;
+
+/**
  Called for insertion of sections.
  */
 - (void)dataController:(ASDataController *)dataController didInsertSections:(NSArray<NSArray<ASCellNode *> *> *)sections atIndexSet:(NSIndexSet *)indexSet withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions;

--- a/AsyncDisplayKit/Details/ASRangeController.h
+++ b/AsyncDisplayKit/Details/ASRangeController.h
@@ -169,6 +169,19 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)rangeController:(ASRangeController *)rangeController didDeleteNodes:(NSArray<ASCellNode *> *)nodes atIndexPaths:(NSArray<NSIndexPath *> *)indexPaths withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions;
 
 /**
+ * Called for nodes reload.
+ *
+ * @param rangeController Sender.
+ *
+ * @param nodes Inserted nodes.
+ *
+ * @param indexPaths Index path of inserted nodes.
+ *
+ * @param animationOptions Animation options. See ASDataControllerAnimationOptions.
+ */
+- (void)rangeController:(ASRangeController *)rangeController didReloadNodes:(NSArray<ASCellNode *> *)nodes atIndexPaths:(NSArray<NSIndexPath *> *)indexPaths withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions;
+
+/**
  * Called for section insertion.
  *
  * @param rangeController Sender.

--- a/AsyncDisplayKit/Details/ASRangeController.mm
+++ b/AsyncDisplayKit/Details/ASRangeController.mm
@@ -245,6 +245,14 @@
   });
 }
 
+- (void)dataController:(ASDataController *)dataController didReloadNodes:(NSArray<ASCellNode *> *)nodes atIndexPaths:(NSArray<NSIndexPath *> *)indexPaths withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions{
+  ASDisplayNodeAssert(nodes.count == indexPaths.count, @"Invalid index path");
+  ASPerformBlockOnMainThread(^{
+    _rangeIsValid = NO;
+    [_delegate rangeController:self didReloadNodes:nodes atIndexPaths:indexPaths withAnimationOptions:animationOptions];
+  });
+}
+
 - (void)dataController:(ASDataController *)dataController didInsertSections:(NSArray *)sections atIndexSet:(NSIndexSet *)indexSet withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions
 {
   ASDisplayNodeAssert(sections.count == indexSet.count, @"Invalid sections");

--- a/AsyncDisplayKit/Details/ASRangeControllerBeta.mm
+++ b/AsyncDisplayKit/Details/ASRangeControllerBeta.mm
@@ -267,6 +267,14 @@
   });
 }
 
+- (void)dataController:(ASDataController *)dataController didReloadNodes:(NSArray<ASCellNode *> *)nodes atIndexPaths:(NSArray<NSIndexPath *> *)indexPaths withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions{
+  ASDisplayNodeAssert(nodes.count == indexPaths.count, @"Invalid index path");
+  ASPerformBlockOnMainThread(^{
+    _rangeIsValid = NO;
+    [_delegate rangeController:self didReloadNodes:nodes atIndexPaths:indexPaths withAnimationOptions:animationOptions];
+  });
+}
+
 - (void)dataController:(ASDataController *)dataController didDeleteNodes:(NSArray *)nodes atIndexPaths:(NSArray *)indexPaths withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions
 {
   ASPerformBlockOnMainThread(^{


### PR DESCRIPTION
Currently, ASDK ASDataController removes all cells in the reloading sections and add them back. This results in an incorrect animation being executed. It should be calling reloadSections on UITableView/UICollectionView.