### PR TITLE
[ASVideoNode] Several small bug fixes, improved code quality, added more tests.

### DIFF
--- a/AsyncDisplayKit/ASVideoNode.h
+++ b/AsyncDisplayKit/ASVideoNode.h
@@ -11,6 +11,8 @@
 @class AVAsset, AVPlayer, AVPlayerItem;
 @protocol ASVideoNodeDelegate;
 
+NS_ASSUME_NONNULL_BEGIN
+
 // IMPORTANT NOTES:
 // 1. Applications using ASVideoNode must link AVFoundation! (this provides the AV* classes below)
 // 2. This is a relatively new component of AsyncDisplayKit.  It has many useful features, but
@@ -19,34 +21,47 @@
 
 @interface ASVideoNode : ASControlNode
 
-- (instancetype)init; // ASVideoNode is created with a simple alloc/init.
-
 - (void)play;
 - (void)pause;
 - (BOOL)isPlaying;
 
-@property (atomic, strong, readwrite) AVAsset *asset;
+@property (nullable, atomic, strong, readwrite) AVAsset *asset;
 
-@property (atomic, strong, readonly) AVPlayer *player;
-@property (atomic, strong, readonly) AVPlayerItem *currentItem;
+@property (nullable, atomic, strong, readonly) AVPlayer *player;
+@property (nullable, atomic, strong, readonly) AVPlayerItem *currentItem;
 
-// When autoplay is set to true, a video node will play when it has both loaded and entered the "visible" interfaceState.
-// If it leaves the visible interfaceState it will pause but will resume once it has returned
+/**
+ * When shouldAutoplay is set to true, a video node will play when it has both loaded and entered the "visible" interfaceState.
+ * If it leaves the visible interfaceState it will pause but will resume once it has returned.
+ */
 @property (nonatomic, assign, readwrite) BOOL shouldAutoplay;
 @property (nonatomic, assign, readwrite) BOOL shouldAutorepeat;
 
 @property (nonatomic, assign, readwrite) BOOL muted;
 
+//! Defaults to AVLayerVideoGravityResizeAspect
 @property (atomic) NSString *gravity;
-@property (atomic) ASButtonNode *playButton;
 
-@property (atomic, weak, readwrite) id<ASVideoNodeDelegate> delegate;
+//! Defaults to an ASDefaultPlayButton instance.
+@property (nullable, atomic) ASButtonNode *playButton;
+
+@property (nullable, atomic, weak, readwrite) id<ASVideoNodeDelegate> delegate;
 
 @end
 
 @protocol ASVideoNodeDelegate <NSObject>
 @optional
+/**
+ * @abstract Delegate method invoked when the node's video has played to its end time.
+ * @param videoNode The video node has played to its end time.
+ */
 - (void)videoPlaybackDidFinish:(ASVideoNode *)videoNode;
+/**
+ * @abstract Delegate method invoked the node is tapped.
+ * @param videoNode The video node that was tapped.
+ * @discussion The video's play state is toggled if this method is not implemented.
+ */
 - (void)videoNodeWasTapped:(ASVideoNode *)videoNode;
 @end
 
+NS_ASSUME_NONNULL_END

