### PR TITLE
[ASTextNode] Stopped trying to cache the currentScaleFactor

### DIFF
--- a/AsyncDisplayKit/ASTextNode+Beta.h
+++ b/AsyncDisplayKit/ASTextNode+Beta.h
@@ -15,4 +15,16 @@
  */
 @property (nonatomic, copy) NSArray *pointSizeScaleFactors;
 
+#pragma mark - ASTextKit Customization
+/**
+ A block to provide a hook to provide a custom NSLayoutManager to the ASTextKitRenderer
+ */
+@property (nonatomic, copy) NSLayoutManager * (^layoutManagerCreationBlock)(void);
+
+/**
+ A block to provide a hook to provide a NSTextStorage to the Text Kit's layout manager.
+ */
+@property (nonatomic, copy) NSTextStorage * (^textStorageCreationBlock)(NSAttributedString *attributedString);
+
+
 @end

--- a/AsyncDisplayKit/ASTextNode+Beta.h
+++ b/AsyncDisplayKit/ASTextNode+Beta.h
@@ -15,9 +15,4 @@
  */
 @property (nonatomic, copy) NSArray *pointSizeScaleFactors;
 
-/**
- @abstract The currently applied scale factor, or 0 if the text node is not being scaled.
- */
-@property (nonatomic, assign, readonly) CGFloat currentScaleFactor;
-
 @end

--- a/AsyncDisplayKit/ASTextNode.h
+++ b/AsyncDisplayKit/ASTextNode.h
@@ -213,17 +213,6 @@ typedef NS_ENUM(NSUInteger, ASTextNodeHighlightStyle) {
  */
 @property (nonatomic, assign) BOOL passthroughNonlinkTouches;
 
-#pragma mark - ASTextKit Customization
-/**
- A block to provide a hook to provide a custom NSLayoutManager to the ASTextKitRenderer
- */
-@property (nonatomic, copy) NSLayoutManager * (^layoutManagerCreationBlock)(void);
-
-/**
- A block to provide a hook to provide a NSTextStorage to the Text Kit's layout manager.
- */
-@property (nonatomic, copy) NSTextStorage * (^textStorageCreationBlock)(NSAttributedString *attributedString);
-
 @end
 
 /**

--- a/AsyncDisplayKit/ASTextNode.mm
+++ b/AsyncDisplayKit/ASTextNode.mm
@@ -244,7 +244,6 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
     .maximumNumberOfLines = _maximumNumberOfLines,
     .exclusionPaths = _exclusionPaths,
     .pointSizeScaleFactors = _pointSizeScaleFactors,
-    .currentScaleFactor = self.currentScaleFactor,
     .layoutManagerCreationBlock = self.layoutManagerCreationBlock,
     .textStorageCreationBlock = self.textStorageCreationBlock,
   };
@@ -338,10 +337,7 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
 
   [self setNeedsDisplay];
   
-  CGSize size = [[self _renderer] size];
-  // the renderer computes the current scale factor during sizing, so let's grab it here
-  _currentScaleFactor = _renderer.currentScaleFactor;
-  return size;
+  return [[self _renderer] size];
 }
 
 #pragma mark - Modifying User Text
@@ -380,8 +376,6 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
     self.isAccessibilityElement = YES;
   }
 
-  // reset the scale factor if we get a new string.
-  _currentScaleFactor = 0;
   if (attributedString.length > 0) {
     CGFloat screenScale = ASScreenScale();
     self.ascender = round([[attributedString attribute:NSFontAttributeName atIndex:0 effectiveRange:NULL] ascender] * screenScale)/screenScale;

--- a/AsyncDisplayKit/TextKit/ASTextKitAttributes.h
+++ b/AsyncDisplayKit/TextKit/ASTextKitAttributes.h
@@ -87,10 +87,6 @@ struct ASTextKitAttributes {
    */
   NSArray *pointSizeScaleFactors;
   /**
-   The currently applied scale factor. Only valid if pointSizeScaleFactors are provided. Defaults to 0 (no scaling)
-   */
-  CGFloat currentScaleFactor;
-  /**
    An optional block that returns a custom layout manager subclass. If nil, defaults to NSLayoutManager.
    */
   NSLayoutManager * (^layoutManagerCreationBlock)(void);
@@ -123,7 +119,6 @@ struct ASTextKitAttributes {
       shadowOpacity,
       shadowRadius,
       pointSizeScaleFactors,
-      currentScaleFactor,
       layoutManagerCreationBlock,
       layoutManagerDelegate,
       textStorageCreationBlock,
@@ -138,7 +133,6 @@ struct ASTextKitAttributes {
     && shadowOpacity == other.shadowOpacity
     && shadowRadius == other.shadowRadius
     && [pointSizeScaleFactors isEqualToArray:other.pointSizeScaleFactors]
-    && currentScaleFactor == currentScaleFactor
     && layoutManagerCreationBlock == other.layoutManagerCreationBlock
     && textStorageCreationBlock == other.textStorageCreationBlock
     && CGSizeEqualToSize(shadowOffset, other.shadowOffset)

--- a/AsyncDisplayKit/TextKit/ASTextKitRenderer.mm
+++ b/AsyncDisplayKit/TextKit/ASTextKitRenderer.mm
@@ -139,7 +139,7 @@ static NSCharacterSet *_defaultAvoidTruncationCharacterSet()
 {
   [self truncater];
   // if we have no scale factors or an unconstrained width, there is no reason to try to adjust the font size
-  if ([_attributes.pointSizeScaleFactors count] > 0 && isinf(_constrainedSize.width) == NO) {
+  if (isinf(_constrainedSize.width) == NO && [_attributes.pointSizeScaleFactors count] > 0) {
     _currentScaleFactor = [[self fontSizeAdjuster] scaleFactor];
   }
 
@@ -174,7 +174,7 @@ static NSCharacterSet *_defaultAvoidTruncationCharacterSet()
   ASDisplayNodeAssertNotNil(context, @"This is no good without a context.");
   
   // This renderer may not be the one that did the sizing. If that is the case its _currentScaleFactor will not be set, so we should compute it now
-  if ([_attributes.pointSizeScaleFactors count] > 0 && isinf(_constrainedSize.width) == NO && _sizeIsCalculated == NO) {
+  if (_sizeIsCalculated == NO && isinf(_constrainedSize.width) == NO && [_attributes.pointSizeScaleFactors count] > 0) {
     _currentScaleFactor = [[self fontSizeAdjuster] scaleFactor];
   }
 


### PR DESCRIPTION
Was running into issues where the scale factor would get cleared when setting a new `atributedString` on `ASTextNode`.

I was clearing out `currentScaleFactor` when setting an attributedString into `ASTextNode`. It appears that `_calculateSize` isn't always called when setting a new string into a `ASTextNode`. It can be the case that only `drawInContext:bounds:` is called. With `_currentScaleFactor` cleared out the newly created renderer that calls`drawInContext...` was being created with a scaleFactor of 0.

It could be that the fix could simply be to remove the clearing of `currentScaleFactor` from `setAttributedString`, but clearing the scale factor there seems like the right thing to do. Regardless, leaving scaling all in the renderer (what this PR does) seems like the safer fix to me. It does, however, require an extra run through the font adjuster when enabled.