### PR TITLE
[AsyncDisplayKit.org] Cleaning up the "next" link on most of the pages

### DIFF
--- a/_docs/automatic-layout-basics.md
+++ b/_docs/automatic-layout-basics.md
@@ -2,6 +2,7 @@
 title: Layout Basics
 layout: docs
 permalink: /docs/automatic-layout-basics.html
+next: automatic-layout-containers.html
 ---
 
 ##Box Model Layout

--- a/_docs/automatic-layout-containers.md
+++ b/_docs/automatic-layout-containers.md
@@ -2,6 +2,7 @@
 title: Layout Containers
 layout: docs
 permalink: /docs/automatic-layout-containers.html
+next: automatic-layout-examples.html
 ---
 
 AsyncDisplayKit includes a library of components that can be composed to declaratively specify a layout. The following LayoutSpecs allow you to have multiple children:

--- a/_docs/automatic-layout-debugging.md
+++ b/_docs/automatic-layout-debugging.md
@@ -2,6 +2,7 @@
 title: Layout Debugging
 layout: docs
 permalink: /docs/automatic-layout-debugging.html
+next: layout-options.html
 ---
 
 ##Debugging with ASCII Art

--- a/_docs/automatic-layout-examples.md
+++ b/_docs/automatic-layout-examples.md
@@ -2,7 +2,9 @@
 title: Layout Examples
 layout: docs
 permalink: /docs/automatic-layout-examples.html
+next: automatic-layout-debugging.html
 ---
+
 Three examples in increasing order of complexity. 
 #NSSpain Talk Example
 

--- a/_docs/button-node.md
+++ b/_docs/button-node.md
@@ -2,6 +2,7 @@
 title: ASButtonNode
 layout: docs
 permalink: /docs/button-node.html
+next: text-node.html
 ---
 
 `ASButtonNode` (a subclass of `ASControlNode`) supports simple buttons, with multiple states for a text label and an image with a few different layout options. Enables layerBacking for subnodes to significantly lighten main thread impact relative to UIButton (though async preparation is the bigger win).

--- a/_docs/control-node.md
+++ b/_docs/control-node.md
@@ -2,6 +2,7 @@
 title: ASControlNode
 layout: docs
 permalink: /docs/control-node.html
+next: button-node.html
 ---
 
-<div class = "warning">😑 This page is coming soon...</div>
+<div>😑 This page is coming soon...</div>

--- a/_docs/debug-tool-hit-test-slop.md
+++ b/_docs/debug-tool-hit-test-slop.md
@@ -2,7 +2,9 @@
 title: Hit Test Visualization
 layout: docs
 permalink: /docs/debug-tool-hit-test-slop.html
+next: debug-tool-ASRangeController.html
 ---
+
 ## Visualize tappable areas on ASControlNodes
 ### Description
 This debug feature adds a semi-transparent neon green highlight overlay on any ASControlNodes that have a `target:action:` pair added. The tappable range is defined as the ASControlNode’s frame + its hitTestSlop (UIEdgeInsets used by the ASControlNode to extend it’s tappable range). 

--- a/_docs/debug-tool-pixel-scaling.md
+++ b/_docs/debug-tool-pixel-scaling.md
@@ -2,7 +2,9 @@
 title: Image Scaling
 layout: docs
 permalink: /docs/debug-tool-pixel-scaling.html
+next: debug-tool-hit-test-slop.html
 ---
+
 ## Visualize ASImageNode.image’s pixel scaling
 ### Description
 This debug feature adds a red text label overlay on the bottom right hand corner of an ASImageNode if (and only if) the image’s size in pixels does not match it’s bounds size in pixels, e.g.

--- a/_docs/display-node.md
+++ b/_docs/display-node.md
@@ -2,6 +2,7 @@
 title: ASDisplayNode
 layout: docs
 permalink: /docs/display-node.html
+next: cell-node.html
 ---
 
 ASDisplayNode is the main view abstraction over UIView and CALayer.  It initializes and owns a UIView in the same way UIViews create and own their own backing CALayers.  

