### PR TITLE
[ASDisplayNode] Added callbacks for entering and exiting fetch data and display ranges

### DIFF
--- a/AsyncDisplayKit/ASCellNode.mm
+++ b/AsyncDisplayKit/ASCellNode.mm
@@ -214,9 +214,9 @@
   // To be overriden by subclasses
 }
 
-- (void)visibileStateDidChange:(BOOL)isVisible
+- (void)visibleStateDidChange:(BOOL)isVisible
 {
-  [super visibileStateDidChange:isVisible];
+  [super visibleStateDidChange:isVisible];
   
   CGRect cellFrame = CGRectZero;
   if (_scrollView) {

--- a/AsyncDisplayKit/ASCellNode.mm
+++ b/AsyncDisplayKit/ASCellNode.mm
@@ -214,9 +214,9 @@
   // To be overriden by subclasses
 }
 
-- (void)visibilityDidChange:(BOOL)isVisible
+- (void)visibileStateDidChange:(BOOL)isVisible
 {
-  [super visibilityDidChange:isVisible];
+  [super visibileStateDidChange:isVisible];
   
   CGRect cellFrame = CGRectZero;
   if (_scrollView) {

--- a/AsyncDisplayKit/ASCollectionNode.mm
+++ b/AsyncDisplayKit/ASCollectionNode.mm
@@ -173,9 +173,9 @@
 }
 
 #if ASRangeControllerLoggingEnabled
-- (void)visibileStateDidChange:(BOOL)isVisible
+- (void)visibleStateDidChange:(BOOL)isVisible
 {
-  [super visibileStateDidChange:isVisible];
+  [super visibleStateDidChange:isVisible];
   NSLog(@"%@ - visible: %d", self, isVisible);
 }
 #endif

--- a/AsyncDisplayKit/ASCollectionNode.mm
+++ b/AsyncDisplayKit/ASCollectionNode.mm
@@ -173,9 +173,9 @@
 }
 
 #if ASRangeControllerLoggingEnabled
-- (void)visibilityDidChange:(BOOL)isVisible
+- (void)visibileStateDidChange:(BOOL)isVisible
 {
-  [super visibilityDidChange:isVisible];
+  [super visibileStateDidChange:isVisible];
   NSLog(@"%@ - visible: %d", self, isVisible);
 }
 #endif

--- a/AsyncDisplayKit/ASDisplayNode+Subclasses.h
+++ b/AsyncDisplayKit/ASDisplayNode+Subclasses.h
@@ -243,32 +243,22 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)visibilityDidChange:(BOOL)isVisible ASDISPLAYNODE_REQUIRES_SUPER;
 
 /**
- * @abstract Called whenever the the node enters the display range.
+ * @abstract Called whenever the the node has entered or left the display state.
  *
- * @discussion Subclasses may use this to monitor when they enter the display range.
+ * @discussion Subclasses may use this to monitor when a node should be rendering its content.
+ *
+ * @note This method can be called from any thread and should therefore be thread safe.
  */
-- (void)didEnterDisplayRange ASDISPLAYNODE_REQUIRES_SUPER;
+- (void)displayStateDidChange:(BOOL)inDisplayState ASDISPLAYNODE_REQUIRES_SUPER;
 
 /**
- * @abstract Called whenever the the node exits the display range.
+ * @abstract Called whenever the the node has entered or left the load state.
  *
- * @discussion Subclasses may use this to monitor when they exit the display range.
- */
-- (void)didExitDisplayRange ASDISPLAYNODE_REQUIRES_SUPER;
-
-/**
- * @abstract Called whenever the the node enters the fetch data range.
+ * @discussion Subclasses may use this to monitor data for a node should be loaded, either from a local or remote source.  
  *
- * @discussion Subclasses may use this to monitor when they enter the fetch data range.
+ * @note This method can be called from any thread and should therefore be thread safe.
  */
-- (void)didEnterFetchDataRange ASDISPLAYNODE_REQUIRES_SUPER;
-
-/**
- * @abstract Called whenever the the node exits the fetch data range.
- *
- * @discussion Subclasses may use this to monitor when they exit the fetch data range.
- */
-- (void)didExitFetchDataRange ASDISPLAYNODE_REQUIRES_SUPER;
+- (void)loadStateDidChange:(BOOL)inLoadState ASDISPLAYNODE_REQUIRES_SUPER;
 
 /**
  * Called just before the view is added to a window.

--- a/AsyncDisplayKit/ASDisplayNode+Subclasses.h
+++ b/AsyncDisplayKit/ASDisplayNode+Subclasses.h
@@ -242,6 +242,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)visibilityDidChange:(BOOL)isVisible ASDISPLAYNODE_REQUIRES_SUPER;
 
+- (void)didEnterDisplayRange ASDISPLAYNODE_REQUIRES_SUPER;
+- (void)didExitDisplayRange ASDISPLAYNODE_REQUIRES_SUPER;
+- (void)didEnterFetchDataRange ASDISPLAYNODE_REQUIRES_SUPER;
+- (void)didExitFetchDataRange ASDISPLAYNODE_REQUIRES_SUPER;
+
 /**
  * Called just before the view is added to a window.
  */

