### PR TITLE
[ASImageNode] Annotate imageModificationBlock as nullable

### DIFF
--- a/AsyncDisplayKit/ASImageNode.h
+++ b/AsyncDisplayKit/ASImageNode.h
@@ -94,7 +94,7 @@ typedef UIImage * _Nullable (^asimagenode_modification_block_t)(UIImage *image);
  * @discussion Can be used to add image effects (such as rounding, adding
  * borders, or other pattern overlays) without extraneous display calls.
  */
-@property (nonatomic, readwrite, copy) asimagenode_modification_block_t imageModificationBlock;
+@property (nullable, nonatomic, readwrite, copy) asimagenode_modification_block_t imageModificationBlock;
 
 /**
  * @abstract Marks the receiver as needing display and performs a block after


### PR DESCRIPTION
`imageModificationBlock` defaults to nil, and can be set to nil.