### PR TITLE
[ASCellNode] Use ASViewController.node Directly Instead of Wrapping

### DIFF
--- a/AsyncDisplayKit/ASCellNode.h
+++ b/AsyncDisplayKit/ASCellNode.h
@@ -79,16 +79,16 @@ typedef NSUInteger ASCellNodeAnimation;
 - (void)setNeedsLayout;
 
 /**
- * @abstract Initializes a cell with a given viewControllerBlock.
+ * @abstract Initializes a cell with a given view controller block.
  *
- * @param viewBlock The block that will be used to create the backing view.
- * @param didLoadBlock The block that will be called after the view created by the viewBlock is loaded
+ * @param viewControllerBlock The block that will be used to create the backing view controller.
+ * @param didLoadBlock The block that will be called after the view controller's view is loaded.
  *
  * @return An ASCellNode created using the root view of the view controller provided by the viewControllerBlock.
  * The view controller's root view is resized to match the calcuated size produced during layout.
  *
  */
-- (instancetype)initWithViewControllerBlock:(ASDisplayNodeViewControllerBlock)viewControllerBlock didLoadBlock:(ASDisplayNodeDidLoadBlock)didLoadBlock;
+- (instancetype)initWithViewControllerBlock:(ASDisplayNodeViewControllerBlock)viewControllerBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock;
 
 - (void)visibleNodeDidScroll:(UIScrollView *)scrollView withCellFrame:(CGRect)cellFrame;
 

--- a/AsyncDisplayKit/ASCellNode.m
+++ b/AsyncDisplayKit/ASCellNode.m
@@ -20,7 +20,6 @@
 
 @interface ASCellNode ()
 {
-  UIViewController *_viewController;
   ASDisplayNode *_viewControllerNode;
 }
 

--- a/AsyncDisplayKit/ASCellNode.m
+++ b/AsyncDisplayKit/ASCellNode.m
@@ -13,6 +13,7 @@
 #import <AsyncDisplayKit/ASDisplayNode+Subclasses.h>
 #import <AsyncDisplayKit/ASTextNode.h>
 
+#import <AsyncDisplayKit/ASViewController.h>
 #import <AsyncDisplayKit/ASInsetLayoutSpec.h>
 
 #pragma mark -
@@ -20,6 +21,8 @@
 
 @interface ASCellNode ()
 {
+  ASDisplayNodeViewControllerBlock _viewControllerBlock;
+  ASDisplayNodeDidLoadBlock _viewControllerDidLoadBlock;
   ASDisplayNode *_viewControllerNode;
 }
 
@@ -45,18 +48,39 @@
     return nil;
   
   ASDisplayNodeAssertNotNil(viewControllerBlock, @"should initialize with a valid block that returns a UIViewController");
-  
-  if (viewControllerBlock) {
-    
-    _viewControllerNode = [[ASDisplayNode alloc] initWithViewBlock:^UIView *{
-      _viewController = viewControllerBlock();
-      return _viewController.view;
-    } didLoadBlock:didLoadBlock];
-    
-    [self addSubnode:_viewControllerNode];
-  }
+  _viewControllerBlock = viewControllerBlock;
+  _viewControllerDidLoadBlock = didLoadBlock;
 
   return self;
+}
+
+- (void)didLoad
+{
+  [super didLoad];
+
+  if (_viewControllerBlock != nil) {
+
+    UIViewController *viewController = _viewControllerBlock();
+    _viewControllerBlock = nil;
+
+    if ([viewController isKindOfClass:[ASViewController class]]) {
+      ASViewController *asViewController = (ASViewController *)viewController;
+      _viewControllerNode = asViewController.node;
+    } else {
+      _viewControllerNode = [[ASDisplayNode alloc] initWithViewBlock:^{
+        return viewController.view;
+      }];
+    }
+    [self addSubnode:_viewControllerNode];
+
+    // Since we just loaded our node, and added _viewControllerNode as a subnode,
+    // _viewControllerNode must have just loaded its view, so now is an appropriate
+    // time to execute our didLoadBlock, if we were given one.
+    if (_viewControllerDidLoadBlock != nil) {
+      _viewControllerDidLoadBlock(self);
+      _viewControllerDidLoadBlock = nil;
+    }
+  }
 }
 
 - (void)layout

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -1238,13 +1238,9 @@ static bool disableNotificationsForMovingBetweenParents(ASDisplayNode *from, ASD
     // Otherwise there is no way for the subnode's view or layer to enter the hierarchy, except recursing down all
     // subnodes on the main thread after the node tree has been created but before the first display (which
     // could introduce performance problems).
-    if (ASDisplayNodeThreadIsMain()) {
+    ASPerformBlockOnMainThread(^{
       [self _addSubnodeSubviewOrSublayer:subnode];
-    } else {
-      dispatch_async(dispatch_get_main_queue(), ^{
-        [self _addSubnodeSubviewOrSublayer:subnode];
-      });
-    }
+    });
   }
 
   ASDisplayNodeAssert(isMovingEquivalentParents == disableNotificationsForMovingBetweenParents(oldParent, self), @"Invariant violated");

--- a/AsyncDisplayKit/Private/ASInternalHelpers.mm
+++ b/AsyncDisplayKit/Private/ASInternalHelpers.mm
@@ -13,6 +13,7 @@
 #import <functional>
 #import <objc/runtime.h>
 
+#import "ASThread.h"
 #import "ASLayout.h"
 
 BOOL ASSubclassOverridesSelector(Class superclass, Class subclass, SEL selector)
@@ -35,7 +36,7 @@ BOOL ASSubclassOverridesClassSelector(Class superclass, Class subclass, SEL sele
 
 static void ASDispatchOnceOnMainThread(dispatch_once_t *predicate, dispatch_block_t block)
 {
-  if ([NSThread isMainThread]) {
+  if (ASDisplayNodeThreadIsMain()) {
     dispatch_once(predicate, block);
   } else {
     if (DISPATCH_EXPECT(*predicate == 0L, NO)) {
@@ -48,21 +49,17 @@ static void ASDispatchOnceOnMainThread(dispatch_once_t *predicate, dispatch_bloc
 
 void ASPerformBlockOnMainThread(void (^block)())
 {
-  if ([NSThread isMainThread]) {
+  if (ASDisplayNodeThreadIsMain()) {
     block();
   } else {
-    dispatch_async(dispatch_get_main_queue(), ^{
-      block();
-    });
+    dispatch_async(dispatch_get_main_queue(), block);
   }
 }
 
 void ASPerformBlockOnBackgroundThread(void (^block)())
 {
-  if ([NSThread isMainThread]) {
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-      block();
-    });
+  if (ASDisplayNodeThreadIsMain()) {
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), block);
   } else {
     block();
   }


### PR DESCRIPTION
I also snuck in a couple minor tweaks to ASInternalHelpers, replacing [NSThread isMainThread] with ASDisplayNodeThreadIsMain() and using block objects directly rather than wrapping them in more blocks.