### PR TITLE
[Refactoring] ASHorizontalAlignment & ASVerticalAlignment Swift interface

### DIFF
--- a/AsyncDisplayKit/ASButtonNode.h
+++ b/AsyncDisplayKit/ASButtonNode.h
@@ -28,12 +28,12 @@
 @property (nonatomic, assign) BOOL laysOutHorizontally;
 
 /** Horizontally align content (text or image).
- Defaults to ASAlignmentMiddle.
+ Defaults to ASHorizontalAlignmentMiddle.
  */
 @property (nonatomic, assign) ASHorizontalAlignment contentHorizontalAlignment;
 
 /** Vertically align content (text or image).
- Defaults to ASAlignmentCenter.
+ Defaults to ASVerticalAlignmentCenter.
  */
 @property (nonatomic, assign) ASVerticalAlignment contentVerticalAlignment;
 

--- a/AsyncDisplayKit/ASButtonNode.mm
+++ b/AsyncDisplayKit/ASButtonNode.mm
@@ -57,8 +57,8 @@
     
     _contentSpacing = 8.0;
     _laysOutHorizontally = YES;
-    _contentHorizontalAlignment = ASAlignmentMiddle;
-    _contentVerticalAlignment = ASAlignmentCenter;
+    _contentHorizontalAlignment = ASHorizontalAlignmentMiddle;
+    _contentVerticalAlignment = ASVerticalAlignmentCenter;
     _contentEdgeInsets = UIEdgeInsetsZero;
     self.accessibilityTraits = UIAccessibilityTraitButton;
   }

--- a/AsyncDisplayKit/Layout/ASStackLayoutDefines.h
+++ b/AsyncDisplayKit/Layout/ASStackLayoutDefines.h
@@ -8,6 +8,8 @@
  *
  */
 
