### PR TITLE
Ensure that we use the correct default size for collection nodes even

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -780,12 +780,7 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   if (_asyncDataSourceImplementsConstrainedSizeForNode) {
     constrainedSize = [_asyncDataSource collectionView:self constrainedSizeForNodeAtIndexPath:indexPath];
   } else {
-      if (! CGSizeEqualToSize(_maxSizeForNodesConstrainedSize, self.bounds.size)) {
-        _maxSizeForNodesConstrainedSize = self.bounds.size;
-        _ignoreMaxSizeChange = CGSizeEqualToSize(_maxSizeForNodesConstrainedSize, CGSizeZero);
-      }
-
-    CGSize maxSize = _maxSizeForNodesConstrainedSize;
+    CGSize maxSize = CGSizeEqualToSize(_maxSizeForNodesConstrainedSize, CGSizeZero) ? self.bounds.size : _maxSizeForNodesConstrainedSize;
     if (ASScrollDirectionContainsHorizontalDirection([self scrollableDirections])) {
       maxSize.width = FLT_MAX;
     } else {


### PR DESCRIPTION
..if layoutSubviews has not been called yet. This is a more conservative approach than the previous PR #1344 which caused issues for @tomizimobile. This fixes the issues I was seeing and shouldn't break anything else ;) (Previous version could keep the initial relayoutAllNodes from being called in layoutSubviews in some situations.)
