### PR TITLE
[ASDKgram example update] overrode -fetchData in PhotoCellNode & addressed PR comments

### DIFF
--- a/examples/ASDKgram/Sample/AppDelegate.m
+++ b/examples/ASDKgram/Sample/AppDelegate.m
@@ -22,14 +22,15 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
   
-  _window                           = [[WindowWithStatusBarUnderlay alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
-  _window.backgroundColor           = [UIColor whiteColor];
+  // this UIWindow subclass is neccessary to make the status bar opaque
+  _window                  = [[WindowWithStatusBarUnderlay alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
+  _window.backgroundColor  = [UIColor whiteColor];
   
   // UIKit Home Feed viewController & navController
-  PhotoFeedNodeController *asdkHomeFeedVC     = [[PhotoFeedNodeController alloc] init];
-  UINavigationController *asdkHomeFeedNavCtrl = [[UINavigationController alloc] initWithRootViewController:asdkHomeFeedVC];
-  asdkHomeFeedNavCtrl.tabBarItem              = [[UITabBarItem alloc] initWithTitle:@"ASDK" image:[UIImage imageNamed:@"home"] tag:0];
-  asdkHomeFeedNavCtrl.hidesBarsOnSwipe        = YES;
+  PhotoFeedNodeController *asdkHomeFeedVC      = [[PhotoFeedNodeController alloc] init];
+  UINavigationController *asdkHomeFeedNavCtrl  = [[UINavigationController alloc] initWithRootViewController:asdkHomeFeedVC];
+  asdkHomeFeedNavCtrl.tabBarItem               = [[UITabBarItem alloc] initWithTitle:@"ASDK" image:[UIImage imageNamed:@"home"] tag:0];
+  asdkHomeFeedNavCtrl.hidesBarsOnSwipe         = YES;
   
   // ASDK Home Feed viewController & navController
   PhotoFeedViewController *uikitHomeFeedVC     = [[PhotoFeedViewController alloc] init];
@@ -38,24 +39,20 @@
   uikitHomeFeedNavCtrl.hidesBarsOnSwipe        = YES;
 
   // UITabBarController
-  UITabBarController *tabBarController    = [[UITabBarController alloc] init];
-  tabBarController.viewControllers        = @[uikitHomeFeedNavCtrl, asdkHomeFeedNavCtrl];
-  tabBarController.selectedViewController = asdkHomeFeedNavCtrl;
-  tabBarController.delegate               = self;
-  
-  // Nav Bar appearance
-  [[UINavigationBar appearance] setBarTintColor:[UIColor darkBlueColor]];
-  [[UINavigationBar appearance] setTranslucent:NO];
-  NSDictionary *attributes = @{NSForegroundColorAttributeName:[UIColor whiteColor]};
-  [[UINavigationBar appearance] setTitleTextAttributes:attributes];
-  // make the status bar have white text (changes after scrolling, but not on initial app startup)
-  // UINavigationController does not forward on preferredStatusBarStyle calls to its child view controllers.
-  // Instead it manages its own state...http://stackoverflow.com/questions/19022210/preferredstatusbarstyle-isnt-called/19513714#19513714
-  uikitHomeFeedNavCtrl.navigationBar.barStyle = UIBarStyleBlack;
-  asdkHomeFeedNavCtrl.navigationBar.barStyle  = UIBarStyleBlack;
+  UITabBarController *tabBarController         = [[UITabBarController alloc] init];
+  tabBarController.viewControllers             = @[uikitHomeFeedNavCtrl, asdkHomeFeedNavCtrl];
+  tabBarController.selectedViewController      = asdkHomeFeedNavCtrl;
+  tabBarController.delegate                    = self;
+  [[UITabBar appearance] setTintColor:[UIColor darkBlueColor]];
   
   _window.rootViewController = tabBarController;
   [_window makeKeyAndVisible];
+  
+  // Nav Bar appearance
+  NSDictionary *attributes = @{NSForegroundColorAttributeName:[UIColor whiteColor]};
+  [[UINavigationBar appearance] setTitleTextAttributes:attributes];
+  [[UINavigationBar appearance] setBarTintColor:[UIColor darkBlueColor]];
+  [[UINavigationBar appearance] setTranslucent:NO];
   
   // iOS8 hides the status bar in landscape orientation, this forces the status bar hidden status to NO
   [application setStatusBarHidden:YES withAnimation:UIStatusBarAnimationNone];

--- a/examples/ASDKgram/Sample/CommentView.m
+++ b/examples/ASDKgram/Sample/CommentView.m
@@ -11,7 +11,7 @@
 #import "Utilities.h"
 
 #define INTER_COMMENT_SPACING 5
-#define NUM_COMMENTS_TO_SHOW 3
+#define NUM_COMMENTS_TO_SHOW  3
 
 @implementation CommentView
 {

--- a/examples/ASDKgram/Sample/CommentsNode.m
+++ b/examples/ASDKgram/Sample/CommentsNode.m
@@ -9,7 +9,7 @@
 #import "CommentsNode.h"
 
 #define INTER_COMMENT_SPACING 5
-#define NUM_COMMENTS_TO_SHOW 3
+#define NUM_COMMENTS_TO_SHOW  3
 
 @implementation CommentsNode
 {
@@ -52,7 +52,7 @@
     int labelsIndex = 0;
     
     if (addViewAllCommentsLabel) {
-      commentLabelString        = [_commentFeed viewAllCommentsAttributedString];
+      commentLabelString         = [_commentFeed viewAllCommentsAttributedString];
       [[_commentNodes objectAtIndex:labelsIndex] setAttributedString:commentLabelString];
       labelsIndex++;
     }
@@ -90,7 +90,7 @@
   
   for (NSUInteger i = 0; i < numLabelsToAdd; i++) {
     
-    ASTextNode *commentLabel      = [[ASTextNode alloc] init];
+    ASTextNode *commentLabel   = [[ASTextNode alloc] init];
     commentLabel.maximumNumberOfLines = 3;
     
     [_commentNodes addObject:commentLabel];

--- a/examples/ASDKgram/Sample/Info.plist
+++ b/examples/ASDKgram/Sample/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>UIViewControllerBasedStatusBarAppearance</key>
-	<false/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>
@@ -32,6 +30,8 @@
 	<array>
 		<string>armv7</string>
 	</array>
+	<key>UIStatusBarStyle</key>
+	<string>UIStatusBarStyleLightContent</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
@@ -45,5 +45,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<false/>
 </dict>
 </plist>

--- a/examples/ASDKgram/Sample/PhotoCellNode.h
+++ b/examples/ASDKgram/Sample/PhotoCellNode.h
@@ -15,6 +15,5 @@
 @interface PhotoCellNode : ASCellNode
 
 - (instancetype)initWithPhotoObject:(PhotoModel *)photo;
-- (void)loadCommentsForPhoto:(PhotoModel *)photo;
 
 @end

--- a/examples/ASDKgram/Sample/PhotoFeedNodeController.m
+++ b/examples/ASDKgram/Sample/PhotoFeedNodeController.m
@@ -80,7 +80,7 @@
     [_activityIndicatorView stopAnimating];
     
     [self insertNewRowsInTableView:newPhotos];
-    [self requestCommentsForPhotos:newPhotos];
+//    [self requestCommentsForPhotos:newPhotos];
     
     // immediately start second larger fetch
     [self loadPageWithContext:nil];
@@ -93,30 +93,30 @@
   [_photoFeed requestPageWithCompletionBlock:^(NSArray *newPhotos){
     
     [self insertNewRowsInTableView:newPhotos];
-    [self requestCommentsForPhotos:newPhotos];
+//    [self requestCommentsForPhotos:newPhotos];
     if (context) {
       [context completeBatchFetching:YES];
     }
   } numResultsToReturn:20];
 }
 
-- (void)requestCommentsForPhotos:(NSArray *)newPhotos
-{
-  for (PhotoModel *photo in newPhotos) {
-    [photo.commentFeed refreshFeedWithCompletionBlock:^(NSArray *newComments) {
-      
-      NSInteger rowNum      = [_photoFeed indexOfPhotoModel:photo];
-      NSIndexPath *cellPath = [NSIndexPath indexPathForRow:rowNum inSection:0];
-      PhotoCellNode *cell   = (PhotoCellNode *)[_tableNode.view nodeForRowAtIndexPath:cellPath];
-      
-      if (cell) {
-        [cell loadCommentsForPhoto:photo];
-        [_tableNode.view beginUpdates];
-        [_tableNode.view endUpdates];
-      }
-    }];
-  }
-}
+//- (void)requestCommentsForPhotos:(NSArray *)newPhotos
+//{
+//  for (PhotoModel *photo in newPhotos) {
+//    [photo.commentFeed refreshFeedWithCompletionBlock:^(NSArray *newComments) {
+//      
+//      NSInteger rowNum      = [_photoFeed indexOfPhotoModel:photo];
+//      NSIndexPath *cellPath = [NSIndexPath indexPathForRow:rowNum inSection:0];
+//      PhotoCellNode *cell   = (PhotoCellNode *)[_tableNode.view nodeForRowAtIndexPath:cellPath];
+//      
+//      if (cell) {
+//        [cell loadCommentsForPhoto:photo];
+//        [_tableNode.view beginUpdates];
+//        [_tableNode.view endUpdates];
+//      }
+//    }];
+//  }
+//}
 
 - (void)insertNewRowsInTableView:(NSArray *)newPhotos
 {

--- a/examples/ASDKgram/Sample/UserModel.h
+++ b/examples/ASDKgram/Sample/UserModel.h
@@ -8,7 +8,7 @@
 
 @interface UserModel : NSObject
 
-@property (nonatomic, assign, readonly) NSDictionary *dictionaryRepresentation;
+@property (nonatomic, strong, readonly) NSDictionary *dictionaryRepresentation;
 @property (nonatomic, assign, readonly) NSUInteger   userID;
 @property (nonatomic, strong, readonly) NSString     *username;
 @property (nonatomic, strong, readonly) NSString     *firstName;

--- a/examples/ASDKgram/Sample/Utilities.m
+++ b/examples/ASDKgram/Sample/Utilities.m
@@ -14,12 +14,12 @@
 
 + (UIColor *)darkBlueColor
 {
-  return [UIColor colorWithRed:18.0/255.0 green:86.0/255.0 blue:136.0/255.0 alpha:1.0];
+  return [UIColor colorWithRed:70.0/255.0 green:102.0/255.0 blue:118.0/255.0 alpha:1.0];
 }
 
 + (UIColor *)lightBlueColor
 {
-  return [UIColor colorWithRed:0.0 green:122.0/255.0 blue:1.0 alpha:1.0];
+  return [UIColor colorWithRed:70.0/255.0 green:165.0/255.0 blue:196.0/255.0 alpha:1.0];
 }
 
 @end

--- a/examples/ASDKgram/Sample/WindowWithStatusBarUnderlay.h
+++ b/examples/ASDKgram/Sample/WindowWithStatusBarUnderlay.h
@@ -6,6 +6,8 @@
 //  Copyright © 2016 Facebook. All rights reserved.
 //
 
+
+// this subclass is neccessary to make the status bar have an opaque, colored background
 @interface WindowWithStatusBarUnderlay : UIWindow
 
 @end

--- a/examples/ASDKgram/Sample/WindowWithStatusBarUnderlay.m
+++ b/examples/ASDKgram/Sample/WindowWithStatusBarUnderlay.m
@@ -31,10 +31,10 @@
   
   [self bringSubviewToFront:_statusBarOpaqueUnderlayView];
   
-  _statusBarOpaqueUnderlayView.frame = CGRectMake(0,
-                                                  0,
-                                                  [[UIScreen mainScreen] bounds].size.width,
-                                                  [[UIApplication sharedApplication] statusBarFrame].size.height);
+  CGRect statusBarFrame              = CGRectZero;
+  statusBarFrame.size.width          = [[UIScreen mainScreen] bounds].size.width;
+  statusBarFrame.size.height         = [[UIApplication sharedApplication] statusBarFrame].size.height;
+  _statusBarOpaqueUnderlayView.frame = statusBarFrame;
 }
 
 @end

--- a/examples/ASDKgram/Sample/main.m
+++ b/examples/ASDKgram/Sample/main.m
@@ -1,9 +1,3 @@
-
-
-
-
-
-
 //  main.m
 //  ASDKgram
 //


### PR DESCRIPTION
- overrode the -(void)fetchData method in PhotoCellNode.m to download the photo’s comments. This method gets called with the PhotoCellNode enters ASInterfaceStateFetchData, which is set by the rangeController.
    - UIKIT COMPARISON: I left the comment bulk download (for all photos in a page load) in the PhotoFeedViewController side for UIKit because when implemented in the PhotoTableViewCell, each cell jumped around as it changed size when it came on screen.
- minor appearance updates
    - updated color scheme
    - fixed status bar style to darkBackgroundColor
- cleaned up layoutSpecThatFits: in PhotoCellNode