+#import "ASBaseDefines.h"
+
 /** The direction children are stacked in */
 typedef NS_ENUM(NSUInteger, ASStackLayoutDirection) {
   /** Children are stacked vertically */
@@ -88,11 +90,18 @@ typedef NS_ENUM(NSUInteger, ASHorizontalAlignment) {
   /** No alignment specified. Default value */
   ASHorizontalAlignmentNone,
   /** Left aligned */
-  ASAlignmentLeft,
+  ASHorizontalAlignmentLeft,
   /** Center aligned */
-  ASAlignmentMiddle,
+  ASHorizontalAlignmentMiddle,
   /** Right aligned */
-  ASAlignmentRight,
+  ASHorizontalAlignmentRight,
+
+  /** @deprecated Use ASHorizontalAlignmentLeft instead */
+  ASAlignmentLeft ASDISPLAYNODE_DEPRECATED = ASHorizontalAlignmentLeft,
+  /** @deprecated Use ASHorizontalAlignmentMiddle instead */
+  ASAlignmentMiddle ASDISPLAYNODE_DEPRECATED = ASHorizontalAlignmentMiddle,
+  /** @deprecated Use ASHorizontalAlignmentRight instead */
+  ASAlignmentRight ASDISPLAYNODE_DEPRECATED = ASHorizontalAlignmentRight,
 };
 
 /** Orientation of children along vertical axis */
@@ -100,9 +109,16 @@ typedef NS_ENUM(NSUInteger, ASVerticalAlignment) {
   /** No alignment specified. Default value */
   ASVerticalAlignmentNone,
   /** Top aligned */
-  ASAlignmentTop,
+  ASVerticalAlignmentTop,
   /** Center aligned */
-  ASAlignmentCenter,
+  ASVerticalAlignmentCenter,
   /** Bottom aligned */
-  ASAlignmentBottom,
+  ASVerticalAlignmentBottom,
+
+  /** @deprecated Use ASVerticalAlignmentTop instead */
+  ASAlignmentTop ASDISPLAYNODE_DEPRECATED = ASVerticalAlignmentTop,
+  /** @deprecated Use ASVerticalAlignmentCenter instead */
+  ASAlignmentCenter ASDISPLAYNODE_DEPRECATED = ASVerticalAlignmentCenter,
+  /** @deprecated Use ASVerticalAlignmentBottom instead */
+  ASAlignmentBottom ASDISPLAYNODE_DEPRECATED = ASVerticalAlignmentBottom,
 };

--- a/AsyncDisplayKit/Private/ASStackLayoutSpecUtilities.h
+++ b/AsyncDisplayKit/Private/ASStackLayoutSpecUtilities.h
@@ -72,11 +72,11 @@ inline ASStackLayoutAlignItems alignment(ASStackLayoutAlignSelf childAlignment, 
 inline ASStackLayoutAlignItems alignment(ASHorizontalAlignment alignment, ASStackLayoutAlignItems defaultAlignment)
 {
   switch (alignment) {
-    case ASAlignmentLeft:
+    case ASHorizontalAlignmentLeft:
       return ASStackLayoutAlignItemsStart;
-    case ASAlignmentMiddle:
+    case ASHorizontalAlignmentMiddle:
       return ASStackLayoutAlignItemsCenter;
-    case ASAlignmentRight:
+    case ASHorizontalAlignmentRight:
       return ASStackLayoutAlignItemsEnd;
     case ASHorizontalAlignmentNone:
     default:
@@ -87,11 +87,11 @@ inline ASStackLayoutAlignItems alignment(ASHorizontalAlignment alignment, ASStac
 inline ASStackLayoutAlignItems alignment(ASVerticalAlignment alignment, ASStackLayoutAlignItems defaultAlignment)
 {
   switch (alignment) {
-    case ASAlignmentTop:
+    case ASVerticalAlignmentTop:
       return ASStackLayoutAlignItemsStart;
-    case ASAlignmentCenter:
+    case ASVerticalAlignmentCenter:
       return ASStackLayoutAlignItemsCenter;
-    case ASAlignmentBottom:
+    case ASVerticalAlignmentBottom:
       return ASStackLayoutAlignItemsEnd;
     case ASVerticalAlignmentNone:
     default:
@@ -102,11 +102,11 @@ inline ASStackLayoutAlignItems alignment(ASVerticalAlignment alignment, ASStackL
 inline ASStackLayoutJustifyContent justifyContent(ASHorizontalAlignment alignment, ASStackLayoutJustifyContent defaultJustifyContent)
 {
   switch (alignment) {
-    case ASAlignmentLeft:
+    case ASHorizontalAlignmentLeft:
       return ASStackLayoutJustifyContentStart;
-    case ASAlignmentMiddle:
+    case ASHorizontalAlignmentMiddle:
       return ASStackLayoutJustifyContentCenter;
-    case ASAlignmentRight:
+    case ASHorizontalAlignmentRight:
       return ASStackLayoutJustifyContentEnd;
     case ASHorizontalAlignmentNone:
     default:
@@ -117,11 +117,11 @@ inline ASStackLayoutJustifyContent justifyContent(ASHorizontalAlignment alignmen
 inline ASStackLayoutJustifyContent justifyContent(ASVerticalAlignment alignment, ASStackLayoutJustifyContent defaultJustifyContent)
 {
   switch (alignment) {
-    case ASAlignmentTop:
+    case ASVerticalAlignmentTop:
       return ASStackLayoutJustifyContentStart;
-    case ASAlignmentCenter:
+    case ASVerticalAlignmentCenter:
       return ASStackLayoutJustifyContentCenter;
-    case ASAlignmentBottom:
+    case ASVerticalAlignmentBottom:
       return ASStackLayoutJustifyContentEnd;
     case ASVerticalAlignmentNone:
     default:

--- a/AsyncDisplayKitTests/ASStackLayoutSpecSnapshotTests.mm
+++ b/AsyncDisplayKitTests/ASStackLayoutSpecSnapshotTests.mm
@@ -606,19 +606,19 @@ static NSArray *defaultSubnodesWithSameSize(CGSize subnodeSize, BOOL flex)
 
 - (void)testHorizontalAndVerticalAlignments
 {
-  [self testStackLayoutSpecWithDirection:ASStackLayoutDirectionHorizontal itemsHorizontalAlignment:ASAlignmentLeft itemsVerticalAlignment:ASAlignmentTop identifier:@"horizontalTopLeft"];
-  [self testStackLayoutSpecWithDirection:ASStackLayoutDirectionHorizontal itemsHorizontalAlignment:ASAlignmentMiddle itemsVerticalAlignment:ASAlignmentCenter identifier:@"horizontalCenter"];
-  [self testStackLayoutSpecWithDirection:ASStackLayoutDirectionHorizontal itemsHorizontalAlignment:ASAlignmentRight itemsVerticalAlignment:ASAlignmentBottom identifier:@"horizontalBottomRight"];
-  [self testStackLayoutSpecWithDirection:ASStackLayoutDirectionVertical itemsHorizontalAlignment:ASAlignmentLeft itemsVerticalAlignment:ASAlignmentTop identifier:@"verticalTopLeft"];
-  [self testStackLayoutSpecWithDirection:ASStackLayoutDirectionVertical itemsHorizontalAlignment:ASAlignmentMiddle itemsVerticalAlignment:ASAlignmentCenter identifier:@"verticalCenter"];
-  [self testStackLayoutSpecWithDirection:ASStackLayoutDirectionVertical itemsHorizontalAlignment:ASAlignmentRight itemsVerticalAlignment:ASAlignmentBottom identifier:@"verticalBottomRight"];
+  [self testStackLayoutSpecWithDirection:ASStackLayoutDirectionHorizontal itemsHorizontalAlignment:ASHorizontalAlignmentLeft itemsVerticalAlignment:ASVerticalAlignmentTop identifier:@"horizontalTopLeft"];
+  [self testStackLayoutSpecWithDirection:ASStackLayoutDirectionHorizontal itemsHorizontalAlignment:ASHorizontalAlignmentMiddle itemsVerticalAlignment:ASVerticalAlignmentCenter identifier:@"horizontalCenter"];
+  [self testStackLayoutSpecWithDirection:ASStackLayoutDirectionHorizontal itemsHorizontalAlignment:ASHorizontalAlignmentRight itemsVerticalAlignment:ASVerticalAlignmentBottom identifier:@"horizontalBottomRight"];
+  [self testStackLayoutSpecWithDirection:ASStackLayoutDirectionVertical itemsHorizontalAlignment:ASHorizontalAlignmentLeft itemsVerticalAlignment:ASVerticalAlignmentTop identifier:@"verticalTopLeft"];
+  [self testStackLayoutSpecWithDirection:ASStackLayoutDirectionVertical itemsHorizontalAlignment:ASHorizontalAlignmentMiddle itemsVerticalAlignment:ASVerticalAlignmentCenter identifier:@"verticalCenter"];
+  [self testStackLayoutSpecWithDirection:ASStackLayoutDirectionVertical itemsHorizontalAlignment:ASHorizontalAlignmentRight itemsVerticalAlignment:ASVerticalAlignmentBottom identifier:@"verticalBottomRight"];
 }
 
 - (void)testDirectionChangeAfterSettingHorizontalAndVerticalAlignments
 {
   ASStackLayoutSpec *stackLayoutSpec = [[ASStackLayoutSpec alloc] init]; // Default direction is horizontal
-  stackLayoutSpec.horizontalAlignment = ASAlignmentRight;
-  stackLayoutSpec.verticalAlignment = ASAlignmentCenter;
+  stackLayoutSpec.horizontalAlignment = ASHorizontalAlignmentRight;
+  stackLayoutSpec.verticalAlignment = ASVerticalAlignmentCenter;
   XCTAssertEqual(stackLayoutSpec.alignItems, ASStackLayoutAlignItemsCenter);
   XCTAssertEqual(stackLayoutSpec.justifyContent, ASStackLayoutJustifyContentEnd);
   
@@ -636,8 +636,8 @@ static NSArray *defaultSubnodesWithSameSize(CGSize subnodeSize, BOOL flex)
   stackLayoutSpec.justifyContent = ASStackLayoutJustifyContentEnd;
 
   // Set alignments and assert that assertions are thrown
-  stackLayoutSpec.horizontalAlignment = ASAlignmentMiddle;
-  stackLayoutSpec.verticalAlignment = ASAlignmentCenter;
+  stackLayoutSpec.horizontalAlignment = ASHorizontalAlignmentMiddle;
+  stackLayoutSpec.verticalAlignment = ASVerticalAlignmentCenter;
   XCTAssertThrows(stackLayoutSpec.alignItems = ASStackLayoutAlignItemsEnd);
   XCTAssertThrows(stackLayoutSpec.justifyContent = ASStackLayoutJustifyContentEnd);
 


### PR DESCRIPTION
The Swift interface of these enums are improved when given a consistent prefix. The old names are marked deprecated, and internal uses have been updated.

ex.
``` swift
contentHorizontalAlignment = foo ? .AlignmentLeft : .HorizontalAlignmentNone
```
is now
``` swift
contentHorizontalAlignment = foo ? .Left : .None
```


Interface before:
``` swift
/** Orientation of children along horizontal axis */
public enum ASHorizontalAlignment : UInt {
  /** No alignment specified. Default value */
  case HorizontalAlignmentNone
  /** Left aligned */
  case AlignmentLeft
  /** Center aligned */
  case AlignmentMiddle
  /** Right aligned */
  case AlignmentRight
}

/** Orientation of children along vertical axis */
public enum ASVerticalAlignment : UInt {
  /** No alignment specified. Default value */
  case VerticalAlignmentNone
  /** Top aligned */
  case AlignmentTop
  /** Center aligned */
  case AlignmentCenter
  /** Bottom aligned */
  case AlignmentBottom
}
```

Interface after:
``` swift
/** Orientation of children along horizontal axis */
public enum ASHorizontalAlignment : UInt {
  /** No alignment specified. Default value */
  case None
  /** Left aligned */
  case Left
  /** Center aligned */
  case Middle
  /** Right aligned */
  case Right
}

/** Orientation of children along vertical axis */
public enum ASVerticalAlignment : UInt {
  /** No alignment specified. Default value */
  case None
  /** Top aligned */
  case Top
  /** Center aligned */
  case Center
  /** Bottom aligned */
  case Bottom
}
```