### PR TITLE
Example improvements

### DIFF
--- a/examples/ASCollectionView/Sample/PresentingViewController.m
+++ b/examples/ASCollectionView/Sample/PresentingViewController.m
@@ -18,6 +18,7 @@
 - (void)viewDidLoad
 {
   [super viewDidLoad];
+  
   self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@"Push Details" style:UIBarButtonItemStylePlain target:self action:@selector(pushNewViewController)];
 }
 

--- a/examples/ASCollectionView/Sample/SupplementaryNode.m
+++ b/examples/ASCollectionView/Sample/SupplementaryNode.m
@@ -17,9 +17,11 @@
 
 static CGFloat kInsets = 15.0;
 
-@implementation SupplementaryNode {
-  ASTextNode *_textNode;
-}
+@interface SupplementaryNode ()
+@property (nonatomic, strong) ASTextNode *textNode;
+@end
+
+@implementation SupplementaryNode
 
 - (instancetype)initWithText:(NSString *)text
 {
@@ -37,7 +39,7 @@ static CGFloat kInsets = 15.0;
 {
   ASCenterLayoutSpec *center = [[ASCenterLayoutSpec alloc] init];
   center.centeringOptions = ASCenterLayoutSpecCenteringXY;
-  center.child = _textNode;
+  center.child = self.textNode;
   UIEdgeInsets insets = UIEdgeInsetsMake(kInsets, kInsets, kInsets, kInsets);
   return [ASInsetLayoutSpec insetLayoutSpecWithInsets:insets child:center];
 }
@@ -47,9 +49,9 @@ static CGFloat kInsets = 15.0;
 - (NSDictionary *)textAttributes
 {
   return @{
-           NSFontAttributeName: [UIFont systemFontOfSize:18.0],
-           NSForegroundColorAttributeName: [UIColor whiteColor],
-           };
+    NSFontAttributeName: [UIFont systemFontOfSize:18.0],
+    NSForegroundColorAttributeName: [UIColor whiteColor],
+  };
 }
 
 @end

--- a/examples/ASCollectionView/Sample/ViewController.m
+++ b/examples/ASCollectionView/Sample/ViewController.m
@@ -15,50 +15,48 @@
 #import "SupplementaryNode.h"
 #import "ItemNode.h"
 
+@interface ViewController ()
+@property (nonatomic, strong) ASCollectionView *collectionView;
+@property (nonatomic, strong) NSArray *data;
+@end
+
 @interface ViewController () <ASCollectionViewDataSource, ASCollectionViewDelegateFlowLayout>
-{
-  ASCollectionView *_collectionView;
-  NSArray *_data;
-}
 
 @end
 
 
 @implementation ViewController
 
-#pragma mark -
-#pragma mark UIViewController.
-
-- (instancetype)init
+- (void)dealloc
 {
-  if (!(self = [super init]))
-    return nil;
+  self.collectionView.asyncDataSource = nil;
+  self.collectionView.asyncDelegate = nil;
   
-  UICollectionViewFlowLayout *layout = [[UICollectionViewFlowLayout alloc] init];
-  layout.headerReferenceSize = CGSizeMake(50.0, 50.0);
-  layout.footerReferenceSize = CGSizeMake(50.0, 50.0);
-  
-  _collectionView = [[ASCollectionView alloc] initWithFrame:CGRectZero collectionViewLayout:layout];
-  _collectionView.asyncDataSource = self;
-  _collectionView.asyncDelegate = self;
-  _collectionView.backgroundColor = [UIColor whiteColor];
-  
-  [_collectionView registerSupplementaryNodeOfKind:UICollectionElementKindSectionHeader];
-  [_collectionView registerSupplementaryNodeOfKind:UICollectionElementKindSectionFooter];
-  
-#if !SIMULATE_WEB_RESPONSE
-  self.navigationItem.leftItemsSupplementBackButton = YES;
-  self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemRefresh target:self action:@selector(reloadTapped)];
-#endif
-  
-  return self;
+  NSLog(@"ViewController is deallocing");
 }
 
 - (void)viewDidLoad
 {
   [super viewDidLoad];
   
-  [self.view addSubview:_collectionView];
+  UICollectionViewFlowLayout *layout = [[UICollectionViewFlowLayout alloc] init];
+  layout.headerReferenceSize = CGSizeMake(50.0, 50.0);
+  layout.footerReferenceSize = CGSizeMake(50.0, 50.0);
+  
+  self.collectionView = [[ASCollectionView alloc] initWithFrame:self.view.bounds collectionViewLayout:layout];
+  self.collectionView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+  self.collectionView.asyncDataSource = self;
+  self.collectionView.asyncDelegate = self;
+  self.collectionView.backgroundColor = [UIColor whiteColor];
+  
+  [self.collectionView registerSupplementaryNodeOfKind:UICollectionElementKindSectionHeader];
+  [self.collectionView registerSupplementaryNodeOfKind:UICollectionElementKindSectionFooter];
+  [self.view addSubview:self.collectionView];
+  
+#if !SIMULATE_WEB_RESPONSE
+  self.navigationItem.leftItemsSupplementBackButton = YES;
+  self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemRefresh target:self action:@selector(reloadTapped)];
+#endif
 
 #if SIMULATE_WEB_RESPONSE
   __weak typeof(self) weakSelf = self;
