### PR TITLE
[ASDataController] Improvements to index paths shifting reloads in changesets.

### DIFF
--- a/AsyncDisplayKit/Details/ASChangeSetDataController.m
+++ b/AsyncDisplayKit/Details/ASChangeSetDataController.m
@@ -11,6 +11,8 @@
 #import "_ASHierarchyChangeSet.h"
 #import "ASAssert.h"
 
+#import "ASDataController+Subclasses.h"
+
 @interface ASChangeSetDataController ()
 
 @property (nonatomic, assign) NSUInteger batchUpdateCounter;
@@ -51,15 +53,7 @@
     [_changeSet markCompleted];
     
     [super beginUpdates];
-  
-    for (_ASHierarchySectionChange *change in [_changeSet sectionChangesOfType:_ASHierarchyChangeTypeReload]) {
-      [super reloadSections:change.indexSet withAnimationOptions:change.animationOptions];
-    }
-    
-    for (_ASHierarchyItemChange *change in [_changeSet itemChangesOfType:_ASHierarchyChangeTypeReload]) {
-      [super reloadRowsAtIndexPaths:change.indexPaths withAnimationOptions:change.animationOptions];
-    }
-    
+
     for (_ASHierarchyItemChange *change in [_changeSet itemChangesOfType:_ASHierarchyChangeTypeDelete]) {
       [super deleteRowsAtIndexPaths:change.indexPaths withAnimationOptions:change.animationOptions];
     }
@@ -67,7 +61,15 @@
     for (_ASHierarchySectionChange *change in [_changeSet sectionChangesOfType:_ASHierarchyChangeTypeDelete]) {
       [super deleteSections:change.indexSet withAnimationOptions:change.animationOptions];
     }
-    
+
+    for (_ASHierarchySectionChange *change in [_changeSet sectionChangesOfType:_ASHierarchyChangeTypeReload]) {
+      [super reloadSections:change.indexSet withAnimationOptions:change.animationOptions];
+    }
+
+    for (_ASHierarchyItemChange *change in [_changeSet itemChangesOfType:_ASHierarchyChangeTypeReload]) {
+      [super reloadRowsAtIndexPaths:change.indexPaths withIndexPathsAfterUpdates:change.indexPathsAfterUpdates withAnimationOptions:change.animationOptions];
+    }
+
     for (_ASHierarchySectionChange *change in [_changeSet sectionChangesOfType:_ASHierarchyChangeTypeInsert]) {
       [super insertSections:change.indexSet withAnimationOptions:change.animationOptions];
     }
@@ -75,7 +77,7 @@
     for (_ASHierarchyItemChange *change in [_changeSet itemChangesOfType:_ASHierarchyChangeTypeInsert]) {
       [super insertRowsAtIndexPaths:change.indexPaths withAnimationOptions:change.animationOptions];
     }
-    
+
     [super endUpdatesAnimated:animated completion:completion];
     
     _changeSet = nil;

--- a/AsyncDisplayKit/Details/ASDataController+Subclasses.h
+++ b/AsyncDisplayKit/Details/ASDataController+Subclasses.h
@@ -50,6 +50,14 @@
  */
 - (ASSizeRange)constrainedSizeForNodeOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath;
 
+#pragma mark - Row Editing (Internal API)
+
+/**
+ * reload a set of IndexPaths requires deleting the cells at their current indexPaths 
+ * and then inserting new ones at their future indexPaths, and these two sets of indexPath will be different in many cases
+ */
+- (void)reloadRowsAtIndexPaths:(NSArray *)indexPaths withIndexPathsAfterUpdates:(NSArray *)indexPathAfterUpdates withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions;
+
 #pragma mark - Node & Section Insertion/Deletion API
 
 /**

--- a/AsyncDisplayKit/Private/_ASHierarchyChangeSet.h
+++ b/AsyncDisplayKit/Private/_ASHierarchyChangeSet.h
@@ -30,7 +30,9 @@ typedef NS_ENUM(NSInteger, _ASHierarchyChangeType) {
 @property (nonatomic, readonly) ASDataControllerAnimationOptions animationOptions;
 
 /// Index paths are sorted descending for changeType .Delete, ascending otherwise
-@property (nonatomic, strong) NSArray *indexPaths;
+@property (nonatomic, strong, readonly) NSArray *indexPaths;
+/// Calculated indexPaths after any insertions or deletions
+@property (nonatomic, strong) NSArray *indexPathsAfterUpdates;
 @property (nonatomic, readonly) _ASHierarchyChangeType changeType;
 
 + (NSDictionary *)sectionToIndexSetMapFromChanges:(NSArray *)changes ofType:(_ASHierarchyChangeType)changeType;


### PR DESCRIPTION
Addressed issues @Adlai-Holler mentioned in the [previous PR](https://github.com/facebook/AsyncDisplayKit/pull/1219)

Added an internal API:
`- (void)reloadRowsAtIndexPaths:(NSArray *)indexPaths withIndexPathsAfterUpdates:(NSArray *)indexPathAfterUpdates withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions`
because with reloads as we just delete+insert them, and after the inserted nodes are completed, we call the super methods on the UICollectionView. This means that the delete indexPaths should be current and insert indexPaths should be future, which will be different in many cases, but we are passing through the same set.

@appleguy @rahul-malik

We need a lot of testing on this, I'll try to write a testing app soon, but I'm really out of cycles at the moment.