### PR TITLE
Fix ASVideoNodeTests testPlayerLayerNodeIsNotAddedIfVisibleButShouldN…

### DIFF
--- a/AsyncDisplayKitTests/ASVideoNodeTests.m
+++ b/AsyncDisplayKitTests/ASVideoNodeTests.m
@@ -140,7 +140,7 @@
   _videoNode.asset = _firstAsset;
 
   [_videoNode pause];
-  [_videoNode setInterfaceState:ASInterfaceStateVisible];
+  [_videoNode setInterfaceState:(ASInterfaceStateVisible & ASInterfaceStateDisplay)];
   [_videoNode didLoad];
   
   XCTAssert(![_videoNode.subnodes containsObject:_videoNode.playerNode]);


### PR DESCRIPTION
…otBePlaying test

With a recent change the pre condition for setting an interface state of a display node to so that it should never be possible for a node to be visible but not be allowed / expected to display. In the testPlayerLayerNodeIsNotAddedIfVisibleButShouldNotBePlaying test the interface state is only set to ASInterfaceStateVisible and does not include ASInterfaceStateDisplay. This will let the test to fail.