### PR TITLE
[ASMultiplexImageNode] Check loadedImageIdentifer before sending it to delegate

### DIFF
--- a/AsyncDisplayKit/ASMultiplexImageNode.mm
+++ b/AsyncDisplayKit/ASMultiplexImageNode.mm
@@ -219,7 +219,7 @@ typedef void(^ASMultiplexImageLoadCompletionBlock)(UIImage *image, id imageIdent
 
   [self _setDownloadIdentifier:nil];
   
-  if (_cacheSupportsClearing) {
+  if (_cacheSupportsClearing && self.loadedImageIdentifier != nil) {
     [_cache clearFetchedImageFromCacheWithURL:[_dataSource multiplexImageNode:self URLForImageIdentifier:self.loadedImageIdentifier]];
   }
 


### PR DESCRIPTION
As the delegate `- (nullable NSURL *)multiplexImageNode:(ASMultiplexImageNode *)imageNode URLForImageIdentifier:(ASImageIdentifier)imageIdentifier;` does not require `imageIdentifier` to be nullable, we need to check `loadedImageIdentifier` before sending it to the delegate.

I'm not pretty sure why this variable is null, but when using this class on Swift, it causes crashing from my end.