### PR TITLE
[ASDisplayNode] Automatically integrate with Accessibility even for layer-backed or rasterized subtrees.

### DIFF
--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -264,6 +264,10 @@
 		698548661CA9E025008A345F /* ASEnvironment.m in Sources */ = {isa = PBXBuildFile; fileRef = 698548621CA9E025008A345F /* ASEnvironment.m */; };
 		698C8B611CAB49FC0052DC3F /* ASLayoutableExtensibility.h in Headers */ = {isa = PBXBuildFile; fileRef = 698C8B601CAB49FC0052DC3F /* ASLayoutableExtensibility.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		698C8B621CAB49FC0052DC3F /* ASLayoutableExtensibility.h in Headers */ = {isa = PBXBuildFile; fileRef = 698C8B601CAB49FC0052DC3F /* ASLayoutableExtensibility.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		69CB62AB1CB8165900024920 /* _ASDisplayViewAccessiblity.h in Headers */ = {isa = PBXBuildFile; fileRef = 69CB62A91CB8165900024920 /* _ASDisplayViewAccessiblity.h */; };
+		69CB62AC1CB8165900024920 /* _ASDisplayViewAccessiblity.h in Headers */ = {isa = PBXBuildFile; fileRef = 69CB62A91CB8165900024920 /* _ASDisplayViewAccessiblity.h */; };
+		69CB62AD1CB8165900024920 /* _ASDisplayViewAccessiblity.mm in Sources */ = {isa = PBXBuildFile; fileRef = 69CB62AA1CB8165900024920 /* _ASDisplayViewAccessiblity.mm */; };
+		69CB62AE1CB8165900024920 /* _ASDisplayViewAccessiblity.mm in Sources */ = {isa = PBXBuildFile; fileRef = 69CB62AA1CB8165900024920 /* _ASDisplayViewAccessiblity.mm */; };
 		69E1006D1CA89CB600D88C1B /* ASEnvironmentInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 69E100691CA89CB600D88C1B /* ASEnvironmentInternal.h */; };
 		69E1006E1CA89CB600D88C1B /* ASEnvironmentInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 69E100691CA89CB600D88C1B /* ASEnvironmentInternal.h */; };
 		69E1006F1CA89CB600D88C1B /* ASEnvironmentInternal.mm in Sources */ = {isa = PBXBuildFile; fileRef = 69E1006A1CA89CB600D88C1B /* ASEnvironmentInternal.mm */; };
@@ -745,6 +749,8 @@
 		698548611CA9E025008A345F /* ASEnvironment.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASEnvironment.h; sourceTree = "<group>"; };
 		698548621CA9E025008A345F /* ASEnvironment.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASEnvironment.m; sourceTree = "<group>"; };
 		698C8B601CAB49FC0052DC3F /* ASLayoutableExtensibility.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASLayoutableExtensibility.h; path = AsyncDisplayKit/Layout/ASLayoutableExtensibility.h; sourceTree = "<group>"; };
+		69CB62A91CB8165900024920 /* _ASDisplayViewAccessiblity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _ASDisplayViewAccessiblity.h; sourceTree = "<group>"; };
+		69CB62AA1CB8165900024920 /* _ASDisplayViewAccessiblity.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _ASDisplayViewAccessiblity.mm; sourceTree = "<group>"; };
 		69E100691CA89CB600D88C1B /* ASEnvironmentInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASEnvironmentInternal.h; sourceTree = "<group>"; };
 		69E1006A1CA89CB600D88C1B /* ASEnvironmentInternal.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASEnvironmentInternal.mm; sourceTree = "<group>"; };
 		69F10C851C84C35D0026140C /* ASRangeControllerUpdateRangeProtocol+Beta.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ASRangeControllerUpdateRangeProtocol+Beta.h"; sourceTree = "<group>"; };
@@ -1123,6 +1129,8 @@
 				058D09E3195D050800B7D73C /* _ASDisplayLayer.mm */,
 				058D09E4195D050800B7D73C /* _ASDisplayView.h */,
 				058D09E5195D050800B7D73C /* _ASDisplayView.mm */,
+				69CB62A91CB8165900024920 /* _ASDisplayViewAccessiblity.h */,
+				69CB62AA1CB8165900024920 /* _ASDisplayViewAccessiblity.mm */,
 				205F0E171B37339C007741D0 /* ASAbstractLayoutController.h */,
 				205F0E181B37339C007741D0 /* ASAbstractLayoutController.mm */,
 				054963471A1EA066000F8E56 /* ASBasicImageDownloader.h */,
@@ -1510,6 +1518,7 @@
 				0574D5E219C110940097DC25 /* ASTableViewProtocols.h in Headers */,
 				81EE384F1C8E94F000456208 /* ASRunLoopQueue.h in Headers */,
 				CC3B20831C3F76D600798563 /* ASPendingStateController.h in Headers */,
+				69CB62AB1CB8165900024920 /* _ASDisplayViewAccessiblity.h in Headers */,
 				058D0A51195D05CB00B7D73C /* ASTextNode.h in Headers */,
 				058D0A81195D05F900B7D73C /* ASThread.h in Headers */,
 				ACC945A91BA9E7A0005E1FB8 /* ASViewController.h in Headers */,
@@ -1553,6 +1562,7 @@
 				DE84918D1C8FFF2B003D89E9 /* ASRunLoopQueue.h in Headers */,
 				254C6B731BF94DF4003EC431 /* ASTextKitCoreTextAdditions.h in Headers */,
 				254C6B7A1BF94DF4003EC431 /* ASTextKitRenderer.h in Headers */,
+				69CB62AC1CB8165900024920 /* _ASDisplayViewAccessiblity.h in Headers */,
 				254C6B7C1BF94DF4003EC431 /* ASTextKitRenderer+TextChecking.h in Headers */,
 				34EFC7611B701C9C00AD841F /* ASBackgroundLayoutSpec.h in Headers */,
 				B35062591B010F070018CF92 /* ASBaseDefines.h in Headers */,
@@ -1940,6 +1950,7 @@
 				7A06A73A1C35F08800FE8DAA /* ASRelativeLayoutSpec.mm in Sources */,
 				257754921BED28F300737CA5 /* ASEqualityHashHelpers.mm in Sources */,
 				E52405B31C8FEF03004DC8E7 /* ASDisplayNodeLayoutContext.mm in Sources */,
+				69CB62AD1CB8165900024920 /* _ASDisplayViewAccessiblity.mm in Sources */,
 				257754AB1BEE44CD00737CA5 /* ASTextKitEntityAttribute.m in Sources */,
 				055F1A3919ABD413004DAFF1 /* ASRangeController.mm in Sources */,
 				044285091BAA63FE00D16268 /* ASBatchFetching.m in Sources */,
@@ -2051,6 +2062,7 @@
 				34EFC7641B701CC600AD841F /* ASCenterLayoutSpec.mm in Sources */,
 				18C2ED831B9B7DE800F627B3 /* ASCollectionNode.mm in Sources */,
 				E55D86331CA8A14000A0C26F /* ASLayoutable.mm in Sources */,
+				69CB62AE1CB8165900024920 /* _ASDisplayViewAccessiblity.mm in Sources */,
 				B35061F61B010EFD0018CF92 /* ASCollectionView.mm in Sources */,
 				509E68641B3AEDB7009B9150 /* ASCollectionViewLayoutController.mm in Sources */,
 				B35061F91B010EFD0018CF92 /* ASControlNode.mm in Sources */,

--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -711,7 +711,7 @@ NS_ASSUME_NONNULL_END
 @property (atomic, assign)           BOOL accessibilityViewIsModal;
 @property (atomic, assign)           BOOL shouldGroupAccessibilityChildren;
 
-@property (nonatomic) UIAccessibilityNavigationStyle accessibilityNavigationStyle NS_AVAILABLE_IOS(8_0);
+@property (nonatomic) UIAccessibilityNavigationStyle accessibilityNavigationStyle;
 #if TARGET_OS_TV
 @property(nullable, nonatomic, copy) NSArray *accessibilityHeaderElements;
 #endif

