### PR TITLE
[ASDelegateProxy] Fix "[NSProxy methodSignatureForSelector:] called!" crash

### DIFF
--- a/AsyncDisplayKit/Details/ASDelegateProxy.m
+++ b/AsyncDisplayKit/Details/ASDelegateProxy.m
@@ -131,6 +131,31 @@
   }
 }
 
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector
+{
+  // Check for a compiled definition for the selector
+  NSMethodSignature *methodSignature = nil;
+  if ([self interceptsSelector:aSelector]) {
+    methodSignature = [[_interceptor class] instanceMethodSignatureForSelector:aSelector];
+  } else {
+    methodSignature = [[_target class] instanceMethodSignatureForSelector:aSelector];
+  }
+  
+  // Unfortunately, in order to get this object to work properly, the use of a method which creates an NSMethodSignature
+  // from a C string. -methodSignatureForSelector is called when a compiled definition for the selector cannot be found.
+  // This is the place where we have to create our own dud NSMethodSignature. This is necessary because if this method
+  // returns nil, a selector not found exception is raised. The string argument to -signatureWithObjCTypes: outlines
+  // the return type and arguments to the message. To return a dud NSMethodSignature, pretty much any signature will
+  // suffice. Since the -forwardInvocation call will do nothing if the delegate does not respond to the selector,
+  // the dud NSMethodSignature simply gets us around the exception.
+  return methodSignature ?: [NSMethodSignature signatureWithObjCTypes:"@^v^c"];
+}
+
+- (void)forwardInvocation:(NSInvocation *)invocation
+{
+    // If we are down here this means _interceptor and _target where nil. Just don't do anything to prevent a crash
+}
+
 - (BOOL)interceptsSelector:(SEL)selector
 {
   ASDisplayNodeAssert(NO, @"This method must be overridden by subclasses.");


### PR DESCRIPTION
Currently if the _interceptor and the _target object in ASDelegateProxy are nil and an object calls a method on the ASDelegateProxy it will raise a [NSProxy methodSignatureForSelector:] exception.

The reason for that is that we are not implementing -methodSignatureForSelector that will be called in case -respondsToSelector: will return NO and -forwardingTargetForSelector: will return nil.

Unfortunately just returning nil from -methodSignatureForSelector will not help in this case we have to return some kind of NSMethodSignature. If we would return nil in -methodSignatureForSelector it would raise an selector not found exception. In order to get this object to work properly, the use of a method which creates an NSMethodSignature from a C string and just returns that if no method signature was found at _interceptor and _target. After that -forwardInvocation: will be called and we just don't do anything in there.

Should fix: #1492 