### PR TITLE
[Table, Collection, Pager] Update data source protocols to not @require non-block node method.

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.h
+++ b/AsyncDisplayKit/ASCollectionView.h
@@ -340,6 +340,8 @@ NS_ASSUME_NONNULL_BEGIN
 #define ASCollectionViewDataSource ASCollectionDataSource
 @protocol ASCollectionDataSource <ASCommonCollectionViewDataSource, NSObject>
 
+@optional
+
 /**
  * Similar to -collectionView:cellForItemAtIndexPath:.
  *
@@ -353,16 +355,15 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (ASCellNode *)collectionView:(ASCollectionView *)collectionView nodeForItemAtIndexPath:(NSIndexPath *)indexPath;
 
-
-@optional
-
 /**
+ * Similar to -collectionView:nodeForItemAtIndexPath:
+ * This method takes precedence over collectionView:nodeForItemAtIndexPath: if implemented.
  *
  * @param collectionView The sender.
  *
  * @param indexPath The index path of the requested node.
  *
- * @returns a block that creates the node for display at this indexpath.  
+ * @returns a block that creates the node for display at this indexpath.
  *   Must be thread-safe (can be called on the main thread or a background
  *   queue) and should not implement reuse (it will be called once per row).
  */

--- a/AsyncDisplayKit/ASPagerNode.h
+++ b/AsyncDisplayKit/ASPagerNode.h
@@ -10,15 +10,44 @@
 
 @class ASPagerNode;
 @protocol ASPagerNodeDataSource <NSObject>
-// This method replaces -collectionView:numberOfItemsInSection:
-- (NSInteger)numberOfPagesInPagerNode:(ASPagerNode *)pagerNode;
 
-// This method replaces -collectionView:nodeForItemAtIndexPath:
-- (ASCellNode *)pagerNode:(ASPagerNode *)pagerNode nodeAtIndex:(NSInteger)index;
+/**
+ * This method replaces -collectionView:numberOfItemsInSection:
+ *
+ * @param pagerNode The sender.
+ *
+ *
+ * @returns The total number of pages that can display in the pagerNode.
+ */
+- (NSInteger)numberOfPagesInPagerNode:(ASPagerNode *)pagerNode;
 
 @optional
 
-// This method replaces -collectionView:nodeBlockForItemAtIndexPath:
+/**
+ * This method replaces -collectionView:nodeForItemAtIndexPath:
+ *
+ * @param pagerNode The sender.
+ *
+ * @param index The index of the requested node.
+ *
+ * @returns a node for display at this index. This will be called on the main thread and should
+ *   not implement reuse (it will be called once per row).  Unlike UICollectionView's version,
+ *   this method is not called when the row is about to display.
+ */
+- (ASCellNode *)pagerNode:(ASPagerNode *)pagerNode nodeAtIndex:(NSInteger)index;
+
+/**
+ * This method replaces -collectionView:nodeBlockForItemAtIndexPath:
+ * This method takes precedence over pagerNode:nodeAtIndex: if implemented.
+ *
+ * @param pagerNode The sender.
+ *
+ * @param index The index of the requested node.
+ *
+ * @returns a block that creates the node for display at this index.
+ *   Must be thread-safe (can be called on the main thread or a background
+ *   queue) and should not implement reuse (it will be called once per row).
+ */
 - (ASCellNodeBlock)pagerNode:(ASPagerNode *)pagerNode nodeBlockAtIndex:(NSInteger)index;
 
 @end

--- a/AsyncDisplayKit/ASPagerNode.m
+++ b/AsyncDisplayKit/ASPagerNode.m
@@ -83,13 +83,6 @@
 
 #pragma mark - ASCollectionViewDataSource
 
