### PR TITLE
[ASDataController] Adjust index paths for reloads contained in the same changeset as deletes / inserts.

### DIFF
--- a/AsyncDisplayKit/Private/_ASHierarchyChangeSet.h
+++ b/AsyncDisplayKit/Private/_ASHierarchyChangeSet.h
@@ -30,8 +30,10 @@ typedef NS_ENUM(NSInteger, _ASHierarchyChangeType) {
 @property (nonatomic, readonly) ASDataControllerAnimationOptions animationOptions;
 
 /// Index paths are sorted descending for changeType .Delete, ascending otherwise
-@property (nonatomic, strong, readonly) NSArray *indexPaths;
+@property (nonatomic, strong) NSArray *indexPaths;
 @property (nonatomic, readonly) _ASHierarchyChangeType changeType;
+
++ (NSDictionary *)sectionToIndexSetMapFromChanges:(NSArray *)changes ofType:(_ASHierarchyChangeType)changeType;
 @end
 
 @interface _ASHierarchyChangeSet : NSObject


### PR DESCRIPTION
I'm basically updating the indexPaths of all the reloads based on any deletion/insertions before it.

Here's the verified UIKit behavior, for reference:
**delete/reload** indexPaths that you pass in should all be their** current** indexPaths
**insert** indexPaths that you pass in should all be their **future** indexPaths after deletions

@appleguy @rahul-malik @Adlai-Holler