### PR TITLE
[ASTableView] Fix recent regression to ensure scrollViewDidScroll: is forwarded correctly

### DIFF
--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -287,8 +287,10 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
   if (asyncDelegate == nil) {
     _asyncDelegate = nil;
     _proxyDelegate = _isDeallocating ? nil : [[ASTableViewProxy alloc] initWithTarget:nil interceptor:self];
+    _asyncDelegateImplementsScrollviewDidScroll = NO;
   } else {
     _asyncDelegate = asyncDelegate;
+    _asyncDelegateImplementsScrollviewDidScroll = [_asyncDelegate respondsToSelector:@selector(scrollViewDidScroll:)];
     _proxyDelegate = [[ASTableViewProxy alloc] initWithTarget:_asyncDelegate interceptor:self];
   }
   


### PR DESCRIPTION
Initialize `_asyncDelegateImplementsScrollviewDidScroll` so we forward `scrollViewDidScroll:` calls correctly.
@Xinchi 