--- a/_docs/drawing-priority.md
+++ b/_docs/drawing-priority.md
@@ -2,6 +2,7 @@
 title: Drawing Priority
 layout: docs
 permalink: /docs/drawing-priority.html
+next: hit-test-slop.html
 ---
 
 <div class = "warning">😑 This page is coming soon...</div>

--- a/_docs/editable-text-node.md
+++ b/_docs/editable-text-node.md
@@ -2,7 +2,9 @@
 title: ASEditableTextNode
 layout: docs
 permalink: /docs/editable-text-node.html
+next: image-node.html
 ---
+
 `ASEditableTextNode` provides a flexible, efficient, and animation-friendly editable text component. 
 
 Features:

--- a/_docs/getting-started.md
+++ b/_docs/getting-started.md
@@ -2,7 +2,7 @@
 title: Getting Started
 layout: docs
 permalink: /docs/getting-started.html
-next: philosphy.html
+next: philosophy.html
 ---
 
 AsyncDisplayKit's basic unit is the `node`.  ASDisplayNode is an abstraction

--- a/_docs/hit-test-slop.md
+++ b/_docs/hit-test-slop.md
@@ -2,6 +2,7 @@
 title: Hit Test Slop
 layout: docs
 permalink: /docs/hit-test-slop.html
+next: image-modification-block.html
 ---
 
 <div class = "warning">😑 This page is coming soon...</div>

--- a/_docs/image-modification-block.md
+++ b/_docs/image-modification-block.md
@@ -2,6 +2,7 @@
 title: Image Modification Blocks
 layout: docs
 permalink: /docs/image-modification-block.html
+next: placeholder-fade-duration.html
 ---
 
 <div class = "warning">😑 This page is coming soon...</div>

--- a/_docs/image-node.md
+++ b/_docs/image-node.md
@@ -2,6 +2,7 @@
 title: ASImageNode
 layout: docs
 permalink: /docs/image-node.html
+next: network-image-node.html
 ---
 
-<div class = "warning">😑 This page is coming soon...</div>
+<div>😑 This page is coming soon...</div>

--- a/_docs/layer-backing.md
+++ b/_docs/layer-backing.md
@@ -2,6 +2,7 @@
 title: Layer Backing
 layout: docs
 permalink: /docs/layer-backing.html
+next: synchronous-concurrency.html
 ---
 
 Layer-backing. In some cases, you can substantially improve your app's performance by using layers instead of views. Manually converting view-based code to layers is laborious due to the difference in APIs. Worse, if at some point you need to enable touch handling or other view-specific functionality, you have to manually convert everything back (and risk regressions!).

--- a/_docs/layout-options.md
+++ b/_docs/layout-options.md
@@ -2,6 +2,7 @@
 title: Layout Options
 layout: docs
 permalink: /docs/layout-options.html
+next: layer-backing.html
 ---
 
 When using ASDK, you have three options for layout. Note that UIKit Autolayout is **not** supported by ASDK. 

--- a/_docs/map-node.md
+++ b/_docs/map-node.md
@@ -2,6 +2,7 @@
 title: ASMapNode
 layout: docs
 permalink: /docs/map-node.html
+next: video-node.html
 ---
 
 `ASMapNode` offers completely asynchronous preparation, automatic preloading, and efficient memory handling. Its standard mode is a fully asynchronous snapshot, with liveMap mode loading automatically triggered by any `ASTableView` or `ASCollectionView`; its `.liveMap` mode can be flipped on with ease (even on a background thread) to provide a cached, fully interactive map when necessary. 

--- a/_docs/network-image-node.md
+++ b/_docs/network-image-node.md
@@ -2,6 +2,7 @@
 title: ASNetworkImageNode
 layout: docs
 permalink: /docs/network-image-node.html
+next: map-node.html
 ---
 
-<div class = "warning">😑 This page is coming soon...</div>
+<div>😑 This page is coming soon...</div>

