### PR TITLE
Add Core subspec

### DIFF
--- a/AsyncDisplayKit.podspec
+++ b/AsyncDisplayKit.podspec
@@ -58,7 +58,7 @@ Pod::Spec.new do |spec|
       pin.dependency 'AsyncDisplayKit/Core'
   end
   
-  # Include optional FLAnimatedImage module
+  # Include optional PINRemoteImage module
   spec.default_subspec = 'PINRemoteImage'
 
   spec.social_media_url = 'https://twitter.com/fbOpenSource'

--- a/AsyncDisplayKit.podspec
+++ b/AsyncDisplayKit.podspec
@@ -9,37 +9,39 @@ Pod::Spec.new do |spec|
 
   spec.documentation_url = 'http://asyncdisplaykit.org/appledoc/'
 
-  spec.public_header_files = [
-      'AsyncDisplayKit/*.h',
-      'AsyncDisplayKit/Details/**/*.h',
-      'AsyncDisplayKit/Layout/*.h',
-      'Base/*.h',
-      'AsyncDisplayKit/TextKit/ASTextNodeTypes.h',
-      'AsyncDisplayKit/TextKit/ASTextKitComponents.h'
-  ]
-
-  spec.source_files = [
-      'AsyncDisplayKit/**/*.{h,m,mm}',
-      'Base/*.{h,m}',
-      
-      # Most TextKit components are not public because the C++ content
-      # in the headers will cause build errors when using
-      # `use_frameworks!` on 0.39.0 & Swift 2.1.
-      # See https://github.com/facebook/AsyncDisplayKit/issues/1153
-      'AsyncDisplayKit/TextKit/*.h',
-  ]
-
   spec.frameworks = 'AssetsLibrary'
   spec.weak_frameworks = 'Photos','MapKit'
-
-  # ASDealloc2MainObject must be compiled with MRR
   spec.requires_arc = true
-  spec.exclude_files = [
-    'AsyncDisplayKit/Details/ASDealloc2MainObject.h',
-    'AsyncDisplayKit/Details/ASDealloc2MainObject.m',
-  ]
   
-  #Subspecs
+  # Subspecs
+  spec.subspec 'Core' do |core|
+    core.public_header_files = [
+        'AsyncDisplayKit/*.h',
+        'AsyncDisplayKit/Details/**/*.h',
+        'AsyncDisplayKit/Layout/*.h',
+        'Base/*.h',
+        'AsyncDisplayKit/TextKit/ASTextNodeTypes.h',
+        'AsyncDisplayKit/TextKit/ASTextKitComponents.h'
+    ]
+    
+    # ASDealloc2MainObject must be compiled with MRR
+    core.exclude_files = [
+      'AsyncDisplayKit/Private/_AS-objc-internal.h',
+      'AsyncDisplayKit/Details/ASDealloc2MainObject.h',
+      'AsyncDisplayKit/Details/ASDealloc2MainObject.m',
+    ]
+    core.source_files = [
+        'AsyncDisplayKit/**/*.{h,m,mm}',
+        'Base/*.{h,m}',
+      
+        # Most TextKit components are not public because the C++ content
+        # in the headers will cause build errors when using
+        # `use_frameworks!` on 0.39.0 & Swift 2.1.
+        # See https://github.com/facebook/AsyncDisplayKit/issues/1153
+        'AsyncDisplayKit/TextKit/*.h',
+    ]
+    core.dependency  'AsyncDisplayKit/ASDealloc2MainObject'
+  end
   
   spec.subspec 'ASDealloc2MainObject' do |mrr|
     mrr.requires_arc = false
@@ -53,7 +55,7 @@ Pod::Spec.new do |spec|
   spec.subspec 'PINRemoteImage' do |pin|
       pin.xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) PIN_REMOTE_IMAGE=1' }
       pin.dependency 'PINRemoteImage/iOS', '>= 2.1.2'
-      pin.dependency 'AsyncDisplayKit/ASDealloc2MainObject'
+      pin.dependency 'AsyncDisplayKit/Core'
   end
   
   # Include optional FLAnimatedImage module


### PR DESCRIPTION
# Description
This pull request moves all mandatory files into its own `Core` subspec.

# Resolved problem
Cocoapods that have AsyncDisplayKit as a dependency can not exclude `PINRemoteImage`.

# Solution
Cocoapods are able to specify the `Core` subspec as a dependency:
```
spec.dependency 'AsyncDisplayKit/Core', '~> 1.9.7'
```

# Podspec linter output
```
$ pod spec lint AsyncDisplayKit.podspec

 -> AsyncDisplayKit (1.9.7.2)

Analyzed 1 podspec.

AsyncDisplayKit.podspec passed validation.
```