--- a/AsyncDisplayKit/ASDisplayNode+Subclasses.h
+++ b/AsyncDisplayKit/ASDisplayNode+Subclasses.h
@@ -240,10 +240,17 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @discussion Subclasses may use this to monitor when they become visible.
  */
-- (void)visibileStateDidChange:(BOOL)isVisible ASDISPLAYNODE_REQUIRES_SUPER;
+- (void)visibilityDidChange:(BOOL)isVisible ASDISPLAYNODE_REQUIRES_SUPER;
 
 /**
- * @abstract Called whenever the the node has entered or left the display state.
+ * @abstract Called whenever the visiblity of the node changed.
+ *
+ * @discussion Subclasses may use this to monitor when they become visible.
+ */
+- (void)visibleStateDidChange:(BOOL)isVisible ASDISPLAYNODE_REQUIRES_SUPER;
+
+/**
+ * @abstract Called whenever the the node has entered or exited the display state.
  *
  * @discussion Subclasses may use this to monitor when a node should be rendering its content.
  *

--- a/AsyncDisplayKit/ASDisplayNode+Subclasses.h
+++ b/AsyncDisplayKit/ASDisplayNode+Subclasses.h
@@ -242,9 +242,32 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)visibilityDidChange:(BOOL)isVisible ASDISPLAYNODE_REQUIRES_SUPER;
 
+/**
+ * @abstract Called whenever the the node enters the display range.
+ *
+ * @discussion Subclasses may use this to monitor when they enter the display range.
+ */
 - (void)didEnterDisplayRange ASDISPLAYNODE_REQUIRES_SUPER;
+
+/**
+ * @abstract Called whenever the the node exits the display range.
+ *
+ * @discussion Subclasses may use this to monitor when they exit the display range.
+ */
 - (void)didExitDisplayRange ASDISPLAYNODE_REQUIRES_SUPER;
+
+/**
+ * @abstract Called whenever the the node enters the fetch data range.
+ *
+ * @discussion Subclasses may use this to monitor when they enter the fetch data range.
+ */
 - (void)didEnterFetchDataRange ASDISPLAYNODE_REQUIRES_SUPER;
+
+/**
+ * @abstract Called whenever the the node exits the fetch data range.
+ *
+ * @discussion Subclasses may use this to monitor when they exit the fetch data range.
+ */
 - (void)didExitFetchDataRange ASDISPLAYNODE_REQUIRES_SUPER;
 
 /**

--- a/AsyncDisplayKit/ASDisplayNode+Subclasses.h
+++ b/AsyncDisplayKit/ASDisplayNode+Subclasses.h
@@ -240,7 +240,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @discussion Subclasses may use this to monitor when they become visible.
  */
