### PR TITLE
[ASImageNode] -setDefaultImage: should release lock before calling -setImage:

### DIFF
--- a/AsyncDisplayKit/ASNetworkImageNode.mm
+++ b/AsyncDisplayKit/ASNetworkImageNode.mm
@@ -132,15 +132,22 @@ static const CGSize kMinReleaseImageOnBackgroundSize = {20.0, 20.0};
 
 - (void)setDefaultImage:(UIImage *)defaultImage
 {
-  ASDN::MutexLocker l(_lock);
+  _lock.lock();
 
   if (ASObjectIsEqual(defaultImage, _defaultImage)) {
+    _lock.unlock();
     return;
   }
   _defaultImage = defaultImage;
 
   if (!_imageLoaded) {
-    self.image = _defaultImage;
+    _lock.unlock();
+    // Locking: it is important to release _lock before entering setImage:, as it needs to release the lock before -invalidateCalculatedLayout.
+    // If we continue to hold the lock here, it will still be locked until the next unlock() call, causing a possible deadlock with
+    // -[ASNetworkImageNode displayWillStart] (which is called on a different thread / main, at an unpredictable time due to ASMainRunloopQueue).
+    self.image = defaultImage;
+  } else {
+    _lock.unlock();
   }
 }
 


### PR DESCRIPTION
This allows -setImage: to fully unlock before it calls -invalidateCalculatedSize.