### PR TITLE
[ASEditableTextNode] Allow TextKit component customization

### DIFF
--- a/AsyncDisplayKit/ASEditableTextNode.h
+++ b/AsyncDisplayKit/ASEditableTextNode.h
@@ -7,6 +7,7 @@
  */
 
 #import <AsyncDisplayKit/ASDisplayNode.h>
+#import <AsyncDisplayKit/ASTextKitHelpers.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -17,6 +18,17 @@ NS_ASSUME_NONNULL_BEGIN
  @discussion Does not support layer backing.
  */
 @interface ASEditableTextNode : ASDisplayNode
+
+/**
+ * @abstract Initializes a editable text node with a provided TextKit stack.
+ *
+ * @param textKitComponents The TextKit stack used to render text.
+ * @param placeholderTextKitComponents The TextKit stack used to render placeholder text.
+ *
+ * @returns An initialized ASEditableTextNode.
+ */
+- (instancetype)initWithTextKitComponents:(ASTextKitComponents *)textKitComponents
+             placeholderTextKitComponents:(ASTextKitComponents *)placeholderTextKitComponents;
 
 //! @abstract The text node's delegate, which must conform to the <ASEditableTextNodeDelegate> protocol.
 @property (nonatomic, readwrite, weak) id <ASEditableTextNodeDelegate> delegate;

--- a/AsyncDisplayKit/ASEditableTextNode.mm
+++ b/AsyncDisplayKit/ASEditableTextNode.mm
@@ -12,7 +12,6 @@
 
 #import "ASDisplayNode+Subclasses.h"
 #import "ASEqualityHelpers.h"
-#import "ASTextKitHelpers.h"
 #import "ASTextNodeWordKerner.h"
 #import "ASThread.h"
 
