### PR TITLE
[ASVideoNode] Re-enables HLS support

### DIFF
--- a/AsyncDisplayKit/ASVideoNode.mm
+++ b/AsyncDisplayKit/ASVideoNode.mm
@@ -89,7 +89,11 @@
   [self removePlayerItemObservers];
   
   if (_asset) {
-    _currentPlayerItem = [[AVPlayerItem alloc] initWithAsset:_asset];
+    if ([_asset.tracks count]) {
+      _currentPlayerItem = [[AVPlayerItem alloc] initWithAsset:_asset];
+    } else {
+      _currentPlayerItem = [[AVPlayerItem alloc] initWithURL:((AVURLAsset *)_asset).URL];
+    }
   }
   
   if (_currentPlayerItem) {


### PR DESCRIPTION
According to AVFoundation [guide](https://developer.apple.com/library/ios/documentation/AudioVideo/Conceptual/AVFoundationPG/Articles/02_Playback.html) on playback, we can't use an AVAsset directly for HTTP live stream media. The latest changes unifying the API under `AVAsset` broke HLS for me.

This change: 
1. first checks if there are tracks loaded on the `AVAsset`
2. if not, creates an `AVPlayerItem` directly from URL

Let me know your thoughts on this change. Thanks!