### PR TITLE
[ASMapNode] Never Provide Invalid Snapshot Dimensions to MapKit

### DIFF
--- a/AsyncDisplayKit/ASMapNode.mm
+++ b/AsyncDisplayKit/ASMapNode.mm
@@ -279,7 +279,7 @@
 #pragma mark - Layout
 - (void)setSnapshotSizeWithReloadIfNeeded:(CGSize)snapshotSize
 {
-  if (!CGSizeEqualToSize(self.options.size, snapshotSize)) {
+  if (snapshotSize.height > 0 && snapshotSize.width > 0 && !CGSizeEqualToSize(self.options.size, snapshotSize)) {
     _options.size = snapshotSize;
     if (_snapshotter) {
       [self destroySnapshotter];


### PR DESCRIPTION
Sometimes during the first layout passes for complex hierarchies, my map node will get measured with 0-height or 0-width, and MapKit will throw an exception if you set MKMapSnapshotOptions.size with 0 area. This avoids that exception.