### PR TITLE
Readme update 

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ to implement node hierarchies or custom drawing.
 
 ### Learn more
 
-* Read the [Getting Started guide](http://asyncdisplaykit.org/docs/getting-started.html/)
+* Read the [Getting Started guide](http://asyncdisplaykit.org/docs/getting-started.html)
 * Get the [sample projects](https://github.com/facebook/AsyncDisplayKit/tree/master/examples)
 * Browse the [API reference](http://asyncdisplaykit.org/appledocs.html)
 * Watch the [NSLondon talk](http://vimeo.com/103589245) or the [NSSpain talk](https://www.youtube.com/watch?v=RY_X7l1g79Q)


### PR DESCRIPTION
Apparently a trailing slash doesn't work with the links to a gh-pages site.  My bad.