### PR TITLE
[NSArray+Diffing] Static analyzer issue with common indexes algorithm in _asdk_commonIndexesWithArray:

### DIFF
--- a/AsyncDisplayKit/Private/NSArray+Diffing.m
+++ b/AsyncDisplayKit/Private/NSArray+Diffing.m
@@ -50,30 +50,36 @@
 - (NSIndexSet *)_asdk_commonIndexesWithArray:(NSArray *)array compareBlock:(BOOL (^)(id lhs, id rhs))comparison
 {
   NSAssert(comparison != nil, @"Comparison block is required");
-  NSInteger lengths[self.count+1][array.count+1];
-  for (NSInteger i = self.count; i >= 0; i--) {
-    for (NSInteger j = array.count; j >= 0; j--) {
-      if (i == self.count || j == array.count) {
+  
+  NSInteger selfCount = self.count;
+  NSInteger arrayCount = array.count;
+  
+  NSInteger lengths[selfCount+1][arrayCount+1];
+  for (NSInteger i = 0; i <= selfCount; i++) {
+    for (NSInteger j = 0; j <= arrayCount; j++) {
+      if (i == 0 || j == 0) {
         lengths[i][j] = 0;
-      } else if (comparison(self[i], array[j])) {
-        lengths[i][j] = 1 + lengths[i+1][j+1];
+      } else if (comparison(self[i-1], array[j-1])) {
+        lengths[i][j] = 1 + lengths[i-1][j-1];
       } else {
-        lengths[i][j] = MAX(lengths[i+1][j], lengths[i][j+1]);
+        lengths[i][j] = MAX(lengths[i-1][j], lengths[i][j-1]);
       }
     }
   }
   
   NSMutableIndexSet *common = [NSMutableIndexSet indexSet];
-  for (NSInteger i = 0, j = 0; i < self.count && j < array.count;) {
-    if (comparison(self[i], array[j])) {
-      [common addIndex:i];
-      i++; j++;
-    } else if (lengths[i+1][j] >= lengths[i][j+1]) {
-      i++;
+  NSInteger i = selfCount, j = arrayCount;
+  while(i > 0 && j > 0) {
+    if (comparison(self[i-1], array[j-1])) {
+      [common addIndex:(i-1)];
+      i--; j--;
+    } else if (lengths[i-1][j] > lengths[i][j-1]) {
+      i--;
     } else {
-      j++;
+      j--;
     }
   }
+  
   return common;
 }
 

--- a/AsyncDisplayKitTests/ArrayDiffingTests.m
+++ b/AsyncDisplayKitTests/ArrayDiffingTests.m
@@ -10,13 +10,58 @@
 
 #import "NSArray+Diffing.h"
 
+@interface NSArray (ArrayDiffingTests)
+- (NSIndexSet *)_asdk_commonIndexesWithArray:(NSArray *)array compareBlock:(BOOL (^)(id lhs, id rhs))comparison;
+@end
+
 @interface ArrayDiffingTests : XCTestCase
 
 @end
 
 @implementation ArrayDiffingTests
 
-- (void)testDiffing {
+- (void)testDiffingCommonIndexes
+{
+  NSArray<NSArray *> *tests = @[
+    @[
+      @[@"bob", @"alice", @"dave"],
+      @[@"bob", @"alice", @"dave", @"gary"],
+      @[@0, @1, @2]
+    ],
+    @[
+      @[@"bob", @"alice", @"dave"],
+      @[@"bob", @"gary", @"dave"],
+      @[@0, @2]
+    ],
+    @[
+      @[@"bob", @"alice"],
+      @[@"gary", @"dave"],
+      @[],
+    ],
+    @[
+      @[@"bob", @"alice", @"dave"],
+      @[],
+      @[],
+    ],
+    @[
+      @[],
+      @[@"bob", @"alice", @"dave"],
+      @[],
+    ],
+  ];
+
+  for (NSArray *test in tests) {
+    NSIndexSet *indexSet = [test[0] _asdk_commonIndexesWithArray:test[1] compareBlock:^BOOL(id lhs, id rhs) {
+      return [lhs isEqual:rhs];
+    }];
+    
+    for (NSNumber *index in (NSArray *)test[2]) {
+      XCTAssert([indexSet containsIndex:[index integerValue]]);
+    }
+  }
+}
+
+- (void)testDiffingInsertionsAndDeletions {
   NSArray<NSArray *> *tests = @[
       @[
         @[@"bob", @"alice", @"dave"],


### PR DESCRIPTION
The issue was: The left operand of '>=' is a garbage value in else if check for lengths[i+1][j] ... I had to rewrite the algorithm to quiet the static analyzer.

I also added a couple of tests for _asdk_commonIndexesWithArray:

@levi @appleguy Could you guys take a look over it please.