@@ -94,6 +93,13 @@
 #pragma mark - NSObject Overrides
 - (instancetype)init
 {
+  return [self initWithTextKitComponents:[ASTextKitComponents componentsWithAttributedSeedString:nil textContainerSize:CGSizeZero]
+            placeholderTextKitComponents:[ASTextKitComponents componentsWithAttributedSeedString:nil textContainerSize:CGSizeZero]];
+}
+
+- (instancetype)initWithTextKitComponents:(ASTextKitComponents *)textKitComponents
+             placeholderTextKitComponents:(ASTextKitComponents *)placeholderTextKitComponents
+{
   if (!(self = [super init]))
     return nil;
 
@@ -101,14 +107,14 @@
   _scrollEnabled = YES;
 
   // Create the scaffolding for the text view.
-  _textKitComponents = [ASTextKitComponents componentsWithAttributedSeedString:nil textContainerSize:CGSizeZero];
+  _textKitComponents = textKitComponents;
   _textKitComponents.layoutManager.delegate = self;
   _wordKerner = [[ASTextNodeWordKerner alloc] init];
   _returnKeyType = UIReturnKeyDefault;
   _textContainerInset = UIEdgeInsetsZero;
   
   // Create the placeholder scaffolding.
-  _placeholderTextKitComponents = [ASTextKitComponents componentsWithAttributedSeedString:nil textContainerSize:CGSizeZero];
+  _placeholderTextKitComponents = placeholderTextKitComponents;
   _placeholderTextKitComponents.layoutManager.delegate = self;
 
   return self;

--- a/AsyncDisplayKit/ASTextNode+Beta.h
+++ b/AsyncDisplayKit/ASTextNode+Beta.h
@@ -6,6 +6,7 @@
 //  Copyright © 2016 Facebook. All rights reserved.
 //
 
+NS_ASSUME_NONNULL_BEGIN
 
 @interface ASTextNode ()
 
@@ -13,18 +14,19 @@
  @abstract An array of descending scale factors that will be applied to this text node to try to make it fit within its constrained size
  @default nil (no scaling)
  */
-@property (nonatomic, copy) NSArray *pointSizeScaleFactors;
+@property (nullable, nonatomic, copy) NSArray *pointSizeScaleFactors;
 
 #pragma mark - ASTextKit Customization
 /**
  A block to provide a hook to provide a custom NSLayoutManager to the ASTextKitRenderer
  */
-@property (nonatomic, copy) NSLayoutManager * (^layoutManagerCreationBlock)(void);
+@property (nullable, nonatomic, copy) NSLayoutManager * (^layoutManagerCreationBlock)(void);
 
 /**
- A block to provide a hook to provide a NSTextStorage to the Text Kit's layout manager.
+ A block to provide a hook to provide a NSTextStorage to the TextKit's layout manager.
  */
-@property (nonatomic, copy) NSTextStorage * (^textStorageCreationBlock)(NSAttributedString *attributedString);
-
+@property (nullable, nonatomic, copy) NSTextStorage * (^textStorageCreationBlock)(NSAttributedString *_Nullable attributedString);
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/AsyncDisplayKit/AsyncDisplayKit.h
+++ b/AsyncDisplayKit/AsyncDisplayKit.h
@@ -15,7 +15,6 @@
 #import <AsyncDisplayKit/ASButtonNode.h>
 #import <AsyncDisplayKit/ASMapNode.h>
 #import <AsyncDisplayKit/ASVideoNode.h>
-
 #import <AsyncDisplayKit/ASEditableTextNode.h>
 
 #import <AsyncDisplayKit/ASBasicImageDownloader.h>
@@ -77,5 +76,6 @@
 #import <AsyncDisplayKit/UICollectionViewLayout+ASConvenience.h>
 #import <AsyncDisplayKit/UIView+ASConvenience.h>
 #import <AsyncDisplayKit/ASRunLoopQueue.h>
+#import <AsyncDisplayKit/ASTextKitHelpers.h>
 
 #import <AsyncDisplayKit/AsyncDisplayKit+Debug.h>

--- a/AsyncDisplayKit/TextKit/ASTextKitHelpers.h
+++ b/AsyncDisplayKit/TextKit/ASTextKitHelpers.h
@@ -37,8 +37,20 @@ ASDISPLAYNODE_INLINE CGSize ceilSizeValue(CGSize s)
  @return An `ASTextKitComponents` containing the created components. The text view component will be nil.
  @discussion The returned components will be hooked up together, so they are ready for use as a system upon return.
  */
-+ (ASTextKitComponents *)componentsWithAttributedSeedString:(nullable NSAttributedString *)attributedSeedString
-                                          textContainerSize:(CGSize)textContainerSize;
++ (instancetype)componentsWithAttributedSeedString:(nullable NSAttributedString *)attributedSeedString
+                                 textContainerSize:(CGSize)textContainerSize;
+
+/**
+ @abstract Creates the stack of TextKit components.
+ @param textStorage The NSTextStorage to use.
+ @param textContainerSize The size of the text-container. Typically, size specifies the constraining width of the layout, and FLT_MAX for height. Pass CGSizeZero if these components will be hooked up to a UITextView, which will manage the text container's size itself.
+ @param layoutManager The NSLayoutManager to use.
+ @return An `ASTextKitComponents` containing the created components. The text view component will be nil.
+ @discussion The returned components will be hooked up together, so they are ready for use as a system upon return.
+ */
++ (instancetype)componentsWithTextStorage:(NSTextStorage *)textStorage
+                        textContainerSize:(CGSize)textContainerSize
+                            layoutManager:(NSLayoutManager *)layoutManager;
 
 /**
  @abstract Returns the bounding size for the text view's text.

--- a/AsyncDisplayKit/TextKit/ASTextKitHelpers.h
+++ b/AsyncDisplayKit/TextKit/ASTextKitHelpers.h
@@ -6,9 +6,6 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <objc/message.h>
-
-#import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 #import "ASBaseDefines.h"
 

--- a/AsyncDisplayKit/TextKit/ASTextKitHelpers.mm
+++ b/AsyncDisplayKit/TextKit/ASTextKitHelpers.mm
@@ -19,15 +19,25 @@
 
 @implementation ASTextKitComponents
 
-+ (ASTextKitComponents *)componentsWithAttributedSeedString:(NSAttributedString *)attributedSeedString
-                                          textContainerSize:(CGSize)textContainerSize
++ (instancetype)componentsWithAttributedSeedString:(NSAttributedString *)attributedSeedString
+                                 textContainerSize:(CGSize)textContainerSize
 {
-  ASTextKitComponents *components = [[ASTextKitComponents alloc] init];
+  NSTextStorage *textStorage = attributedSeedString ? [[NSTextStorage alloc] initWithAttributedString:attributedSeedString] : [[NSTextStorage alloc] init];
 
-  // Create the TextKit component stack with our default configuration.
-  components.textStorage = (attributedSeedString ? [[NSTextStorage alloc] initWithAttributedString:attributedSeedString] : [[NSTextStorage alloc] init]);
+  return [self componentsWithTextStorage:textStorage
+                       textContainerSize:textContainerSize
+                           layoutManager:[[NSLayoutManager alloc] init]];
+}
 
-  components.layoutManager = [[NSLayoutManager alloc] init];
++ (instancetype)componentsWithTextStorage:(NSTextStorage *)textStorage
+                        textContainerSize:(CGSize)textContainerSize
+                            layoutManager:(NSLayoutManager *)layoutManager
+{
+  ASTextKitComponents *components = [[self alloc] init];
+
+  components.textStorage = textStorage;
+
+  components.layoutManager = layoutManager;
   [components.textStorage addLayoutManager:components.layoutManager];
 
   components.textContainer = [[NSTextContainer alloc] initWithSize:textContainerSize];


### PR DESCRIPTION
This change opens up the option of using NSLayoutManager & NSTextStorage subclass within ASEditableTextNodes.