### PR TITLE
[ASVideoNode] Fix UI thread blocking with remote assets

### DIFF
--- a/AsyncDisplayKit/ASVideoNode.mm
+++ b/AsyncDisplayKit/ASVideoNode.mm
@@ -99,17 +99,13 @@ static NSString * const kStatus = @"status";
 {
   ASDN::MutexLocker l(_videoLock);
 
-  AVPlayerItem *playerItem = nil;
-  
-  if (_asset != nil) {
-    if (_asset.tracks.count > 0) {
-      playerItem = [[AVPlayerItem alloc] initWithAsset:_asset];
-    } else if ([_asset isKindOfClass:[AVURLAsset class]]) {
-      playerItem = [[AVPlayerItem alloc] initWithURL:((AVURLAsset *)_asset).URL];
-    }
+  if ([_asset isKindOfClass:[AVURLAsset class]]) {
+    return [[AVPlayerItem alloc] initWithURL:((AVURLAsset *)_asset).URL];
+  } else if (_asset != nil) {
+    return [[AVPlayerItem alloc] initWithAsset:_asset];
   }
 
-  return playerItem;
+  return nil;
 }
 
 - (void)addPlayerItemObservers:(AVPlayerItem *)playerItem

--- a/AsyncDisplayKit/ASVideoNode.mm
+++ b/AsyncDisplayKit/ASVideoNode.mm
@@ -173,16 +173,16 @@ static NSString * const kStatus = @"status";
 - (void)imageAtTime:(CMTime)imageTime completionHandler:(void(^)(UIImage *image))completionHandler
 {
   ASPerformBlockOnBackgroundThread(^{
-    ASDN::MutexLocker l(_videoLock);
+    AVAsset *asset = self.asset;
 
     // Skip the asset image generation if we don't have any tracks available that are capable of supporting it
-    NSArray<AVAssetTrack *>* visualAssetArray = [_asset tracksWithMediaCharacteristic:AVMediaCharacteristicVisual];
+    NSArray<AVAssetTrack *>* visualAssetArray = [asset tracksWithMediaCharacteristic:AVMediaCharacteristicVisual];
     if (visualAssetArray.count == 0) {
       completionHandler(nil);
       return;
     }
 
-    AVAssetImageGenerator *previewImageGenerator = [AVAssetImageGenerator assetImageGeneratorWithAsset:_asset];
+    AVAssetImageGenerator *previewImageGenerator = [AVAssetImageGenerator assetImageGeneratorWithAsset:asset];
     previewImageGenerator.appliesPreferredTrackTransform = YES;
 
     [previewImageGenerator generateCGImagesAsynchronouslyForTimes:@[[NSValue valueWithCMTime:imageTime]]

--- a/AsyncDisplayKit/ASVideoNode.mm
+++ b/AsyncDisplayKit/ASVideoNode.mm
@@ -99,10 +99,12 @@ static NSString * const kStatus = @"status";
 {
   ASDN::MutexLocker l(_videoLock);
 
-  if ([_asset isKindOfClass:[AVURLAsset class]]) {
-    return [[AVPlayerItem alloc] initWithURL:((AVURLAsset *)_asset).URL];
-  } else if (_asset != nil) {
-    return [[AVPlayerItem alloc] initWithAsset:_asset];
+  if (_asset != nil) {
+    if ([_asset isKindOfClass:[AVURLAsset class]]) {
+      return [[AVPlayerItem alloc] initWithURL:((AVURLAsset *)_asset).URL];
+    } else {
+      return [[AVPlayerItem alloc] initWithAsset:_asset];
+    }
   }
 
   return nil;


### PR DESCRIPTION
## Background
Originally [reported in Slack](https://asyncdisplaykit.slack.com/archives/general/p1461569479000382). `ASVideoNode` is blocking the UI thread while it loads metadata. It's hard to notice when using a local file, but it's obvious with a remote file on a poor network. @yichungwang created a [simple project to demonstrate the issue](https://asyncdisplaykit.slack.com/files/daydreamer/F1429JP26/videonodesample.zip) 👏 

## Cause
`AVAsset`'s tracks metadata properties block the calling thread until it the track metadata is known. If the asset is remote, this blocks the thread while waiting on the network.

1.  PR https://github.com/facebook/AsyncDisplayKit/pull/1552 added a call to the `tracks` property on the main thread. 
2.  The changed pulled in from https://github.com/facebook/AsyncDisplayKit/pull/1546 added a call to `tracksWithMediaCharacteristic:` while `_videoLock` is locked.

## Proposed Fix
1.  Restructure `constructPlayerItem` so `tracks` does not need to be checked.
2.  Limit the locking in `imageAtTime`.