--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -700,26 +700,25 @@ NS_ASSUME_NONNULL_END
 @interface ASDisplayNode (UIViewBridgeAccessibility)
 
 // Accessibility support
-@property (atomic, assign)           BOOL isAccessibilityElement;
-@property (nullable, atomic, copy)   NSString *accessibilityLabel;
-@property (nullable, atomic, copy)   NSString *accessibilityHint;
-@property (nullable, atomic, copy)   NSString *accessibilityValue;
-@property (atomic, assign)           UIAccessibilityTraits accessibilityTraits;
-@property (atomic, assign)           CGRect accessibilityFrame;
-@property (nullable, atomic, strong) NSString *accessibilityLanguage;
-@property (atomic, assign)           BOOL accessibilityElementsHidden;
-@property (atomic, assign)           BOOL accessibilityViewIsModal;
-@property (atomic, assign)           BOOL shouldGroupAccessibilityChildren;
-
-@property (nonatomic) UIAccessibilityNavigationStyle accessibilityNavigationStyle;
+@property (nonatomic, assign)           BOOL isAccessibilityElement;
+@property (nonatomic, copy, nullable)   NSString *accessibilityLabel;
+@property (nonatomic, copy, nullable)   NSString *accessibilityHint;
+@property (nonatomic, copy, nullable)   NSString *accessibilityValue;
+@property (nonatomic, assign)           UIAccessibilityTraits accessibilityTraits;
+@property (nonatomic, assign)           CGRect accessibilityFrame;
+@property (nonatomic, copy, nullable)   UIBezierPath *accessibilityPath;
+@property (nonatomic, assign)           CGPoint accessibilityActivationPoint;
+@property (nonatomic, copy, nullable)   NSString *accessibilityLanguage;
+@property (nonatomic, assign)           BOOL accessibilityElementsHidden;
+@property (nonatomic, assign)           BOOL accessibilityViewIsModal;
+@property (nonatomic, assign)           BOOL shouldGroupAccessibilityChildren;
+@property (nonatomic, assign)           UIAccessibilityNavigationStyle accessibilityNavigationStyle;
 #if TARGET_OS_TV
-@property(nullable, nonatomic, copy) NSArray *accessibilityHeaderElements;
+@property(nonatomic, copy, nullable) 	NSArray *accessibilityHeaderElements;
 #endif
-@property (nonatomic) CGPoint accessibilityActivationPoint;
-@property (nullable, nonatomic, copy) UIBezierPath *accessibilityPath;
 
 // Accessibility identification support
-@property (nullable, nonatomic, copy) NSString *accessibilityIdentifier;
+@property (nonatomic, copy, nullable)   NSString *accessibilityIdentifier;
 
 @end
 

--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -695,6 +695,10 @@ NS_ASSUME_NONNULL_END
 - (nullable UIView *)preferredFocusedView;
 #endif
 
+@end
+
+@interface ASDisplayNode (UIViewBridgeAccessibility)
+
 // Accessibility support
 @property (atomic, assign)           BOOL isAccessibilityElement;
 @property (nullable, atomic, copy)   NSString *accessibilityLabel;

--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -711,6 +711,13 @@ NS_ASSUME_NONNULL_END
 @property (atomic, assign)           BOOL accessibilityViewIsModal;
 @property (atomic, assign)           BOOL shouldGroupAccessibilityChildren;
 
+@property (nonatomic) UIAccessibilityNavigationStyle accessibilityNavigationStyle NS_AVAILABLE_IOS(8_0);
+#if TARGET_OS_TV
+@property(nullable, nonatomic, copy) NSArray *accessibilityHeaderElements;
+#endif
+@property (nonatomic) CGPoint accessibilityActivationPoint;
+@property (nullable, nonatomic, copy) UIBezierPath *accessibilityPath;
+
 // Accessibility identification support
 @property (nullable, nonatomic, copy) NSString *accessibilityIdentifier;
 

--- a/AsyncDisplayKit/ASDisplayNodeExtras.h
+++ b/AsyncDisplayKit/ASDisplayNodeExtras.h
@@ -88,6 +88,12 @@ extern ASDisplayNode *ASDisplayNodeUltimateParentOfNode(ASDisplayNode *node);
 extern void ASDisplayNodePerformBlockOnEveryNode(CALayer * _Nullable layer, ASDisplayNode * _Nullable node, void(^block)(ASDisplayNode *node));
 
 /**
+ This function will walk the node hierarchy in a breadth first fashion. It does run the block on the node provided
+ directly to the function call.
+ */
+extern void ASDisplayNodePerformBlockOnEveryNodeBFS(ASDisplayNode *node, void(^block)(ASDisplayNode *node));
+
+/**
  Identical to ASDisplayNodePerformBlockOnEveryNode, except it does not run the block on the
  node provided directly to the function call - only on all descendants.
  */

--- a/AsyncDisplayKit/ASDisplayNodeExtras.mm
+++ b/AsyncDisplayKit/ASDisplayNodeExtras.mm
@@ -10,6 +10,8 @@
 #import "ASDisplayNodeInternal.h"
 #import "ASDisplayNode+FrameworkPrivate.h"
 
+#import <queue>
+
 extern ASInterfaceState ASInterfaceStateForDisplayNode(ASDisplayNode *displayNode, UIWindow *window)
 {
     ASDisplayNodeCAssert(![displayNode isLayerBacked], @"displayNode must not be layer backed as it may have a nil window");
@@ -60,6 +62,24 @@ extern void ASDisplayNodePerformBlockOnEveryNode(CALayer *layer, ASDisplayNode *
     for (ASDisplayNode *subnode in [node subnodes]) {
       ASDisplayNodePerformBlockOnEveryNode(nil, subnode, block);
     }
+  }
+}
+
+extern void ASDisplayNodePerformBlockOnEveryNodeBFS(ASDisplayNode *node, void(^block)(ASDisplayNode *node))
+{
+  // Queue used to keep track of subnodes while traversing this layout in a BFS fashion.
+  std::queue<ASDisplayNode *> queue;
+  queue.push(node);
+  
+  while (!queue.empty()) {
+    node = queue.front();
+    queue.pop();
+    
+    block(node);
+
+    // Add all subnodes to process in next step
+    for (int i = 0; i < node.subnodes.count; i++)
+      queue.push(node.subnodes[i]);
   }
 }
 

--- a/AsyncDisplayKit/Details/_ASDisplayView.mm
+++ b/AsyncDisplayKit/Details/_ASDisplayView.mm
@@ -382,22 +382,6 @@
 
 #pragma mark - Accessibility
 
-static BOOL ASNodeValidForAccessibility(ASDisplayNode *node)
-{
-  if (node.isAccessibilityElement) {
-    return YES;
-  }
-  
-  if (node.isLayerBacked) {
-    // Assume for now that all nodes that have an accessibility label or
-    return node.accessibilityLabel.length > 0 ||
-           node.accessibilityValue.length > 0 ||
-           ((node.accessibilityTraits & UIAccessibilityTraitNone) != UIAccessibilityTraitNone);
-  }
-  
-  return NO;
-}
-
 static const char *ASDisplayNodeAssociatedNodeKey = "ASAssociatedNode";
 
 @implementation UIAccessibilityElement (_ASDisplayView)
@@ -449,7 +433,7 @@ static const char *ASDisplayNodeAssociatedNodeKey = "ASAssociatedNode";
       queue.pop();
       
       // Check if we have to add the node to the accessiblity nodes as it's an accessiblity element
