### PR TITLE
[ASViewController] Trigger measurement pass at viewWillAppear: to ensure implicit hierarchy operations complete in time for UIKit inset configuration.

### DIFF
--- a/AsyncDisplayKit/ASViewController.m
+++ b/AsyncDisplayKit/ASViewController.m
@@ -85,6 +85,7 @@
 {
   [super viewWillAppear:animated];
   _ensureDisplayed = YES;
+  [_node measureWithSizeRange:[self nodeConstrainedSize]];
   [_node recursivelyFetchData];
     
   [self updateCurrentRangeModeWithModeIfPossible:ASLayoutRangeModeFull];


### PR DESCRIPTION
…licitHierarchyManagement set to YES

There are content inset problems if a ASViewController is initialized with a root node (e.g a ASCollectionNode subclass) that has usesImplicitHierarchyManagement set to YES. The reason for that is that the subviews (e.g. the UICollectionView) of the ASViewController root node get's added to the view hierarchy in measureWithSizeRange: in ASDisplayNode.  measureWithSizeRange: of the root node is called in -viewWillLayoutSubviews in ASViewController. That is too late, so UIKit does not apply the automatic content inset to the UICollectionView anymore.