### PR TITLE
[Tests] Replace sleep() with XCTest asynchronous expectations

### DIFF
--- a/AsyncDisplayKitTests/ASBasicImageDownloaderTests.m
+++ b/AsyncDisplayKitTests/ASBasicImageDownloaderTests.m
@@ -1,5 +1,5 @@
 //
-//  ASZBasicImageDownloaderTests.m
+//  ASBasicImageDownloaderTests.m
 //  AsyncDisplayKit
 //
 //  Created by Victor Mayorov on 10/06/15.
@@ -10,7 +10,6 @@
 
 #import <AsyncDisplayKit/ASBasicImageDownloader.h>
 
-// Z in the name to delay running until after the test instance is operating normally.
 @interface ASBasicImageDownloaderTests : XCTestCase
 
 @end
@@ -19,35 +18,30 @@
 
 - (void)testAsynchronouslyDownloadTheSameURLTwice
 {
-    ASBasicImageDownloader *downloader = [ASBasicImageDownloader sharedImageDownloader];
-    
-    NSURL *URL = [NSURL URLWithString:@"http://wrongPath/wrongResource.png"];
+  XCTestExpectation *firstExpectation = [self expectationWithDescription:@"First ASBasicImageDownloader completion handler should be called within 3 seconds"];
+  XCTestExpectation *secondExpectation = [self expectationWithDescription:@"Second ASBasicImageDownloader completion handler should be called within 3 seconds"];
+
+  ASBasicImageDownloader *downloader = [ASBasicImageDownloader sharedImageDownloader];
+  NSURL *URL = [NSURL URLWithString:@"http://wrongPath/wrongResource.png"];
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  [downloader downloadImageWithURL:URL
+                     callbackQueue:dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)
+             downloadProgressBlock:nil
+                        completion:^(CGImageRef image, NSError *error) {
+                          [firstExpectation fulfill];
+                        }];
 
-    __block BOOL firstDone = NO;
-    
-    [downloader downloadImageWithURL:URL
-                       callbackQueue:dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)
-               downloadProgressBlock:nil
-                          completion:^(CGImageRef image, NSError *error) {
-                              firstDone = YES;
-                          }];
-    
-    __block BOOL secondDone = NO;
-    
-    [downloader downloadImageWithURL:URL
-                       callbackQueue:dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)
-               downloadProgressBlock:nil
-                          completion:^(CGImageRef image, NSError *error) {
-                              secondDone = YES;
-                          }];
-
+  [downloader downloadImageWithURL:URL
+                     callbackQueue:dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)
+             downloadProgressBlock:nil
+                        completion:^(CGImageRef image, NSError *error) {
+                          [secondExpectation fulfill];
+                        }];
 #pragma clang diagnostic pop
 
-    sleep(3);
-    XCTAssert(firstDone && secondDone, @"Not all ASBasicImageDownloader completion handlers have been called after 3 seconds");
+  [self waitForExpectationsWithTimeout:3 handler:nil];
 }
 
 @end


### PR DESCRIPTION
This test fails occasionally in Travis CI. I've had better luck with asynchronous test consistency when XCTest expectations are used.