### PR TITLE
[ASControlNode] A debug feature on ASControlNode to visualize tap-able areas

### DIFF
--- a/AsyncDisplayKit/ASControlNode+Subclasses.h
+++ b/AsyncDisplayKit/ASControlNode+Subclasses.h
@@ -7,6 +7,7 @@
  */
 
 #import "ASControlNode.h"
+#import "ASDisplayNode+Subclasses.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/AsyncDisplayKit/ASControlNode.h
+++ b/AsyncDisplayKit/ASControlNode.h
@@ -120,6 +120,11 @@ typedef NS_OPTIONS(NSUInteger, ASControlState) {
  */
 - (void)sendActionsForControlEvents:(ASControlNodeEvent)controlEvents withEvent:(nullable UIEvent *)event;
 
+/**
+ Class method to enable a visualization overlay of the tapable area on the ASControlNode. For app debugging purposes only.
+ @param enabled Specify YES to make this debug feature enabled when messaging the ASControlNode class.
+ */
++ (void)setEnableHitTestDebug:(BOOL)enable;
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
[ASControlNode] A debug feature on ASControlNode to visualize tap-able areas (by adding a highlight overlay ASDisplayNode as a subnode) when addTarget:action:ControlEvent: is called. Uses hitTestSlop to get ASControlNode's UIEdgeInset and set the highlight overlay's frame to be the ASControlNode frame + edge insets. Disables clip to bounds on ASControlNode. Enabled by calling +[ASControlNode setEnableHitTestDebug:YES];