### PR TITLE
[CustomCollectionView Example] Fix shouldInvalidateLayoutForBoundsChange: method

### DIFF
--- a/examples/CustomCollectionView/Sample/MosaicCollectionViewLayout.m
+++ b/examples/CustomCollectionView/Sample/MosaicCollectionViewLayout.m
@@ -119,7 +119,7 @@
 
 - (BOOL)shouldInvalidateLayoutForBoundsChange:(CGRect)newBounds
 {
-  if (!CGRectEqualToRect(self.collectionView.bounds, newBounds)) {
+  if (!CGSizeEqualToSize(self.collectionView.bounds.size, newBounds.size)) {
     return YES;
   }
   return NO;


### PR DESCRIPTION
Issue (#1366):
CustomColelctionView example app always returns YES from shouldInvalidateLayoutForBoundsChange: which triggers a re-layout.

Fix:
Comparing CGSize rather than CGRect is enough to  handle rotation support without always triggering a re-layout.