### PR TITLE
[ASWeakSet] Support -allObjects to return a retained array of contents.

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -867,7 +867,10 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
 - (NSArray *)visibleNodeIndexPathsForRangeController:(ASRangeController *)rangeController
 {
   ASDisplayNodeAssertMainThread();
-  return [self indexPathsForVisibleItems];
+  // Calling visibleNodeIndexPathsForRangeController: will trigger UIKit to call reloadData if it never has, which can result
+  // in incorrect layout if performed at zero size.  We can use the fact that nothing can be visible at zero size to return fast.
+  BOOL isZeroSized = CGRectEqualToRect(self.bounds, CGRectZero);
+  return isZeroSized ? @[] : [self indexPathsForVisibleItems];
 }
 
 - (CGSize)viewportSizeForRangeController:(ASRangeController *)rangeController

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -718,6 +718,12 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
 {
   ASDisplayNodeAssertMainThread();
   
+  // Calling indexPathsForVisibleRows will trigger UIKit to call reloadData if it never has, which can result
+  // in incorrect layout if performed at zero size.  We can use the fact that nothing can be visible at zero size to return fast.
+  if (CGRectEqualToRect(self.bounds, CGRectZero)) {
+    return @[];
+  }
+  
   NSArray *visibleIndexPaths = self.indexPathsForVisibleRows;
   
   if (_pendingVisibleIndexPath) {

--- a/AsyncDisplayKit/Details/ASRangeController.mm
+++ b/AsyncDisplayKit/Details/ASRangeController.mm
@@ -149,6 +149,17 @@ static UIApplicationState __ApplicationState = UIApplicationStateActive;
     return;
   }
   
+  // allNodes is a 2D array: it contains arrays for each section, each containing nodes.
+  NSArray<NSArray *> *allNodes = [_dataSource completedNodes];
+  NSUInteger numberOfSections = [allNodes count];
+  
+  if (_allPreviousIndexPaths.count == 0 && allNodes.count == 0) {
+    // In certain cases, such as on app suspend, an update may be triggered before we've loaded anything.
+    // For example, an ASCollectionNode inside another scrollable area will not load content until it has entered
+    // the display range, but the object may have been allocated by a cell and added to the set of active range controllers.
+    return;
+  }
+  
   // TODO: Consider if we need to use this codepath, or can rely on something more similar to the data & display ranges
   // Example: ... = [_layoutController indexPathsForScrolling:_scrollDirection rangeType:ASLayoutRangeTypeVisible];
   NSArray<NSIndexPath *> *visibleNodePaths = [_dataSource visibleNodeIndexPathsForRangeController:self];
@@ -164,10 +175,6 @@ static UIApplicationState __ApplicationState = UIApplicationStateActive;
   if (_layoutControllerImplementsSetVisibleIndexPaths) {
     [_layoutController setVisibleNodeIndexPaths:visibleNodePaths];
   }
-  
-  // allNodes is a 2D array: it contains arrays for each section, each containing nodes.
-  NSArray<NSArray *> *allNodes = [_dataSource completedNodes];
-  NSUInteger numberOfSections = [allNodes count];
   
   NSArray<ASDisplayNode *> *currentSectionNodes = nil;
   NSInteger currentSectionIndex = -1; // Set to -1 so we don't match any indexPath.section on the first iteration.

--- a/AsyncDisplayKit/Details/ASRangeController.mm
+++ b/AsyncDisplayKit/Details/ASRangeController.mm
@@ -490,19 +490,22 @@ static ASLayoutRangeMode __rangeModeForMemoryWarnings = ASLayoutRangeModeVisible
 
 + (void)didReceiveMemoryWarning:(NSNotification *)notification
 {
-#if ASRangeControllerLoggingEnabled
-  NSLog(@"+[ASRangeController didReceiveMemoryWarning] with controllers: %@", [self allRangeControllersWeakSet]);
-#endif
-  for (ASRangeController *rangeController in [self allRangeControllersWeakSet]) {
+  NSArray *allRangeControllers = [[self allRangeControllersWeakSet] allObjects];
+  for (ASRangeController *rangeController in allRangeControllers) {
     BOOL isDisplay = ASInterfaceStateIncludesDisplay([rangeController interfaceState]);
     [rangeController updateCurrentRangeWithMode:isDisplay ? ASLayoutRangeModeMinimum : __rangeModeForMemoryWarnings];
     [rangeController performRangeUpdate];
   }
+  
+#if ASRangeControllerLoggingEnabled
+  NSLog(@"+[ASRangeController didReceiveMemoryWarning] with controllers: %@", allRangeControllers);
+#endif
 }
 
 + (void)didEnterBackground:(NSNotification *)notification
 {
-  for (ASRangeController *rangeController in [self allRangeControllersWeakSet]) {
+  NSArray *allRangeControllers = [[self allRangeControllersWeakSet] allObjects];
+  for (ASRangeController *rangeController in allRangeControllers) {
     // We do not want to fully collapse the Display ranges of any visible range controllers so that flashes can be avoided when
     // the app is resumed.  Non-visible controllers can be more aggressively culled to the LowMemory state (see definitions for documentation)
     BOOL isVisible = ASInterfaceStateIncludesVisible([rangeController interfaceState]);
@@ -511,27 +514,28 @@ static ASLayoutRangeMode __rangeModeForMemoryWarnings = ASLayoutRangeModeVisible
   
   // Because -interfaceState checks __ApplicationState and always clears the "visible" bit if Backgrounded, we must set this after updating the range mode.
   __ApplicationState = UIApplicationStateBackground;
-  for (ASRangeController *rangeController in [self allRangeControllersWeakSet]) {
+  for (ASRangeController *rangeController in allRangeControllers) {
     // Trigger a range update immediately, as we may not be allowed by the system to run the update block scheduled by changing range mode.
     [rangeController performRangeUpdate];
   }
   
 #if ASRangeControllerLoggingEnabled
-  NSLog(@"+[ASRangeController didEnterBackground] with controllers, after backgrounding: %@", [self allRangeControllersWeakSet]);
+  NSLog(@"+[ASRangeController didEnterBackground] with controllers, after backgrounding: %@", allRangeControllers);
 #endif
 }
 
 + (void)willEnterForeground:(NSNotification *)notification
 {
+  NSArray *allRangeControllers = [[self allRangeControllersWeakSet] allObjects];
   __ApplicationState = UIApplicationStateActive;
-  for (ASRangeController *rangeController in [self allRangeControllersWeakSet]) {
+  for (ASRangeController *rangeController in allRangeControllers) {
     BOOL isVisible = ASInterfaceStateIncludesVisible([rangeController interfaceState]);
     [rangeController updateCurrentRangeWithMode:isVisible ? ASLayoutRangeModeMinimum : ASLayoutRangeModeVisibleOnly];
     [rangeController performRangeUpdate];
   }
   
 #if ASRangeControllerLoggingEnabled
-  NSLog(@"+[ASRangeController willEnterForeground] with controllers, after foregrounding: %@", [self allRangeControllersWeakSet]);
+  NSLog(@"+[ASRangeController willEnterForeground] with controllers, after foregrounding: %@", allRangeControllers);
 #endif
 }
 

--- a/AsyncDisplayKit/Private/ASWeakSet.h
+++ b/AsyncDisplayKit/Private/ASWeakSet.h
@@ -27,6 +27,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// Removes all objects from the set.
 - (void)removeAllObjects;
 
+/// Returns a standard *retained* NSArray of all objects.  Not free to generate, but useful for iterating over contents.
+- (NSArray *)allObjects;
+
 /**
  How many objects are contained in this set.
  

--- a/AsyncDisplayKit/Private/ASWeakSet.m
+++ b/AsyncDisplayKit/Private/ASWeakSet.m
@@ -26,7 +26,7 @@
 
 - (void)addObject:(id)object
 {
-  [_mapTable setObject:kCFNull forKey:object];
+  [_mapTable setObject:(NSNull *)kCFNull forKey:object];
 }
 
 - (void)removeObject:(id)object

--- a/AsyncDisplayKit/Private/ASWeakSet.m
+++ b/AsyncDisplayKit/Private/ASWeakSet.m
@@ -7,6 +7,7 @@
 //
 
 #import "ASWeakSet.h"
+#import <Foundation/NSMapTable.h>
 
 @interface ASWeakSet<__covariant ObjectType> ()
 @property (nonatomic, strong, readonly) NSMapTable<ObjectType, NSNull *> *mapTable;
@@ -25,7 +26,7 @@
 
 - (void)addObject:(id)object
 {
-  [_mapTable setObject:[NSNull null] forKey:object];
+  [_mapTable setObject:kCFNull forKey:object];
 }
 
 - (void)removeObject:(id)object
@@ -36,6 +37,22 @@
 - (void)removeAllObjects
 {
   [_mapTable removeAllObjects];
+}
+
+- (NSArray *)allObjects
+{
+  // We use keys instead of values in the map table for efficiency and better characteristics when the keys are deallocated.
+  // Documentation is currently unclear on whether -keyEnumerator retains its values, but does imply that modifying a
+  // mutable collection is still not safe while enumerating that way - which is one of the main uses for this method.
+  // A helper function called NSAllMapTableKeys() might do exactly what we want and should be more efficient, but unfortunately
+  // is throwing a strange compiler error and may not be available in practice on the latest iOS version.
+  // Lastly, even -dictionaryRepresentation and then -allKeys won't work, because it attemps to copy the values of each key,
+  // which may not support copying (such as ASRangeControllers).
+  NSMutableArray *allObjects = [NSMutableArray array];
+  for (id object in _mapTable) {
+    [allObjects addObject:object];
+  }
+  return allObjects;
 }
 
 - (BOOL)containsObject:(id)object


### PR DESCRIPTION
Use this array while enumerating ASRangeController instances in response to UIApplication notifications,
as it is possible for these events to trigger the mutation of the ASWeakSet and cause an enumeration error.