### PR TITLE
[ASRangeController] Ensure Cells That Are in Window Are Always in FetchData, Display Ranges

### DIFF
--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -34,6 +34,7 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
 
 @protocol _ASTableViewCellDelegate <NSObject>
 - (void)didLayoutSubviewsOfTableViewCell:(_ASTableViewCell *)tableViewCell;
+- (void)tableViewCell:(_ASTableViewCell *)tableViewCell didMoveToWindow:(nullable UIWindow *)window;
 @end
 
 @interface _ASTableViewCell : UITableViewCell
@@ -43,6 +44,12 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
 
 @implementation _ASTableViewCell
 // TODO add assertions to prevent use of view-backed UITableViewCell properties (eg .textLabel)
+
+- (void)didMoveToWindow
+{
+  [super didMoveToWindow];
+  [_delegate tableViewCell:self didMoveToWindow:self.window];
+}
 
 - (void)layoutSubviews
 {
@@ -964,6 +971,15 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     CGSize calculatedSize = [[node measureWithSizeRange:constrainedSize] size];
     node.frame = CGRectMake(0, 0, calculatedSize.width, calculatedSize.height);
     [self endUpdates];
+  }
+}
+
+- (void)tableViewCell:(_ASTableViewCell *)tableViewCell didMoveToWindow:(UIWindow *)window
+{
+  if (window != nil) {
+    ASCellNode *node = tableViewCell.node;
+    ASDisplayNodeAssertNotNil(node, @"Expected table view cell to contain a node when moved into a window.");
+    [_rangeController cellNode:node viewDidMoveToWindow:window];
   }
 }
 

--- a/AsyncDisplayKit/Details/ASRangeController.h
+++ b/AsyncDisplayKit/Details/ASRangeController.h
@@ -45,14 +45,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)visibleNodeIndexPathsDidChangeWithScrollDirection:(ASScrollDirection)scrollDirection;
 
 /**
- * Notify the range controller that the given cell's view has moved into a window.
+ * Notify the range controller that the given cell's view has moved into a window (or out of a window).
  * This is called to give the range controller a chance to update the cell node's ranges immediately after it's cell enters the hierarchy.
  * Rationale: Typically the range controller throttles its updating by dispatching
  * asynchronously onto the main queue. But in cases such as `neverShowPlaceholders` it can
  * be valuable to add the cell node into the Fetch and Display ranges synchronously.
  *
  * @param cellNode The cell node whose view has moved into the window.
- * @param window The window that the cell node's view moved into. Note this is nonnull.
+ * @param window The window that the cell node's view moved into, or nil if it moved out of a window.
  */
 - (void)cellNode:(ASCellNode *)cellNode viewDidMoveToWindow:(nullable UIWindow *)window;
 

--- a/AsyncDisplayKit/Details/ASRangeController.h
+++ b/AsyncDisplayKit/Details/ASRangeController.h
@@ -45,16 +45,16 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)visibleNodeIndexPathsDidChangeWithScrollDirection:(ASScrollDirection)scrollDirection;
 
 /**
- * Notify the range controller that the given cell's view has moved into a window (or out of a window).
+ * Notify the range controller that the given cell's view has moved into a window.
  * This is called to give the range controller a chance to update the cell node's ranges immediately after it's cell enters the hierarchy.
  * Rationale: Typically the range controller throttles its updating by dispatching
  * asynchronously onto the main queue. But in cases such as `neverShowPlaceholders` it can
  * be valuable to add the cell node into the Fetch and Display ranges synchronously.
  *
  * @param cellNode The cell node whose view has moved into the window.
- * @param window The window that the cell node's view moved into, or nil if it moved out of a window.
+ * @param window The window that the cell node's view moved into. Note this is nonnull.
  */
-- (void)cellNode:(ASCellNode *)cellNode viewDidMoveToWindow:(nullable UIWindow *)window;
+- (void)cellNode:(ASCellNode *)cellNode viewDidMoveToWindow:(UIWindow *)window;
 
 /**
  * Add the sized node for `indexPath` as a subview of `contentView`.

--- a/AsyncDisplayKit/Details/ASRangeController.h
+++ b/AsyncDisplayKit/Details/ASRangeController.h
@@ -45,6 +45,18 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)visibleNodeIndexPathsDidChangeWithScrollDirection:(ASScrollDirection)scrollDirection;
 
 /**
+ * Notify the range controller that the given cell's view has moved into a window.
+ * This is called to give the range controller a chance to update the cell node's ranges immediately after it's cell enters the hierarchy.
+ * Rationale: Typically the range controller throttles its updating by dispatching
+ * asynchronously onto the main queue. But in cases such as `neverShowPlaceholders` it can
+ * be valuable to add the cell node into the Fetch and Display ranges synchronously.
+ *
+ * @param cellNode The cell node whose view has moved into the window.
+ * @param window The window that the cell node's view moved into. Note this is nonnull.
+ */
+- (void)cellNode:(ASCellNode *)cellNode viewDidMoveToWindow:(nullable UIWindow *)window;
+
+/**
  * Add the sized node for `indexPath` as a subview of `contentView`.
  *
  * @param contentView UIView to add a (sized) node's view to.

--- a/AsyncDisplayKit/Details/ASRangeController.mm
+++ b/AsyncDisplayKit/Details/ASRangeController.mm
@@ -70,6 +70,17 @@
   [self scheduleRangeUpdate];
 }
 
+- (void)cellNode:(ASCellNode *)cellNode viewDidMoveToWindow:(UIWindow *)window
+{
+  const ASInterfaceState oldInterfaceState = cellNode.interfaceState;
+  ASInterfaceState interfaceState = oldInterfaceState;
+  interfaceState |= ASInterfaceStateFetchData;
+  interfaceState |= ASInterfaceStateDisplay;
+  if (interfaceState != oldInterfaceState) {
+    [cellNode recursivelySetInterfaceState:interfaceState];
+  }
+}
+
 - (void)scheduleRangeUpdate
 {
   if (_queuedRangeUpdate) {


### PR DESCRIPTION
@appleguy I decided to run this alongside the existing cables for `_ASTableViewCellDelegate`. 

It works great! With this change, I was able to ensure the first cell in a presented table view was rendered before it came on screen! :zap: 