-      if (node != selfNode && ASNodeValidForAccessibility(node)) {
+      if (node != selfNode && node.isAccessibilityElement) {
         UIAccessibilityElement *accessibilityElement = [[UIAccessibilityElement alloc] initWithAccessibilityContainer:self];
         accessibilityElement.asyncdisplaykit_node = node;
         [_accessibleElements addObject:accessibilityElement];
@@ -469,7 +453,7 @@ static const char *ASDisplayNodeAssociatedNodeKey = "ASAssociatedNode";
     if (!subnode.isAccessibilityElement && [subnode accessibilityElementCount] > 0) {
       // We are good and the view is an UIAccessibilityContainer so add that
       [_accessibleElements addObject:subnode.view];
-    } else if (ASNodeValidForAccessibility(subnode)) {
+    } else if (subnode.isAccessibilityElement) {
       // Create a accessiblity element from the subnode
       UIAccessibilityElement *accessibilityElement = [[UIAccessibilityElement alloc] initWithAccessibilityContainer:self];
       accessibilityElement.asyncdisplaykit_node = subnode;

--- a/AsyncDisplayKit/Details/_ASDisplayView.mm
+++ b/AsyncDisplayKit/Details/_ASDisplayView.mm
@@ -8,17 +8,10 @@
 
 #import "_ASDisplayView.h"
 
-#import <objc/runtime.h>
-
 #import "_ASCoreAnimationExtras.h"
-#import "_ASAsyncTransactionContainer.h"
-#import "ASAssert.h"
-#import "ASDisplayNodeExtras.h"
 #import "ASDisplayNodeInternal.h"
 #import "ASDisplayNode+FrameworkPrivate.h"
 #import "ASDisplayNode+Subclasses.h"
-
-#import <queue>
 
 @interface _ASDisplayView ()
 @property (nonatomic, assign, readwrite) ASDisplayNode *asyncdisplaykit_node;
@@ -377,131 +370,4 @@
   return [_node preferredFocusedView];
 }
 #endif
-@end
-
-
-#pragma mark - Accessibility
-
-static const char *ASDisplayNodeAssociatedNodeKey = "ASAssociatedNode";
-
-@implementation UIAccessibilityElement (_ASDisplayView)
-
-- (void)setAsyncdisplaykit_node:(ASDisplayNode *)node
-{
-  objc_setAssociatedObject(self, ASDisplayNodeAssociatedNodeKey, node, OBJC_ASSOCIATION_ASSIGN); // Weak reference to avoid cycle, since the node retains the layer.
-  
-  // Update UIAccessibilityElement properties from node
-  self.accessibilityIdentifier = node.accessibilityIdentifier;
-  self.accessibilityLabel = node.accessibilityLabel;
-  self.accessibilityHint = node.accessibilityHint;
-  self.accessibilityValue = node.accessibilityValue;
-  self.accessibilityTraits = node.accessibilityTraits;
-}
-
-- (ASDisplayNode *)asyncdisplaykit_node
-{
-  return objc_getAssociatedObject(self, ASDisplayNodeAssociatedNodeKey);
-}
-
-@end
-
-@implementation _ASDisplayView (UIAccessibilityContainer)
-
-#pragma mark - UIAccessibility
-
-- (NSArray *)accessibleElements
-{
-  _accessibleElements = [[NSMutableArray alloc] init];
- 
-  ASDisplayNode *selfNode = self.asyncdisplaykit_node;
-  
-  // Handle rasterize case
-  if (selfNode.shouldRasterizeDescendants) {
-    // In this case we have to go through the whole subnodes tree in BFS fashion and create all
-    // accessibility elements ourselves as the view hierarchy is flattened
-    
-    // Queue used to keep track of subnodes while traversing this layout in a BFS fashion.
-    std::queue<ASDisplayNode *> queue;
-    queue.push(selfNode);
-    
-    while (!queue.empty()) {
-      ASDisplayNode *node = queue.front();
-      queue.pop();
-      
-      // Check if we have to add the node to the accessiblity nodes as it's an accessiblity element
-      if (node != selfNode && node.isAccessibilityElement) {
-        UIAccessibilityElement *accessibilityElement = [[UIAccessibilityElement alloc] initWithAccessibilityContainer:self];
-        accessibilityElement.asyncdisplaykit_node = node;
-        [_accessibleElements addObject:accessibilityElement];
-      }
-
-      // Add all subnodes to process in next step
-      for (int i = 0; i < node.subnodes.count; i++)
-        queue.push(node.subnodes[i]);
-    }
-    return _accessibleElements;
-  }
-  
-  // Handle not rasterize case
-  // Create UI accessiblity elements for each subnode that represent an elment within the accessibility container
-  for (ASDisplayNode *subnode in selfNode.subnodes) {
-      // Check if this subnode is a UIAccessibilityContainer
-    if (!subnode.isAccessibilityElement && [subnode accessibilityElementCount] > 0) {
-      // We are good and the view is an UIAccessibilityContainer so add it
-      [_accessibleElements addObject:subnode.view];
-    } else if (subnode.isAccessibilityElement) {
-      // Create a accessiblity element from the subnode
-      UIAccessibilityElement *accessibilityElement = [[UIAccessibilityElement alloc] initWithAccessibilityContainer:self];
-      accessibilityElement.asyncdisplaykit_node = subnode;
-      [_accessibleElements addObject:accessibilityElement];
-    }
-  }
-  
-  return _accessibleElements;
-}
-
-- (NSInteger)accessibilityElementCount
-{
-  return [self accessibleElements].count;
-}
-
-- (id)accessibilityElementAtIndex:(NSInteger)index
-{
-  if (_accessibleElements == nil) {
-    return nil;
-  }
-  
-  UIAccessibilityElement *accessibilityElement = [_accessibleElements objectAtIndex:index];
-  ASDisplayNode *accessibilityElementNode = accessibilityElement.asyncdisplaykit_node;
-  if (accessibilityElementNode == nil) {
-    return nil;
-  }
-  
-  // We have to update the accessiblity frame in accessibilityElementAtIndex: as the accessibility frame is in screen
-  // coordinates and between creating the accessibilityElement and returning it in accessibilityElementAtIndex:
-  // the frame can change
-  
-  // Handle if node is rasterized
-  ASDisplayNode *selfNode = self.asyncdisplaykit_node;
-  if (selfNode.shouldRasterizeDescendants) {
-    // We need to convert the accessibilityElementNode frame into the coordinate system of the selfNode
-    CGRect frame = [selfNode convertRect:accessibilityElementNode.bounds fromNode:accessibilityElementNode];
-    accessibilityElement.accessibilityFrame = UIAccessibilityConvertFrameToScreenCoordinates(frame, self);
-    return accessibilityElement;
-  }
-
-  // Handle non rasterized case
-  accessibilityElement.accessibilityFrame = UIAccessibilityConvertFrameToScreenCoordinates(accessibilityElementNode.frame, self);
-  return accessibilityElement;
-}
-
-- (NSInteger)indexOfAccessibilityElement:(id)element
-{
-  if (_accessibleElements == nil) {
-    return NSNotFound;
-  }
-  
-  return [_accessibleElements indexOfObject:element];
-}
-
 @end

--- a/AsyncDisplayKit/Details/_ASDisplayView.mm
+++ b/AsyncDisplayKit/Details/_ASDisplayView.mm
@@ -395,7 +395,7 @@ static BOOL ASNodeValidForAccessibility(ASDisplayNode *node)
            ((node.accessibilityTraits & UIAccessibilityTraitNone) != UIAccessibilityTraitNone);
   }
   
-  return YES;
+  return NO;
 }
 
 static const char *ASDisplayNodeAssociatedNodeKey = "ASAssociatedNode";

--- a/AsyncDisplayKit/Details/_ASDisplayView.mm
+++ b/AsyncDisplayKit/Details/_ASDisplayView.mm
@@ -407,6 +407,7 @@ static const char *ASDisplayNodeAssociatedNodeKey = "ASAssociatedNode";
   objc_setAssociatedObject(self, ASDisplayNodeAssociatedNodeKey, node, OBJC_ASSOCIATION_ASSIGN); // Weak reference to avoid cycle, since the node retains the layer.
   
   // Update UIAccessibilityElement properties from node
+  self.accessibilityIdentifier = node.accessibilityIdentifier;
   self.accessibilityLabel = node.accessibilityLabel;
   self.accessibilityHint = node.accessibilityHint;
   self.accessibilityValue = node.accessibilityValue;

