### PR TITLE
[ASRangeController] Improvements to application state change and memory warning handling

### DIFF
--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -1675,7 +1675,6 @@
 				058D09B9195D04C000B7D73C /* Frameworks */,
 				058D09BA195D04C000B7D73C /* Resources */,
 				3B9D88CDF51B429C8409E4B6 /* Copy Pods Resources */,
-				BD5CC779F736EBA28F5313FB /* Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1803,21 +1802,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-AsyncDisplayKitTests/Pods-AsyncDisplayKitTests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		BD5CC779F736EBA28F5313FB /* Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-AsyncDisplayKitTests/Pods-AsyncDisplayKitTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -1040,20 +1040,12 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
 
 - (void)clearContents
 {
-  for (NSArray *section in [_dataController completedNodes]) {
-    for (ASDisplayNode *node in section) {
-      [node exitInterfaceState:ASInterfaceStateDisplay];
-    }
-  }
+  [_rangeController clearContents];
 }
 
 - (void)clearFetchedData
 {
-  for (NSArray *section in [_dataController completedNodes]) {
-    for (ASDisplayNode *node in section) {
-      [node exitInterfaceState:ASInterfaceStateFetchData];
-    }
-  }
+  [_rangeController clearFetchedData];
 }
 
 #pragma mark - _ASDisplayView behavior substitutions

--- a/AsyncDisplayKit/ASImageNode.mm
+++ b/AsyncDisplayKit/ASImageNode.mm
@@ -128,13 +128,15 @@
 
 - (void)setImage:(UIImage *)image
 {
-  ASDN::MutexLocker l(_imageLock);
+  _imageLock.lock();
   if (!ASObjectIsEqual(_image, image)) {
     _image = image;
 
-    ASDN::MutexUnlocker u(_imageLock);
+    _imageLock.unlock();
     [self invalidateCalculatedLayout];
     [self setNeedsDisplay];
+  } else {
+    _imageLock.unlock(); // We avoid using MutexUnlocker as it needlessly re-locks at the end of the scope.
   }
 }
 

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -1037,20 +1037,12 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
 
 - (void)clearContents
 {
-  for (NSArray *section in [_dataController completedNodes]) {
-    for (ASDisplayNode *node in section) {
-      [node recursivelyClearContents];
-    }
-  }
+  [_rangeController clearContents];
 }
 
 - (void)clearFetchedData
 {
-  for (NSArray *section in [_dataController completedNodes]) {
-    for (ASDisplayNode *node in section) {
-      [node recursivelyClearFetchedData];
-    }
-  }
+  [_rangeController clearFetchedData];
 }
 
 #pragma mark - _ASDisplayView behavior substitutions

--- a/AsyncDisplayKit/Details/ASAbstractLayoutController.mm
+++ b/AsyncDisplayKit/Details/ASAbstractLayoutController.mm
@@ -51,6 +51,18 @@ extern BOOL ASRangeTuningParametersEqualToRangeTuningParameters(ASRangeTuningPar
     .trailingBufferScreenfuls = 2
   };
   
+  _tuningParameters[ASLayoutRangeModeVisibleOnly][ASLayoutRangeTypeDisplay] = {
+    .leadingBufferScreenfuls = 0,
+    .trailingBufferScreenfuls = 0
+  };
+  _tuningParameters[ASLayoutRangeModeVisibleOnly][ASLayoutRangeTypeFetchData] = {
+    .leadingBufferScreenfuls = 0,
+    .trailingBufferScreenfuls = 0
+  };
+  
+  // The Low Memory range mode has special handling. Because a zero range still includes the visible area / bounds,
+  // in order to implement the behavior of releasing all graphics memory (backing stores), ASRangeController must check
+  // for this range mode and use an empty set for displayIndexPaths rather than querying the ASLayoutController for the indexPaths.
   _tuningParameters[ASLayoutRangeModeLowMemory][ASLayoutRangeTypeDisplay] = {
     .leadingBufferScreenfuls = 0,
     .trailingBufferScreenfuls = 0

--- a/AsyncDisplayKit/Details/ASLayoutRangeType.h
+++ b/AsyncDisplayKit/Details/ASLayoutRangeType.h
@@ -29,9 +29,18 @@ typedef NS_ENUM(NSUInteger, ASLayoutRangeMode) {
   ASLayoutRangeModeFull,
   
   /**
-   * Low Memory mode is used when a range controller should limit the amount of work it performs to 0.
-   * Thus, it discards most of the views/layers that are created and it is trying to save as much system
-   * resources as possible.
+   * Visible Only mode is used when a range controller should set its display and fetch data regions to only the size of their bounds.
+   * This causes all additional backing stores & fetched data to be released, while ensuring a user revisiting the view will
+   * still be able to see the expected content.  This mode is automatically set on all ASRangeControllers when the app suspends,
+   * allowing the operating system to keep the app alive longer and increase the chance it is still warm when the user returns.
+   */
+  ASLayoutRangeModeVisibleOnly,
+  
+  /**
+   * Low Memory mode is used when a range controller should discard ALL graphics buffers, including for the area that would be visible
+   * the next time the user views it (bounds).  The only range it preserves is Fetch Data, which is limited to the bounds, allowing
+   * the content to be restored relatively quickly by re-decoding images (the compressed images are ~10% the size of the decoded ones,
+   * and text is a tiny fraction of its rendered size).
    */
   ASLayoutRangeModeLowMemory,
   ASLayoutRangeModeCount

