### PR TITLE
[ASNetworkImageNode] Fix threading issue in current image quality

### DIFF
--- a/AsyncDisplayKit/ASNetworkImageNode.mm
+++ b/AsyncDisplayKit/ASNetworkImageNode.mm
@@ -124,9 +124,15 @@ static const CGSize kMinReleaseImageOnBackgroundSize = {20.0, 20.0};
 
   if (reset || _URL == nil) {
     self.image = _defaultImage;
-    ASPerformBlockOnMainThread(^{
-      self.currentImageQuality = 1.0;
-    });
+    if (_URL == nil) {
+      ASPerformBlockOnMainThread(^{
+        self.currentImageQuality = 1.0;
+      });
+    } else {
+      ASPerformBlockOnMainThread(^{
+        self.currentImageQuality = 0.0;
+      });
+    }
   }
 
   if (self.interfaceState & ASInterfaceStateFetchData) {
@@ -151,9 +157,15 @@ static const CGSize kMinReleaseImageOnBackgroundSize = {20.0, 20.0};
   _defaultImage = defaultImage;
 
   if (!_imageLoaded) {
-    ASPerformBlockOnMainThread(^{
-      self.currentImageQuality = 0.0;
-    });
+    if (_URL == nil) {
+      ASPerformBlockOnMainThread(^{
+        self.currentImageQuality = 1.0;
+      });
+    } else {
+      ASPerformBlockOnMainThread(^{
+        self.currentImageQuality = 0.0;
+      });
+    }
     _lock.unlock();
     // Locking: it is important to release _lock before entering setImage:, as it needs to release the lock before -invalidateCalculatedLayout.
     // If we continue to hold the lock here, it will still be locked until the next unlock() call, causing a possible deadlock with
@@ -229,7 +241,9 @@ static const CGSize kMinReleaseImageOnBackgroundSize = {20.0, 20.0};
       if (result) {
         self.image = result;
         _imageLoaded = YES;
-        _currentImageQuality = 1.0;
+        dispatch_async(dispatch_get_main_queue(), ^{
+          _currentImageQuality = 1.0;
+        });
       }
     }
   }


### PR DESCRIPTION
Summary:
Because we trampoline to main when setting _currentImageQuality, there would be situations where displayWillStart was called, we get a cached image and set currentImageQuality to 1.0, and then a background thread calling setDefaultImage would enqueue an operation that sets currentImageQuality to 0 and overwrites the correct value.