### PR TITLE
Enable animated bounds changes in ASCollectionView

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -645,7 +645,7 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
     if (_ignoreMaxSizeChange) {
       _ignoreMaxSizeChange = NO;
     } else {
-      [self performBatchAnimated:NO updates:^{
+      [self performBatchAnimated:YES updates:^{
         [_dataController relayoutAllNodes];
       } completion:nil];
     }

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -645,6 +645,9 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
     if (_ignoreMaxSizeChange) {
       _ignoreMaxSizeChange = NO;
     } else {
+      // This actually doesn't perform an animation, but prevents the transaction block from being processed in the
+      // data controller's prevent animation block that would interupt an interupted relayout happening in an animation block
+      // ie. ASCollectionView bounds change on rotation or mutl-tasking split view resize.
       [self performBatchAnimated:YES updates:^{
         [_dataController relayoutAllNodes];
       } completion:nil];


### PR DESCRIPTION
Talked to @nguyenhuy and it sounds like there wasn't any need for disabling animations during this resize operation. Enabling this fixes a few animation issues we've been seeing in m3 as of late.