### PR TITLE
Tweak rangeMode update API

### DIFF
--- a/AsyncDisplayKit/ASCollectionNode.mm
+++ b/AsyncDisplayKit/ASCollectionNode.mm
@@ -229,6 +229,11 @@
   [self.view.rangeController updateCurrentRangeWithMode:rangeMode];
 }
 
+- (void)clearCurrentRangeModeUpdate
+{
+  [self.view.rangeController clearCurrentRangeModeUpdate];
+}
+
 - (void)reloadDataWithCompletion:(void (^)())completion
 {
   [self.view reloadDataWithCompletion:completion];

--- a/AsyncDisplayKit/ASTableNode.m
+++ b/AsyncDisplayKit/ASTableNode.m
@@ -79,11 +79,20 @@
 
 - (void)updateCurrentRangeWithMode:(ASLayoutRangeMode)rangeMode
 {
-    if (!self.isNodeLoaded) {
-        return;
-    }
-    
-    [self.view.rangeController updateCurrentRangeWithMode:rangeMode];
+  if (!self.isNodeLoaded) {
+    return;
+  }
+  
+  [self.view.rangeController updateCurrentRangeWithMode:rangeMode];
+}
+
+- (void)clearCurrentRangeModeUpdate
+{
+  if (!self.isNodeLoaded) {
+    return;
+  }
+
+  [self.view.rangeController clearCurrentRangeModeUpdate];
 }
 
 - (_ASTablePendingState *)pendingState

--- a/AsyncDisplayKit/Details/ASRangeController.mm
+++ b/AsyncDisplayKit/Details/ASRangeController.mm
@@ -104,6 +104,12 @@ static UIApplicationState __ApplicationState = UIApplicationStateActive;
   }
 }
 
+- (void)clearCurrentRangeModeUpdate
+{
+  _didUpdateCurrentRange = NO;
+  [self scheduleRangeUpdate];
+}
+
 - (void)scheduleRangeUpdate
 {
   if (_queuedRangeUpdate) {
@@ -227,7 +233,6 @@ static UIApplicationState __ApplicationState = UIApplicationStateActive;
   _allPreviousIndexPaths = allCurrentIndexPaths;
   
   _currentRangeMode = rangeMode;
-  _didUpdateCurrentRange = NO;
   
   if (!_rangeIsValid) {
     [allIndexPaths addObjectsFromArray:ASIndexPathsForMultidimensionalArray(allNodes)];

--- a/AsyncDisplayKit/Details/ASRangeControllerUpdateRangeProtocol+Beta.h
+++ b/AsyncDisplayKit/Details/ASRangeControllerUpdateRangeProtocol+Beta.h
@@ -16,9 +16,14 @@
 @protocol ASRangeControllerUpdateRangeProtocol <NSObject>
 
 /**
- * Updates the current range mode of the range controller for at least the next range update.
+ * Updates the current range mode of the range controller until updated again or cleared
  */
 - (void)updateCurrentRangeWithMode:(ASLayoutRangeMode)rangeMode;
+
+/**
+ * Clear the updates made to the current range mode of the range controller and resume to the appropriate default range mode
+ */
+- (void)clearCurrentRangeModeUpdate;
 
 /**
  * Only ASLayoutRangeModeVisibleOnly or ASLayoutRangeModeLowMemory are recommended.  Default is ASLayoutRangeModeVisibleOnly,


### PR DESCRIPTION
Instead of updating until next rangeUpdate, we update it until we manually clearing it. feels like it's easier to use and makes the SDK less of a black box (not knowing when the next rangeUpdate will occur).