### PR TITLE
[_ASAsyncTransaction] Reduce locking overhead by removing C++ stack-allocated MutexLocker objects.

### DIFF
--- a/AsyncDisplayKit/Details/ASThread.h
+++ b/AsyncDisplayKit/Details/ASThread.h
@@ -45,6 +45,7 @@ static inline BOOL ASDisplayNodeThreadIsMain()
   _Pragma("clang diagnostic push"); \
   _Pragma("clang diagnostic ignored \"-Wunused-variable\""); \
   volatile int res = (x_); \
+  ASDisplayNodeCAssert(res == 0, @"Return value of operation nonzero: %d", res); \
   assert(res == 0); \
   _Pragma("clang diagnostic pop"); \
 } while (0)


### PR DESCRIPTION
Also, support assertion to log specific return value for pthread_mutex_destroy failures.