### PR TITLE
Account for contentInset when calculating ASScrollDirection

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -622,10 +622,10 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
 - (ASScrollDirection)nonFlowLayoutScrollableDirections
 {
   ASScrollDirection scrollableDirection = ASScrollDirectionNone;
-  if (self.contentSize.width + self.contentInset.left > self.bounds.size.width) { // Can scroll horizontally.
+  if (self.contentSize.width + self.contentInset.left + self.contentInset.right > self.bounds.size.width) { // Can scroll horizontally.
     scrollableDirection |= ASScrollDirectionHorizontalDirections;
   }
-  if (self.contentSize.height + self.contentInset.top > self.bounds.size.height) { // Can scroll vertically.
+  if (self.contentSize.height + self.contentInset.top + self.contentInset.bottom > self.bounds.size.height) { // Can scroll vertically.
     scrollableDirection |= ASScrollDirectionVerticalDirections;
   }
   return scrollableDirection;

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -622,10 +622,10 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
 - (ASScrollDirection)nonFlowLayoutScrollableDirections
 {
   ASScrollDirection scrollableDirection = ASScrollDirectionNone;
-  if (self.contentSize.width > self.bounds.size.width) { // Can scroll horizontally.
+  if (self.contentSize.width + self.contentInset.left > self.bounds.size.width) { // Can scroll horizontally.
     scrollableDirection |= ASScrollDirectionHorizontalDirections;
   }
-  if (self.contentSize.height > self.bounds.size.height) { // Can scroll vertically.
+  if (self.contentSize.height + self.contentInset.top > self.bounds.size.height) { // Can scroll vertically.
     scrollableDirection |= ASScrollDirectionVerticalDirections;
   }
   return scrollableDirection;


### PR DESCRIPTION
In the Pinterest notifications You tab, the collectionView contentSize height for the first page is always smaller than the bounds height because we need to add a top contentInset so the collectionView doesn't underlap the segmented control node.

<img width="376" alt="screen shot 2016-02-29 at 5 13 28 pm" src="https://cloud.githubusercontent.com/assets/1455838/13414436/c4bdebe6-df07-11e5-9020-a3cbb7c1cfc8.png">

We need to include the contentInset in the scrollDirection calculation otherwise it returns ASScrollDirectionNone and the collectionView does not fetch any additional pages.