--- a/_docs/placeholder-fade-duration.md
+++ b/_docs/placeholder-fade-duration.md
@@ -2,6 +2,7 @@
 title: Placeholder Fade Duration
 layout: docs
 permalink: /docs/placeholder-fade-duration.html
+next: debug-tool-pixel-scaling.html
 ---
 
 <div class = "warning">😑 This page is coming soon...</div>

--- a/_docs/scroll-node.md
+++ b/_docs/scroll-node.md
@@ -2,6 +2,7 @@
 title: ASScrollNode
 layout: docs
 permalink: /docs/scroll-node.html
+next: automatic-layout-basics.html
 ---
 
-<div class = "warning">😑 This page is coming soon...</div>
+<div>😑 This page is coming soon...</div>

--- a/_docs/subtree-rasterization.md
+++ b/_docs/subtree-rasterization.md
@@ -2,6 +2,7 @@
 title: Subtree Rasterization
 layout: docs
 permalink: /docs/subtree-rasterization.html
+next: drawing-priority.html
 ---
 
 Precompositing. Flattening an entire view hierarchy into a single layer also improves performance, but comes with a hit to maintainability and hierarchy-based reasoning. Nodes can do this for you too!

--- a/_docs/synchronous-concurrency.md
+++ b/_docs/synchronous-concurrency.md
@@ -2,6 +2,7 @@
 title: Synchronous Concurrency
 layout: docs
 permalink: /docs/synchronous-concurrency.html
+next: subtree-rasterization.html
 ---
 
 <div class = "warning">😑 This page is coming soon...</div>

--- a/_docs/text-node.md
+++ b/_docs/text-node.md
@@ -2,6 +2,7 @@
 title: ASTextNode
 layout: docs
 permalink: /docs/text-node.html
+next: editable-text-node.html
 ---
 
-<div class = "warning">😑 This page is coming soon...</div>
+<div>😑 This page is coming soon...</div>

--- a/_docs/video-node.md
+++ b/_docs/video-node.md
@@ -2,6 +2,7 @@
 title: ASVideoNode
 layout: docs
 permalink: /docs/video-node.html
+next: scroll-node.html
 ---
 
 `ASVideoNode` is a newer class that exposes a relatively full-featured API, and is designed for both efficient and convenient implementation of embedded videos in scrolling views.

--- a/_site/docs/automatic-layout-basics.html
+++ b/_site/docs/automatic-layout-basics.html
@@ -5684,6 +5684,8 @@
     <div class="docs-prevnext">
       
       
+        <a class="right" href="/docs/automatic-layout-containers.html">Next &rarr;</a>
+      
     </div>
 
     <a id="_"></a>

--- a/_site/docs/automatic-layout-containers.html
+++ b/_site/docs/automatic-layout-containers.html
@@ -5675,6 +5675,8 @@
     <div class="docs-prevnext">
       
       
+        <a class="right" href="/docs/automatic-layout-examples.html">Next &rarr;</a>
+      
     </div>
 
     <a id="_"></a>

--- a/_site/docs/automatic-layout-debugging.html
+++ b/_site/docs/automatic-layout-debugging.html
@@ -5657,6 +5657,8 @@
     <div class="docs-prevnext">
       
       
+        <a class="right" href="/docs/layout-options.html">Next &rarr;</a>
+      
     </div>
 
     <a id="_"></a>

--- a/_site/docs/automatic-layout-examples.html
+++ b/_site/docs/automatic-layout-examples.html
@@ -5815,6 +5815,8 @@
     <div class="docs-prevnext">
       
       
+        <a class="right" href="/docs/automatic-layout-debugging.html">Next &rarr;</a>
+      
     </div>
 
     <a id="_"></a>

--- a/_site/docs/background-layout-spec.html
+++ b/_site/docs/background-layout-spec.html
@@ -5649,7 +5649,8 @@
     </h1>
     <p></p>
 
-    
+    <div class = "warning">😑 This page is coming soon...</div>
+
 
     <div class="docs-prevnext">
       

--- a/_site/docs/button-node.html
+++ b/_site/docs/button-node.html
@@ -5665,6 +5665,8 @@
     <div class="docs-prevnext">
       
       
