### PR TITLE
[ASMapNode] Remove Live Map in clearFetchedData, Not clearContents

### DIFF
--- a/AsyncDisplayKit/ASMapNode.mm
+++ b/AsyncDisplayKit/ASMapNode.mm
@@ -13,6 +13,7 @@
 #import <AsyncDisplayKit/ASInsetLayoutSpec.h>
 #import <AsyncDisplayKit/ASCenterLayoutSpec.h>
 #import <AsyncDisplayKit/ASThread.h>
+#import <AsyncDisplayKit/ASInternalHelpers.h>
 
 @interface ASMapNode()
 {
@@ -63,19 +64,23 @@
 - (void)fetchData
 {
   [super fetchData];
-  if (self.isLiveMap) {
-    [self addLiveMap];
-  } else {
-    [self takeSnapshot];
-  }
+  ASPerformBlockOnMainThread(^{
+    if (self.isLiveMap) {
+      [self addLiveMap];
+    } else {
+      [self takeSnapshot];
+    }
+  });
 }
 
-- (void)clearContents
+- (void)clearFetchedData
 {
-  [super clearContents];
-  if (self.isLiveMap) {
-    [self removeLiveMap];
-  }
+  [super clearFetchedData];
+  ASPerformBlockOnMainThread(^{
+    if (self.isLiveMap) {
+      [self removeLiveMap];
+    }
+  });
 }
 
 #pragma mark - Settings


### PR DESCRIPTION
@appleguy This is pretty critical, since if you have a live map and it leaves the display range but stays in the fetch data range, and you scroll back to it, your map will be gone!

I used ASPerformBlockOnMainThread because I believe `fetchData` and `clearFetchedData` may be called off the main thread. If that's not correct, or some other approach is needed, let me know.