### PR TITLE
[ASCellNode] Remove check to fix layout issues

### DIFF
--- a/AsyncDisplayKit/ASCellNode.m
+++ b/AsyncDisplayKit/ASCellNode.m
@@ -163,7 +163,7 @@
 
 - (void)didRelayoutFromOldSize:(CGSize)oldSize toNewSize:(CGSize)newSize
 {
-  if (_layoutDelegate != nil && self.isNodeLoaded) {
+  if (_layoutDelegate != nil) {
     ASPerformBlockOnMainThread(^{
       BOOL sizeChanged = !CGSizeEqualToSize(oldSize, newSize);
       [_layoutDelegate nodeDidRelayout:self sizeChanged:sizeChanged];


### PR DESCRIPTION
As discussed in Slack (starting here: https://asyncdisplaykit.slack.com/archives/general/p1461252947000266) there can be layout issues with ASCellNodes in an ASCollectionView. The scenario uses a cell that loads an image from the network, and the size of the image is unknown, so a default aspect ratio is used for layout purposes. When the image loads, the cell is resized using `setNeedsLayout()`. This can occasionally cause cells to overlap, or for there to be large gaps between cells. Removing the check for `self.isNodeLoaded` resolves the issue.