@@ -86,11 +84,6 @@
 #endif
 }
 
-- (void)viewWillLayoutSubviews
-{
-  _collectionView.frame = self.view.bounds;
-}
-
 - (BOOL)prefersStatusBarHidden
 {
   return YES;
@@ -98,7 +91,7 @@
 
 - (void)reloadTapped
 {
-  [_collectionView reloadData];
+  [self.collectionView reloadData];
 }
 
 #pragma mark -
@@ -116,11 +109,8 @@
 {
   NSString *text = [kind isEqualToString:UICollectionElementKindSectionHeader] ? @"Header" : @"Footer";
   SupplementaryNode *node = [[SupplementaryNode alloc] initWithText:text];
-  if ([kind isEqualToString:UICollectionElementKindSectionHeader]) {
-    node.backgroundColor = [UIColor blueColor];
-  } else {
-    node.backgroundColor = [UIColor redColor];
-  }
+  BOOL isHeaderSection = [kind isEqualToString:UICollectionElementKindSectionHeader];
+  node.backgroundColor = isHeaderSection ? [UIColor blueColor] : [UIColor redColor];
   return node;
 }
 
@@ -155,15 +145,9 @@
   [context completeBatchFetching:YES];
 }
 
-- (UIEdgeInsets)collectionView:(ASCollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout insetForSectionAtIndex:(NSInteger)section {
+- (UIEdgeInsets)collectionView:(ASCollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout insetForSectionAtIndex:(NSInteger)section
+{
   return UIEdgeInsetsMake(20.0, 20.0, 20.0, 20.0);
 }
-
-#if SIMULATE_WEB_RESPONSE
--(void)dealloc
-{
-  NSLog(@"ViewController is deallocing");
-}
-#endif
 
 @end

--- a/examples/ASCollectionView/Sample/ViewController.m
+++ b/examples/ASCollectionView/Sample/ViewController.m
@@ -104,10 +104,12 @@
 #pragma mark -
 #pragma mark ASCollectionView data source.
 
-- (ASCellNode *)collectionView:(ASCollectionView *)collectionView nodeForItemAtIndexPath:(NSIndexPath *)indexPath
+- (ASCellNodeBlock)collectionView:(ASCollectionView *)collectionView nodeBlockForItemAtIndexPath:(NSIndexPath *)indexPath;
 {
   NSString *text = [NSString stringWithFormat:@"[%zd.%zd] says hi", indexPath.section, indexPath.item];
-  return [[ItemNode alloc] initWithString:text];
+  return ^{
+    return [[ItemNode alloc] initWithString:text];
+  };
 }
 
 - (ASCellNode *)collectionView:(ASCollectionView *)collectionView nodeForSupplementaryElementOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath

--- a/examples/CatDealsCollectionView/Sample/ViewController.m
+++ b/examples/CatDealsCollectionView/Sample/ViewController.m
@@ -159,10 +159,12 @@ static const CGFloat kVerticalSectionPadding = 20.0f;
 #pragma mark -
 #pragma mark ASCollectionView data source.
 
-- (ASCellNode *)collectionView:(ASCollectionView *)collectionView nodeForItemAtIndexPath:(NSIndexPath *)indexPath
+- (ASCellNodeBlock)collectionView:(ASCollectionView *)collectionView nodeBlockForItemAtIndexPath:(NSIndexPath *)indexPath
 {
   ItemViewModel *viewModel = _data[indexPath.item];
-  return [[ItemNode alloc] initWithViewModel:viewModel];
+  return ^{
+    return [[ItemNode alloc] initWithViewModel:viewModel];
+  };
 }
 
 - (ASCellNode *)collectionView:(UICollectionView *)collectionView nodeForSupplementaryElementOfKind:(nonnull NSString *)kind atIndexPath:(nonnull NSIndexPath *)indexPath {

--- a/examples/CollectionViewWithViewControllerCells/Sample/ViewController.m
+++ b/examples/CollectionViewWithViewControllerCells/Sample/ViewController.m
@@ -90,16 +90,17 @@ static NSUInteger kNumberOfImages = 14;
 #pragma mark -
 #pragma mark ASCollectionView data source.
 
-- (ASCellNode *)collectionView:(ASCollectionView *)collectionView nodeForItemAtIndexPath:(NSIndexPath *)indexPath
+- (ASCellNodeBlock)collectionView:(ASCollectionView *)collectionView nodeBlockForItemAtIndexPath:(NSIndexPath *)indexPath
 {
-  ASCellNode *node = [[ASCellNode alloc] initWithViewControllerBlock:^UIViewController *{
-    return [[ImageViewController alloc] initWithImage:_sections[indexPath.section][indexPath.item]];
-  } didLoadBlock:nil];
-  
-  node.layer.borderWidth = 1.0;
-  node.layer.borderColor = [UIColor blackColor].CGColor;
-  
-  return node;
+  UIImage *image = _sections[indexPath.section][indexPath.item];
+  return ^{
+    return [[ASCellNode alloc] initWithViewControllerBlock:^UIViewController *{
+      return [[ImageViewController alloc] initWithImage:image];
+    } didLoadBlock:^(ASDisplayNode * _Nonnull node) {
+      node.layer.borderWidth = 1.0;
+      node.layer.borderColor = [UIColor blackColor].CGColor;
+    }];
+  };
 }
 
 - (ASCellNode *)collectionView:(ASCollectionView *)collectionView nodeForSupplementaryElementOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath

--- a/examples/CollectionViewWithViewControllerCells/Sample/ViewController.m
+++ b/examples/CollectionViewWithViewControllerCells/Sample/ViewController.m
@@ -34,34 +34,21 @@ static NSUInteger kNumberOfImages = 14;
 
 - (instancetype)init
 {
-  if (!(self = [super init]))
-    return nil;
-  
-  _sections = [NSMutableArray array];
-  [_sections addObject:[NSMutableArray array]];
-  for (NSUInteger idx = 0, section = 0; idx < kNumberOfImages; idx++) {
-    NSString *name = [NSString stringWithFormat:@"image_%lu.jpg", (unsigned long)idx];
-    [_sections[section] addObject:[UIImage imageNamed:name]];
-    if ((idx + 1) % 5 == 0 && idx < kNumberOfImages - 1) {
-      section++;
-      [_sections addObject:[NSMutableArray array]];
+  self = [super init];
+  if (self) {
+    
+    _sections = [NSMutableArray array];
+    [_sections addObject:[NSMutableArray array]];
+    for (NSUInteger idx = 0, section = 0; idx < kNumberOfImages; idx++) {
+      NSString *name = [NSString stringWithFormat:@"image_%lu.jpg", (unsigned long)idx];
+      [_sections[section] addObject:[UIImage imageNamed:name]];
+      if ((idx + 1) % 5 == 0 && idx < kNumberOfImages - 1) {
+        section++;
+        [_sections addObject:[NSMutableArray array]];
+      }
     }
+    
   }
-  
-  MosaicCollectionViewLayout *layout = [[MosaicCollectionViewLayout alloc] init];
-  layout.numberOfColumns = 2;
-  layout.headerHeight = 44.0;
-  
-  _layoutInspector = [[MosaicCollectionViewLayoutInspector alloc] init];
-  
-  _collectionView = [[ASCollectionView alloc] initWithFrame:CGRectZero collectionViewLayout:layout asyncDataFetching:YES];
-  _collectionView.asyncDataSource = self;
-  _collectionView.asyncDelegate = self;
-  _collectionView.layoutInspector = _layoutInspector;
-  _collectionView.backgroundColor = [UIColor whiteColor];
-  
-  [_collectionView registerSupplementaryNodeOfKind:UICollectionElementKindSectionHeader];
-  
   return self;
 }
 
@@ -69,12 +56,27 @@ static NSUInteger kNumberOfImages = 14;
 {
   [super viewDidLoad];
   
+  MosaicCollectionViewLayout *layout = [[MosaicCollectionViewLayout alloc] init];
+  layout.numberOfColumns = 2;
+  layout.headerHeight = 44.0;
+  
+  _layoutInspector = [[MosaicCollectionViewLayoutInspector alloc] init];
+  
+  _collectionView = [[ASCollectionView alloc] initWithFrame:self.view.bounds collectionViewLayout:layout];
+  _collectionView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
+  _collectionView.asyncDataSource = self;
+  _collectionView.asyncDelegate = self;
+  _collectionView.layoutInspector = _layoutInspector;
+  _collectionView.backgroundColor = [UIColor whiteColor];
+  
+  [_collectionView registerSupplementaryNodeOfKind:UICollectionElementKindSectionHeader];
   [self.view addSubview:_collectionView];
 }
 
-- (void)viewWillLayoutSubviews
+- (void)dealloc
 {
-  _collectionView.frame = self.view.bounds;
+  _collectionView.asyncDataSource = nil;
+  _collectionView.asyncDelegate = nil;
 }
 
 - (BOOL)prefersStatusBarHidden
@@ -109,11 +111,13 @@ static NSUInteger kNumberOfImages = 14;
   return [[SupplementaryNode alloc] initWithText:text];
 }
 
-- (NSInteger)numberOfSectionsInCollectionView:(UICollectionView *)collectionView {
+- (NSInteger)numberOfSectionsInCollectionView:(UICollectionView *)collectionView
+{
   return _sections.count;
 }
 
-- (NSInteger)collectionView:(UICollectionView *)collectionView numberOfItemsInSection:(NSInteger)section {
+- (NSInteger)collectionView:(UICollectionView *)collectionView numberOfItemsInSection:(NSInteger)section
+{
   return [_sections[section] count];
 }
 

--- a/examples/CustomCollectionView/Sample/ImageCellNode.m
+++ b/examples/CustomCollectionView/Sample/ImageCellNode.m
@@ -31,6 +31,8 @@
 
 - (void)layout
 {
+  [super layout];
+  
   _imageNode.frame = CGRectMake(0, 0, _imageNode.calculatedSize.width, _imageNode.calculatedSize.height);
 }
 

--- a/examples/CustomCollectionView/Sample/ViewController.m
+++ b/examples/CustomCollectionView/Sample/ViewController.m
@@ -90,14 +90,18 @@ static NSUInteger kNumberOfImages = 14;
 #pragma mark -
 #pragma mark ASCollectionView data source.
 
-- (ASCellNode *)collectionView:(ASCollectionView *)collectionView nodeForItemAtIndexPath:(NSIndexPath *)indexPath
+- (ASCellNodeBlock)collectionView:(ASCollectionView *)collectionView nodeBlockForItemAtIndexPath:(NSIndexPath *)indexPath
 {
-  return [[ImageCellNode alloc] initWithImage:_sections[indexPath.section][indexPath.item]];
+  UIImage *image = _sections[indexPath.section][indexPath.item];
+  return ^{
+    return [[ImageCellNode alloc] initWithImage:image];
+  };
 }
+
 
 - (ASCellNode *)collectionView:(ASCollectionView *)collectionView nodeForSupplementaryElementOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath
 {
-  NSString *text = [NSString stringWithFormat:@"Section %d", (int)indexPath.section + 1];
+  NSString *text = [NSString stringWithFormat:@"Section %zd", indexPath.section + 1];
   return [[SupplementaryNode alloc] initWithText:text];
 }
 

--- a/examples/CustomCollectionView/Sample/ViewController.m
+++ b/examples/CustomCollectionView/Sample/ViewController.m
@@ -65,6 +65,12 @@ static NSUInteger kNumberOfImages = 14;
   return self;
 }
 
+- (void)dealloc
+{
+  _collectionView.asyncDataSource = nil;
+  _collectionView.asyncDelegate = nil;
+}
+
 - (void)viewDidLoad
 {
   [super viewDidLoad];

--- a/examples/HorizontalWithinVerticalScrolling/Sample/HorizontalScrollCellNode.mm
+++ b/examples/HorizontalWithinVerticalScrolling/Sample/HorizontalScrollCellNode.mm
@@ -67,11 +67,13 @@ static const CGFloat kInnerPadding = 10.0f;
   return 5;
 }
 
-- (ASCellNode *)collectionView:(ASCollectionView *)collectionView nodeForItemAtIndexPath:(NSIndexPath *)indexPath
+- (ASCellNodeBlock)collectionView:(ASCollectionView *)collectionView nodeBlockForItemAtIndexPath:(NSIndexPath *)indexPath
 {
-  RandomCoreGraphicsNode *elementNode = [[RandomCoreGraphicsNode alloc] init];
-  elementNode.preferredFrameSize = _elementSize;
-  return elementNode;
+  return ^{
+    RandomCoreGraphicsNode *elementNode = [[RandomCoreGraphicsNode alloc] init];
+    elementNode.preferredFrameSize = _elementSize;
+    return elementNode;
+  };
 }
 
 - (ASLayoutSpec *)layoutSpecThatFits:(ASSizeRange)constrainedSize

--- a/examples/SocialAppLayout/Sample/CommentsNode.h
+++ b/examples/SocialAppLayout/Sample/CommentsNode.h
@@ -11,14 +11,7 @@
 
 #import <AsyncDisplayKit/AsyncDisplayKit.h>
 
-@interface CommentsNode : ASControlNode {
-    
-    ASImageNode *_iconNode;
-    ASTextNode *_countNode;
-    
-    NSInteger _comentsCount;
-    
-}
+@interface CommentsNode : ASControlNode
 
 - (instancetype)initWithCommentsCount:(NSInteger)comentsCount;
 

--- a/examples/SocialAppLayout/Sample/CommentsNode.m
+++ b/examples/SocialAppLayout/Sample/CommentsNode.m
@@ -12,32 +12,32 @@
 #import "CommentsNode.h"
 #import "TextStyles.h"
 
+@interface CommentsNode ()
+@property (nonatomic, strong) ASImageNode *iconNode;
+@property (nonatomic, strong) ASTextNode *countNode;
+@property (nonatomic, assign) NSInteger commentsCount;
+@end
+
 @implementation CommentsNode
 
 - (instancetype)initWithCommentsCount:(NSInteger)comentsCount {
     
     self = [super init];
-    
-    if(self) {
-        
-        _comentsCount = comentsCount;
+    if (self) {
+        _commentsCount = comentsCount;
         
         _iconNode = [[ASImageNode alloc] init];
         _iconNode.image = [UIImage imageNamed:@"icon_comment.png"];
         [self addSubnode:_iconNode];
         
         _countNode = [[ASTextNode alloc] init];
-        if(_comentsCount > 0) {
-            
-           _countNode.attributedString = [[NSAttributedString alloc] initWithString:[NSString stringWithFormat:@"%ld", (long)_comentsCount] attributes:[TextStyles cellControlStyle]];
-            
+        if (_commentsCount > 0) {
+           _countNode.attributedString = [[NSAttributedString alloc] initWithString:[NSString stringWithFormat:@"%zd", _commentsCount] attributes:[TextStyles cellControlStyle]];
         }
-        
         [self addSubnode:_countNode];
         
         // make it tappable easily
         self.hitTestSlop = UIEdgeInsetsMake(-10, -10, -10, -10);
-        
     }
     
     return self;
@@ -46,18 +46,13 @@
 
 - (ASLayoutSpec *)layoutSpecThatFits:(ASSizeRange)constrainedSize {
     
-    ASStackLayoutSpec *mainStack =  [ASStackLayoutSpec stackLayoutSpecWithDirection:ASStackLayoutDirectionHorizontal spacing:6.0 justifyContent:ASStackLayoutJustifyContentStart alignItems:ASStackLayoutAlignItemsCenter children:@[_iconNode, _countNode]];
+    ASStackLayoutSpec *mainStack =  [ASStackLayoutSpec stackLayoutSpecWithDirection:ASStackLayoutDirectionHorizontal spacing:6.0 justifyContent:ASStackLayoutJustifyContentStart alignItems:ASStackLayoutAlignItemsCenter children:@[self.iconNode, self.countNode]];
     
     // set sizeRange to make width fixed to 60
-    mainStack.sizeRange = ASRelativeSizeRangeMake(ASRelativeSizeMake(
-                                                                     ASRelativeDimensionMakeWithPoints(60.0),
-                                                                     ASRelativeDimensionMakeWithPoints(0.0)
-                                                                     ), ASRelativeSizeMake(
-                                                                                           ASRelativeDimensionMakeWithPoints(60.0),
-                                                                                           ASRelativeDimensionMakeWithPoints(40.0)
-                                                                                           ));
+    ASRelativeSize min = ASRelativeSizeMake(ASRelativeDimensionMakeWithPoints(60.0), ASRelativeDimensionMakeWithPoints(0.0));
+    ASRelativeSize max = ASRelativeSizeMake(ASRelativeDimensionMakeWithPoints(60.0), ASRelativeDimensionMakeWithPoints(40.0));
+    mainStack.sizeRange = ASRelativeSizeRangeMake(min,max);
     return [ASStaticLayoutSpec staticLayoutSpecWithChildren:@[mainStack]];
-    
 }
 
 

--- a/examples/SocialAppLayout/Sample/LikesNode.h
+++ b/examples/SocialAppLayout/Sample/LikesNode.h
@@ -11,18 +11,8 @@
 
 #import <AsyncDisplayKit/AsyncDisplayKit.h>
 
-@interface LikesNode : ASControlNode {
-    
-    ASImageNode *_iconNode;
-    ASTextNode *_countNode;
-    
-    NSInteger _likesCount;
-    BOOL _liked;
-    
-}
+@interface LikesNode : ASControlNode
 
 - (instancetype)initWithLikesCount:(NSInteger)likesCount;
-
-+ (BOOL) getYesOrNo;
 
 @end

--- a/examples/SocialAppLayout/Sample/LikesNode.m
+++ b/examples/SocialAppLayout/Sample/LikesNode.m
@@ -12,14 +12,19 @@
 #import "LikesNode.h"
 #import "TextStyles.h"
 
-@implementation LikesNode 
+@interface LikesNode ()
+@property (nonatomic, strong) ASImageNode *iconNode;
+@property (nonatomic, strong) ASTextNode *countNode;
+@property (nonatomic, assign) NSInteger likesCount;
+@property (nonatomic, assign) BOOL liked;
+@end
+
+@implementation LikesNode
 
 - (instancetype)initWithLikesCount:(NSInteger)likesCount {
     
     self = [super init];
-    
-    if(self) {
-        
+    if (self) {
         _likesCount = likesCount;
         _liked = (_likesCount > 0) ? [LikesNode getYesOrNo] : NO;
         
@@ -28,16 +33,12 @@
         [self addSubnode:_iconNode];
         
         _countNode = [[ASTextNode alloc] init];
-        if(_likesCount > 0) {
+        if (_likesCount > 0) {
             
-            if(_liked) {
-                _countNode.attributedString = [[NSAttributedString alloc] initWithString:[NSString stringWithFormat:@"%ld", (long)_likesCount] attributes:[TextStyles cellControlColoredStyle]];
-            }else {
-                _countNode.attributedString = [[NSAttributedString alloc] initWithString:[NSString stringWithFormat:@"%ld", (long)_likesCount] attributes:[TextStyles cellControlStyle]];
-            }
+            NSDictionary *attributes = _liked ? [TextStyles cellControlColoredStyle] : [TextStyles cellControlStyle];
+            _countNode.attributedString = [[NSAttributedString alloc] initWithString:[NSString stringWithFormat:@"%ld", (long)_likesCount] attributes:attributes];
             
         }
-        
         [self addSubnode:_countNode];
         
         // make it tappable easily
@@ -51,8 +52,9 @@
 + (BOOL) getYesOrNo
 {
     int tmp = (arc4random() % 30)+1;
-    if(tmp % 5 == 0)
+    if (tmp % 5 == 0) {
         return YES;
+    }
     return NO;
 }
 
@@ -61,13 +63,9 @@
     ASStackLayoutSpec *mainStack = [ASStackLayoutSpec stackLayoutSpecWithDirection:ASStackLayoutDirectionHorizontal spacing:6.0 justifyContent:ASStackLayoutJustifyContentStart alignItems:ASStackLayoutAlignItemsCenter children:@[_iconNode, _countNode]];
     
     // set sizeRange to make width fixed to 60
-    mainStack.sizeRange = ASRelativeSizeRangeMake(ASRelativeSizeMake(
-                                                                     ASRelativeDimensionMakeWithPoints(60.0),
-                                                                     ASRelativeDimensionMakeWithPoints(0.0)
-                                                                     ), ASRelativeSizeMake(
-                                                                                           ASRelativeDimensionMakeWithPoints(60.0),
-                                                                                           ASRelativeDimensionMakeWithPoints(40.0)
-                                                                                           ));
+    ASRelativeSize min = ASRelativeSizeMake(ASRelativeDimensionMakeWithPoints(60.0), ASRelativeDimensionMakeWithPoints(0.0));
+    ASRelativeSize max = ASRelativeSizeMake(ASRelativeDimensionMakeWithPoints(60.0), ASRelativeDimensionMakeWithPoints(40.0));
+    mainStack.sizeRange = ASRelativeSizeRangeMake(min, max);
     return [ASStaticLayoutSpec staticLayoutSpecWithChildren:@[mainStack]];
     
 }

--- a/examples/SocialAppLayout/Sample/Post.h
+++ b/examples/SocialAppLayout/Sample/Post.h
@@ -13,12 +13,12 @@
 
 @interface Post : NSObject
 
-@property (nonatomic, strong) NSString *username;
-@property (nonatomic, strong) NSString *name;
-@property (nonatomic, strong) NSString *photo;
-@property (nonatomic, strong) NSString *post;
-@property (nonatomic, strong) NSString *time;
-@property (nonatomic, strong) NSString *media;
+@property (nonatomic, copy) NSString *username;
+@property (nonatomic, copy) NSString *name;
+@property (nonatomic, copy) NSString *photo;
+@property (nonatomic, copy) NSString *post;
+@property (nonatomic, copy) NSString *time;
+@property (nonatomic, copy) NSString *media;
 @property (nonatomic, assign) NSInteger via;
 
 @property (nonatomic, assign) NSInteger likes;

--- a/examples/SocialAppLayout/Sample/PostNode.h
+++ b/examples/SocialAppLayout/Sample/PostNode.h
@@ -10,28 +10,10 @@
  */
 
 #import <AsyncDisplayKit/AsyncDisplayKit.h>
-#import "Post.h"
 
-@class LikesNode;
-@class CommentsNode;
+@class Post;
 
-@interface PostNode : ASCellNode <ASTextNodeDelegate> {
-    
-    Post *_post;
-    
-    ASDisplayNode *_divider;
-    ASTextNode *_nameNode;
-    ASTextNode *_usernameNode;
-    ASTextNode *_timeNode;
-    ASTextNode *_postNode;
-    ASImageNode *_viaNode;
-    ASNetworkImageNode *_avatarNode;
-    ASNetworkImageNode *_mediaNode;
-    LikesNode *_likesNode;
-    CommentsNode *_commentsNode;
-    ASImageNode *_optionsNode;
-    
-}
+@interface PostNode : ASCellNode
 
 - (instancetype)initWithPost:(Post *)post;
 

--- a/examples/SocialAppLayout/Sample/TextStyles.m
+++ b/examples/SocialAppLayout/Sample/TextStyles.m
@@ -16,58 +16,58 @@
 + (NSDictionary *)nameStyle
 {
     return @{
-             NSFontAttributeName : [UIFont boldSystemFontOfSize:15.0],
-             NSForegroundColorAttributeName: [UIColor blackColor]
+        NSFontAttributeName : [UIFont boldSystemFontOfSize:15.0],
+        NSForegroundColorAttributeName: [UIColor blackColor]
     };
 }
 
 + (NSDictionary *)usernameStyle
 {
     return @{
-             NSFontAttributeName : [UIFont systemFontOfSize:13.0],
-             NSForegroundColorAttributeName: [UIColor lightGrayColor]
-             };
+        NSFontAttributeName : [UIFont systemFontOfSize:13.0],
+        NSForegroundColorAttributeName: [UIColor lightGrayColor]
+    };
 }
 
 + (NSDictionary *)timeStyle
 {
     return @{
-             NSFontAttributeName : [UIFont systemFontOfSize:13.0],
-             NSForegroundColorAttributeName: [UIColor grayColor]
-             };
+        NSFontAttributeName : [UIFont systemFontOfSize:13.0],
+        NSForegroundColorAttributeName: [UIColor grayColor]
+    };
 }
 
 + (NSDictionary *)postStyle
 {
     return @{
-             NSFontAttributeName : [UIFont systemFontOfSize:15.0],
-             NSForegroundColorAttributeName: [UIColor blackColor]
-             };
+        NSFontAttributeName : [UIFont systemFontOfSize:15.0],
+        NSForegroundColorAttributeName: [UIColor blackColor]
+    };
 }
 
 + (NSDictionary *)postLinkStyle
 {
     return @{
-             NSFontAttributeName : [UIFont systemFontOfSize:15.0],
-             NSForegroundColorAttributeName: [UIColor colorWithRed:59.0/255.0 green:89.0/255.0 blue:152.0/255.0 alpha:1.0],
-             NSUnderlineStyleAttributeName: @(NSUnderlineStyleSingle)
-             };
+        NSFontAttributeName : [UIFont systemFontOfSize:15.0],
+        NSForegroundColorAttributeName: [UIColor colorWithRed:59.0/255.0 green:89.0/255.0 blue:152.0/255.0 alpha:1.0],
+        NSUnderlineStyleAttributeName: @(NSUnderlineStyleSingle)
+    };
 }
 
 + (NSDictionary *)cellControlStyle {
     
     return @{
-             NSFontAttributeName : [UIFont systemFontOfSize:13.0],
-             NSForegroundColorAttributeName: [UIColor lightGrayColor]
-             };
+        NSFontAttributeName : [UIFont systemFontOfSize:13.0],
+        NSForegroundColorAttributeName: [UIColor lightGrayColor]
+    };
 }
 
 + (NSDictionary *)cellControlColoredStyle {
     
     return @{
-             NSFontAttributeName : [UIFont systemFontOfSize:13.0],
-             NSForegroundColorAttributeName: [UIColor colorWithRed:59.0/255.0 green:89.0/255.0 blue:152.0/255.0 alpha:1.0]
-             };
+        NSFontAttributeName : [UIFont systemFontOfSize:13.0],
+        NSForegroundColorAttributeName: [UIColor colorWithRed:59.0/255.0 green:89.0/255.0 blue:152.0/255.0 alpha:1.0]
+    };
 }
 
 @end

--- a/examples/SocialAppLayout/Sample/ViewController.m
+++ b/examples/SocialAppLayout/Sample/ViewController.m
@@ -15,46 +15,46 @@
 
 #import <AsyncDisplayKit/AsyncDisplayKit.h>
 #import <AsyncDisplayKit/ASAssert.h>
+
 #include <stdlib.h>
 
 @interface ViewController () <ASTableViewDataSource, ASTableViewDelegate>
-{
-    ASTableView *_tableView;
-    
-    NSMutableArray *_socialAppDataSource;
 
-}
+@property (nonatomic, strong) ASTableView *tableView;
+@property (nonatomic, strong) NSMutableArray *socialAppDataSource;
 
 @end
+
 
 @implementation ViewController
 
 - (instancetype)init
 {
-    if (!(self = [super init]))
-        return nil;
-    
-    _tableView = [[ASTableView alloc] initWithFrame:CGRectZero style:UITableViewStylePlain asyncDataFetching:YES];
-    _tableView.separatorStyle = UITableViewCellSeparatorStyleNone; // SocialAppNode has its own separator
-    _tableView.asyncDataSource = self;
-    _tableView.asyncDelegate = self;
-    
-    [self createSocialAppDataSource];
-    
-    self.title = @"Timeline";
-    
+    self = [super init];
+    if (self) {
+        self.title = @"Timeline";
+        [self createSocialAppDataSource];
+    }
     return self;
+}
+
+
+- (void)dealloc
+{
+    _tableView.asyncDataSource = nil;
+    _tableView.asyncDelegate = nil;
 }
 
 - (void)viewDidLoad {
     
     [super viewDidLoad];
-    [self.view addSubview:_tableView];
-}
-
-- (void)viewWillLayoutSubviews
-{
-    _tableView.frame = self.view.bounds;
+    
+    self.tableView = [[ASTableView alloc] initWithFrame:self.view.bounds style:UITableViewStylePlain asyncDataFetching:YES];
+    self.tableView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    self.tableView.separatorStyle = UITableViewCellSeparatorStyleNone; // SocialAppNode has its own separator
+    self.tableView.asyncDataSource = self;
+    self.tableView.asyncDelegate = self;
+    [self.view addSubview:self.tableView];
 }
 
 - (BOOL)prefersStatusBarHidden
@@ -76,7 +76,6 @@
     newPost.via = 0;
     newPost.likes = arc4random_uniform(74);
     newPost.comments = arc4random_uniform(40);
-    
     [_socialAppDataSource addObject:newPost];
     
     newPost = [[Post alloc] init];
@@ -89,7 +88,6 @@
     newPost.via = 1;
     newPost.likes = arc4random_uniform(74);
     newPost.comments = arc4random_uniform(40);
-    
     [_socialAppDataSource addObject:newPost];
     
     newPost = [[Post alloc] init];
@@ -102,7 +100,6 @@
     newPost.via = 2;
     newPost.likes = arc4random_uniform(74);
     newPost.comments = arc4random_uniform(40);
-    
     [_socialAppDataSource addObject:newPost];
     
     newPost = [[Post alloc] init];
@@ -115,29 +112,28 @@
     newPost.via = 1;
     newPost.likes = arc4random_uniform(74);
     newPost.comments = arc4random_uniform(40);
-    
     [_socialAppDataSource addObject:newPost];
 }
 
-#pragma mark -
-#pragma mark ASTableView.
+#pragma mark - ASTableView
 
-- (ASCellNode *)tableView:(ASTableView *)tableView nodeForRowAtIndexPath:(NSIndexPath *)indexPath
+- (ASCellNodeBlock)tableView:(ASTableView *)tableView nodeBlockForRowAtIndexPath:(nonnull NSIndexPath *)indexPath
 {
-    Post *post = _socialAppDataSource[indexPath.row];
-    PostNode *node = [[PostNode alloc] initWithPost:post];
-    return node;
+    Post *post = self.socialAppDataSource[indexPath.row];
+    return ^{
+        return [[PostNode alloc] initWithPost:post];
+    };
 }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section
 {
-    return _socialAppDataSource.count;
+    return self.socialAppDataSource.count;
 }
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
 {
     PostNode *postNode = (PostNode *)[_tableView nodeForRowAtIndexPath:indexPath];
-    Post *post = _socialAppDataSource[indexPath.row];
+    Post *post = self.socialAppDataSource[indexPath.row];
   
     BOOL shouldRasterize = postNode.shouldRasterizeDescendants;
     shouldRasterize = !shouldRasterize;


### PR DESCRIPTION
Update examples to use collectionView:nodeBlockForItemAtIndexPath: or tableView:nodeBlockForItemAtIndexPath: to return node blocks in ASCollectionDataSource / ASTableDataSource objects as well as overall code improvements.