### PR TITLE
[ASVideoNode] AVAsset type cast safety

### DIFF
--- a/AsyncDisplayKit/ASVideoNode.mm
+++ b/AsyncDisplayKit/ASVideoNode.mm
@@ -277,7 +277,10 @@
 {
   ASDN::MutexLocker l(_videoLock);
   
-  if (ASObjectIsEqual(((AVURLAsset *)asset).URL, ((AVURLAsset *)_asset).URL)) {
+  if (ASObjectIsEqual(asset, _asset)
+    || ([asset isKindOfClass:[AVURLAsset class]]
+      && [_asset isKindOfClass:[AVURLAsset class]]
+      && ASObjectIsEqual(((AVURLAsset *)asset).URL, ((AVURLAsset *)_asset).URL))) {
     return;
   }
   

--- a/AsyncDisplayKitTests/ASVideoNodeTests.m
+++ b/AsyncDisplayKitTests/ASVideoNodeTests.m
@@ -13,7 +13,7 @@
 @interface ASVideoNodeTests : XCTestCase
 {
   ASVideoNode *_videoNode;
-  AVAsset *_firstAsset;
+  AVURLAsset *_firstAsset;
   AVAsset *_secondAsset;
 }
 @end
@@ -43,7 +43,7 @@
 - (void)setUp
 {
   _videoNode = [[ASVideoNode alloc] init];
-  _firstAsset = [AVAsset assetWithURL:[NSURL URLWithString:@"firstURL"]];
+  _firstAsset = [AVURLAsset assetWithURL:[NSURL URLWithString:@"firstURL"]];
   _secondAsset = [AVAsset assetWithURL:[NSURL URLWithString:@"secondURL"]];
 }
 
@@ -67,7 +67,7 @@
   _videoNode.asset = _firstAsset;
   AVPlayerItem *item = [_videoNode currentItem];
   
-  _videoNode.asset = _firstAsset;
+  _videoNode.asset = [AVAsset assetWithURL:_firstAsset.URL];
   AVPlayerItem *secondItem = [_videoNode currentItem];
   
   XCTAssertEqualObjects(item, secondItem);


### PR DESCRIPTION
The current implementation of `setAsset:` does an unsafe cast to `AVURLAsset`. This causes a crash when a AVAsset subclass other than `AVURLAsset` (ex `AVComposition`) is used.

`testVideoNodeDoesNotReplaceAVPlayerItemWhenSameURLIsSet` has also been updated to check if setting different objects with the same URL does not replace the AVPlayerItem.