-- (void)visibilityDidChange:(BOOL)isVisible ASDISPLAYNODE_REQUIRES_SUPER;
+- (void)visibileStateDidChange:(BOOL)isVisible ASDISPLAYNODE_REQUIRES_SUPER;
 
 /**
  * @abstract Called whenever the the node has entered or left the display state.

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -2106,7 +2106,7 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
   if (![self supportsRangeManagedInterfaceState]) {
     self.interfaceState = ASInterfaceStateNone;
   } else {
-    // This case is important when tearing down hierarchies.  We must deliver a visibilityDidChange:NO callback, as part our API guarantee that this method can be used for
+    // This case is important when tearing down hierarchies.  We must deliver a visibileStateDidChange:NO callback, as part our API guarantee that this method can be used for
     // things like data analytics about user content viewing.  We cannot call the method in the dealloc as any incidental retain operations in client code would fail.
     // Additionally, it may be that a Standard UIView which is containing us is moving between hierarchies, and we should not send the call if we will be re-added in the
     // same runloop.  Strategy: strong reference (might be the last!), wait one runloop, and confirm we are still outside the hierarchy (both layer-backed and view-backed).
@@ -2173,7 +2173,7 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
   });
 }
 
-- (void)visibilityDidChange:(BOOL)isVisible
+- (void)visibileStateDidChange:(BOOL)isVisible
 {
     // subclass override
 }
@@ -2295,7 +2295,7 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
   BOOL wasVisible = ASInterfaceStateIncludesVisible(oldState);
 
   if (nowVisible != wasVisible) {
-    [self visibilityDidChange:nowVisible];
+    [self visibileStateDidChange:nowVisible];
   }
 
   [self interfaceStateDidChange:newState fromState:oldState];

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -2242,10 +2242,12 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
   if (nowFetchData != wasFetchData) {
     if (nowFetchData) {
       [self fetchData];
+      [self didEnterFetchDataRange];
     } else {
       if ([self supportsRangeManagedInterfaceState]) {
         [self clearFetchedData];
       }
+      [self didExitFetchDataRange];
     }
   }
 
@@ -2289,6 +2291,12 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
         }
       }
     }
+    
+    if (nowDisplay) {
+      [self didEnterDisplayRange];
+    } else {
+      [self didExitDisplayRange];
+    }
   }
 
   // Became visible or invisible.  When range-managed, this represents literal visibility - at least one pixel
@@ -2299,29 +2307,7 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
   if (nowVisible != wasVisible) {
     [self visibilityDidChange:nowVisible];
   }
-  
-  BOOL nowInDisplay = ASInterfaceStateIncludesDisplay(newState);
-  BOOL wasInDisplay = ASInterfaceStateIncludesDisplay(oldState);
-  
-  if (nowInDisplay != wasInDisplay) {
-    if (nowInDisplay) {
-      [self didEnterDisplayRange];
-    } else {
-      [self didExitDisplayRange];
-    }
-  }
-  
-  BOOL nowInFetchData = ASInterfaceStateIncludesFetchData(newState);
-  BOOL wasInFetchData = ASInterfaceStateIncludesFetchData(oldState);
 
-  if (nowInFetchData != wasInFetchData) {
-    if (nowInFetchData) {
-      [self didEnterFetchDataRange];
-    } else {
-      [self didExitFetchDataRange];
-    }
-  }
-  
   [self interfaceStateDidChange:newState fromState:oldState];
 }
 

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -2173,9 +2173,14 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
   });
 }
 
-- (void)visibileStateDidChange:(BOOL)isVisible
+- (void)visibilityDidChange:(BOOL)isVisible
 {
-    // subclass override
+  // subclass override
+}
+
+- (void)visibleStateDidChange:(BOOL)isVisible
+{
+  // subclass override
 }
 
 - (void)displayStateDidChange:(BOOL)inDisplayState
@@ -2282,11 +2287,7 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
       }
     }
     
-    if (nowDisplay) {
-      [self displayStateDidChange:YES];
-    } else {
-      [self displayStateDidChange:NO];
-    }
+    [self displayStateDidChange:nowDisplay];
   }
 
   // Became visible or invisible.  When range-managed, this represents literal visibility - at least one pixel
@@ -2295,7 +2296,8 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
   BOOL wasVisible = ASInterfaceStateIncludesVisible(oldState);
 
   if (nowVisible != wasVisible) {
-    [self visibileStateDidChange:nowVisible];
+    [self visibleStateDidChange:nowVisible];
+    [self visibilityDidChange:nowVisible];   //TODO: remove once this method has been deprecated
   }
 
   [self interfaceStateDidChange:newState fromState:oldState];

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -2178,22 +2178,12 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
     // subclass override
 }
 
-- (void)didEnterDisplayRange
+- (void)displayStateDidChange:(BOOL)inDisplayState
 {
   //subclass override
 }
 
-- (void)didExitDisplayRange
-{
-  //subclass override
-}
-
-- (void)didEnterFetchDataRange
-{
-  //subclass override
-}
-
-- (void)didExitFetchDataRange
+- (void)loadStateDidChange:(BOOL)inLoadState
 {
   //subclass override
 }
@@ -2242,12 +2232,12 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
   if (nowFetchData != wasFetchData) {
     if (nowFetchData) {
       [self fetchData];
-      [self didEnterFetchDataRange];
+      [self loadStateDidChange:YES];
     } else {
       if ([self supportsRangeManagedInterfaceState]) {
         [self clearFetchedData];
       }
-      [self didExitFetchDataRange];
+      [self loadStateDidChange:NO];
     }
   }
 
@@ -2293,9 +2283,9 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
     }
     
     if (nowDisplay) {
-      [self didEnterDisplayRange];
+      [self displayStateDidChange:YES];
     } else {
-      [self didExitDisplayRange];
+      [self displayStateDidChange:NO];
     }
   }
 

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -2084,6 +2084,8 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
   ASDisplayNodeAssertMainThread();
 }
 
+#pragma mark Hierarchy State
+
 - (void)willEnterHierarchy
 {
   ASDisplayNodeAssertMainThread();
@@ -2122,6 +2124,8 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
     }
   }
 }
+
+#pragma mark Interface State
 
 - (void)clearContents
 {
@@ -2172,6 +2176,26 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
 - (void)visibilityDidChange:(BOOL)isVisible
 {
     // subclass override
+}
+
+- (void)didEnterDisplayRange
+{
+  //subclass override
+}
+
+- (void)didExitDisplayRange
+{
+  //subclass override
+}
+
+- (void)didEnterFetchDataRange
+{
+  //subclass override
+}
+
+- (void)didExitFetchDataRange
+{
+  //subclass override
 }
 
 /**
@@ -2276,11 +2300,34 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
     [self visibilityDidChange:nowVisible];
   }
   
+  BOOL nowInDisplay = ASInterfaceStateIncludesDisplay(newState);
+  BOOL wasInDisplay = ASInterfaceStateIncludesDisplay(oldState);
+  
+  if (nowInDisplay != wasInDisplay) {
+    if (nowInDisplay) {
+      [self didEnterDisplayRange];
+    } else {
+      [self didExitDisplayRange];
+    }
+  }
+  
+  BOOL nowInFetchData = ASInterfaceStateIncludesFetchData(newState);
+  BOOL wasInFetchData = ASInterfaceStateIncludesFetchData(oldState);
+
+  if (nowInFetchData != wasInFetchData) {
+    if (nowInFetchData) {
+      [self didEnterFetchDataRange];
+    } else {
+      [self didExitFetchDataRange];
+    }
+  }
+  
   [self interfaceStateDidChange:newState fromState:oldState];
 }
 
 - (void)interfaceStateDidChange:(ASInterfaceState)newState fromState:(ASInterfaceState)oldState
 {
+  // subclass hook
 }
 
 - (void)enterInterfaceState:(ASInterfaceState)interfaceState

--- a/AsyncDisplayKit/ASImageNode+AnimatedImage.mm
+++ b/AsyncDisplayKit/ASImageNode+AnimatedImage.mm
@@ -135,9 +135,9 @@
   [self.animatedImage clearAnimatedImageCache];
 }
 
-- (void)visibileStateDidChange:(BOOL)isVisible
+- (void)visibleStateDidChange:(BOOL)isVisible
 {
-  [super visibileStateDidChange:isVisible];
+  [super visibleStateDidChange:isVisible];
   
   ASDisplayNodeAssertMainThread();
   if (isVisible) {

--- a/AsyncDisplayKit/ASImageNode+AnimatedImage.mm
+++ b/AsyncDisplayKit/ASImageNode+AnimatedImage.mm
@@ -135,9 +135,9 @@
   [self.animatedImage clearAnimatedImageCache];
 }
 
-- (void)visibilityDidChange:(BOOL)isVisible
+- (void)visibileStateDidChange:(BOOL)isVisible
 {
-  [super visibilityDidChange:isVisible];
+  [super visibileStateDidChange:isVisible];
   
   ASDisplayNodeAssertMainThread();
   if (isVisible) {

--- a/AsyncDisplayKit/ASMultiplexImageNode.mm
+++ b/AsyncDisplayKit/ASMultiplexImageNode.mm
@@ -295,11 +295,11 @@ typedef void(^ASMultiplexImageLoadCompletionBlock)(UIImage *image, id imageIdent
   }
 }
 
-/* visibilityDidChange in ASNetworkImageNode has a very similar implementation. Changes here are likely necessary
+/* visibileStateDidChange in ASNetworkImageNode has a very similar implementation. Changes here are likely necessary
  in ASNetworkImageNode as well. */
