### PR TITLE
[Refactoring] ASCellNodeVisibilityEvent Swift interface

### DIFF
--- a/AsyncDisplayKit/ASCellNode.h
+++ b/AsyncDisplayKit/ASCellNode.h
@@ -14,9 +14,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef NSUInteger ASCellNodeAnimation;
 
-typedef enum : NSUInteger {
-  /** 
-   * Indicates a cell has just became visible 
+typedef NS_ENUM(NSUInteger, ASCellNodeVisibilityEvent) {
+  /**
+   * Indicates a cell has just became visible
    */
   ASCellNodeVisibilityEventVisible,
   /**
@@ -26,11 +26,11 @@ typedef enum : NSUInteger {
    * Use CGRectIntersect between cellFrame and scrollView.bounds to get this rectangle
    */
   ASCellNodeVisibilityEventVisibleRectChanged,
-  /** 
-   * Indicates a cell is no longer visible 
+  /**
+   * Indicates a cell is no longer visible
    */
   ASCellNodeVisibilityEventInvisible,
-} ASCellNodeVisibilityEvent;
+};
 
 /**
  * Generic cell node.  Subclass this instead of `ASDisplayNode` to use with `ASTableView` and `ASCollectionView`.


### PR DESCRIPTION
Using NS_ENUM macro on ASCellNodeVisibilityEvent improves its Swift interface. This change should cause no side effects in the Objective-C interface.

Interface before:
``` swift
public struct ASCellNodeVisibilityEvent : RawRepresentable, Equatable {
  public init(_ rawValue: UInt)
  public init(rawValue: UInt)
  public var rawValue: UInt
}

/** 
 * Indicates a cell has just became visible 
 */
public var ASCellNodeVisibilityEventVisible: ASCellNodeVisibilityEvent { get }
/**
 * Its position (determined by scrollView.contentOffset) has changed while at least 1px remains visible.
 * It is possible that 100% of the cell is visible both before and after and only its position has changed,
 * or that the position change has resulted in more or less of the cell being visible.
 * Use CGRectIntersect between cellFrame and scrollView.bounds to get this rectangle
 */
public var ASCellNodeVisibilityEventVisibleRectChanged: ASCellNodeVisibilityEvent { get }
/** 
 * Indicates a cell is no longer visible 
 */
public var ASCellNodeVisibilityEventInvisible: ASCellNodeVisibilityEvent { get }
```
Interface after:
``` swift
public enum ASCellNodeVisibilityEvent : UInt {
  /**
   * Indicates a cell has just became visible
   */
  case Visible
  /**
   * Its position (determined by scrollView.contentOffset) has changed while at least 1px remains visible.
   * It is possible that 100% of the cell is visible both before and after and only its position has changed,
   * or that the position change has resulted in more or less of the cell being visible.
   * Use CGRectIntersect between cellFrame and scrollView.bounds to get this rectangle
   */
  case VisibleRectChanged
  /**
   * Indicates a cell is no longer visible
   */
  case Invisible
}
```