### PR TITLE
[ASVideoNode] Limit resuming of buffered videos to those that are visible

### DIFF
--- a/AsyncDisplayKit/ASVideoNode.mm
+++ b/AsyncDisplayKit/ASVideoNode.mm
@@ -242,7 +242,7 @@ static NSString * const kStatus = @"status";
       }
     }
   } else if ([keyPath isEqualToString:kPlaybackLikelyToKeepUpKey]) {
-    if (_shouldBePlaying && [change[NSKeyValueChangeNewKey] boolValue] == true) {
+    if (_shouldBePlaying && [change[NSKeyValueChangeNewKey] boolValue] == true && ASInterfaceStateIncludesVisible(self.interfaceState)) {
       [self play]; // autoresume after buffer catches up
     }
   }


### PR DESCRIPTION
Limits the [resuming of buffered videos](https://github.com/facebook/AsyncDisplayKit/pull/1535) to nodes that are visible.