### PR TITLE
Ensure that we use the correct default size for collection nodes even if layoutSubviews has not been called yet

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -780,6 +780,11 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   if (_asyncDataSourceImplementsConstrainedSizeForNode) {
     constrainedSize = [_asyncDataSource collectionView:self constrainedSizeForNodeAtIndexPath:indexPath];
   } else {
+      if (! CGSizeEqualToSize(_maxSizeForNodesConstrainedSize, self.bounds.size)) {
+        _maxSizeForNodesConstrainedSize = self.bounds.size;
+        _ignoreMaxSizeChange = CGSizeEqualToSize(_maxSizeForNodesConstrainedSize, CGSizeZero);
+      }
+
     CGSize maxSize = _maxSizeForNodesConstrainedSize;
     if (ASScrollDirectionContainsHorizontalDirection([self scrollableDirections])) {
       maxSize.width = FLT_MAX;


### PR DESCRIPTION
This is important when the ASCollectionNode is itself in a node (like a ASTableView of Collections) where the ASCollectionNode is constructed with a zero size and then later resized to the correct size by the layout system.