-- (void)visibileStateDidChange:(BOOL)isVisible
+- (void)visibleStateDidChange:(BOOL)isVisible
 {
-  [super visibileStateDidChange:isVisible];
+  [super visibleStateDidChange:isVisible];
   
   if (_downloaderImplementsSetPriority) {
     ASDN::MutexLocker l(_downloadIdentifierLock);

--- a/AsyncDisplayKit/ASMultiplexImageNode.mm
+++ b/AsyncDisplayKit/ASMultiplexImageNode.mm
@@ -297,9 +297,9 @@ typedef void(^ASMultiplexImageLoadCompletionBlock)(UIImage *image, id imageIdent
 
 /* visibilityDidChange in ASNetworkImageNode has a very similar implementation. Changes here are likely necessary
  in ASNetworkImageNode as well. */
-- (void)visibilityDidChange:(BOOL)isVisible
+- (void)visibileStateDidChange:(BOOL)isVisible
 {
-  [super visibilityDidChange:isVisible];
+  [super visibileStateDidChange:isVisible];
   
   if (_downloaderImplementsSetPriority) {
     ASDN::MutexLocker l(_downloadIdentifierLock);

--- a/AsyncDisplayKit/ASNetworkImageNode.mm
+++ b/AsyncDisplayKit/ASNetworkImageNode.mm
@@ -280,9 +280,9 @@ static const CGSize kMinReleaseImageOnBackgroundSize = {20.0, 20.0};
 
 /* visibilityDidChange in ASMultiplexImageNode has a very similar implementation. Changes here are likely necessary
  in ASMultiplexImageNode as well. */
-- (void)visibilityDidChange:(BOOL)isVisible
+- (void)visibileStateDidChange:(BOOL)isVisible
 {
-  [super visibilityDidChange:isVisible];
+  [super visibileStateDidChange:isVisible];
 
   if (_downloaderImplementsSetPriority) {
     _lock.lock();

--- a/AsyncDisplayKit/ASNetworkImageNode.mm
+++ b/AsyncDisplayKit/ASNetworkImageNode.mm
@@ -278,11 +278,11 @@ static const CGSize kMinReleaseImageOnBackgroundSize = {20.0, 20.0};
   }
 }
 
-/* visibilityDidChange in ASMultiplexImageNode has a very similar implementation. Changes here are likely necessary
+/* visibileStateDidChange in ASMultiplexImageNode has a very similar implementation. Changes here are likely necessary
  in ASMultiplexImageNode as well. */
-- (void)visibileStateDidChange:(BOOL)isVisible
+- (void)visibleStateDidChange:(BOOL)isVisible
 {
-  [super visibileStateDidChange:isVisible];
+  [super visibleStateDidChange:isVisible];
 
   if (_downloaderImplementsSetPriority) {
     _lock.lock();

--- a/AsyncDisplayKit/ASTableNode.mm
+++ b/AsyncDisplayKit/ASTableNode.mm
@@ -145,9 +145,9 @@
 }
 
 #if ASRangeControllerLoggingEnabled
-- (void)visibileStateDidChange:(BOOL)isVisible
+- (void)visibleStateDidChange:(BOOL)isVisible
 {
-  [super visibileStateDidChange:isVisible];
+  [super visibleStateDidChange:isVisible];
   NSLog(@"%@ - visible: %d", self, isVisible);
 }
 #endif

--- a/AsyncDisplayKit/ASTableNode.mm
+++ b/AsyncDisplayKit/ASTableNode.mm
@@ -145,9 +145,9 @@
 }
 
 #if ASRangeControllerLoggingEnabled
-- (void)visibilityDidChange:(BOOL)isVisible
+- (void)visibileStateDidChange:(BOOL)isVisible
 {
-  [super visibilityDidChange:isVisible];
+  [super visibileStateDidChange:isVisible];
   NSLog(@"%@ - visible: %d", self, isVisible);
 }
 #endif

--- a/AsyncDisplayKit/ASVideoNode.mm
+++ b/AsyncDisplayKit/ASVideoNode.mm
@@ -382,9 +382,9 @@ static NSString * const kStatus = @"status";
   }
 }
 
-- (void)visibilityDidChange:(BOOL)isVisible
+- (void)visibileStateDidChange:(BOOL)isVisible
 {
-  [super visibilityDidChange:isVisible];
+  [super visibileStateDidChange:isVisible];
   
   ASDN::MutexLocker l(_videoLock);
   

--- a/AsyncDisplayKit/ASVideoNode.mm
+++ b/AsyncDisplayKit/ASVideoNode.mm
@@ -382,9 +382,9 @@ static NSString * const kStatus = @"status";
   }
 }
 
-- (void)visibileStateDidChange:(BOOL)isVisible
+- (void)visibleStateDidChange:(BOOL)isVisible
 {
-  [super visibileStateDidChange:isVisible];
+  [super visibleStateDidChange:isVisible];
   
   ASDN::MutexLocker l(_videoLock);
   

--- a/AsyncDisplayKit/ASVideoPlayerNode.mm
+++ b/AsyncDisplayKit/ASVideoPlayerNode.mm
@@ -163,9 +163,9 @@ static void *ASVideoPlayerNodeContext = &ASVideoPlayerNodeContext;
   }
 }
 
-- (void)visibilityDidChange:(BOOL)isVisible
+- (void)visibleStateDidChange:(BOOL)isVisible
 {
-  [super visibilityDidChange:isVisible];
+  [super visibleStateDidChange:isVisible];
 
   ASDN::MutexLocker l(_videoPlayerLock);
 

--- a/AsyncDisplayKit/Details/ASRangeController.mm
+++ b/AsyncDisplayKit/Details/ASRangeController.mm
@@ -95,7 +95,7 @@ static UIApplicationState __ApplicationState = UIApplicationStateActive;
 {
   _scrollDirection = scrollDirection;
 
-  // Perform update immediately, so that cells receive a visibilityDidChange: call before their first pixel is visible.
+  // Perform update immediately, so that cells receive a visibileStateDidChange: call before their first pixel is visible.
   [self scheduleRangeUpdate];
 }
 

--- a/AsyncDisplayKit/Details/ASRangeController.mm
+++ b/AsyncDisplayKit/Details/ASRangeController.mm
@@ -95,7 +95,7 @@ static UIApplicationState __ApplicationState = UIApplicationStateActive;
 {
   _scrollDirection = scrollDirection;
 
-  // Perform update immediately, so that cells receive a visibileStateDidChange: call before their first pixel is visible.
+  // Perform update immediately, so that cells receive a visibleStateDidChange: call before their first pixel is visible.
   [self scheduleRangeUpdate];
 }
 

--- a/AsyncDisplayKitTests/ASDisplayNodeTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeTests.m
@@ -87,11 +87,11 @@ for (ASDisplayNode *n in @[ nodes ]) {\
 @property (atomic, copy) CGSize(^calculateSizeBlock)(ASTestDisplayNode *node, CGSize size);
 @property (atomic) BOOL hasFetchedData;
 
-@property (atomic) BOOL didCallEnterDisplayRange;
-@property (atomic) BOOL didCallExitDisplayRange;
+@property (atomic) BOOL displayRangeStateChangedToYES;
+@property (atomic) BOOL displayRangeStateChangedToNO;
 
-@property (atomic) BOOL didCallEnterFetchDataRange;
-@property (atomic) BOOL didCallExitFetchDataRange;
+@property (atomic) BOOL loadStateChangedToYES;
+@property (atomic) BOOL loadStateChangedToNO;
 @end
 
 @interface ASTestResponderNode : ASTestDisplayNode
@@ -116,28 +116,26 @@ for (ASDisplayNode *n in @[ nodes ]) {\
   self.hasFetchedData = NO;
 }
 
-- (void)didEnterDisplayRange
+- (void)displayStateDidChange:(BOOL)inDisplayState
 {
-  [super didEnterDisplayRange];
-  self.didCallEnterDisplayRange = YES;
+  [super displayStateDidChange:inDisplayState];
+  
+  if (inDisplayState) {
+    self.displayRangeStateChangedToYES = YES;
+  } else {
+    self.displayRangeStateChangedToNO = YES;
+  }
 }
 
-- (void)didExitDisplayRange
+- (void)loadStateDidChange:(BOOL)inLoadState
 {
-  [super didExitDisplayRange];
-  self.didCallExitDisplayRange = YES;
-}
-
-- (void)didEnterFetchDataRange
-{
-  [super didEnterFetchDataRange];
-  self.didCallEnterFetchDataRange = YES;
-}
-
-- (void)didExitFetchDataRange
-{
-  [super didExitFetchDataRange];
-  self.didCallExitFetchDataRange = YES;
+  [super loadStateDidChange:inLoadState];
+  
+  if (inLoadState) {
+    self.loadStateChangedToYES = YES;
+  } else {
+    self.loadStateChangedToNO = YES;
+  }
 }
 
 - (void)dealloc
@@ -1914,7 +1912,7 @@ static bool stringContainsPointer(NSString *description, const void *p) {
 
   [node recursivelySetInterfaceState:ASInterfaceStateDisplay];
   
-  XCTAssert([node didCallEnterDisplayRange]);
+  XCTAssert([node displayRangeStateChangedToYES]);
 }
 
 - (void)testDidExitDisplayIsCalledWhenNodesExitDisplayRange
@@ -1924,7 +1922,7 @@ static bool stringContainsPointer(NSString *description, const void *p) {
   [node recursivelySetInterfaceState:ASInterfaceStateDisplay];
   [node recursivelySetInterfaceState:ASInterfaceStateFetchData];
   
-  XCTAssert([node didCallExitDisplayRange]);
+  XCTAssert([node displayRangeStateChangedToNO]);
 }
 
 - (void)testDidEnterFetchDataIsCalledWhenNodesEnterFetchDataRange
@@ -1933,7 +1931,7 @@ static bool stringContainsPointer(NSString *description, const void *p) {
   
   [node recursivelySetInterfaceState:ASInterfaceStateFetchData];
   
-  XCTAssert([node didCallEnterFetchDataRange]);
+  XCTAssert([node loadStateChangedToYES]);
 }
 
 - (void)testDidExitFetchDataIsCalledWhenNodesExitFetchDataRange
@@ -1943,7 +1941,7 @@ static bool stringContainsPointer(NSString *description, const void *p) {
   [node recursivelySetInterfaceState:ASInterfaceStateFetchData];
   [node recursivelySetInterfaceState:ASInterfaceStateDisplay];
 
-  XCTAssert([node didCallExitFetchDataRange]);
+  XCTAssert([node loadStateChangedToNO]);
 }
 
 @end

--- a/AsyncDisplayKitTests/ASDisplayNodeTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeTests.m
@@ -86,6 +86,12 @@ for (ASDisplayNode *n in @[ nodes ]) {\
 @property (atomic, copy) void (^willDeallocBlock)(ASTestDisplayNode *node);
 @property (atomic, copy) CGSize(^calculateSizeBlock)(ASTestDisplayNode *node, CGSize size);
 @property (atomic) BOOL hasFetchedData;
+
+@property (atomic) BOOL didCallEnterDisplayRange;
+@property (atomic) BOOL didCallExitDisplayRange;
+
+@property (atomic) BOOL didCallEnterFetchDataRange;
+@property (atomic) BOOL didCallExitFetchDataRange;
 @end
 
 @interface ASTestResponderNode : ASTestDisplayNode
@@ -108,6 +114,30 @@ for (ASDisplayNode *n in @[ nodes ]) {\
 {
   [super clearFetchedData];
   self.hasFetchedData = NO;
+}
+
+- (void)didEnterDisplayRange
+{
+  [super didEnterDisplayRange];
+  self.didCallEnterDisplayRange = YES;
+}
+
+- (void)didExitDisplayRange
+{
+  [super didExitDisplayRange];
+  self.didCallExitDisplayRange = YES;
+}
+
+- (void)didEnterFetchDataRange
+{
+  [super didEnterFetchDataRange];
+  self.didCallEnterFetchDataRange = YES;
+}
+
+- (void)didExitFetchDataRange
+{
+  [super didExitFetchDataRange];
+  self.didCallExitFetchDataRange = YES;
 }
 
 - (void)dealloc
@@ -1877,5 +1907,43 @@ static bool stringContainsPointer(NSString *description, const void *p) {
   XCTAssert(node.bounds.size.width == 7, @"Wrong ASDisplayNode.bounds.size.width");
   XCTAssert(node.bounds.size.height == 8, @"Wrong ASDisplayNode.bounds.size.height");
 }
+
+//- (void)testDidEnterDisplayIsCalledWhenNodesEnterDisplayRange
+//{
+//  ASTestDisplayNode *node = [[ASTestDisplayNode alloc] init];
+//
+//  [node recursivelySetInterfaceState:ASInterfaceStateDisplay];
+//  
+//  XCTAssert([node didCallEnterDisplayRange]);
+//}
+//
+//- (void)testDidExitDisplayIsCalledWhenNodesExitDisplayRange
+//{
+//  ASTestDisplayNode *node = [[ASTestDisplayNode alloc] init];
+//  
+//  [node recursivelySetInterfaceState:ASInterfaceStateDisplay];
+//  [node recursivelySetInterfaceState:ASInterfaceStateFetchData];
+//  
+//  XCTAssert([node didCallExitDisplayRange]);
+//}
+//
+//- (void)testDidEnterFetchDataIsCalledWhenNodesEnterFetchDataRange
+//{
+//  ASTestDisplayNode *node = [[ASTestDisplayNode alloc] init];
+//  
+//  [node recursivelySetInterfaceState:ASInterfaceStateFetchData];
+//  
+//  XCTAssert([node didCallEnterFetchDataRange]);
+//}
+//
+//- (void)testDidExitFetchDataIsCalledWhenNodesExitFetchDataRange
+//{
+//  ASTestDisplayNode *node = [[ASTestDisplayNode alloc] init];
+//  
+//  [node recursivelySetInterfaceState:ASInterfaceStateFetchData];
+//  [node recursivelySetInterfaceState:ASInterfaceStateDisplay];
+//
+//  XCTAssert([node didCallExitFetchDataRange]);
+//}
 
 @end

--- a/AsyncDisplayKitTests/ASDisplayNodeTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeTests.m
@@ -1908,42 +1908,42 @@ static bool stringContainsPointer(NSString *description, const void *p) {
   XCTAssert(node.bounds.size.height == 8, @"Wrong ASDisplayNode.bounds.size.height");
 }
 
-//- (void)testDidEnterDisplayIsCalledWhenNodesEnterDisplayRange
-//{
-//  ASTestDisplayNode *node = [[ASTestDisplayNode alloc] init];
-//
-//  [node recursivelySetInterfaceState:ASInterfaceStateDisplay];
-//  
-//  XCTAssert([node didCallEnterDisplayRange]);
-//}
-//
-//- (void)testDidExitDisplayIsCalledWhenNodesExitDisplayRange
-//{
-//  ASTestDisplayNode *node = [[ASTestDisplayNode alloc] init];
-//  
-//  [node recursivelySetInterfaceState:ASInterfaceStateDisplay];
-//  [node recursivelySetInterfaceState:ASInterfaceStateFetchData];
-//  
-//  XCTAssert([node didCallExitDisplayRange]);
-//}
-//
-//- (void)testDidEnterFetchDataIsCalledWhenNodesEnterFetchDataRange
-//{
-//  ASTestDisplayNode *node = [[ASTestDisplayNode alloc] init];
-//  
-//  [node recursivelySetInterfaceState:ASInterfaceStateFetchData];
-//  
-//  XCTAssert([node didCallEnterFetchDataRange]);
-//}
-//
-//- (void)testDidExitFetchDataIsCalledWhenNodesExitFetchDataRange
-//{
-//  ASTestDisplayNode *node = [[ASTestDisplayNode alloc] init];
-//  
-//  [node recursivelySetInterfaceState:ASInterfaceStateFetchData];
-//  [node recursivelySetInterfaceState:ASInterfaceStateDisplay];
-//
-//  XCTAssert([node didCallExitFetchDataRange]);
-//}
+- (void)testDidEnterDisplayIsCalledWhenNodesEnterDisplayRange
+{
+  ASTestDisplayNode *node = [[ASTestDisplayNode alloc] init];
+
+  [node recursivelySetInterfaceState:ASInterfaceStateDisplay];
+  
+  XCTAssert([node didCallEnterDisplayRange]);
+}
+
+- (void)testDidExitDisplayIsCalledWhenNodesExitDisplayRange
+{
+  ASTestDisplayNode *node = [[ASTestDisplayNode alloc] init];
+  
+  [node recursivelySetInterfaceState:ASInterfaceStateDisplay];
+  [node recursivelySetInterfaceState:ASInterfaceStateFetchData];
+  
+  XCTAssert([node didCallExitDisplayRange]);
+}
+
+- (void)testDidEnterFetchDataIsCalledWhenNodesEnterFetchDataRange
+{
+  ASTestDisplayNode *node = [[ASTestDisplayNode alloc] init];
+  
+  [node recursivelySetInterfaceState:ASInterfaceStateFetchData];
+  
+  XCTAssert([node didCallEnterFetchDataRange]);
+}
+
+- (void)testDidExitFetchDataIsCalledWhenNodesExitFetchDataRange
+{
+  ASTestDisplayNode *node = [[ASTestDisplayNode alloc] init];
+  
+  [node recursivelySetInterfaceState:ASInterfaceStateFetchData];
+  [node recursivelySetInterfaceState:ASInterfaceStateDisplay];
+
+  XCTAssert([node didCallExitFetchDataRange]);
+}
 
 @end

--- a/AsyncDisplayKitTests/ASVideoNodeTests.m
+++ b/AsyncDisplayKitTests/ASVideoNodeTests.m
@@ -223,7 +223,7 @@
   }];
   _videoNode.playerNode.layer.frame = CGRectZero;
   
-  [_videoNode visibilityDidChange:YES];
+  [_videoNode visibileStateDidChange:YES];
 
   XCTAssertTrue(_videoNode.shouldBePlaying);
 }

--- a/AsyncDisplayKitTests/ASVideoNodeTests.m
+++ b/AsyncDisplayKitTests/ASVideoNodeTests.m
@@ -223,11 +223,10 @@
   }];
   _videoNode.playerNode.layer.frame = CGRectZero;
   
-  [_videoNode visibileStateDidChange:YES];
+  [_videoNode visibleStateDidChange:YES];
 
   XCTAssertTrue(_videoNode.shouldBePlaying);
 }
-
 
 - (void)testVideoShouldPauseWhenItLeavesVisibleButShouldKnowPlayingShouldRestartLater
 {


### PR DESCRIPTION
So at the moment, the naming that seemed to make the most sense was something similar to the view controller lifecycle callback naming conventions.

- (void)didEnterDisplayRange;
- (void)didExitDisplayRange;

- (void)didEnterFetchDataRange;
- (void)didExitFetchDataRange;

I like that -visibilityDidChange: returns a boolean representing whether it is entering or exiting the visible range, but getting the other ones to work that way seems like it would be tough to do without having some sort of difficult to understand naming going on.

Also, I know there is already -fetchData and -clearFetchedData as well as -clearContents, but having these specifically as override methods that don't necessarily imply that you have to do anything specific could be nice?
