### PR TITLE
Remove unncessary batch layout calls in ASCollectionDataController

### DIFF
--- a/AsyncDisplayKit/Details/ASCollectionDataController.mm
+++ b/AsyncDisplayKit/Details/ASCollectionDataController.mm
@@ -46,9 +46,6 @@
     NSMutableArray<ASIndexedNodeContext *> *contexts = [NSMutableArray array];
     [self _populateSupplementaryNodesOfKind:kind withMutableContexts:contexts];
     _pendingContexts[kind] = contexts;
-    
-    // Measure loaded nodes before leaving the main thread
-    [self batchLayoutNodesFromContexts:contexts ofKind:kind completion:nil];
   }
 }
 
@@ -85,9 +82,6 @@
     NSMutableArray<ASIndexedNodeContext *> *contexts = [NSMutableArray array];
     [self _populateSupplementaryNodesOfKind:kind withSections:sections mutableContexts:contexts];
     _pendingContexts[kind] = contexts;
-    
-    // Measure loaded nodes before leaving the main thread
-    [self batchLayoutNodesFromContexts:contexts ofKind:kind completion:nil];
   }
 }
 
@@ -123,9 +117,6 @@
     NSMutableArray<ASIndexedNodeContext *> *contexts = [NSMutableArray array];
     [self _populateSupplementaryNodesOfKind:kind withSections:sections mutableContexts:contexts];
     _pendingContexts[kind] = contexts;
-    
-    // Measure loaded nodes before leaving the main thread
-    [self batchLayoutNodesFromContexts:contexts ofKind:kind completion:nil];
   }
 }
 


### PR DESCRIPTION
- These calls cause supplementary nodes to be allocated and laid out, but not inserted afterward. So the nodes are thrown away.
- Next time when it is the right time to allocate these nodes, it is the second allocation request and triggers assertion in ASIndexedNodeContext #1296.

@smyrgl Please help me to test this and make sure supplementary nodes are correctly handled.