### PR TITLE
[ASMapNode] Promote annotations to a Formal Property

### DIFF
--- a/AsyncDisplayKit/ASMapNode.h
+++ b/AsyncDisplayKit/ASMapNode.h
@@ -48,10 +48,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, weak) id <MKMapViewDelegate> mapDelegate;
 
 /**
- * @discussion This method sets the annotations of the static map view and also to the live map view. Passing an empty array clears the map of any annotations.
- * @param annotations An array of objects that conform to the MKAnnotation protocol
+ * @abstract The annotations to display on the map.
  */
-- (void)setAnnotations:(NSArray<id<MKAnnotation>> *)annotations;
+@property (nonatomic, copy) NSArray<id<MKAnnotation>> *annotations;
 
 @end
 

--- a/AsyncDisplayKit/ASMapNode.mm
+++ b/AsyncDisplayKit/ASMapNode.mm
@@ -43,6 +43,7 @@
   _needsMapReloadOnBoundsChange = YES;
   _liveMap = NO;
   _centerCoordinateOfMap = kCLLocationCoordinate2DInvalid;
+  _annotations = @[];
   return self;
 }
 
@@ -251,8 +252,18 @@
   _mapView = nil;
 }
 
+- (NSArray *)annotations
+{
+  ASDN::MutexLocker l(_propertyLock);
+  return _annotations;
+}
+
 - (void)setAnnotations:(NSArray *)annotations
 {
+  if (annotations == nil) {
+    annotations = @[];
+  }
+
   ASDN::MutexLocker l(_propertyLock);
   _annotations = [annotations copy];
   if (self.isLiveMap) {

--- a/AsyncDisplayKit/ASMapNode.mm
+++ b/AsyncDisplayKit/ASMapNode.mm
@@ -260,12 +260,10 @@
 
 - (void)setAnnotations:(NSArray *)annotations
 {
-  if (annotations == nil) {
-    annotations = @[];
-  }
+  annotations = [annotations copy] ?: @[];
 
   ASDN::MutexLocker l(_propertyLock);
-  _annotations = [annotations copy];
+  _annotations = annotations;
   if (self.isLiveMap) {
     [_mapView removeAnnotations:_mapView.annotations];
     [_mapView addAnnotations:annotations];


### PR DESCRIPTION
I decided to make it `nonnull` which incurs a slight performance penalty but it makes for safer code, and it mirrors MKMapView's `annotations` property.