### PR TITLE
[ASEditableTextNode] Assign textView's scrollEnabled on creation

### DIFF
--- a/AsyncDisplayKit/ASCellNode.h
+++ b/AsyncDisplayKit/ASCellNode.h
@@ -66,12 +66,12 @@ typedef NS_ENUM(NSUInteger, ASCellNodeVisibilityEvent) {
 //@property (atomic, retain) UIColor *backgroundColor;
 @property (nonatomic) UITableViewCellSelectionStyle selectionStyle;
 
-/*
+/**
  * A Boolean value that indicates whether the node is selected.
  */
 @property (nonatomic, assign) BOOL selected;
 
-/*
+/**
  * A Boolean value that indicates whether the node is highlighted.
  */
 @property (nonatomic, assign) BOOL highlighted;

--- a/AsyncDisplayKit/ASEditableTextNode.h
+++ b/AsyncDisplayKit/ASEditableTextNode.h
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface ASEditableTextNode : ASDisplayNode
 
-// @abstract The text node's delegate, which must conform to the <ASEditableTextNodeDelegate> protocol.
+//! @abstract The text node's delegate, which must conform to the <ASEditableTextNodeDelegate> protocol.
 @property (nonatomic, readwrite, weak) id <ASEditableTextNodeDelegate> delegate;
 
 #pragma mark - Configuration
@@ -66,12 +66,12 @@ NS_ASSUME_NONNULL_BEGIN
 //! @abstract The text input mode used by the receiver's keyboard, if it is visible. This value is undefined if the receiver is not the first responder.
 @property (nonatomic, readonly) UITextInputMode *textInputMode;
 
-/*
+/**
  @abstract The textContainerInset of both the placeholder and typed textView. This value defaults to UIEdgeInsetsZero.
  */
 @property (nonatomic, readwrite) UIEdgeInsets textContainerInset;
 
-/*
+/**
  @abstract The returnKeyType of the keyboard. This value defaults to UIReturnKeyDefault.
  */
 @property (nonatomic, readwrite) UIReturnKeyType returnKeyType;

--- a/AsyncDisplayKit/ASEditableTextNode.mm
+++ b/AsyncDisplayKit/ASEditableTextNode.mm
@@ -98,6 +98,7 @@
     return nil;
 
   _displayingPlaceholder = YES;
+  _scrollEnabled = YES;
 
   // Create the scaffolding for the text view.
   _textKitComponents = [ASTextKitComponents componentsWithAttributedSeedString:nil textContainerSize:CGSizeZero];

--- a/AsyncDisplayKit/ASEditableTextNode.mm
+++ b/AsyncDisplayKit/ASEditableTextNode.mm
@@ -161,7 +161,7 @@
 
   // Create and configure our text view.
   _textKitComponents.textView = self.textView;
-  //_textKitComponents.textView = NO; // Unfortunately there's a bug here with iOS 7 DP5 that causes the text-view to only be one line high when scrollEnabled is NO. rdar://14729288
+  _textKitComponents.textView.scrollEnabled = _scrollEnabled;
   _textKitComponents.textView.delegate = self;
   #if TARGET_OS_IOS
   _textKitComponents.textView.editable = YES;

--- a/AsyncDisplayKit/Details/ASDataController+Subclasses.h
+++ b/AsyncDisplayKit/Details/ASDataController+Subclasses.h
@@ -38,7 +38,7 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCellNode *> *nodes, NS
  */
 - (void)batchLayoutNodesFromContexts:(NSArray<ASIndexedNodeContext *> *)contexts ofKind:(NSString *)kind completion:(ASDataControllerCompletionBlock)completionBlock;
 
-/*
+/**
  * Perform measurement and layout of loaded nodes on the main thread, skipping unloaded nodes.
  *
  * @discussion Once nodes have loaded their views, we can't layout in the background so this is a chance

--- a/AsyncDisplayKit/TextKit/ASTextKitRenderer.h
+++ b/AsyncDisplayKit/TextKit/ASTextKitRenderer.h
@@ -58,7 +58,7 @@
 @property (nonatomic, assign, readonly) CGFloat currentScaleFactor;
 
 #pragma mark - Drawing
-/*
+/**
  Draw the renderer's text content into the bounds provided.
 
  @param bounds The rect in which to draw the contents of the renderer.
@@ -67,20 +67,20 @@
 
 #pragma mark - Layout
 
-/*
+/**
  Returns the computed size of the renderer given the constrained size and other parameters in the initializer.
  */
 - (CGSize)size;
 
 #pragma mark - Text Ranges
 
-/*
+/**
  The character range from the original attributedString that is displayed by the renderer given the parameters in the
  initializer.
  */
 - (std::vector<NSRange>)visibleRanges;
 
-/*
+/**
  The number of lines shown in the string.
  */
 - (NSUInteger)lineCount;


### PR DESCRIPTION
Prior to this change: `ASPanningOverriddenUITextView`'s `_shouldBlockPanGesture` would not reflect `scrollEnabled`'s value unless you assigned it after `didLoad` was invoked.