### PR TITLE
[ASEditableTextNode] Synchronize scrollsToTop with scrollEnabled

### DIFF
--- a/AsyncDisplayKit/ASEditableTextNode.mm
+++ b/AsyncDisplayKit/ASEditableTextNode.mm
@@ -45,6 +45,8 @@
 - (void)setScrollEnabled:(BOOL)scrollEnabled
 {
   _shouldBlockPanGesture = !scrollEnabled;
+  self.scrollsToTop = scrollEnabled;
+
   [super setScrollEnabled:YES];
 }
 


### PR DESCRIPTION
A normal `UITextView` with `scrollEnabled == false` does not capture the scroll-to-top gesture. Which makes sense. If there's nothing to scroll, a command to scrolling to the top would do nothing. This behavior  allows other scroll views a chance to capture the gesture. 

`ASEditableTextNode` does not follow this behavior. This is due to `ASPanningOverriddenUITextView`'s `scrollEnabled` setter preventing changes to the base value.

This change synchronizes `ASPanningOverriddenUITextView`'s `scrollsToTop` value with `scrollEnabled` in its overridden setter. Restoring the base `UITextView` behavior.

Code like this:
```obj-c
editableTextNode.scrollEnabled = NO
editableTextNode.textView.scrollsToTop = NO
```

Is now simply:

```obj-c
editableTextNode.scrollEnabled = NO
```