### PR TITLE
[ASCollection/TableView] Add -waitUntilAllUpdatesAreCommitted to wait for concurrent measurement to finish

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.h
+++ b/AsyncDisplayKit/ASCollectionView.h
@@ -166,6 +166,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)reloadDataImmediately;
 
 /**
+ *  Blocks execution of the main thread until all section and row updates are committed. This method must be called from the main thread.
+ */
+- (void)waitUntilAllUpdatesAreCommitted;
+
+/**
  * Registers the given kind of supplementary node for use in creating node-backed supplementary views.
  *
  * @param kind The kind of supplementary node that will be requested through the data source.

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -268,6 +268,12 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   [super reloadData];
 }
 
+- (void)waitUntilAllUpdatesAreCommitted
+{
+  ASDisplayNodeAssertMainThread();
+  [_dataController waitUntilAllUpdatesAreCommitted];
+}
+
 - (void)setDataSource:(id<UICollectionViewDataSource>)dataSource
 {
   // UIKit can internally generate a call to this method upon changing the asyncDataSource; only assert for non-nil.

--- a/AsyncDisplayKit/ASTableView.h
+++ b/AsyncDisplayKit/ASTableView.h
@@ -164,6 +164,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)endUpdatesAnimated:(BOOL)animated completion:(void (^ _Nullable)(BOOL completed))completion;
 
 /**
+ *  Blocks execution of the main thread until all section and row updates are committed. This method must be called from the main thread.
+ */
+- (void)waitUntilAllUpdatesAreCommitted;
+
+/**
  * Inserts one or more sections, with an option to animate the insertion.
  *
  * @param sections An index set that specifies the sections to insert.

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -394,6 +394,12 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
   [_dataController endUpdatesAnimated:animated completion:completion];
 }
 
+- (void)waitUntilAllUpdatesAreCommitted
+{
+  ASDisplayNodeAssertMainThread();
+  [_dataController waitUntilAllUpdatesAreCommitted];
+}
+
 - (void)layoutSubviews
 {
   if (_nodesConstrainedWidth != self.bounds.size.width) {

--- a/AsyncDisplayKit/Details/ASChangeSetDataController.m
+++ b/AsyncDisplayKit/Details/ASChangeSetDataController.m
@@ -15,7 +15,7 @@
 
 @interface ASChangeSetDataController ()
 
-@property (nonatomic, assign) NSUInteger batchUpdateCounter;
+@property (nonatomic, assign) NSUInteger changeSetBatchUpdateCounter;
 @property (nonatomic, strong) _ASHierarchyChangeSet *changeSet;
 
 @end
@@ -28,7 +28,7 @@
     return nil;
   }
   
-  _batchUpdateCounter = 0;
+  _changeSetBatchUpdateCounter = 0;
   
   return self;
 }
@@ -38,18 +38,18 @@
 - (void)beginUpdates
 {
   ASDisplayNodeAssertMainThread();
-  if (_batchUpdateCounter == 0) {
+  if (_changeSetBatchUpdateCounter == 0) {
     _changeSet = [_ASHierarchyChangeSet new];
   }
-  _batchUpdateCounter++;
+  _changeSetBatchUpdateCounter++;
 }
 
 - (void)endUpdatesAnimated:(BOOL)animated completion:(void (^)(BOOL))completion
 {
   ASDisplayNodeAssertMainThread();
-  _batchUpdateCounter--;
+  _changeSetBatchUpdateCounter--;
   
-  if (_batchUpdateCounter == 0) {
+  if (_changeSetBatchUpdateCounter == 0) {
     [_changeSet markCompleted];
     
     [super beginUpdates];
@@ -86,7 +86,7 @@
 
 - (BOOL)batchUpdating
 {
-  BOOL batchUpdating = (_batchUpdateCounter != 0);
+  BOOL batchUpdating = (_changeSetBatchUpdateCounter != 0);
   // _changeSet must be available during batch update
   ASDisplayNodeAssertTrue(batchUpdating == (_changeSet != nil));
   return batchUpdating;

--- a/AsyncDisplayKit/Details/ASDataController.h
+++ b/AsyncDisplayKit/Details/ASDataController.h
@@ -181,6 +181,8 @@ FOUNDATION_EXPORT NSString * const ASDataControllerRowNodeKind;
 
 - (void)reloadDataImmediatelyWithAnimationOptions:(ASDataControllerAnimationOptions)animationOptions;
 
+- (void)waitUntilAllUpdatesAreCommitted;
+
 /** @name Data Querying */
 
 - (NSUInteger)numberOfSections;


### PR DESCRIPTION
The API allows consumer of ASTableView or ASCollectionCiew to block execution of the main thread until all section and row updates are committed.