### PR TITLE
Disable App Transport Security in AsyncDisplayKitTestsHost target

### DIFF
--- a/AsyncDisplayKitTestHost/Info.plist
+++ b/AsyncDisplayKitTestHost/Info.plist
@@ -22,6 +22,11 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>


### PR DESCRIPTION
To be able to make http requests in tests we should disable the NSAppTransportSecurity of the AsyncDisplayKitTestsHost target. Otherwise tests like -[ASBasicImageDownloaderTests testAsynchronouslyDownloadTheSameURLTwice] will show an error.