### PR TITLE
[ASMapNode] Remove assertion that checks calculatedSize rather than options.size.

### DIFF
--- a/AsyncDisplayKit/ASMapNode.mm
+++ b/AsyncDisplayKit/ASMapNode.mm
@@ -209,7 +209,6 @@
 
 - (void)setUpSnapshotter
 {
-  ASDisplayNodeAssert(!CGSizeEqualToSize(CGSizeZero, self.calculatedSize), @"self.calculatedSize can not be zero. Make sure that you are setting a preferredFrameSize or wrapping ASMapNode in a ASRatioLayoutSpec or similar.");
   _snapshotter = [[MKMapSnapshotter alloc] initWithOptions:self.options];
 }
 


### PR DESCRIPTION
@hannahmbanana @appleguy @garrettmoon 

Thanks for waiting a bit longer while I spent a deeper time looking at this issue. Apologies @hannahmbanana after re-reading your implementation another time it's clear that the issue would be fixed your way also.

However upon reproducing your initial crash (I created a sample project with your example code) and walking through the code, I realised that this assert is no longer needed and is actually a misguiding assert, YES - `self.calculatedSize` may be zero *but* this is actually ok. This is because previously we used to set `self.options.size` to `self.calculatedSize` without any check but this is now in place L:127 & L:281 so this assert is no longer needed. I'm confident that this will solve your issue but please put it to test fully and let me know of your results.
