### PR TITLE
[ASMultiplexImageNode] Deallocate image on background thread

### DIFF
--- a/AsyncDisplayKit/ASNetworkImageNode.mm
+++ b/AsyncDisplayKit/ASNetworkImageNode.mm
@@ -254,14 +254,13 @@ static const CGSize kMinReleaseImageOnBackgroundSize = {20.0, 20.0};
   // Destruction of bigger images on the main thread can be expensive
   // and can take some time, so we dispatch onto a bg queue to
   // actually dealloc.
-  UIImage *image = self.image;
+  __block UIImage *image = self.image;
   CGSize imageSize = image.size;
   BOOL shouldReleaseImageOnBackgroundThread = imageSize.width > kMinReleaseImageOnBackgroundSize.width ||
                                               imageSize.height > kMinReleaseImageOnBackgroundSize.height;
   if (shouldReleaseImageOnBackgroundThread) {
-    __block UIImage *blockImage = image;
     ASPerformBlockOnBackgroundThread(^{
-      blockImage = nil;
+      image = nil;
     });
   }
   self.image = _defaultImage;


### PR DESCRIPTION
Add deallocation of image in ASMultiplexImageNode. It's mostly the same code as in ASNetworkImage for now. We need to revisit that as soon as we implement the other task and we can streamline that.

Furthermore removed the unecessary extra __block variable in ASNetworkImageNode and ASMultiplexImageNode