### PR TITLE
Remove wordkerner in ASTextNode to fix jumbled text bug

### DIFF
--- a/AsyncDisplayKit/ASTextNode.mm
+++ b/AsyncDisplayKit/ASTextNode.mm
@@ -21,7 +21,6 @@
 #import "ASTextKitRenderer.h"
 #import "ASTextKitRenderer+Positioning.h"
 #import "ASTextKitShadower.h"
-#import "ASTextNodeWordKerner.h"
 
 #import "ASInternalHelpers.h"
 #import "ASEqualityHelpers.h"
@@ -81,10 +80,6 @@ static NSString *ASTextNodeTruncationTokenAttributeName = @"ASTextNodeTruncation
   ASTextKitRenderer *_renderer;
 
   UILongPressGestureRecognizer *_longPressGestureRecognizer;
-  
-  ASDN::Mutex _wordKernerLock;
-  ASTextNodeWordKerner *_wordKerner;
-  
 }
 @dynamic placeholderEnabled;
 
@@ -248,7 +243,6 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
     .maximumNumberOfLines = _maximumNumberOfLines,
     .exclusionPaths = _exclusionPaths,
     .minimumScaleFactor = _minimumScaleFactor,
-    .layoutManagerDelegate = [self _wordKerner],
   };
 }
 
@@ -282,15 +276,6 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
     _constrainedSize = CGSizeMake(-INFINITY, -INFINITY);
     [self _invalidateRenderer];
   }
-}
-
-- (ASTextNodeWordKerner *)_wordKerner
-{
-    ASDN::MutexLocker l(_wordKernerLock);
-    if (_wordKerner == nil) {
-        _wordKerner = [[ASTextNodeWordKerner alloc] init];
-    }
-    return _wordKerner;
 }
 
 #pragma mark - Layout and Sizing


### PR DESCRIPTION
Before:
![screen shot 2016-02-16 at 09 31 52](https://cloud.githubusercontent.com/assets/285809/13084919/8bd77e36-d490-11e5-9d33-9cf13410ae54.png)

After:
![screen shot 2016-02-16 at 09 31 17](https://cloud.githubusercontent.com/assets/285809/13084921/8fa9ccee-d490-11e5-9d99-c4f011786936.png)

Here is a simple app to recreate the bug:
[JumbledText.zip](https://github.com/facebook/AsyncDisplayKit/files/132985/JumbledText.zip)

Eventually I want to look into the issue, but until then this will stop the text error.

Word Kerner is also used in ASEditableTextNode. Should we take it out there as well?