--- a/AsyncDisplayKit/Details/ASRangeController.h
+++ b/AsyncDisplayKit/Details/ASRangeController.h
@@ -13,8 +13,7 @@
 #import <AsyncDisplayKit/ASLayoutController.h>
 #import <AsyncDisplayKit/ASLayoutRangeType.h>
 
-#define ASRangeControllerLoggingEnabled 1
-#define ASRangeControllerAutomaticLowMemoryHandling 1
+#define ASRangeControllerLoggingEnabled 0
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -58,6 +57,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setTuningParameters:(ASRangeTuningParameters)tuningParameters forRangeMode:(ASLayoutRangeMode)rangeMode rangeType:(ASLayoutRangeType)rangeType;
 
 - (ASRangeTuningParameters)tuningParametersForRangeMode:(ASLayoutRangeMode)rangeMode rangeType:(ASLayoutRangeType)rangeType;
+
+// These methods call the corresponding method on each node, visiting each one that
+// the range controller has set a non-default interface state on.
+- (void)clearContents;
+- (void)clearFetchedData;
 
 /**
  * An object that describes the layout behavior of the ranged component (table view, collection view, etc.)

--- a/AsyncDisplayKit/Details/ASRangeControllerUpdateRangeProtocol+Beta.h
+++ b/AsyncDisplayKit/Details/ASRangeControllerUpdateRangeProtocol+Beta.h
@@ -20,6 +20,15 @@
  */
 - (void)updateCurrentRangeWithMode:(ASLayoutRangeMode)rangeMode;
 
+/**
+ * Only ASLayoutRangeModeVisibleOnly or ASLayoutRangeModeLowMemory are recommended.  Default is ASLayoutRangeModeVisibleOnly,
+ * because this is the only way to ensure an application will not have blank / flashing views as the user navigates back after
+ * a memory warning.  Apps that wish to use the more effective / aggressive ASLayoutRangeModeLowMemory may need to take steps
+ * to mitigate this behavior, including: restoring a larger range mode to the next controller before the user navigates there,
+ * enabling .neverShowPlaceholders on ASCellNodes so that the navigation operation is blocked on redisplay completing, etc.
+ */
++ (void)setRangeModeForMemoryWarnings:(ASLayoutRangeMode)rangeMode;
+
 @end
 
 

--- a/AsyncDisplayKit/Private/ASWeakSet.m
+++ b/AsyncDisplayKit/Private/ASWeakSet.m
@@ -73,4 +73,9 @@
   return [_mapTable countByEnumeratingWithState:state objects:buffer count:len];
 }
 
+- (NSString *)description
+{
+  return [[super description] stringByAppendingFormat:@" count: %lu, contents: %@", self.count, _mapTable];
+}
+
 @end

--- a/AsyncDisplayKit/Private/_ASPendingState.mm
+++ b/AsyncDisplayKit/Private/_ASPendingState.mm
@@ -291,6 +291,11 @@ static UIColor *defaultTintColor = nil;
 
 - (void)setBounds:(CGRect)newBounds
 {
+  ASDisplayNodeAssert(!isnan(newBounds.size.width) && !isnan(newBounds.size.height), @"Invalid bounds %@ provided to %@", NSStringFromCGRect(newBounds), self);
+  if (isnan(newBounds.size.width))
+    newBounds.size.width = 0.0;
+  if (isnan(newBounds.size.height))
+    newBounds.size.height = 0.0;
   bounds = newBounds;
   _flags.setBounds = YES;
 }
@@ -359,6 +364,11 @@ static UIColor *defaultTintColor = nil;
 
 - (void)setPosition:(CGPoint)newPosition
 {
+  ASDisplayNodeAssert(!isnan(newPosition.x) && !isnan(newPosition.y), @"Invalid position %@ provided to %@", NSStringFromCGPoint(newPosition), self);
+  if (isnan(newPosition.x))
+    newPosition.x = 0.0;
+  if (isnan(newPosition.y))
+    newPosition.y = 0.0;
   position = newPosition;
   _flags.setPosition = YES;
 }


### PR DESCRIPTION
Introduces ASLayoutRangeModeVisibleOnly, allowing the preservation of decoded backing stores without any extra padding to
strictly minimize memory usage while supporting immediate re-display of content.  Set visible range controllers to this mode
upon app suspend / memory warning, while more aggressively clearing others to the ASLayoutRangeModeLowMemory mode.

By default, when the app is running and recieves a memory warning, we set the range mode for non-visible controllers to
ASLayoutRangeModeVisibleOnly.  This is because, unlike in the app suspend case where on app resume we can restore controllers
from LowMemory to VisibleOnly, the memory warning doesn't provide a good opportunity to do this.

A new +Beta API to control this behavior is called +setRangeModeForMemoryWarnings:, as some apps may prefer to use LowMemory
in the memory warning scenario.  For these apps, optimal user experience will require manually setting the range mode back
to some larger value as the user navigates the app, or they will encounter controllers that are temporarily blank and need
a moment to re-display their contents as they start to become visible.