### PR TITLE
[ASTextNode] Fix default ellipsis not showing for line breaks

### DIFF
--- a/AsyncDisplayKit/ASTextNode.mm
+++ b/AsyncDisplayKit/ASTextNode.mm
@@ -1120,6 +1120,10 @@ static NSAttributedString *DefaultTruncationAttributedString()
  */
 - (NSAttributedString *)_composedTruncationString
 {
+  //If we have neither return the default
+  if (!_additionalTruncationMessage && !_truncationAttributedString) {
+    return _composedTruncationString;
+  }
   // Short circuit if we only have one or the other.
   if (!_additionalTruncationMessage) {
     return _truncationAttributedString;


### PR DESCRIPTION
@appleguy Appreciate your super busy at the moment.

Little fix to address #1295. There is an easy workaround for this but turned out to be a simple fix to correct it to the expected behaviour.