--- a/AsyncDisplayKit/ASVideoNode.mm
+++ b/AsyncDisplayKit/ASVideoNode.mm
@@ -339,7 +339,10 @@ static UIViewContentMode ASContentModeFromVideoGravity(NSString *videoGravity) {
 - (void)setPlayButton:(ASButtonNode *)playButton
 {
   ASDN::MutexLocker l(_videoLock);
-  
+
+  [_playButton removeTarget:self action:@selector(tapped) forControlEvents:ASControlNodeEventTouchUpInside];
+  [_playButton removeFromSupernode];
+
   _playButton = playButton;
   
   [self addSubnode:playButton];
@@ -565,6 +568,7 @@ static UIViewContentMode ASContentModeFromVideoGravity(NSString *videoGravity) {
 
 - (void)dealloc
 {
+  [_playButton removeTarget:self action:@selector(tapped) forControlEvents:ASControlNodeEventTouchUpInside];
   [self removePlayerItemObservers];
   
   @try {

--- a/AsyncDisplayKitTests/ASVideoNodeTests.m
+++ b/AsyncDisplayKitTests/ASVideoNodeTests.m
@@ -297,4 +297,19 @@
   XCTAssertEqual(UIViewContentModeScaleAspectFill, _videoNode.placeholderImageNode.contentMode);
 }
 
+- (void)testChangingPlayButtonPerformsProperCleanup
+{
+  ASButtonNode *firstButton = _videoNode.playButton;
+  XCTAssertTrue([firstButton.allTargets containsObject:_videoNode]);
+
+  ASButtonNode *secondButton = [[ASButtonNode alloc] init];
+  _videoNode.playButton = secondButton;
+
+  XCTAssertTrue([secondButton.allTargets containsObject:_videoNode]);
+  XCTAssertEqual(_videoNode, secondButton.supernode);
+
+  XCTAssertFalse([firstButton.allTargets containsObject:_videoNode]);
+  XCTAssertNotEqual(_videoNode, firstButton.supernode);
+}
+
 @end

--- a/AsyncDisplayKitTests/ASVideoNodeTests.m
+++ b/AsyncDisplayKitTests/ASVideoNodeTests.m
@@ -24,25 +24,14 @@
   ASDisplayNode *_playerNode;
   AVPlayer *_player;
 }
-@property (atomic) ASInterfaceState interfaceState;
-@property (atomic) ASDisplayNode *spinner;
-@property (atomic) ASDisplayNode *playerNode;
-@property (atomic) BOOL shouldBePlaying;
+@property (atomic, readwrite) ASInterfaceState interfaceState;
+@property (atomic, readonly) ASDisplayNode *spinner;
+@property (atomic, readonly) ASImageNode *placeholderImageNode;
+@property (atomic, readwrite) ASDisplayNode *playerNode;
+@property (atomic, readwrite) AVPlayer *player;
+@property (atomic, readonly) BOOL shouldBePlaying;
 
-- (void)setPlayerNode:(ASDisplayNode *)playerNode;
-@end
-
-@implementation ASVideoNode (Test)
-
-- (void)setPlayerNode:(ASDisplayNode *)playerNode
-{
-  _playerNode = playerNode;
-}
-
-- (void)setPlayer:(AVPlayer *)player
-{
-  _player = player;
-}
+- (void)setPlaceholderImage:(UIImage *)image;
 
 @end
 
@@ -291,6 +280,21 @@
   _videoNode.muted = NO;
 
   XCTAssertFalse(_videoNode.player.muted);
+}
+
+- (void)testSettingVideoGravityChangesPlaceholderContentMode
+{
+  [_videoNode setPlaceholderImage:[[UIImage alloc] init]];
+  XCTAssertEqual(UIViewContentModeScaleAspectFit, _videoNode.placeholderImageNode.contentMode);
+
+  _videoNode.gravity = AVLayerVideoGravityResize;
+  XCTAssertEqual(UIViewContentModeScaleToFill, _videoNode.placeholderImageNode.contentMode);
+
+  _videoNode.gravity = AVLayerVideoGravityResizeAspect;
+  XCTAssertEqual(UIViewContentModeScaleAspectFit, _videoNode.placeholderImageNode.contentMode);
+
+  _videoNode.gravity = AVLayerVideoGravityResizeAspectFill;
+  XCTAssertEqual(UIViewContentModeScaleAspectFill, _videoNode.placeholderImageNode.contentMode);
 }
 
 @end


### PR DESCRIPTION
Isolated fixes extracted from https://github.com/facebook/AsyncDisplayKit/pull/1496 These changes do not touch the player construction / fetchData cleanup from the original PR. I will rebase those changes in a separate PR.

1. Corrects map between `AVLayerVideoGravityResize` and its corresponding `UIViewContentMode` (`ScaleToFill` instead of `Redraw`).
2. Changing gravity now updates the placeholder node's `contentMode`.
3. Replacing the `playButton` now cleans-up the previous button's state.
4. Fix video stalling caused by backgrounding & foregrounding the app.