### PR TITLE
[ASVideoNode] Prepare asset for playback in a uniform way

### DIFF
--- a/AsyncDisplayKit/ASVideoNode.mm
+++ b/AsyncDisplayKit/ASVideoNode.mm
@@ -106,7 +106,7 @@ static NSString * const kStatus = @"status";
   return nil;
 }
 
-- (void)prepareToPlayAsset:(AVAsset *)asset withKeys:(NSArray *)requestedKeys
+- (void)prepareToPlayAsset:(AVAsset *)asset withKeys:(NSArray<NSString *> *)requestedKeys
 {
   for (NSString *key in requestedKeys) {
     NSError *error = nil;
@@ -122,7 +122,7 @@ static NSString * const kStatus = @"status";
   }
     
   AVPlayerItem *playerItem = [self constructPlayerItem];
-  self.currentItem = playerItem;
+  [self setCurrentItem:playerItem];
   
   if (_player != nil) {
     [_player replaceCurrentItemWithPlayerItem:playerItem];
@@ -289,14 +289,13 @@ static NSString * const kStatus = @"status";
   {
     ASDN::MutexLocker l(_videoLock);
 
-    if (_asset != nil) {
-      NSArray *requestedKeys = @[ @"playable" ];
-      [_asset loadValuesAsynchronouslyForKeys:requestedKeys completionHandler:^{
-          dispatch_async(dispatch_get_main_queue(), ^{
-            [self prepareToPlayAsset:_asset withKeys:requestedKeys];
-          });
-      }];
-    }
+    AVAsset *asset = self.asset;
+    NSArray<NSString *> *requestedKeys = @[ @"playable" ];
+    [asset loadValuesAsynchronouslyForKeys:requestedKeys completionHandler:^{
+      ASPerformBlockOnMainThread(^{
+        [self prepareToPlayAsset:asset withKeys:requestedKeys];
+      });
+    }];
   }
 }
 

--- a/AsyncDisplayKitTests/ASVideoNodeTests.m
+++ b/AsyncDisplayKitTests/ASVideoNodeTests.m
@@ -316,9 +316,8 @@
 
   [_videoNode didLoad];
   [_videoNode setInterfaceState:ASInterfaceStateVisible | ASInterfaceStateDisplay | ASInterfaceStateFetchData];
-  [_videoNode play];
-
   [_videoNode prepareToPlayAsset:assetMock withKeys:_requestedKeys];
+  [_videoNode play];
   
   XCTAssertTrue(_videoNode.isPlaying);
 
@@ -330,11 +329,15 @@
 
 - (void)testVideoThatAutorepeatsShouldRepeatOnPlaybackEnd
 {
-  _videoNode.asset = _firstAsset;
+  id assetMock = [OCMockObject partialMockForObject:_firstAsset];
+  [[[assetMock stub] andReturnValue:@YES] isPlayable];
+  
+  _videoNode.asset = assetMock;
   _videoNode.shouldAutorepeat = YES;
 
   [_videoNode didLoad];
   [_videoNode setInterfaceState:ASInterfaceStateVisible | ASInterfaceStateDisplay | ASInterfaceStateFetchData];
+  [_videoNode prepareToPlayAsset:assetMock withKeys:_requestedKeys];
   [_videoNode play];
 
   [[NSNotificationCenter defaultCenter] postNotificationName:AVPlayerItemDidPlayToEndTimeNotification object:_videoNode.currentItem];
@@ -344,9 +347,13 @@
 
 - (void)testVideoResumedWhenBufferIsLikelyToKeepUp
 {
-  _videoNode.asset = _firstAsset;
+  id assetMock = [OCMockObject partialMockForObject:_firstAsset];
+  [[[assetMock stub] andReturnValue:@YES] isPlayable];
+  
+  _videoNode.asset = assetMock;
 
   [_videoNode setInterfaceState:ASInterfaceStateVisible | ASInterfaceStateDisplay | ASInterfaceStateFetchData];
+  [_videoNode prepareToPlayAsset:assetMock withKeys:_requestedKeys];
   [_videoNode pause];
   _videoNode.shouldBePlaying = YES;
 


### PR DESCRIPTION
Following up with issue #1600, the following PR modifies `-fetchData` so that we can prepare an asset (HLS and non-HLS) for playback in a uniform way.

Namely:
1. Calls [`-loadValuesAsynchronouslyForKeys:completionHandler:`](https://developer.apple.com/library/ios/documentation/AVFoundation/Reference/AVAsynchronousKeyValueLoading_Protocol/index.html#//apple_ref/occ/intfm/AVAsynchronousKeyValueLoading/loadValuesAsynchronouslyForKeys:completionHandler:) in `-fetchData`.
2. Creates the `AVPlayerItem` and `AVPlayer` in `-prepareToPlayAsset:withKeys:`.
3. No longer extracts the URL from an AVAsset.

In doing so, the AVPlayer is not immediately available when `-fetchData` is called. Thanks and let me know your thoughts :)

@gazreese @ejensen 