+        <a class="right" href="/docs/text-node.html">Next &rarr;</a>
+      
     </div>
 
     <a id="_"></a>

--- a/_site/docs/control-node.html
+++ b/_site/docs/control-node.html
@@ -5649,11 +5649,13 @@
     </h1>
     <p></p>
 
-    <div class = "warning">😑 This page is coming soon...</div>
+    <div>😑 This page is coming soon...</div>
 
 
     <div class="docs-prevnext">
       
+      
+        <a class="right" href="/docs/button-node.html">Next &rarr;</a>
       
     </div>
 

--- a/_site/docs/debug-tool-hit-test-slop.html
+++ b/_site/docs/debug-tool-hit-test-slop.html
@@ -5671,6 +5671,8 @@
     <div class="docs-prevnext">
       
       
+        <a class="right" href="/docs/debug-tool-ASRangeController.html">Next &rarr;</a>
+      
     </div>
 
     <a id="_"></a>

--- a/_site/docs/debug-tool-pixel-scaling.html
+++ b/_site/docs/debug-tool-pixel-scaling.html
@@ -5676,6 +5676,8 @@
     <div class="docs-prevnext">
       
       
+        <a class="right" href="/docs/debug-tool-hit-test-slop.html">Next &rarr;</a>
+      
     </div>
 
     <a id="_"></a>

--- a/_site/docs/display-node.html
+++ b/_site/docs/display-node.html
@@ -5663,6 +5663,8 @@
     <div class="docs-prevnext">
       
       
+        <a class="right" href="/docs/cell-node.html">Next &rarr;</a>
+      
     </div>
 
     <a id="_"></a>

--- a/_site/docs/drawing-priority.html
+++ b/_site/docs/drawing-priority.html
@@ -5655,6 +5655,8 @@
     <div class="docs-prevnext">
       
       
+        <a class="right" href="/docs/hit-test-slop.html">Next &rarr;</a>
+      
     </div>
 
     <a id="_"></a>

--- a/_site/docs/editable-text-node.html
+++ b/_site/docs/editable-text-node.html
@@ -5665,6 +5665,8 @@
     <div class="docs-prevnext">
       
       
+        <a class="right" href="/docs/image-node.html">Next &rarr;</a>
+      
     </div>
 
     <a id="_"></a>

--- a/_site/docs/getting-started.html
+++ b/_site/docs/getting-started.html
@@ -5716,7 +5716,7 @@ rich text support.</li>
     <div class="docs-prevnext">
       
       
-        <a class="right" href="/docs/philosphy.html">Next &rarr;</a>
+        <a class="right" href="/docs/philosophy.html">Next &rarr;</a>
       
     </div>
 

--- a/_site/docs/hit-test-slop.html
+++ b/_site/docs/hit-test-slop.html
@@ -5655,6 +5655,8 @@
     <div class="docs-prevnext">
       
       
+        <a class="right" href="/docs/image-modification-block.html">Next &rarr;</a>
+      
     </div>
 
     <a id="_"></a>

--- a/_site/docs/image-modification-block.html
+++ b/_site/docs/image-modification-block.html
@@ -5655,6 +5655,8 @@
     <div class="docs-prevnext">
       
       
+        <a class="right" href="/docs/placeholder-fade-duration.html">Next &rarr;</a>
+      
     </div>
 
     <a id="_"></a>

--- a/_site/docs/image-node.html
+++ b/_site/docs/image-node.html
@@ -5649,11 +5649,13 @@
     </h1>
     <p></p>
 
-    <div class = "warning">😑 This page is coming soon...</div>
+    <div>😑 This page is coming soon...</div>
 
 
     <div class="docs-prevnext">
       
+      
+        <a class="right" href="/docs/network-image-node.html">Next &rarr;</a>
       
     </div>
 

--- a/_site/docs/layer-backing.html
+++ b/_site/docs/layer-backing.html
@@ -5660,6 +5660,8 @@
     <div class="docs-prevnext">
       
       
