### PR TITLE
ASPagerNode's api was not updated while addressing comments

### DIFF
--- a/AsyncDisplayKit/ASPagerNode.m
+++ b/AsyncDisplayKit/ASPagerNode.m
@@ -90,7 +90,7 @@
   return pageNode;
 }
 
-- (ASCellNodeBlock)collectionView:(ASCollectionView *)collectionView nodeBlockAtIndexPath:(NSIndexPath *)indexPath
+- (ASCellNodeBlock)collectionView:(ASCollectionView *)collectionView nodeBlockForItemAtIndexPath:(NSIndexPath *)indexPath
 {
   ASDisplayNodeAssert(_pagerDataSource != nil, @"ASPagerNode must have a data source to load nodes to display");
   if (!_pagerDataSourceImplementsNodeBlockAtIndex) {

--- a/AsyncDisplayKitTests/ASCollectionViewFlowLayoutInspectorTests.m
+++ b/AsyncDisplayKitTests/ASCollectionViewFlowLayoutInspectorTests.m
@@ -25,7 +25,7 @@
   return [[ASCellNode alloc] init];
 }
 
-- (ASCellNodeBlock)collectionView:(ASCollectionView *)collectionView nodeBlockAtIndexPath:(NSIndexPath *)indexPath
+- (ASCellNodeBlock)collectionView:(ASCollectionView *)collectionView nodeBlockForItemAtIndexPath:(NSIndexPath *)indexPath
 {
   return ^{ return [[ASCellNode alloc] init]; };
 }

--- a/AsyncDisplayKitTests/ASCollectionViewTests.m
+++ b/AsyncDisplayKitTests/ASCollectionViewTests.m
@@ -36,7 +36,7 @@
 }
 
 
-- (ASCellNodeBlock)collectionView:(ASCollectionView *)collectionView nodeBlockAtIndexPath:(NSIndexPath *)indexPath {
+- (ASCellNodeBlock)collectionView:(ASCollectionView *)collectionView nodeBlockForItemAtIndexPath:(NSIndexPath *)indexPath {
   return ^{
     ASTextCellNode *textCellNode = [ASTextCellNode new];
     textCellNode.text = indexPath.description;


### PR DESCRIPTION
ASPagerNode's api was not updated while addressing comments in the initial ASCellNode background allocation PR. This change fixes that issue.