### PR TITLE
[ASDisplayNode] Placeholder Image bug fix

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -1676,7 +1676,7 @@ static NSInteger incrementIfFound(NSInteger i) {
   [_pendingDisplayNodes removeObject:node];
 
   // only trampoline if there is a placeholder and nodes are done displaying
-  if ([self _pendingDisplayNodesHaveFinished] && _placeholderLayer.superlayer) {
+  if (self.layer.contents && [self _pendingDisplayNodesHaveFinished] && _placeholderLayer.superlayer) {
     void (^cleanupBlock)() = ^{
       [self _tearDownPlaceholderLayer];
     };

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -2260,14 +2260,23 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
   [self _pendingNodeWillDisplay:self];
 
   [_supernode subnodeDisplayWillStart:self];
-
-  if (_placeholderImage && _placeholderLayer && self.layer.contents == nil) {
-    [CATransaction begin];
-    [CATransaction setDisableActions:YES];
-    [self _setupPlaceholderLayerContents];
-    _placeholderLayer.opacity = 1.0;
-    [CATransaction commit];
-    [self.layer addSublayer:_placeholderLayer];
+  
+  if (_placeholderEnabled && self.layer.contents == nil && [self __implementsDisplay]) {
+    if (!_placeholderImage) {
+      _placeholderImage = [self placeholderImage];
+    }
+    if (!_placeholderLayer) {
+      [self _setupPlaceholderLayerContents];
+    }
+    // from __completeLayoutCalculation
+    if (_placeholderImage && _placeholderLayer) {
+      [CATransaction begin];
+      [CATransaction setDisableActions:YES];
+      [self _setupPlaceholderLayerContents];
+      _placeholderLayer.opacity = 1.0;
+      [CATransaction commit];
+      [self.layer addSublayer:_placeholderLayer];
+    }
   }
 }
 


### PR DESCRIPTION
Issue:
- The placeholder image layer does not seem to reload if you scroll past an ASDisplayNode far enough that its contents are cleared and then return.
- E.g. if you scroll past an ASNetworkImageNode node before the image has loaded, (if enabled) the placeholder image will display the first time. If you keep scrolling far enough down so that the node contents clear and then scroll back up past it (again before the image has loaded), the placeholder image will not reload.

Fix:
- When a node is becoming visible, we should check if it’s placeholder layer still exists and if not (and placeholder is enabled), we should recreate it
- check that the node implements display

Notes:
- I’m not sure if this is the correct approach. I dug around in the code, tried this fix in my app and it seems to work.
- I am unsure about whether to call _setupPlaceholderLayer: or _setupPlaceholderLayerContents: or both to handle the recreation of the placeholder image layer.