### PR TITLE
Enter hierarchy state on the  main thread for nodes that are loaded via legacy node datasource methods 

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -699,10 +699,10 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   if (!_asyncDataSourceImplementsNodeBlockForItemAtIndexPath) {
     ASCellNode *node = [_asyncDataSource collectionView:self nodeForItemAtIndexPath:indexPath];
     ASDisplayNodeAssert([node isKindOfClass:ASCellNode.class], @"invalid node class, expected ASCellNode");
+    [node enterHierarchyState:ASHierarchyStateRangeManaged];
     __weak __typeof__(self) weakSelf = self;
     return ^{
       __typeof__(self) strongSelf = weakSelf;
-      [node enterHierarchyState:ASHierarchyStateRangeManaged];
       if (node.layoutDelegate == nil) {
         node.layoutDelegate = strongSelf;
       }
@@ -717,6 +717,7 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
     __typeof__(self) strongSelf = weakSelf;
 
     ASCellNode *node = block();
+    ASDisplayNodeAssertFalse(node.isNodeLoaded);
     [node enterHierarchyState:ASHierarchyStateRangeManaged];
     if (node.layoutDelegate == nil) {
       node.layoutDelegate = strongSelf;

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -879,11 +879,11 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
 - (ASCellNodeBlock)dataController:(ASDataController *)dataController nodeBlockAtIndexPath:(NSIndexPath *)indexPath {
   if (![_asyncDataSource respondsToSelector:@selector(tableView:nodeBlockForRowAtIndexPath:)]) {
     ASCellNode *node = [_asyncDataSource tableView:self nodeForRowAtIndexPath:indexPath];
+    [node enterHierarchyState:ASHierarchyStateRangeManaged];
     ASDisplayNodeAssert([node isKindOfClass:ASCellNode.class], @"invalid node class, expected ASCellNode");
     __weak __typeof__(self) weakSelf = self;
     return ^{
       __typeof__(self) strongSelf = weakSelf;
-      [node enterHierarchyState:ASHierarchyStateRangeManaged];
       if (node.layoutDelegate == nil) {
         node.layoutDelegate = strongSelf;
       }
@@ -896,6 +896,7 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
   ASCellNodeBlock configuredNodeBlock = ^{
     __typeof__(self) strongSelf = weakSelf;
     ASCellNode *node = block();
+    ASDisplayNodeAssertFalse(node.isNodeLoaded);
     [node enterHierarchyState:ASHierarchyStateRangeManaged];
     if (node.layoutDelegate == nil) {
       node.layoutDelegate = strongSelf;


### PR DESCRIPTION
Updating flow for setting hierarchy state for nodeForItemAtIndexPath/nodeForRowAtIndexPath in ASTableView / ASCollectionView.
Add assertion in block based API's that the node that is created is not already
loaded.