--- a/AsyncDisplayKit/Details/_ASDisplayView.mm
+++ b/AsyncDisplayKit/Details/_ASDisplayView.mm
@@ -411,10 +411,6 @@ static const char *ASDisplayNodeAssociatedNodeKey = "ASAssociatedNode";
 
 - (NSArray *)accessibleElements
 {
-  if ( _accessibleElements != nil ) {
-    return _accessibleElements;
-  }
-  
   _accessibleElements = [[NSMutableArray alloc] init];
  
   ASDisplayNode *selfNode = self.asyncdisplaykit_node;
@@ -451,7 +447,7 @@ static const char *ASDisplayNodeAssociatedNodeKey = "ASAssociatedNode";
   for (ASDisplayNode *subnode in selfNode.subnodes) {
       // Check if this subnode is a UIAccessibilityContainer
     if (!subnode.isAccessibilityElement && [subnode accessibilityElementCount] > 0) {
-      // We are good and the view is an UIAccessibilityContainer so add that
+      // We are good and the view is an UIAccessibilityContainer so add it
       [_accessibleElements addObject:subnode.view];
     } else if (subnode.isAccessibilityElement) {
       // Create a accessiblity element from the subnode
@@ -471,7 +467,11 @@ static const char *ASDisplayNodeAssociatedNodeKey = "ASAssociatedNode";
 
 - (id)accessibilityElementAtIndex:(NSInteger)index
 {
-  UIAccessibilityElement *accessibilityElement = [[self accessibleElements] objectAtIndex:index];
+  if (_accessibleElements == nil) {
+    return nil;
+  }
+  
+  UIAccessibilityElement *accessibilityElement = [_accessibleElements objectAtIndex:index];
   ASDisplayNode *accessibilityElementNode = accessibilityElement.asyncdisplaykit_node;
   if (accessibilityElementNode == nil) {
     return nil;
@@ -497,7 +497,11 @@ static const char *ASDisplayNodeAssociatedNodeKey = "ASAssociatedNode";
 
 - (NSInteger)indexOfAccessibilityElement:(id)element
 {
-  return [self.accessibleElements indexOfObject:element];
+  if (_accessibleElements == nil) {
+    return NSNotFound;
+  }
+  
+  return [_accessibleElements indexOfObject:element];
 }
 
 @end

--- a/AsyncDisplayKit/Details/_ASDisplayViewAccessiblity.h
+++ b/AsyncDisplayKit/Details/_ASDisplayViewAccessiblity.h
@@ -1,0 +1,9 @@
+/* Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Foundation/Foundation.h>

--- a/AsyncDisplayKit/Details/_ASDisplayViewAccessiblity.mm
+++ b/AsyncDisplayKit/Details/_ASDisplayViewAccessiblity.mm
@@ -1,0 +1,153 @@
+/* Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "_ASDisplayViewAccessiblity.h"
+#import "_ASDisplayView.h"
+#import "ASDisplayNode+FrameworkPrivate.h"
+
+#import <objc/runtime.h>
+#import <queue>
+
+
+#pragma mark - UIAccessibilityElement
+
+static const char *ASDisplayNodeAssociatedNodeKey = "ASAssociatedNode";
+
+@implementation UIAccessibilityElement (_ASDisplayView)
+
+- (void)setAsyncdisplaykit_node:(ASDisplayNode *)node
+{
+  objc_setAssociatedObject(self, ASDisplayNodeAssociatedNodeKey, node, OBJC_ASSOCIATION_ASSIGN); // Weak reference to avoid cycle, since the node retains the layer.
+  
+  // Update UIAccessibilityElement properties from node
+  self.accessibilityIdentifier = node.accessibilityIdentifier;
+  self.accessibilityLabel = node.accessibilityLabel;
+  self.accessibilityHint = node.accessibilityHint;
+  self.accessibilityValue = node.accessibilityValue;
+  self.accessibilityTraits = node.accessibilityTraits;
+}
+
+- (ASDisplayNode *)asyncdisplaykit_node
+{
+  return objc_getAssociatedObject(self, ASDisplayNodeAssociatedNodeKey);
+}
+
+@end
+
+
+#pragma mark - _ASDisplayView
+
+@interface _ASDisplayView () {
+  NSMutableArray *_accessibleElements;
+}
+
+@end
+
+@implementation _ASDisplayView (UIAccessibilityContainer)
+
+#pragma mark - UIAccessibility
+
+- (NSArray *)accessibleElements
+{
+  ASDisplayNode *selfNode = self.asyncdisplaykit_node;
+  if (selfNode == nil) {
+    return nil;
+  }
+  
+  _accessibleElements = [[NSMutableArray alloc] init];
+  
+  // Handle rasterize case
+  if (selfNode.shouldRasterizeDescendants) {
+    // In this case we have to go through the whole subnodes tree in BFS fashion and create all
+    // accessibility elements ourselves as the view hierarchy is flattened
+    
+    // Queue used to keep track of subnodes while traversing this layout in a BFS fashion.
+    std::queue<ASDisplayNode *> queue;
+    queue.push(selfNode);
+    
+    while (!queue.empty()) {
+      ASDisplayNode *node = queue.front();
+      queue.pop();
+      
+      // Check if we have to add the node to the accessiblity nodes as it's an accessiblity element
+      if (node != selfNode && node.isAccessibilityElement) {
+        UIAccessibilityElement *accessibilityElement = [[UIAccessibilityElement alloc] initWithAccessibilityContainer:self];
+        accessibilityElement.asyncdisplaykit_node = node;
+        [_accessibleElements addObject:accessibilityElement];
+      }
+
+      // Add all subnodes to process in next step
+      for (int i = 0; i < node.subnodes.count; i++)
+        queue.push(node.subnodes[i]);
+    }
+    return _accessibleElements;
+  }
+  
+  // Handle not rasterize case
+  // Create UI accessiblity elements for each subnode that represent an elment within the accessibility container
+  for (ASDisplayNode *subnode in selfNode.subnodes) {
+      // Check if this subnode is a UIAccessibilityContainer
+    if (!subnode.isAccessibilityElement && [subnode accessibilityElementCount] > 0) {
+      // We are good and the view is an UIAccessibilityContainer so add it
+      [_accessibleElements addObject:subnode.view];
+    } else if (subnode.isAccessibilityElement) {
+      // Create a accessiblity element from the subnode
+      UIAccessibilityElement *accessibilityElement = [[UIAccessibilityElement alloc] initWithAccessibilityContainer:self];
+      accessibilityElement.asyncdisplaykit_node = subnode;
+      [_accessibleElements addObject:accessibilityElement];
+    }
+  }
+  
+  return _accessibleElements;
+}
+
+- (NSInteger)accessibilityElementCount
+{
+  return [self accessibleElements].count;
+}
+
+- (id)accessibilityElementAtIndex:(NSInteger)index
+{
+  if (_accessibleElements == nil) {
+    return nil;
+  }
+  
+  UIAccessibilityElement *accessibilityElement = [_accessibleElements objectAtIndex:index];
+  ASDisplayNode *accessibilityElementNode = accessibilityElement.asyncdisplaykit_node;
+  if (accessibilityElementNode == nil) {
+    return nil;
+  }
+  
+  // We have to update the accessiblity frame in accessibilityElementAtIndex: as the accessibility frame is in screen
+  // coordinates and between creating the accessibilityElement and returning it in accessibilityElementAtIndex:
+  // the frame can change
+  
+  // Handle if node is rasterized
+  ASDisplayNode *selfNode = self.asyncdisplaykit_node;
+  if (selfNode.shouldRasterizeDescendants) {
+    // We need to convert the accessibilityElementNode frame into the coordinate system of the selfNode
+    CGRect frame = [selfNode convertRect:accessibilityElementNode.bounds fromNode:accessibilityElementNode];
+    accessibilityElement.accessibilityFrame = UIAccessibilityConvertFrameToScreenCoordinates(frame, self);
+    return accessibilityElement;
+  }
+
+  // Handle non rasterized case
+  accessibilityElement.accessibilityFrame = UIAccessibilityConvertFrameToScreenCoordinates(accessibilityElementNode.frame, self);
+  return accessibilityElement;
+}
+
+- (NSInteger)indexOfAccessibilityElement:(id)element
+{
+  if (_accessibleElements == nil) {
+    return NSNotFound;
+  }
+  
+  return [_accessibleElements indexOfObject:element];
+}
+
+@end

--- a/AsyncDisplayKit/Private/ASDisplayNode+UIViewBridge.mm
+++ b/AsyncDisplayKit/Private/ASDisplayNode+UIViewBridge.mm
@@ -709,146 +709,172 @@ if (shouldApply) { _layer.layerProperty = (layerValueExpr); } else { ASDisplayNo
   _setToLayer(edgeAntialiasingMask, edgeAntialiasingMask);
 }
 
+@end
+
+
+#pragma mark - UIViewBridgeAccessibility
+
+// ASDK supports accessibility for view or layer backed nodes. To be able to provide support for layer backed
+// nodes, properties for all of the UIAccessibility protocol defined properties need to be provided an held in sync
+// between node and view
+
+// Helper function with following logic:
+// - If the node is not loaded yet use the property from the pending state
+// - In case the node is loaded
+//  - Check if the node has a view and get the
+//  - If view is not available, e.g. the node is layer backed return the property value
+#define _getAccessibilityFromViewOrProperty(nodeProperty, viewAndPendingViewStateProperty) __loaded(self) ? \
+(_view ? _view.viewAndPendingViewStateProperty : nodeProperty )\
+: ASDisplayNodeGetPendingState(self).viewAndPendingViewStateProperty
+
+// Helper function to set property values on pending state or view and property if loaded
+#define _setAccessibilityToViewAndProperty(nodeProperty, nodeValueExpr, viewAndPendingViewStateProperty, viewAndPendingViewStateExpr) \
+nodeProperty = nodeValueExpr; _setToViewOnly(viewAndPendingViewStateProperty, viewAndPendingViewStateExpr)
+
+@implementation ASDisplayNode (UIViewBridgeAccessibility)
+
 - (BOOL)isAccessibilityElement
 {
   _bridge_prologue_read;
-  return _getFromViewOnly(isAccessibilityElement);
+  return _getAccessibilityFromViewOrProperty(_isAccessibilityElement, isAccessibilityElement);
 }
 
 - (void)setIsAccessibilityElement:(BOOL)isAccessibilityElement
 {
   _bridge_prologue_write;
-  _setToViewOnly(isAccessibilityElement, isAccessibilityElement);
+  _setAccessibilityToViewAndProperty(_isAccessibilityElement, isAccessibilityElement, isAccessibilityElement, isAccessibilityElement);
 }
 
 - (NSString *)accessibilityLabel
 {
   _bridge_prologue_read;
-  return _getFromViewOnly(accessibilityLabel);
+  return _getAccessibilityFromViewOrProperty(_accessibilityLabel, accessibilityLabel);
 }
 
 - (void)setAccessibilityLabel:(NSString *)accessibilityLabel
 {
   _bridge_prologue_write;
-  _setToViewOnly(accessibilityLabel, accessibilityLabel);
+  _setAccessibilityToViewAndProperty(_accessibilityLabel, accessibilityLabel, accessibilityLabel, accessibilityLabel);
 }
 
 - (NSString *)accessibilityHint
 {
   _bridge_prologue_read;
-  return _getFromViewOnly(accessibilityHint);
+  return _getAccessibilityFromViewOrProperty(_accessibilityHint, accessibilityHint);
 }
 
 - (void)setAccessibilityHint:(NSString *)accessibilityHint
 {
   _bridge_prologue_write;
-  _setToViewOnly(accessibilityHint, accessibilityHint);
+  _setAccessibilityToViewAndProperty(_accessibilityHint, accessibilityHint, accessibilityHint, accessibilityHint);
 }
 
 - (NSString *)accessibilityValue
 {
   _bridge_prologue_read;
-  return _getFromViewOnly(accessibilityValue);
+  return _getAccessibilityFromViewOrProperty(_accessibilityValue, accessibilityValue);
 }
 
 - (void)setAccessibilityValue:(NSString *)accessibilityValue
 {
   _bridge_prologue_write;
-  _setToViewOnly(accessibilityValue, accessibilityValue);
+  _setAccessibilityToViewAndProperty(_accessibilityValue, accessibilityValue, accessibilityValue, accessibilityValue);
 }
 
 - (UIAccessibilityTraits)accessibilityTraits
 {
   _bridge_prologue_read;
-  return _getFromViewOnly(accessibilityTraits);
+  return _getAccessibilityFromViewOrProperty(_accessibilityTraits, accessibilityTraits);
 }
 
 - (void)setAccessibilityTraits:(UIAccessibilityTraits)accessibilityTraits
 {
   _bridge_prologue_write;
-  _setToViewOnly(accessibilityTraits, accessibilityTraits);
+  _setAccessibilityToViewAndProperty(_accessibilityTraits, accessibilityTraits, accessibilityTraits, accessibilityTraits);
 }
 
 - (CGRect)accessibilityFrame
 {
   _bridge_prologue_read;
-  return _getFromViewOnly(accessibilityFrame);
+  return _getAccessibilityFromViewOrProperty(_accessibilityFrame, accessibilityFrame);
 }
 
 - (void)setAccessibilityFrame:(CGRect)accessibilityFrame
 {
   _bridge_prologue_write;
-  _setToViewOnly(accessibilityFrame, accessibilityFrame);
+  _setAccessibilityToViewAndProperty(_accessibilityFrame, accessibilityFrame, accessibilityFrame, accessibilityFrame);
 }
 
 - (NSString *)accessibilityLanguage
 {
   _bridge_prologue_read;
-  return _getFromViewOnly(accessibilityLanguage);
+  return _getAccessibilityFromViewOrProperty(_accessibilityLanguage, accessibilityLanguage);
 }
 
 - (void)setAccessibilityLanguage:(NSString *)accessibilityLanguage
 {
   _bridge_prologue_write;
-  _setToViewOnly(accessibilityLanguage, accessibilityLanguage);
+  _setAccessibilityToViewAndProperty(_accessibilityLanguage, accessibilityLanguage, accessibilityLanguage, accessibilityLanguage);
 }
 
 - (BOOL)accessibilityElementsHidden
 {
   _bridge_prologue_read;
-  return _getFromViewOnly(accessibilityElementsHidden);
+  return _getAccessibilityFromViewOrProperty(_accessibilityElementsHidden, accessibilityElementsHidden);
 }
 
 - (void)setAccessibilityElementsHidden:(BOOL)accessibilityElementsHidden
 {
   _bridge_prologue_write;
-  _setToViewOnly(accessibilityElementsHidden, accessibilityElementsHidden);
+  _setAccessibilityToViewAndProperty(_accessibilityElementsHidden, accessibilityElementsHidden, accessibilityElementsHidden, accessibilityElementsHidden);
 }
 
 - (BOOL)accessibilityViewIsModal
 {
   _bridge_prologue_read;
-  return _getFromViewOnly(accessibilityViewIsModal);
+  return _getAccessibilityFromViewOrProperty(_accessibilityViewIsModal, accessibilityViewIsModal);
 }
 
 - (void)setAccessibilityViewIsModal:(BOOL)accessibilityViewIsModal
 {
   _bridge_prologue_write;
-  _setToViewOnly(accessibilityViewIsModal, accessibilityViewIsModal);
+  _setAccessibilityToViewAndProperty(_accessibilityViewIsModal, accessibilityViewIsModal, accessibilityViewIsModal, accessibilityViewIsModal);
 }
 
 - (BOOL)shouldGroupAccessibilityChildren
 {
   _bridge_prologue_read;
-  return _getFromViewOnly(shouldGroupAccessibilityChildren);
+  return _getAccessibilityFromViewOrProperty(_shouldGroupAccessibilityChildren, shouldGroupAccessibilityChildren);
 }
 
 - (void)setShouldGroupAccessibilityChildren:(BOOL)shouldGroupAccessibilityChildren
 {
   _bridge_prologue_write;
-  _setToViewOnly(shouldGroupAccessibilityChildren, shouldGroupAccessibilityChildren);
+  _setAccessibilityToViewAndProperty(_shouldGroupAccessibilityChildren, shouldGroupAccessibilityChildren, shouldGroupAccessibilityChildren, shouldGroupAccessibilityChildren);
 }
 
 - (NSString *)accessibilityIdentifier
 {
   _bridge_prologue_read;
-  return _getFromViewOnly(accessibilityIdentifier);
+  return _getAccessibilityFromViewOrProperty(_accessibilityIdentifier, accessibilityIdentifier);
 }
 
 - (void)setAccessibilityIdentifier:(NSString *)accessibilityIdentifier
 {
   _bridge_prologue_write;
-  _setToViewOnly(accessibilityIdentifier, accessibilityIdentifier);
+  _setAccessibilityToViewAndProperty(_accessibilityIdentifier, accessibilityIdentifier, accessibilityIdentifier, accessibilityIdentifier);
 }
 
 - (NSInteger)accessibilityElementCount
 {
-    _bridge_prologue_read;
-    return _getFromViewOnly(accessibilityElementCount);
+  _bridge_prologue_read;
+  return _getFromViewOnly(accessibilityElementCount);
 }
 
 @end
 
+
+#pragma mark - ASAsyncTransactionContainer
 
 @implementation ASDisplayNode (ASAsyncTransactionContainer)
 

--- a/AsyncDisplayKit/Private/ASDisplayNode+UIViewBridge.mm
+++ b/AsyncDisplayKit/Private/ASDisplayNode+UIViewBridge.mm
@@ -865,6 +865,56 @@ nodeProperty = nodeValueExpr; _setToViewOnly(viewAndPendingViewStateProperty, vi
   _setAccessibilityToViewAndProperty(_accessibilityIdentifier, accessibilityIdentifier, accessibilityIdentifier, accessibilityIdentifier);
 }
 
+- (void)setAccessibilityNavigationStyle:(UIAccessibilityNavigationStyle)accessibilityNavigationStyle
+{
+  _bridge_prologue_write;
+  _setAccessibilityToViewAndProperty(_accessibilityNavigationStyle, accessibilityNavigationStyle, accessibilityNavigationStyle, accessibilityNavigationStyle);
+}
+
+- (UIAccessibilityNavigationStyle)accessibilityNavigationStyle
+{
+  _bridge_prologue_read;
+  return _getAccessibilityFromViewOrProperty(_accessibilityNavigationStyle, accessibilityNavigationStyle);
+}
+
+#if TARGET_OS_TV
+- (void)setAccessibilityHeaderElements:(NSArray *)accessibilityHeaderElements
+{
+  _bridge_prologue_write;
+  _setAccessibilityToViewAndProperty(_accessibilityHeaderElements, accessibilityHeaderElements, accessibilityHeaderElements, accessibilityHeaderElements);
+}
+
+- (NSArray *)accessibilityHeaderElements
+{
+  _bridge_prologue_read;
+  return _getAccessibilityFromViewOrProperty(_accessibilityHeaderElements, accessibilityHeaderElements);
+}
+#endif
+
+- (void)setAccessibilityActivationPoint:(CGPoint)accessibilityActivationPoint
+{
+  _bridge_prologue_write;
+  _setAccessibilityToViewAndProperty(_accessibilityActivationPoint, accessibilityActivationPoint, accessibilityActivationPoint, accessibilityActivationPoint);
+}
+
+- (CGPoint)accessibilityActivationPoint
+{
+  _bridge_prologue_read;
+  return _getAccessibilityFromViewOrProperty(_accessibilityActivationPoint, accessibilityActivationPoint);
+}
+
+- (void)setAccessibilityPath:(UIBezierPath *)accessibilityPath
+{
+  _bridge_prologue_write;
+  _setAccessibilityToViewAndProperty(_accessibilityPath, accessibilityPath, accessibilityPath, accessibilityPath);
+}
+
+- (UIBezierPath *)accessibilityPath
+{
+  _bridge_prologue_read;
+  return _getAccessibilityFromViewOrProperty(_accessibilityPath, accessibilityPath);
+}
+
 - (NSInteger)accessibilityElementCount
 {
   _bridge_prologue_read;

--- a/AsyncDisplayKit/Private/ASDisplayNode+UIViewBridge.mm
+++ b/AsyncDisplayKit/Private/ASDisplayNode+UIViewBridge.mm
@@ -841,6 +841,12 @@ if (shouldApply) { _layer.layerProperty = (layerValueExpr); } else { ASDisplayNo
   _setToViewOnly(accessibilityIdentifier, accessibilityIdentifier);
 }
 
+- (NSInteger)accessibilityElementCount
+{
+    _bridge_prologue_read;
+    return _getFromViewOnly(accessibilityElementCount);
+}
+
 @end
 
 

--- a/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
+++ b/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
@@ -141,6 +141,10 @@ FOUNDATION_EXPORT NSString * const ASRenderingEngineDidDisplayNodesScheduledBefo
   BOOL _accessibilityViewIsModal;
   BOOL _shouldGroupAccessibilityChildren;
   NSString *_accessibilityIdentifier;
+  UIAccessibilityNavigationStyle _accessibilityNavigationStyle;
+  NSArray *_accessibilityHeaderElements;
+  CGPoint _accessibilityActivationPoint;
+  UIBezierPath *_accessibilityPath;
 
 #if TIME_DISPLAYNODE_OPS
 @public

--- a/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
+++ b/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
@@ -129,6 +129,19 @@ FOUNDATION_EXPORT NSString * const ASRenderingEngineDidDisplayNodesScheduledBefo
   ASDisplayNodeContextModifier _willDisplayNodeContentWithRenderingContext;
   ASDisplayNodeContextModifier _didDisplayNodeContentWithRenderingContext;
 
+  // Accessibility support
+  BOOL _isAccessibilityElement;
+  NSString *_accessibilityLabel;
+  NSString *_accessibilityHint;
+  NSString *_accessibilityValue;
+  UIAccessibilityTraits _accessibilityTraits;
+  CGRect _accessibilityFrame;
+  NSString *_accessibilityLanguage;
+  BOOL _accessibilityElementsHidden;
+  BOOL _accessibilityViewIsModal;
+  BOOL _shouldGroupAccessibilityChildren;
+  NSString *_accessibilityIdentifier;
+
 #if TIME_DISPLAYNODE_OPS
 @public
   NSTimeInterval _debugTimeToCreateView;

--- a/AsyncDisplayKit/Private/_ASPendingState.mm
+++ b/AsyncDisplayKit/Private/_ASPendingState.mm
@@ -67,6 +67,10 @@ typedef struct {
   int setAccessibilityViewIsModal:1;
   int setShouldGroupAccessibilityChildren:1;
   int setAccessibilityIdentifier:1;
+  int setAccessibilityNavigationStyle:1;
+  int setAccessibilityHeaderElements:1;
+  int setAccessibilityActivationPoint:1;
+  int setAccessibilityPath:1;
 } ASPendingStateFlags;
 
 @implementation _ASPendingState
@@ -106,6 +110,10 @@ typedef struct {
   BOOL accessibilityViewIsModal;
   BOOL shouldGroupAccessibilityChildren;
   NSString *accessibilityIdentifier;
+  UIAccessibilityNavigationStyle accessibilityNavigationStyle;
+  NSArray *accessibilityHeaderElements;
+  CGPoint accessibilityActivationPoint;
+  UIBezierPath *accessibilityPath;
 
   ASPendingStateFlags _flags;
 }
@@ -226,6 +234,10 @@ static UIColor *defaultTintColor = nil;
   accessibilityViewIsModal = NO;
   shouldGroupAccessibilityChildren = NO;
   accessibilityIdentifier = nil;
+  accessibilityNavigationStyle = UIAccessibilityNavigationStyleAutomatic;
+  accessibilityHeaderElements = nil;
+  accessibilityActivationPoint = CGPointZero;
+  accessibilityPath = nil;
   edgeAntialiasingMask = (kCALayerLeftEdge | kCALayerRightEdge | kCALayerTopEdge | kCALayerBottomEdge);
 
   return self;
@@ -594,6 +606,59 @@ static UIColor *defaultTintColor = nil;
   }
 }
 
+- (UIAccessibilityNavigationStyle)accessibilityNavigationStyle
+{
+  return accessibilityNavigationStyle;
+}
+
+- (void)setAccessibilityNavigationStyle:(UIAccessibilityNavigationStyle)newAccessibilityNavigationStyle
+{
+  _flags.setAccessibilityNavigationStyle = YES;
+  accessibilityNavigationStyle = newAccessibilityNavigationStyle;
+}
+
+- (NSArray *)accessibilityHeaderElements
+{
+  return accessibilityHeaderElements;
+}
+
+- (void)setAccessibilityHeaderElements:(NSArray *)newAccessibilityHeaderElements
+{
+  _flags.setAccessibilityHeaderElements = YES;
+  if (accessibilityHeaderElements != newAccessibilityHeaderElements) {
+    accessibilityHeaderElements = [newAccessibilityHeaderElements copy];
+  }
+}
+
+- (CGPoint)accessibilityActivationPoint
+{
+  if (_flags.setAccessibilityActivationPoint) {
+    return accessibilityActivationPoint;
+  }
+  
+  // Default == Mid-point of the accessibilityFrame
+  return CGPointMake(CGRectGetMidX(accessibilityFrame), CGRectGetMidY(accessibilityFrame));
+}
+
+- (void)setAccessibilityActivationPoint:(CGPoint)newAccessibilityActivationPoint
+{
+  _flags.setAccessibilityActivationPoint = YES;
+  accessibilityActivationPoint = newAccessibilityActivationPoint;
+}
+
+- (UIBezierPath *)accessibilityPath
+{
+  return accessibilityPath;
+}
+
+- (void)setAccessibilityPath:(UIBezierPath *)newAccessibilityPath
+{
+  _flags.setAccessibilityPath = YES;
+  if (accessibilityPath != newAccessibilityPath) {
+    accessibilityPath = newAccessibilityPath;
+  }
+}
+
 - (void)applyToLayer:(CALayer *)layer
 {
   ASPendingStateFlags flags = _flags;
@@ -827,6 +892,20 @@ static UIColor *defaultTintColor = nil;
 
   if (flags.setAccessibilityIdentifier)
     view.accessibilityIdentifier = accessibilityIdentifier;
+  
+  if (flags.setAccessibilityNavigationStyle)
+    view.accessibilityNavigationStyle = accessibilityNavigationStyle;
+  
+#if TARGET_OS_TV
+  if (flags.setAccessibilityHeaderElements)
+    view.accessibilityHeaderElements = accessibilityHeaderElements;
+#endif
+  
+  if (flags.setAccessibilityActivationPoint)
+    view.accessibilityActivationPoint = accessibilityActivationPoint;
+  
+  if (flags.setAccessibilityPath)
+    view.accessibilityPath = accessibilityPath;
 
   // For classes like ASTableNode, ASCollectionNode, ASScrollNode and similar - make sure UIView gets setFrame:
   if (flags.setFrame && setFrameDirectly) {
@@ -926,6 +1005,12 @@ static UIColor *defaultTintColor = nil;
   pendingState.accessibilityViewIsModal = view.accessibilityViewIsModal;
   pendingState.shouldGroupAccessibilityChildren = view.shouldGroupAccessibilityChildren;
   pendingState.accessibilityIdentifier = view.accessibilityIdentifier;
+  pendingState.accessibilityNavigationStyle = view.accessibilityNavigationStyle;
+#if TARGET_OS_TV
+  pendingState.accessibilityHeaderElements = view.accessibilityHeaderElements;
+#endif
+  pendingState.accessibilityActivationPoint = view.accessibilityActivationPoint;
+  pendingState.accessibilityPath = view.accessibilityPath;
   return pendingState;
 }
 
@@ -992,7 +1077,11 @@ static UIColor *defaultTintColor = nil;
   || flags.setAccessibilityElementsHidden
   || flags.setAccessibilityViewIsModal
   || flags.setShouldGroupAccessibilityChildren
-  || flags.setAccessibilityIdentifier);
+  || flags.setAccessibilityIdentifier
+  || flags.setAccessibilityNavigationStyle
+  || flags.setAccessibilityHeaderElements
+  || flags.setAccessibilityActivationPoint
+  || flags.setAccessibilityPath);
 }
 
 - (void)dealloc

--- a/AsyncDisplayKitTests/ASDisplayNodeTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeTests.m
@@ -415,6 +415,10 @@ for (ASDisplayNode *n in @[ nodes ]) {\
   XCTAssertEqual(YES, node.accessibilityElementsHidden, @"accessibilityElementsHidden broken %@", hasLoadedView);
   XCTAssertEqual(YES, node.accessibilityViewIsModal, @"accessibilityViewIsModal broken %@", hasLoadedView);
   XCTAssertEqual(YES, node.shouldGroupAccessibilityChildren, @"shouldGroupAccessibilityChildren broken %@", hasLoadedView);
+  XCTAssertEqual(UIAccessibilityNavigationStyleSeparate, node.accessibilityNavigationStyle, @"accessibilityNavigationStyle broken %@", hasLoadedView);
+  XCTAssertTrue(CGPointEqualToPoint(CGPointMake(1.0, 1.0), node.accessibilityActivationPoint), @"accessibilityActivationPoint broken %@", hasLoadedView);
+  XCTAssertNotNil(node.accessibilityPath, @"accessibilityPath broken %@", hasLoadedView);
+  
 
   if (!isLayerBacked) {
     XCTAssertEqual(UIViewAutoresizingFlexibleLeftMargin, node.autoresizingMask, @"autoresizingMask %@", hasLoadedView);
@@ -468,6 +472,9 @@ for (ASDisplayNode *n in @[ nodes ]) {\
     node.accessibilityElementsHidden = YES;
     node.accessibilityViewIsModal = YES;
     node.shouldGroupAccessibilityChildren = YES;
+    node.accessibilityNavigationStyle = UIAccessibilityNavigationStyleSeparate;
+    node.accessibilityActivationPoint = CGPointMake(1.0, 1.0);
+    node.accessibilityPath = [UIBezierPath bezierPath];
 
     if (!isLayerBacked) {
       node.exclusiveTouch = YES;

--- a/AsyncDisplayKitTests/ASDisplayNodeTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeTests.m
@@ -308,6 +308,17 @@ for (ASDisplayNode *n in @[ nodes ]) {\
   XCTAssertEqual(YES, node.displaysAsynchronously, @"default displaysAsynchronously broken %@", hasLoadedView);
   XCTAssertEqual(NO, node.asyncdisplaykit_asyncTransactionContainer, @"default asyncdisplaykit_asyncTransactionContainer broken %@", hasLoadedView);
   XCTAssertEqualObjects(nil, node.name, @"default name broken %@", hasLoadedView);
+  
+  XCTAssertEqual(NO, node.isAccessibilityElement, @"default isAccessibilityElement is broken %@", hasLoadedView);
+  XCTAssertEqual((id)nil, node.accessibilityLabel, @"default accessibilityLabel is broken %@", hasLoadedView);
+  XCTAssertEqual((id)nil, node.accessibilityHint, @"default accessibilityHint is broken %@", hasLoadedView);
+  XCTAssertEqual((id)nil, node.accessibilityValue, @"default accessibilityValue is broken %@", hasLoadedView);
+  XCTAssertEqual(UIAccessibilityTraitNone, node.accessibilityTraits, @"default accessibilityTraits is broken %@", hasLoadedView);
+  XCTAssertTrue(CGRectEqualToRect(CGRectZero, node.accessibilityFrame), @"default accessibilityFrame is broken %@", hasLoadedView);
+  XCTAssertEqual((id)nil, node.accessibilityLanguage, @"default accessibilityLanguage is broken %@", hasLoadedView);
+  XCTAssertEqual(NO, node.accessibilityElementsHidden, @"default accessibilityElementsHidden is broken %@", hasLoadedView);
+  XCTAssertEqual(NO, node.accessibilityViewIsModal, @"default accessibilityViewIsModal is broken %@", hasLoadedView);
+  XCTAssertEqual(NO, node.shouldGroupAccessibilityChildren, @"default shouldGroupAccessibilityChildren is broken %@", hasLoadedView);
 
   if (!isLayerBacked) {
     XCTAssertEqual(YES, node.userInteractionEnabled, @"default userInteractionEnabled broken %@", hasLoadedView);
@@ -317,19 +328,6 @@ for (ASDisplayNode *n in @[ nodes ]) {\
   } else {
     XCTAssertEqual(NO, node.userInteractionEnabled, @"layer-backed nodes do not support userInteractionEnabled %@", hasLoadedView);
     XCTAssertEqual(NO, node.exclusiveTouch, @"layer-backed nodes do not support exclusiveTouch %@", hasLoadedView);
-  }
-
-  if (!isLayerBacked) {
-    XCTAssertEqual(NO, node.isAccessibilityElement, @"default isAccessibilityElement is broken %@", hasLoadedView);
-    XCTAssertEqual((id)nil, node.accessibilityLabel, @"default accessibilityLabel is broken %@", hasLoadedView);
-    XCTAssertEqual((id)nil, node.accessibilityHint, @"default accessibilityHint is broken %@", hasLoadedView);
-    XCTAssertEqual((id)nil, node.accessibilityValue, @"default accessibilityValue is broken %@", hasLoadedView);
-    XCTAssertEqual(UIAccessibilityTraitNone, node.accessibilityTraits, @"default accessibilityTraits is broken %@", hasLoadedView);
-    XCTAssertTrue(CGRectEqualToRect(CGRectZero, node.accessibilityFrame), @"default accessibilityFrame is broken %@", hasLoadedView);
-    XCTAssertEqual((id)nil, node.accessibilityLanguage, @"default accessibilityLanguage is broken %@", hasLoadedView);
-    XCTAssertEqual(NO, node.accessibilityElementsHidden, @"default accessibilityElementsHidden is broken %@", hasLoadedView);
-    XCTAssertEqual(NO, node.accessibilityViewIsModal, @"default accessibilityViewIsModal is broken %@", hasLoadedView);
-    XCTAssertEqual(NO, node.shouldGroupAccessibilityChildren, @"default shouldGroupAccessibilityChildren is broken %@", hasLoadedView);
   }
 }
 
@@ -406,20 +404,21 @@ for (ASDisplayNode *n in @[ nodes ]) {\
   XCTAssertEqual(NO, node.userInteractionEnabled, @"userInteractionEnabled broken %@", hasLoadedView);
   XCTAssertEqual((BOOL)!isLayerBacked, node.exclusiveTouch, @"exclusiveTouch broken %@", hasLoadedView);
   XCTAssertEqualObjects(@"quack like a duck", node.name, @"name broken %@", hasLoadedView);
+  
+  XCTAssertEqual(YES, node.isAccessibilityElement, @"accessibilityElement broken %@", hasLoadedView);
+  XCTAssertEqualObjects(@"Ship love", node.accessibilityLabel, @"accessibilityLabel broken %@", hasLoadedView);
+  XCTAssertEqualObjects(@"Awesome things will happen", node.accessibilityHint, @"accessibilityHint broken %@", hasLoadedView);
+  XCTAssertEqualObjects(@"1 of 2", node.accessibilityValue, @"accessibilityValue broken %@", hasLoadedView);
+  XCTAssertEqual(UIAccessibilityTraitSelected | UIAccessibilityTraitButton, node.accessibilityTraits, @"accessibilityTraits broken %@", hasLoadedView);
+  XCTAssertTrue(CGRectEqualToRect(CGRectMake(1, 2, 3, 4), node.accessibilityFrame), @"accessibilityFrame broken %@", hasLoadedView);
+  XCTAssertEqualObjects(@"mas", node.accessibilityLanguage, @"accessibilityLanguage broken %@", hasLoadedView);
+  XCTAssertEqual(YES, node.accessibilityElementsHidden, @"accessibilityElementsHidden broken %@", hasLoadedView);
+  XCTAssertEqual(YES, node.accessibilityViewIsModal, @"accessibilityViewIsModal broken %@", hasLoadedView);
+  XCTAssertEqual(YES, node.shouldGroupAccessibilityChildren, @"shouldGroupAccessibilityChildren broken %@", hasLoadedView);
 
   if (!isLayerBacked) {
     XCTAssertEqual(UIViewAutoresizingFlexibleLeftMargin, node.autoresizingMask, @"autoresizingMask %@", hasLoadedView);
     XCTAssertEqual(NO, node.autoresizesSubviews, @"autoresizesSubviews broken %@", hasLoadedView);
-    XCTAssertEqual(YES, node.isAccessibilityElement, @"accessibilityElement broken %@", hasLoadedView);
-    XCTAssertEqualObjects(@"Ship love", node.accessibilityLabel, @"accessibilityLabel broken %@", hasLoadedView);
-    XCTAssertEqualObjects(@"Awesome things will happen", node.accessibilityHint, @"accessibilityHint broken %@", hasLoadedView);
-    XCTAssertEqualObjects(@"1 of 2", node.accessibilityValue, @"accessibilityValue broken %@", hasLoadedView);
-    XCTAssertEqual(UIAccessibilityTraitSelected | UIAccessibilityTraitButton, node.accessibilityTraits, @"accessibilityTraits broken %@", hasLoadedView);
-    XCTAssertTrue(CGRectEqualToRect(CGRectMake(1, 2, 3, 4), node.accessibilityFrame), @"accessibilityFrame broken %@", hasLoadedView);
-    XCTAssertEqualObjects(@"mas", node.accessibilityLanguage, @"accessibilityLanguage broken %@", hasLoadedView);
-    XCTAssertEqual(YES, node.accessibilityElementsHidden, @"accessibilityElementsHidden broken %@", hasLoadedView);
-    XCTAssertEqual(YES, node.accessibilityViewIsModal, @"accessibilityViewIsModal broken %@", hasLoadedView);
-    XCTAssertEqual(YES, node.shouldGroupAccessibilityChildren, @"shouldGroupAccessibilityChildren broken %@", hasLoadedView);
   }
 }
 
@@ -458,21 +457,22 @@ for (ASDisplayNode *n in @[ nodes ]) {\
     node.asyncdisplaykit_asyncTransactionContainer = YES;
     node.userInteractionEnabled = NO;
     node.name = @"quack like a duck";
+    
+    node.isAccessibilityElement = YES;
+    node.accessibilityLabel = @"Ship love";
+    node.accessibilityHint = @"Awesome things will happen";
+    node.accessibilityValue = @"1 of 2";
+    node.accessibilityTraits = UIAccessibilityTraitSelected | UIAccessibilityTraitButton;
+    node.accessibilityFrame = CGRectMake(1, 2, 3, 4);
+    node.accessibilityLanguage = @"mas";
+    node.accessibilityElementsHidden = YES;
+    node.accessibilityViewIsModal = YES;
+    node.shouldGroupAccessibilityChildren = YES;
 
     if (!isLayerBacked) {
       node.exclusiveTouch = YES;
       node.autoresizesSubviews = NO;
       node.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin;
-      node.isAccessibilityElement = YES;
-      node.accessibilityLabel = @"Ship love";
-      node.accessibilityHint = @"Awesome things will happen";
-      node.accessibilityValue = @"1 of 2";
-      node.accessibilityTraits = UIAccessibilityTraitSelected | UIAccessibilityTraitButton;
-      node.accessibilityFrame = CGRectMake(1, 2, 3, 4);
-      node.accessibilityLanguage = @"mas";
-      node.accessibilityElementsHidden = YES;
-      node.accessibilityViewIsModal = YES;
-      node.shouldGroupAccessibilityChildren = YES;
     }
   }];
 


### PR DESCRIPTION
Improves Accessibility support especially for ASDisplayNodes with that has layerBacked or shouldRasterizeDescendants enabled should still supported by the accessibility mechanism. To enable this the _ASDisplayView implements the UIAccessibilityContainer methods now and is responsible for creating UIAccessibilityElement for subnodes.

Open Questions:
- [x] Figure out UIAccessibilityContainers in UIAccessibilityContainers