+        <a class="right" href="/docs/synchronous-concurrency.html">Next &rarr;</a>
+      
     </div>
 
     <a id="_"></a>

--- a/_site/docs/layout-options.html
+++ b/_site/docs/layout-options.html
@@ -5715,6 +5715,8 @@
     <div class="docs-prevnext">
       
       
+        <a class="right" href="/docs/layer-backing.html">Next &rarr;</a>
+      
     </div>
 
     <a id="_"></a>

--- a/_site/docs/map-node.html
+++ b/_site/docs/map-node.html
@@ -5661,6 +5661,8 @@
     <div class="docs-prevnext">
       
       
+        <a class="right" href="/docs/video-node.html">Next &rarr;</a>
+      
     </div>
 
     <a id="_"></a>

--- a/_site/docs/network-image-node.html
+++ b/_site/docs/network-image-node.html
@@ -5649,11 +5649,13 @@
     </h1>
     <p></p>
 
-    <div class = "warning">😑 This page is coming soon...</div>
+    <div>😑 This page is coming soon...</div>
 
 
     <div class="docs-prevnext">
       
+      
+        <a class="right" href="/docs/map-node.html">Next &rarr;</a>
       
     </div>
 

--- a/_site/docs/placeholder-fade-duration.html
+++ b/_site/docs/placeholder-fade-duration.html
@@ -5655,6 +5655,8 @@
     <div class="docs-prevnext">
       
       
+        <a class="right" href="/docs/debug-tool-pixel-scaling.html">Next &rarr;</a>
+      
     </div>
 
     <a id="_"></a>

--- a/_site/docs/scroll-node.html
+++ b/_site/docs/scroll-node.html
@@ -5649,11 +5649,13 @@
     </h1>
     <p></p>
 
-    <div class = "warning">😑 This page is coming soon...</div>
+    <div>😑 This page is coming soon...</div>
 
 
     <div class="docs-prevnext">
       
+      
+        <a class="right" href="/docs/automatic-layout-basics.html">Next &rarr;</a>
       
     </div>
 

--- a/_site/docs/subtree-rasterization.html
+++ b/_site/docs/subtree-rasterization.html
@@ -5658,6 +5658,8 @@
     <div class="docs-prevnext">
       
       
+        <a class="right" href="/docs/drawing-priority.html">Next &rarr;</a>
+      
     </div>
 
     <a id="_"></a>

--- a/_site/docs/synchronous-concurrency.html
+++ b/_site/docs/synchronous-concurrency.html
@@ -5655,6 +5655,8 @@
     <div class="docs-prevnext">
       
       
+        <a class="right" href="/docs/subtree-rasterization.html">Next &rarr;</a>
+      
     </div>
 
     <a id="_"></a>

--- a/_site/docs/text-node.html
+++ b/_site/docs/text-node.html
@@ -5649,11 +5649,13 @@
     </h1>
     <p></p>
 
-    <div class = "warning">😑 This page is coming soon...</div>
+    <div>😑 This page is coming soon...</div>
 
 
     <div class="docs-prevnext">
       
+      
+        <a class="right" href="/docs/editable-text-node.html">Next &rarr;</a>
       
     </div>
 

--- a/_site/docs/video-node.html
+++ b/_site/docs/video-node.html
@@ -5667,6 +5667,8 @@
     <div class="docs-prevnext">
       
       
+        <a class="right" href="/docs/scroll-node.html">Next &rarr;</a>
+      
     </div>
 
     <a id="_"></a>


### PR DESCRIPTION
A lot of pages either had broken or nonexistent links to the next page in the flow.  This seems to be resulting in some weird cases where gh-pages dumps seemingly random chunks of other pages into the current page.

For example:
<img width="500" alt="screen shot 2016-04-10 at 6 27 19 pm" src="https://cloud.githubusercontent.com/assets/432875/14413756/824f946e-ff49-11e5-860f-b330fee58dd4.png">

The gibberish at the bottom of the display node page.  I noticed it only happens on pages without a "next" pages specified so hopefully this fixes it.
