### PR TITLE
[ASDisplayNode] When Enumerating Subtree, Copy sublayers to Avoid NSFastEnumerationMutation Exception

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -351,7 +351,7 @@ NS_ASSUME_NONNULL_BEGIN
 /** 
  * @abstract The receiver's immediate subnodes.
  */
-@property (nonatomic, readonly, strong) NSArray<ASDisplayNode *> *subnodes;
+@property (nonatomic, readonly, copy) NSArray<ASDisplayNode *> *subnodes;
 
 /** 
  * @abstract The receiver's supernode.

--- a/AsyncDisplayKit/ASDisplayNodeExtras.mm
+++ b/AsyncDisplayKit/ASDisplayNodeExtras.mm
@@ -51,7 +51,9 @@ extern void ASDisplayNodePerformBlockOnEveryNode(CALayer *layer, ASDisplayNode *
   }
   
   if (layer) {
-    for (CALayer *sublayer in [layer sublayers]) {
+    /// NOTE: The docs say `sublayers` returns a copy, but it does not.
+    /// See: http://stackoverflow.com/questions/14854480/collection-calayerarray-0x1ed8faa0-was-mutated-while-being-enumerated
+    for (CALayer *sublayer in [[layer sublayers] copy]) {
       ASDisplayNodePerformBlockOnEveryNode(sublayer, nil, block);
     }
   } else if (node) {


### PR DESCRIPTION
I have some insanely complex table view cells, and as I scroll through them, I eventually get an `NSFastEnumerationMutation` exception when a node leaves the display range. It's crunch time and I'm exhausted, so I don't know what code on my end is modifying the layer tree due to leaving the display range, but I'll attach some snapshots. It's easy to reproduce so if you want to investigate @appleguy let me know. Nothing interesting or consistent going on on other threads.

This also corrects the property declaration for `ASDisplayNode.subnodes`.