### PR TITLE
[ASControlNode] Improved hitTestDebug to account for limiting display area by parent .clipsToBounds

### DIFF
--- a/AsyncDisplayKit/ASControlNode.mm
+++ b/AsyncDisplayKit/ASControlNode.mm
@@ -517,19 +517,21 @@ void _ASEnumerateControlEventsIncludedInMaskWithBlock(ASControlNodeEvent mask, v
     CGRect finalRect = [intersectLayer convertRect:intersectRect toLayer:layer];
     UIColor *fillColor = [[UIColor greenColor] colorWithAlphaComponent:0.4];
   
-    // determine which edges were clipped
-    if (clippedEdges != UIRectEdgeNone) {
+    // determine if edges are clipped
+    if (clippedEdges == UIRectEdgeNone) {
+      _debugHighlightOverlay.backgroundColor = fillColor;
+    } else {
       const CGFloat borderWidth = 2.0;
-      UIColor *superhitTestSlopClipsBorderColor = [UIColor colorWithRed:30/255.0 green:90/255.0 blue:50/255.0 alpha:0.7];
-      UIColor *superClipsToBoundsBorderColor = [[UIColor orangeColor] colorWithAlphaComponent:0.8];
+      UIColor *borderColor = [[UIColor orangeColor] colorWithAlphaComponent:0.8];
+      UIColor *clipsBorderColor = [UIColor colorWithRed:30/255.0 green:90/255.0 blue:50/255.0 alpha:0.7];
       CGRect imgRect = CGRectMake(0, 0, 2.0 * borderWidth + 1.0, 2.0 * borderWidth + 1.0);
       UIGraphicsBeginImageContext(imgRect.size);
       
       [fillColor setFill];
       UIRectFill(imgRect);
       
-      [self drawEdgeIfClippedWithEdges:clippedEdges color:superhitTestSlopClipsBorderColor borderWidth:borderWidth imgRect:imgRect];
-      [self drawEdgeIfClippedWithEdges:clipsToBoundsClippedEdges color:superClipsToBoundsBorderColor borderWidth:borderWidth imgRect:imgRect];
+      [self drawEdgeIfClippedWithEdges:clippedEdges color:clipsBorderColor borderWidth:borderWidth imgRect:imgRect];
+      [self drawEdgeIfClippedWithEdges:clipsToBoundsClippedEdges color:borderColor borderWidth:borderWidth imgRect:imgRect];
       
       UIImage *debugHighlightImage = UIGraphicsGetImageFromCurrentImageContext();
       UIGraphicsEndImageContext();
@@ -538,8 +540,6 @@ void _ASEnumerateControlEventsIncludedInMaskWithBlock(ASControlNodeEvent mask, v
       _debugHighlightOverlay.image = [debugHighlightImage resizableImageWithCapInsets:edgeInsets
                                                                          resizingMode:UIImageResizingModeStretch];
       _debugHighlightOverlay.backgroundColor = nil;
-    } else {
-      _debugHighlightOverlay.backgroundColor = fillColor;
     }
     
     _debugHighlightOverlay.frame = finalRect;

--- a/AsyncDisplayKit/AsyncDisplayKit+Debug.h
+++ b/AsyncDisplayKit/AsyncDisplayKit+Debug.h
@@ -12,9 +12,12 @@
 @interface ASControlNode (Debugging)
 
 /**
- Class method to enable a visualization overlay of the tapable area on the ASControlNode. For app debugging purposes only.
- Overlay = translucent green color, edges clipped by hitTestDebug of any parent in the hierarchy = dark green bordered edge,
- edges clipped by clipToBounds = YES of any parent in the hierarchy = orange bordered edge.
+ Class method to enable a visualization overlay of the tappable area on the ASControlNode. For app debugging purposes only.
+ NOTE: GESTURE RECOGNIZERS, (including tap gesture recognizers on a control node) WILL NOT BE VISUALIZED!!!
+ Overlay = translucent GREEN color, 
+ edges that are clipped by the tappable area of any parent (their bounds + hitTestSlop) in the hierarchy = DARK GREEN BORDERED EDGE,
+ edges that are clipped by clipToBounds = YES of any parent in the hierarchy = ORANGE BORDERED EDGE (may still receive touches beyond
+ overlay rect, but can't be visualized).
  @param enable Specify YES to make this debug feature enabled when messaging the ASControlNode class.
  */
 + (void)setEnableHitTestDebug:(BOOL)enable;

--- a/AsyncDisplayKit/AsyncDisplayKit+Debug.h
+++ b/AsyncDisplayKit/AsyncDisplayKit+Debug.h
@@ -13,6 +13,8 @@
 
 /**
  Class method to enable a visualization overlay of the tapable area on the ASControlNode. For app debugging purposes only.
+ Overlay = translucent green color, edges clipped by hitTestDebug of any parent in the hierarchy = dark green bordered edge,
+ edges clipped by clipToBounds = YES of any parent in the hierarchy = orange bordered edge.
  @param enable Specify YES to make this debug feature enabled when messaging the ASControlNode class.
  */
 + (void)setEnableHitTestDebug:(BOOL)enable;


### PR DESCRIPTION
- added orange overlay edge highlighting if tapable area clipped by .clipsToBounds of any parent in the hierarchy
- fixed bug in comparison of child / parent rect edges
- updated +Debug.h header to explain colors
![hittestdebugclipstoboundssuper](https://cloud.githubusercontent.com/assets/3419380/14408648/89d11434-feb2-11e5-9de6-cfed68079df5.png)