-- (ASCellNode *)collectionView:(ASCollectionView *)collectionView nodeForItemAtIndexPath:(NSIndexPath *)indexPath
-{
-  ASDisplayNodeAssert(_pagerDataSource != nil, @"ASPagerNode must have a data source to load nodes to display");
-  ASCellNode *pageNode = [_pagerDataSource pagerNode:self nodeAtIndex:indexPath.item];
-  return pageNode;
-}
-
 - (ASCellNodeBlock)collectionView:(ASCollectionView *)collectionView nodeBlockForItemAtIndexPath:(NSIndexPath *)indexPath
 {
   ASDisplayNodeAssert(_pagerDataSource != nil, @"ASPagerNode must have a data source to load nodes to display");
@@ -123,7 +116,10 @@
   if (pagerDataSource != _pagerDataSource) {
     _pagerDataSource = pagerDataSource;
     _pagerDataSourceImplementsNodeBlockAtIndex = [_pagerDataSource respondsToSelector:@selector(pagerNode:nodeBlockAtIndex:)];
+    // Data source must implement pagerNode:nodeBlockAtIndex: or pagerNode:nodeAtIndex:
+    ASDisplayNodeAssertTrue(_pagerDataSourceImplementsNodeBlockAtIndex || [_pagerDataSource respondsToSelector:@selector(pagerNode:nodeAtIndex:)]);
     _proxy = pagerDataSource ? [[ASPagerNodeProxy alloc] initWithTarget:pagerDataSource interceptor:self] : nil;
+    
     super.dataSource = (id <ASCollectionDataSource>)_proxy;
   }
 }

--- a/AsyncDisplayKit/ASTableView.h
+++ b/AsyncDisplayKit/ASTableView.h
@@ -315,6 +315,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @protocol ASTableDataSource <ASCommonTableViewDataSource, NSObject>
 
+@optional
+
 /**
  * Similar to -tableView:cellForRowAtIndexPath:.
  *
@@ -327,11 +329,10 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (ASCellNode *)tableView:(ASTableView *)tableView nodeForRowAtIndexPath:(NSIndexPath *)indexPath;
 
-@optional
 
 /**
- * Similar to -tableView:nodeForRowAtIndexPath:.
- *
+ * Similar to -tableView:nodeForRowAtIndexPath:
+ * This method takes precedence over tableView:nodeForRowAtIndexPath: if implemented.
  * @param tableView The sender.
  *
  * @param indexPath The index path of the requested node.

--- a/AsyncDisplayKit/Details/ASCollectionDataController.h
+++ b/AsyncDisplayKit/Details/ASCollectionDataController.h
@@ -17,8 +17,6 @@
 
 @protocol ASCollectionDataControllerSource <ASDataControllerSource>
 
-- (ASCellNode *)dataController:(ASCollectionDataController *)dataController supplementaryNodeOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath;
-
 /**
  The constrained size range for layout.
  */
@@ -31,6 +29,8 @@
 - (NSUInteger)dataController:(ASCollectionDataController *)dataController supplementaryNodesOfKind:(NSString *)kind inSection:(NSUInteger)section;
 
 @optional
+
+- (ASCellNode *)dataController:(ASCollectionDataController *)dataController supplementaryNodeOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath;
 
 - (ASCellNodeBlock)dataController:(ASCollectionDataController *)dataController supplementaryNodeBlockOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath;
 

--- a/AsyncDisplayKit/Details/ASCollectionDataController.mm
+++ b/AsyncDisplayKit/Details/ASCollectionDataController.mm
@@ -255,6 +255,8 @@
 {
   [super setDataSource:dataSource];
   _dataSourceImplementsSupplementaryNodeBlockOfKindAtIndexPath = [self.collectionDataSource respondsToSelector:@selector(dataController:supplementaryNodeBlockOfKind:atIndexPath:)];
+
+  ASDisplayNodeAssertTrue(_dataSourceImplementsSupplementaryNodeBlockOfKindAtIndexPath || [self.collectionDataSource respondsToSelector:@selector(dataController:supplementaryNodeOfKind:atIndexPath:)]);
 }
 
 @end

--- a/AsyncDisplayKit/Details/ASDataController.h
+++ b/AsyncDisplayKit/Details/ASDataController.h
@@ -36,11 +36,6 @@ FOUNDATION_EXPORT NSString * const ASDataControllerRowNodeKind;
 @protocol ASDataControllerSource <NSObject>
 
 /**
- Fetch the ASCellNode for specific index path.
- */
-- (ASCellNode *)dataController:(ASDataController *)dataController nodeAtIndexPath:(NSIndexPath *)indexPath;
-
-/**
  Fetch the ASCellNode block for specific index path. This block should return the ASCellNode for the specified index path.
  */
 - (ASCellNodeBlock)dataController:(ASDataController *)dataController nodeBlockAtIndexPath:(NSIndexPath *)indexPath;


### PR DESCRIPTION
This is mostly a follow-up to the original addition of the block-based asynchronous node creation api that was introduced recently. This change makes synchronous node creation api methods optional but enforces that one of the two approaches is implemented when the dataSource property is set.