### PR TITLE
[ASNetworkImageNode] Provide Synchronous Loading Path on Cache Hits

### DIFF
--- a/AsyncDisplayKit/ASMultiplexImageNode.mm
+++ b/AsyncDisplayKit/ASMultiplexImageNode.mm
@@ -78,7 +78,7 @@ typedef void(^ASMultiplexImageLoadCompletionBlock)(UIImage *image, id imageIdent
   __weak NSOperation *_phImageRequestOperation;
   
   // Networking.
-  ASDN::Mutex _downloadIdentifierLock;
+  ASDN::RecursiveMutex _downloadIdentifierLock;
   id _downloadIdentifier;
   
   //set on init only

--- a/AsyncDisplayKit/Details/ASImageProtocols.h
+++ b/AsyncDisplayKit/Details/ASImageProtocols.h
@@ -20,8 +20,7 @@ typedef void(^ASImageCacherCompletion)(UIImage * _Nullable imageFromCache);
 /**
  @abstract Attempts to fetch an image with the given URL from the cache.
  @param URL The URL of the image to retrieve from the cache.
- @param callbackQueue The queue to call `completion` on. If this value is nil, @{ref completion} will be invoked on the
- main-queue.
+ @param callbackQueue The queue to call `completion` on.
  @param completion The block to be called when the cache has either hit or missed.
  @param imageFromCache The image that was retrieved from the cache, if the image could be retrieved; nil otherwise.
  @discussion If `URL` is nil, `completion` will be invoked immediately with a nil image. This method should not block


### PR DESCRIPTION
A good old fashioned main-thread short-circuit for our image loading. @appleguy 