### PR TITLE
Insert/delete should take precedence over Update/Reload

### DIFF
--- a/AsyncDisplayKit/Details/ASChangeSetDataController.m
+++ b/AsyncDisplayKit/Details/ASChangeSetDataController.m
@@ -51,14 +51,6 @@
     [_changeSet markCompleted];
     
     [super beginUpdates];
-  
-    for (_ASHierarchySectionChange *change in [_changeSet sectionChangesOfType:_ASHierarchyChangeTypeReload]) {
-      [super reloadSections:change.indexSet withAnimationOptions:change.animationOptions];
-    }
-    
-    for (_ASHierarchyItemChange *change in [_changeSet itemChangesOfType:_ASHierarchyChangeTypeReload]) {
-      [super reloadRowsAtIndexPaths:change.indexPaths withAnimationOptions:change.animationOptions];
-    }
     
     for (_ASHierarchyItemChange *change in [_changeSet itemChangesOfType:_ASHierarchyChangeTypeDelete]) {
       [super deleteRowsAtIndexPaths:change.indexPaths withAnimationOptions:change.animationOptions];
@@ -74,6 +66,14 @@
     
     for (_ASHierarchyItemChange *change in [_changeSet itemChangesOfType:_ASHierarchyChangeTypeInsert]) {
       [super insertRowsAtIndexPaths:change.indexPaths withAnimationOptions:change.animationOptions];
+    }
+    
+    for (_ASHierarchySectionChange *change in [_changeSet sectionChangesOfType:_ASHierarchyChangeTypeReload]) {
+      [super reloadSections:change.indexSet withAnimationOptions:change.animationOptions];
+    }
+    
+    for (_ASHierarchyItemChange *change in [_changeSet itemChangesOfType:_ASHierarchyChangeTypeReload]) {
+      [super reloadRowsAtIndexPaths:change.indexPaths withAnimationOptions:change.animationOptions];
     }
     
     [super endUpdatesAnimated:animated completion:completion];


### PR DESCRIPTION
@levi @appleguy @nguyenhuy 
When user performs a batchUpdate on a collectionView and combines insertions and reloads:
e.g.
```
insert a row at index 2
update a row at indexes 0 and 3 (after insertion it will be 4)
```
At this point, the data sources for these rows should've updated, meaning:
```
index 0: content is updated
index 2: content is newly inserted
index 3: old content that used to be at index 2
index 4: updated content that used to be at index 3
```

With our current implementation, when you try to update row at old index 3:
You either pass in the index 3:
```
changeSet will trigger reload, which will ask our ASCV dataSource for a new node at index **3** 
and that Node will have **old content that used to be at index 2**, 
but will be put in the correct position because insertion happens afterwards
```
Or you pass in the index 4:
```
changeSet will trigger reload, which will ask our ASCV dataSource for a new node at index 4 and
that Node will have the correct content, but since insertion hasn't happen yet, 
this new node replaces the node at index 4 which has nothing to do with this whole operation
```

Therefore, Update/Reloads should happen after insertion/deletions.