### PR TITLE
[_ASHierarchyChangeSet] Improve reload handling in BatchUpdates

### DIFF
--- a/AsyncDisplayKit/Details/ASChangeSetDataController.m
+++ b/AsyncDisplayKit/Details/ASChangeSetDataController.m
@@ -67,7 +67,7 @@
     }
 
     for (_ASHierarchyItemChange *change in [_changeSet itemChangesOfType:_ASHierarchyChangeTypeReload]) {
-      [super reloadRowsAtIndexPaths:change.indexPaths withIndexPathsAfterUpdates:change.indexPathsAfterUpdates withAnimationOptions:change.animationOptions];
+      [super reloadRowsAtIndexPaths:change.indexPaths withAnimationOptions:change.animationOptions];
     }
 
     for (_ASHierarchySectionChange *change in [_changeSet sectionChangesOfType:_ASHierarchyChangeTypeInsert]) {

--- a/AsyncDisplayKit/Details/ASDataController+Subclasses.h
+++ b/AsyncDisplayKit/Details/ASDataController+Subclasses.h
@@ -50,14 +50,6 @@
  */
 - (ASSizeRange)constrainedSizeForNodeOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath;
 
-#pragma mark - Row Editing (Internal API)
-
-/**
- * reload a set of IndexPaths requires deleting the cells at their current indexPaths 
- * and then inserting new ones at their future indexPaths, and these two sets of indexPath will be different in many cases
- */
-- (void)reloadRowsAtIndexPaths:(NSArray *)indexPaths withIndexPathsAfterUpdates:(NSArray *)indexPathAfterUpdates withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions;
-
 #pragma mark - Node & Section Insertion/Deletion API
 
 /**

--- a/AsyncDisplayKit/Details/ASDataController.mm
+++ b/AsyncDisplayKit/Details/ASDataController.mm
@@ -787,11 +787,6 @@ static void *kASSizingQueueContext = &kASSizingQueueContext;
 
 - (void)reloadRowsAtIndexPaths:(NSArray *)indexPaths withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions
 {
-  [self reloadRowsAtIndexPaths:indexPaths withIndexPathsAfterUpdates:indexPaths withAnimationOptions:animationOptions];
-}
-
-- (void)reloadRowsAtIndexPaths:(NSArray *)indexPaths withIndexPathsAfterUpdates:(NSArray *)indexPathAfterUpdates withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions
-{
   [self performEditCommandWithBlock:^{
     ASDisplayNodeAssertMainThread();
     LOG(@"Edit Command - reloadRows: %@", indexPaths);
@@ -800,20 +795,20 @@ static void *kASSizingQueueContext = &kASSizingQueueContext;
     
     // Reloading requires re-fetching the data.  Load it on the current calling thread, locking the data source.
     [self accessDataSourceWithBlock:^{
-      NSMutableArray *nodes = [[NSMutableArray alloc] initWithCapacity:indexPathAfterUpdates.count];
+      NSMutableArray *nodes = [[NSMutableArray alloc] initWithCapacity:indexPaths.count];
       
       // FIXME: This doesn't currently do anything
       // FIXME: Shouldn't deletes be sorted in descending order?
       [indexPaths sortedArrayUsingSelector:@selector(compare:)];
       
-      for (NSIndexPath *indexPath in indexPathAfterUpdates) {
+      for (NSIndexPath *indexPath in indexPaths) {
         [nodes addObject:[_dataSource dataController:self nodeBlockAtIndexPath:indexPath]];
       }
 
       [_editingTransactionQueue addOperationWithBlock:^{
         LOG(@"Edit Transaction - reloadRows: %@", indexPaths);
         [self _deleteNodesAtIndexPaths:indexPaths withAnimationOptions:animationOptions];
-        [self _batchLayoutNodes:nodes atIndexPaths:indexPathAfterUpdates withAnimationOptions:animationOptions];
+        [self _batchLayoutNodes:nodes atIndexPaths:indexPaths withAnimationOptions:animationOptions];
       }];
     }];
   }];

--- a/AsyncDisplayKit/Private/_ASHierarchyChangeSet.h
+++ b/AsyncDisplayKit/Private/_ASHierarchyChangeSet.h
@@ -31,8 +31,7 @@ typedef NS_ENUM(NSInteger, _ASHierarchyChangeType) {
 
 /// Index paths are sorted descending for changeType .Delete, ascending otherwise
 @property (nonatomic, strong, readonly) NSArray *indexPaths;
-/// Calculated indexPaths after any insertions or deletions
-@property (nonatomic, strong) NSArray *indexPathsAfterUpdates;
+
 @property (nonatomic, readonly) _ASHierarchyChangeType changeType;
 
 + (NSDictionary *)sectionToIndexSetMapFromChanges:(NSArray *)changes ofType:(_ASHierarchyChangeType)changeType;


### PR DESCRIPTION
@adlai-holler @appleguy @rahul-malik

What we are currently doing when batchUpdating:
1. remove the delete items/sections from internal datasource
2. remove the reloading items/section from internal datasource
3. insert reloading items/section from internal datasource
4. insert the insertion items/sections
5. call [super performBatchUpdate] when all nodes are completed.

However, even with index shifting, we run into crashes at step 2 because after we delete items from internal data array in step 1, the indexes of reloads are no longer valid. e.g. original array (item0, item1), we delete item at 0, and reload item at 1. after removing item 0 from internal data array, we try to remove item at index 1, and it crashes.

I think the most straight forward way for us to handle reloads is to just split the changes into deletes and inserts and coalesce them with the existing deletes and inserts.

Right now it's working for all my tests, but they are probably not holistic.

Thoughts?
