### PR TITLE
[ASTableView] Fix crash if called updateCurrentRangeWithMode: on an ASTableNode

### DIFF
--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -720,6 +720,11 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
 
 #pragma mark - ASRangeControllerDataSource
 
+- (ASRangeController *)rangeController
+{
+    return _rangeController;
+}
+
 - (NSArray *)visibleNodeIndexPathsForRangeController:(ASRangeController *)rangeController
 {
   ASDisplayNodeAssertMainThread();


### PR DESCRIPTION
A crash currently occurs if called updateCurrentRangeWithMode: on an ASTableNode. The problem is that the ASTableView within the ASTableNode does not expose the rangeController, but the ASTableNode demands it within updateCurrentRangeWithMode:.