### PR TITLE
[ASDisplayNode] Fix assertion on cell deallocation due visibility not being cleared

### DIFF
--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -394,9 +394,9 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
 
 - (NSArray *)visibleNodes
 {
-  NSArray *indexPaths = [self indexPathsForVisibleRows];
-  NSMutableArray *visibleNodes = [[NSMutableArray alloc] init];
-
+  NSArray *indexPaths = [self visibleNodeIndexPathsForRangeController:_rangeController];
+  
+  NSMutableArray *visibleNodes = [NSMutableArray array];
   for (NSIndexPath *indexPath in indexPaths) {
     ASCellNode *node = [self nodeForRowAtIndexPath:indexPath];
     if (node) {

--- a/AsyncDisplayKit/Details/ASDataController.mm
+++ b/AsyncDisplayKit/Details/ASDataController.mm
@@ -991,9 +991,9 @@ static void *kASSizingQueueContext = &kASSizingQueueContext;
 - (void)dealloc
 {
   ASDisplayNodeAssertMainThread();
-  [_completedNodes enumerateKeysAndObjectsUsingBlock:^(NSString *kind, NSMutableArray *nodes, BOOL *stop) {
-    [nodes enumerateObjectsUsingBlock:^(NSMutableArray *section, NSUInteger sectionIndex, BOOL *stop) {
-      [section enumerateObjectsUsingBlock:^(ASCellNode *node, NSUInteger rowIndex, BOOL *stop) {
+  [_completedNodes enumerateKeysAndObjectsUsingBlock:^(NSString *kind, NSMutableArray *sections, BOOL *stop) {
+    for (NSArray *section in sections) {
+      for (ASCellNode *node in section) {
         if (node.isNodeLoaded) {
           if (node.layerBacked) {
             [node.layer removeFromSuperlayer];
@@ -1001,8 +1001,8 @@ static void *kASSizingQueueContext = &kASSizingQueueContext;
             [node.view removeFromSuperview];
           }
         }
-      }];
-    }];
+      }
+    }
   }];
 }
 


### PR DESCRIPTION
Should fix: #1512 and #1569

Further information:
- We mark every node as visible in the ASRangeController which NSIndexPath is returned from visibleNodeIndexPathsForRangeController:
- In visibleNodeIndexPathsForRangeController: we get the visible index path's via a call to UITableView's "indexPathsForVisibleRows" method.
- Unfortunately in this case we cannot use indexPathsForVisibleRows to get all the visible index paths as apparently in a grouped UITableView it would return index paths for cells that are just a bit over the edge of the visible area.
- But this edge cells will never get a call for -tableView:cellForRowAtIndexPath:, but we will mark them as visible in the range controller
- In tableView:cellForRowAtIndexPath: we call -configureContentView:forCellNode
- Because we never get a -configureContentView:forCellNode call for the edge cells, the _ASDisplayView of the nodes will never be added to the window and get a willMoveToWindow and didMoveToWindow call and it's never get's added to the window for now and so the node is NOT marked as "in the hirarchy"
- If the deallocation of the views are happening without the UITableView ever scrolled, the cells don't get a call to __exitHierarchy as they were never added to the window and stay in the interface state "visible" and an exception will be raised within the dealloc method of the ASDisplayNode