### PR TITLE
Update ASSentinel to use OSAtomicAdd32 to support iOS7.0

### DIFF
--- a/AsyncDisplayKit/Private/ASSentinel.m
+++ b/AsyncDisplayKit/Private/ASSentinel.m
@@ -22,7 +22,7 @@
 
 - (int32_t)increment
 {
-  return OSAtomicIncrement32(&_value);
+  return OSAtomicAdd32(1, &_value);
 }
 
 @end


### PR DESCRIPTION
OSAtomicIncrement32 does not work on OS < 7.1