### PR TITLE
[ASMultidimensionalArrayUtils] Optimization for recursive version, expanded use case of more efficient 2D version

### DIFF
--- a/AsyncDisplayKit/Details/ASRangeController.mm
+++ b/AsyncDisplayKit/Details/ASRangeController.mm
@@ -230,7 +230,7 @@ static UIApplicationState __ApplicationState = UIApplicationStateActive;
   _didUpdateCurrentRange = NO;
   
   if (!_rangeIsValid) {
-    [allIndexPaths addObjectsFromArray:ASIndexPathsForMultidimensionalArray(allNodes)];
+    [allIndexPaths addObjectsFromArray:ASIndexPathsForTwoDimensionalArray(allNodes)];
   }
   
   // TODO Don't register for notifications if this range update doesn't cause any node to enter rendering pipeline.

--- a/AsyncDisplayKit/Private/ASMultidimensionalArrayUtils.mm
+++ b/AsyncDisplayKit/Private/ASMultidimensionalArrayUtils.mm
@@ -44,10 +44,12 @@ static void ASRecursivelyFindIndexPathsForMultidimensionalArray(NSObject *obj, N
   if (![obj isKindOfClass:[NSArray class]]) {
     [res addObject:curIndexPath];
   } else {
-    NSArray *arr = (NSArray *)obj;
-    [arr enumerateObjectsUsingBlock:^(NSObject *subObj, NSUInteger idx, BOOL *stop) {
-      ASRecursivelyFindIndexPathsForMultidimensionalArray(subObj, [curIndexPath indexPathByAddingIndex:idx], res);
-    }];
+    NSArray *array = (NSArray *)obj;
+    NSUInteger idx = 0;
+    for (NSArray *subarray in array) {
+      ASRecursivelyFindIndexPathsForMultidimensionalArray(subarray, [curIndexPath indexPathByAddingIndex:idx], res);
+      idx++;
+    }
   }
 }
 


### PR DESCRIPTION
- optimized ASRecursivelyFindIndexPathsForMultidimensionalArray() to remove enumerateUsingBlock:
- replaced single project call to ASIndexPathsForMultidimensionalArray() in ASRangeController with ASIndexPathsForTwoDimensionalArray()