### PR TITLE
[ASDimension / ASSizeRange] Add ASSizeRangeMakeExactSize method

### DIFF
--- a/AsyncDisplayKit/Layout/ASDimension.h
+++ b/AsyncDisplayKit/Layout/ASDimension.h
@@ -58,6 +58,9 @@ extern CGFloat ASRelativeDimensionResolve(ASRelativeDimension dimension, CGFloat
 
 extern ASSizeRange ASSizeRangeMake(CGSize min, CGSize max);
 
+/** Creates an ASSizeRange with the provided size as both min and max */
+extern ASSizeRange ASSizeRangeMakeWithExactCGSize(CGSize size);
+
 /** Clamps the provided CGSize between the [min, max] bounds of this ASSizeRange. */
 extern CGSize ASSizeRangeClamp(ASSizeRange sizeRange, CGSize size);
 

--- a/AsyncDisplayKit/Layout/ASDimension.h
+++ b/AsyncDisplayKit/Layout/ASDimension.h
@@ -59,7 +59,7 @@ extern CGFloat ASRelativeDimensionResolve(ASRelativeDimension dimension, CGFloat
 extern ASSizeRange ASSizeRangeMake(CGSize min, CGSize max);
 
 /** Creates an ASSizeRange with the provided size as both min and max */
-extern ASSizeRange ASSizeRangeMakeWithExactCGSize(CGSize size);
+extern ASSizeRange ASSizeRangeMakeExactSize(CGSize size);
 
 /** Clamps the provided CGSize between the [min, max] bounds of this ASSizeRange. */
 extern CGSize ASSizeRangeClamp(ASSizeRange sizeRange, CGSize size);

--- a/AsyncDisplayKit/Layout/ASDimension.mm
+++ b/AsyncDisplayKit/Layout/ASDimension.mm
@@ -77,6 +77,11 @@ ASSizeRange ASSizeRangeMake(CGSize min, CGSize max)
   ASSizeRange sizeRange; sizeRange.min = min; sizeRange.max = max; return sizeRange;
 }
 
+ASSizeRange ASSizeRangeMakeWithExactCGSize(CGSize size)
+{
+  return ASSizeRangeMake(size, size);
+}
+
 CGSize ASSizeRangeClamp(ASSizeRange sizeRange, CGSize size)
 {
   return CGSizeMake(MAX(sizeRange.min.width, MIN(sizeRange.max.width, size.width)),

--- a/AsyncDisplayKit/Layout/ASDimension.mm
+++ b/AsyncDisplayKit/Layout/ASDimension.mm
@@ -77,7 +77,7 @@ ASSizeRange ASSizeRangeMake(CGSize min, CGSize max)
   ASSizeRange sizeRange; sizeRange.min = min; sizeRange.max = max; return sizeRange;
 }
 
-ASSizeRange ASSizeRangeMakeWithExactCGSize(CGSize size)
+ASSizeRange ASSizeRangeMakeExactSize(CGSize size)
 {
   return ASSizeRangeMake(size, size);
 }


### PR DESCRIPTION
Often times I find myself doing `[node measureWithSizeRange:ASSizeRangeMake(size, size)]`. Adding this method to make this a little more straightforward to do.