### PR TITLE
[ASCollectionView] Copy _cellsForVisibilityUpdates During Callback for Safety

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -590,11 +590,9 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
     ASDisplayNodeAssertNotNil(cellNode, @"Expected node associated with removed cell not to be nil.");
     [_asyncDelegate collectionView:self didEndDisplayingNode:cellNode forItemAtIndexPath:indexPath];
   }
-  
-  if ([_cellsForVisibilityUpdates containsObject:cell]) {
-    [_cellsForVisibilityUpdates removeObject:cell];
-  }
-  
+
+  [_cellsForVisibilityUpdates removeObject:cell];
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
   if ([_asyncDelegate respondsToSelector:@selector(collectionView:didEndDisplayingNodeForItemAtIndexPath:)]) {
@@ -727,7 +725,7 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
     [_rangeController updateCurrentRangeWithMode:ASLayoutRangeModeFull];
   }
   
-  for (_ASCollectionViewCell *collectionCell in _cellsForVisibilityUpdates) {
+  for (_ASCollectionViewCell *collectionCell in [_cellsForVisibilityUpdates copy]) {
     // Only nodes that respond to the selector are added to _cellsForVisibilityUpdates
     [[collectionCell node] cellNodeVisibilityEvent:ASCellNodeVisibilityEventVisibleRectChanged
                                       inScrollView:scrollView

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -610,7 +610,7 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     [_rangeController updateCurrentRangeWithMode:ASLayoutRangeModeFull];
   }
   
-  for (_ASTableViewCell *tableCell in _cellsForVisibilityUpdates) {
+  for (_ASTableViewCell *tableCell in [_cellsForVisibilityUpdates copy]) {
     [[tableCell node] cellNodeVisibilityEvent:ASCellNodeVisibilityEventVisibleRectChanged
                                  inScrollView:scrollView
                                 withCellFrame:tableCell.frame];
@@ -657,9 +657,7 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     [_asyncDelegate tableView:self didEndDisplayingNode:cellNode forRowAtIndexPath:indexPath];
   }
 
-  if ([_cellsForVisibilityUpdates containsObject:cell]) {
-    [_cellsForVisibilityUpdates removeObject:cell];
-  }
+  [_cellsForVisibilityUpdates removeObject:cell];
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"


### PR DESCRIPTION
@appleguy I hit a NSFastEnumerationMutation exception on this variable, for a particularly rambunctious table view. Snuck in a small optimization as well, love the recent improvements!