### PR TITLE
[ASTextNode] Fix API ASTextNode API inconsistencies

### DIFF
--- a/AsyncDisplayKit/ASTextNode.h
+++ b/AsyncDisplayKit/ASTextNode.h
@@ -276,12 +276,18 @@ typedef NS_ENUM(NSUInteger, ASTextNodeHighlightStyle) {
 @interface ASTextNode (Deprecated)
 
 /**
+ The attributedString and attributedText properties are equivalent, but attributedText is now the standard API
+ name in order to match UILabel and ASEditableTextNode.
+ 
  @see attributedText
  */
 @property (nullable, nonatomic, copy) NSAttributedString *attributedString;
 
 
 /**
+ The truncationAttributedString and truncationAttributedText properties are equivalent, but attributedText is now the
+ standard API name in order to match UILabel and ASEditableTextNode.
+ 
  @see truncationAttributedText
  */
 @property (nullable, nonatomic, copy) NSAttributedString *truncationAttributedString;

--- a/AsyncDisplayKit/ASTextNode.h
+++ b/AsyncDisplayKit/ASTextNode.h
@@ -34,19 +34,19 @@ typedef NS_ENUM(NSUInteger, ASTextNodeHighlightStyle) {
 @interface ASTextNode : ASControlNode
 
 /**
- @abstract The attributed string to show.
+ @abstract The styled text displayed by the node.
  @discussion Defaults to nil, no text is shown.
  For inline image attachments, add an attribute of key NSAttachmentAttributeName, with a value of an NSTextAttachment.
  */
-@property (nullable, nonatomic, copy) NSAttributedString *attributedString;
+@property (nullable, nonatomic, copy) NSAttributedString *attributedText;
 
 #pragma mark - Truncation
 
 /**
- @abstract The attributedString to use when the text must be truncated.
+ @abstract The attributedText to use when the text must be truncated.
  @discussion Defaults to a localized ellipsis character.
  */
-@property (nullable, nonatomic, copy) NSAttributedString *truncationAttributedString;
+@property (nullable, nonatomic, copy) NSAttributedString *truncationAttributedText;
 
 /**
  @summary The second attributed string appended for truncation.
@@ -267,6 +267,24 @@ typedef NS_ENUM(NSUInteger, ASTextNodeHighlightStyle) {
  @return YES if the entity attribute should be treated as a long-press target, NO otherwise.
  */
 - (BOOL)textNode:(ASTextNode *)textNode shouldLongPressLinkAttribute:(NSString *)attribute value:(id)value atPoint:(CGPoint)point;
+
+@end
+
+/**
+ * @abstract Text node deprecated properties
+ */
+@interface ASTextNode (Deprecated)
+
+/**
+ @see attributedText
+ */
+@property (nullable, nonatomic, copy) NSAttributedString *attributedString;
+
+
+/**
+ @see truncationAttributedText
+ */
+@property (nullable, nonatomic, copy) NSAttributedString *truncationAttributedString;
 
 @end
 

--- a/AsyncDisplayKitTests/ASTextNodeTests.m
+++ b/AsyncDisplayKitTests/ASTextNodeTests.m
@@ -44,7 +44,7 @@ static BOOL CGSizeEqualToSizeWithIn(CGSize size1, CGSize size2, CGFloat delta)
 @interface ASTextNodeTests : XCTestCase
 
 @property (nonatomic, readwrite, strong) ASTextNode *textNode;
-@property (nonatomic, readwrite, copy) NSAttributedString *attributedString;
+@property (nonatomic, readwrite, copy) NSAttributedString *attributedText;
 
 @end
 
@@ -80,8 +80,8 @@ static BOOL CGSizeEqualToSizeWithIn(CGSize size1, CGSize size2, CGFloat delta)
   [mas addAttribute:NSParagraphStyleAttributeName value:lastLinePara
               range:NSMakeRange(mas.length - 1, 1)];
   
-  _attributedString = mas;
-  _textNode.attributedString = _attributedString;
+  _attributedText = mas;
+  _textNode.attributedText = _attributedText;
 }
 
 #pragma mark - ASTextNode
@@ -97,8 +97,8 @@ static BOOL CGSizeEqualToSizeWithIn(CGSize size1, CGSize size2, CGFloat delta)
 - (void)testSettingTruncationMessage
 {
   NSAttributedString *truncation = [[NSAttributedString alloc] initWithString:@"..." attributes:nil];
-  _textNode.truncationAttributedString = truncation;
-  XCTAssertTrue([_textNode.truncationAttributedString isEqualToAttributedString:truncation], @"Failed to set truncation message");
+  _textNode.truncationAttributedText = truncation;
+  XCTAssertTrue([_textNode.truncationAttributedText isEqualToAttributedString:truncation], @"Failed to set truncation message");
 }
 
 - (void)testSettingAdditionalTruncationMessage
@@ -142,11 +142,11 @@ static BOOL CGSizeEqualToSizeWithIn(CGSize size1, CGSize size2, CGFloat delta)
 
 - (void)testAccessibility
 {
-  _textNode.attributedString = _attributedString;
+  _textNode.attributedText = _attributedText;
   XCTAssertTrue(_textNode.isAccessibilityElement, @"Should be an accessibility element");
   XCTAssertTrue(_textNode.accessibilityTraits == UIAccessibilityTraitStaticText, @"Should have static text accessibility trait, instead has %llu", _textNode.accessibilityTraits);
 
-  XCTAssertTrue([_textNode.accessibilityLabel isEqualToString:_attributedString.string], @"Accessibility label is incorrectly set to \n%@\n when it should be \n%@\n", _textNode.accessibilityLabel, _attributedString.string);
+  XCTAssertTrue([_textNode.accessibilityLabel isEqualToString:_attributedText.string], @"Accessibility label is incorrectly set to \n%@\n when it should be \n%@\n", _textNode.accessibilityLabel, _attributedText.string);
 }
 
 - (void)testLinkAttribute
@@ -156,7 +156,7 @@ static BOOL CGSizeEqualToSizeWithIn(CGSize size1, CGSize size2, CGFloat delta)
   NSString *linkString = @"Link";
   NSRange linkRange = NSMakeRange(0, linkString.length);
   NSAttributedString *attributedString = [[NSAttributedString alloc] initWithString:linkString attributes:@{ linkAttributeName : linkAttributeValue}];
-  _textNode.attributedString = attributedString;
+  _textNode.attributedText = attributedString;
   _textNode.linkAttributeNames = @[linkAttributeName];
 
   ASTextNodeTestDelegate *delegate = [ASTextNodeTestDelegate new];
@@ -178,7 +178,7 @@ static BOOL CGSizeEqualToSizeWithIn(CGSize size1, CGSize size2, CGFloat delta)
   NSString *linkString = @"Link notalink";
   NSMutableAttributedString *attributedString = [[NSMutableAttributedString alloc] initWithString:linkString];
   [attributedString addAttribute:linkAttributeName value:linkAttributeValue range:NSMakeRange(0, 4)];
-  _textNode.attributedString = attributedString;
+  _textNode.attributedText = attributedString;
   _textNode.linkAttributeNames = @[linkAttributeName];
 
   ASTextNodeTestDelegate *delegate = [ASTextNodeTestDelegate new];


### PR DESCRIPTION
- Deprecate attributedString in ASTextNode in favor of attributedText to be aligned with UILabel
- Deprecate truncationAttributedString in ASTextNode in favor of truncationAttributedText to be aligned with attributedText