### PR TITLE
[TextKit] Replace usage of deprecated NSControlCharacterAction value

### DIFF
--- a/AsyncDisplayKit/TextKit/ASTextNodeWordKerner.m
+++ b/AsyncDisplayKit/TextKit/ASTextNodeWordKerner.m
@@ -68,7 +68,7 @@
 {
   // If it's a space character and we have custom word kerning, use the whitespace action control character.
   if ([layoutManager.textStorage.string characterAtIndex:characterIndex] == ' ')
-    return NSControlCharacterWhitespaceAction;
+    return NSControlCharacterActionWhitespace;
 
   return defaultAction;
 }


### PR DESCRIPTION
`NSControlCharacterWhitespaceAction` has been deprecated since iOS 9. `NSControlCharacterActionWhitespace` is its replacement, which has been available since iOS 7.