### PR TITLE
[ASTextNode] Fix bug with constrained size when rendering text the second time

### DIFF
--- a/AsyncDisplayKit/ASTextNode.mm
+++ b/AsyncDisplayKit/ASTextNode.mm
@@ -320,6 +320,7 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
 {
   ASLayout *layout = self.calculatedLayout;
   if (layout != nil) {
+    _constrainedSize = layout.size;
     _renderer.constrainedSize = layout.size;
   }
 }


### PR DESCRIPTION
A text node's renderer is often invalidated. Save the renderer's constrained size locally so we can use it when creating a new renderer after invalidation.

