### PR TITLE
[ASVideoNode] Several new delegate methods and ASVideoNodePlayerState to monitor and control playback

### DIFF
--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -339,8 +339,6 @@
 		9F06E5CD1B4CAF4200F015D8 /* ASCollectionViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F06E5CC1B4CAF4200F015D8 /* ASCollectionViewTests.m */; };
 		A2763D791CBDD57D00A9ADBD /* ASPINRemoteImageDownloader.h in Headers */ = {isa = PBXBuildFile; fileRef = A2763D771CBDD57D00A9ADBD /* ASPINRemoteImageDownloader.h */; };
 		A2763D7A1CBDD57D00A9ADBD /* ASPINRemoteImageDownloader.h in Headers */ = {isa = PBXBuildFile; fileRef = A2763D771CBDD57D00A9ADBD /* ASPINRemoteImageDownloader.h */; };
-		A2763D7B1CBDD57D00A9ADBD /* ASPINRemoteImageDownloader.m in Sources */ = {isa = PBXBuildFile; fileRef = A2763D781CBDD57D00A9ADBD /* ASPINRemoteImageDownloader.m */; };
-		A2763D7C1CBDD57D00A9ADBD /* ASPINRemoteImageDownloader.m in Sources */ = {isa = PBXBuildFile; fileRef = A2763D781CBDD57D00A9ADBD /* ASPINRemoteImageDownloader.m */; };
 		A32FEDD51C501B6A004F642A /* ASTextKitFontSizeAdjuster.h in Headers */ = {isa = PBXBuildFile; fileRef = A32FEDD31C501B6A004F642A /* ASTextKitFontSizeAdjuster.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A373200F1C571B730011FC94 /* ASTextNode+Beta.h in Headers */ = {isa = PBXBuildFile; fileRef = A373200E1C571B050011FC94 /* ASTextNode+Beta.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A37320101C571B740011FC94 /* ASTextNode+Beta.h in Headers */ = {isa = PBXBuildFile; fileRef = A373200E1C571B050011FC94 /* ASTextNode+Beta.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -751,7 +749,7 @@
 		257754BB1BEE458E00737CA5 /* ASTextKitCoreTextAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASTextKitCoreTextAdditions.h; path = TextKit/ASTextKitCoreTextAdditions.h; sourceTree = "<group>"; };
 		257754BC1BEE458E00737CA5 /* ASTextNodeTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASTextNodeTypes.h; path = TextKit/ASTextNodeTypes.h; sourceTree = "<group>"; };
 		257754BD1BEE458E00737CA5 /* ASTextNodeWordKerner.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ASTextNodeWordKerner.m; path = TextKit/ASTextNodeWordKerner.m; sourceTree = "<group>"; };
-		25E327541C16819500A2170C /* ASPagerNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = ASPagerNode.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
+		25E327541C16819500A2170C /* ASPagerNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = ASPagerNode.h; sourceTree = "<group>"; };
 		25E327551C16819500A2170C /* ASPagerNode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = ASPagerNode.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		2911485B1A77147A005D0878 /* ASControlNodeTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASControlNodeTests.m; sourceTree = "<group>"; };
 		292C59991A956527007E5DD6 /* ASLayoutRangeType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASLayoutRangeType.h; sourceTree = "<group>"; };

--- a/AsyncDisplayKit/ASVideoNode.h
+++ b/AsyncDisplayKit/ASVideoNode.h
@@ -12,6 +12,14 @@
 @class AVAsset, AVPlayer, AVPlayerItem;
 @protocol ASVideoNodeDelegate;
 
+typedef enum {
+  ASVideoNodePlayerStateUnknown,
+  ASVideoNodePlayerStatePlaying,
+  ASVideoNodePlayerStateLoading,
+  ASVideoNodePlayerStatePaused,
+  ASVideoNodePlayerStateFinished
+} ASVideoNodePlayerState;
+
 NS_ASSUME_NONNULL_BEGIN
 
 // IMPORTANT NOTES:
@@ -40,6 +48,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, assign, readwrite) BOOL muted;
 
+@property (nonatomic, assign, readonly) ASVideoNodePlayerState playerState;
+//! Defaults to 100
+@property (nonatomic, assign, readwrite) int32_t periodicTimeObserverTimescale;
+
 //! Defaults to AVLayerVideoGravityResizeAspect
 @property (atomic) NSString *gravity;
 
@@ -63,6 +75,31 @@ NS_ASSUME_NONNULL_BEGIN
  * @discussion The video's play state is toggled if this method is not implemented.
  */
 - (void)videoNodeWasTapped:(ASVideoNode *)videoNode;
+/**
+ * @abstract Delegate method invoked when player changes state.
+ * @param videoNode The video node that was tapped.
+ * @param state player state before this change.
+ * @param toSate player new state.
+ * @discussion This method is called after each state change
+ */
+- (void)videoNode:(ASVideoNode *)videoNode willChangePlayerState:(ASVideoNodePlayerState)state toState:(ASVideoNodePlayerState)toSate;
+/**
+ * @abstract Ssks delegate if state change is allowed
+ * ASVideoNodePlayerStatePlaying or ASVideoNodePlayerStatePaused.
+ * asks delegate if state change is allowed.
+ * @param videoNode The video node that was tapped.
+ * @param state player state that is going to be set.
+ * @discussion Delegate method invoked when player changes it's state to
+ * ASVideoNodePlayerStatePlaying or ASVideoNodePlayerStatePaused 
+ * and asks delegate if state change is valid
+ */
+- (BOOL)videoNode:(ASVideoNode*)videoNode shouldChangePlayerStateTo:(ASVideoNodePlayerState)state;
+/**
+ * @abstract Delegate method invoked when player playback time is updated.
+ * @param videoNode The video node that was tapped.
+ * @param second current playback time in seconds.
+ */
+- (void)videoNode:(ASVideoNode *)videoNode didPlayToSecond:(NSTimeInterval)second;
 @end
 NS_ASSUME_NONNULL_END
 #endif

--- a/AsyncDisplayKit/ASVideoNode.h
+++ b/AsyncDisplayKit/ASVideoNode.h
@@ -50,7 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, assign, readonly) ASVideoNodePlayerState playerState;
 //! Defaults to 100
-@property (nonatomic, assign, readwrite) int32_t periodicTimeObserverTimescale;
+@property (nonatomic, assign) int32_t periodicTimeObserverTimescale;
 
 //! Defaults to AVLayerVideoGravityResizeAspect
 @property (atomic) NSString *gravity;

--- a/AsyncDisplayKit/ASVideoNode.mm
+++ b/AsyncDisplayKit/ASVideoNode.mm
@@ -101,7 +101,7 @@ static NSString * const kStatus = @"status";
 - (ASDisplayNode *)constructPlayerNode
 {
   ASVideoNode * __weak weakSelf = self;
-  
+
   return [[ASDisplayNode alloc] initWithLayerBlock:^CALayer *{
     AVPlayerLayer *playerLayer = [[AVPlayerLayer alloc] init];
     playerLayer.player = weakSelf.player;
@@ -113,7 +113,7 @@ static NSString * const kStatus = @"status";
 - (AVPlayerItem *)constructPlayerItem
 {
   ASDN::MutexLocker l(_videoLock);
-  
+
   if (_asset != nil) {
     return [[AVPlayerItem alloc] initWithAsset:_asset];
   }
@@ -135,7 +135,7 @@ static NSString * const kStatus = @"status";
     NSLog(@"Asset is not playable.");
     return;
   }
-  
+
   AVPlayerItem *playerItem = [self constructPlayerItem];
   [self setCurrentItem:playerItem];
   
@@ -178,7 +178,7 @@ static NSString * const kStatus = @"status";
   @catch (NSException * __unused exception) {
     NSLog(@"Unnecessary KVO removal");
   }
-  
+
   NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
   [notificationCenter removeObserver:self name:AVPlayerItemDidPlayToEndTimeNotification object:playerItem];
   [notificationCenter removeObserver:self name:AVPlayerItemFailedToPlayToEndTimeNotification object:playerItem];
@@ -209,7 +209,7 @@ static NSString * const kStatus = @"status";
 {
   ASVideoNode * __weak weakSelf = self;
   AVAsset * __weak asset = self.asset;
-  
+
   [self imageAtTime:kCMTimeZero completionHandler:^(UIImage *image) {
     ASPerformBlockOnMainThread(^{
       // Ensure the asset hasn't changed since the image request was made
@@ -224,17 +224,17 @@ static NSString * const kStatus = @"status";
 {
   ASPerformBlockOnBackgroundThread(^{
     AVAsset *asset = self.asset;
-    
+
     // Skip the asset image generation if we don't have any tracks available that are capable of supporting it
     NSArray<AVAssetTrack *>* visualAssetArray = [asset tracksWithMediaCharacteristic:AVMediaCharacteristicVisual];
     if (visualAssetArray.count == 0) {
       completionHandler(nil);
       return;
     }
-    
+
     AVAssetImageGenerator *previewImageGenerator = [AVAssetImageGenerator assetImageGeneratorWithAsset:asset];
     previewImageGenerator.appliesPreferredTrackTransform = YES;
-    
+
     [previewImageGenerator generateCGImagesAsynchronouslyForTimes:@[[NSValue valueWithCMTime:imageTime]]
                                                 completionHandler:^(CMTime requestedTime, CGImageRef image, CMTime actualTime, AVAssetImageGeneratorResult result, NSError *error) {
                                                   if (error != nil && result != AVAssetImageGeneratorCancelled) {
@@ -248,18 +248,18 @@ static NSString * const kStatus = @"status";
 - (void)setVideoPlaceholderImage:(UIImage *)image
 {
   ASDN::MutexLocker l(_videoLock);
-  
+
   if (_placeholderImageNode == nil && image != nil) {
     _placeholderImageNode = [[ASImageNode alloc] init];
     _placeholderImageNode.layerBacked = YES;
     _placeholderImageNode.contentMode = ASContentModeFromVideoGravity(_gravity);
   }
-  
+
   _placeholderImageNode.image = image;
-  
+
   ASPerformBlockOnMainThread(^{
     ASDN::MutexLocker l(_videoLock);
-    
+
     if (_placeholderImageNode != nil) {
       [self insertSubnode:_placeholderImageNode atIndex:0];
       [self setNeedsLayout];
@@ -270,11 +270,11 @@ static NSString * const kStatus = @"status";
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
 {
   ASDN::MutexLocker l(_videoLock);
-  
+
   if (object != _currentPlayerItem) {
     return;
   }
-  
+
   if ([keyPath isEqualToString:kStatus]) {
     if ([change[NSKeyValueChangeNewKey] integerValue] == AVPlayerItemStatusReadyToPlay) {
       [self removeSpinner];
@@ -345,7 +345,7 @@ static NSString * const kStatus = @"status";
   
   {
     ASDN::MutexLocker l(_videoLock);
-  
+
     self.player = nil;
     self.currentItem = nil;
     _placeholderImageNode.image = nil;
@@ -391,10 +391,10 @@ static NSString * const kStatus = @"status";
 - (void)setPlayButton:(ASButtonNode *)playButton
 {
   ASDN::MutexLocker l(_videoLock);
-  
+
   [_playButton removeTarget:self action:@selector(tapped) forControlEvents:ASControlNodeEventTouchUpInside];
   [_playButton removeFromSupernode];
-  
+
   _playButton = playButton;
   
   [self addSubnode:playButton];
@@ -416,13 +416,13 @@ static NSString * const kStatus = @"status";
   if (ASAssetIsEqual(asset, _asset)) {
     return;
   }
-  
+
   [self clearFetchedData];
-  
+
   _asset = asset;
-  
+
   [self setNeedsDataFetch];
-  
+
   if (_shouldAutoplay) {
     [self play];
   }
@@ -495,18 +495,18 @@ static NSString * const kStatus = @"status";
 - (void)play
 {
   ASDN::MutexLocker l(_videoLock);
-  
+
   if (![self isStateChangeValid:ASVideoNodePlayerStatePlaying]) {
     return;
   }
-  
+
   if (_player == nil) {
     [self setNeedsDataFetch];
   }
-  
+
   if (_playerNode == nil) {
     _playerNode = [self constructPlayerNode];
-    
+
     if (_playButton.supernode == self) {
       [self insertSubnode:_playerNode belowSubnode:_playButton];
     } else {
@@ -604,7 +604,7 @@ static NSString * const kStatus = @"status";
     [_delegate videoPlaybackDidFinish:self];
   }
   [_player seekToTime:kCMTimeZero];
-  
+
   if (_shouldAutorepeat) {
     [self play];
   } else {
@@ -652,11 +652,11 @@ static NSString * const kStatus = @"status";
 - (void)setCurrentItem:(AVPlayerItem *)currentItem
 {
   ASDN::MutexLocker l(_videoLock);
-  
+
   [self removePlayerItemObservers:_currentPlayerItem];
-  
+
   _currentPlayerItem = currentItem;
-  
+
   [self addPlayerItemObservers:currentItem];
 }
 

--- a/AsyncDisplayKit/ASVideoNode.mm
+++ b/AsyncDisplayKit/ASVideoNode.mm
@@ -117,7 +117,7 @@ static NSString * const kStatus = @"status";
   if (_asset != nil) {
     return [[AVPlayerItem alloc] initWithAsset:_asset];
   }
-  
+
   return nil;
 }
 
@@ -282,7 +282,7 @@ static NSString * const kStatus = @"status";
       if (_placeholderImageNode.image == nil) {
         [self generatePlaceholderImage];
       }
-      if(_shouldBePlaying) {
+      if (_shouldBePlaying) {
         self.playerState = ASVideoNodePlayerStatePlaying;
       }
     }
@@ -334,7 +334,7 @@ static NSString * const kStatus = @"status";
     return;
   }
   
-  if(_delegateFlags.delegateVideoNodeDidPlayToSecond){
+  if (_delegateFlags.delegateVideoNodeDidPlayToSecond) {
     [_delegate videoNode:self didPlayToSecond:timeInSeconds];
   }
 }
@@ -344,11 +344,11 @@ static NSString * const kStatus = @"status";
   [super clearFetchedData];
   
   {
-  ASDN::MutexLocker l(_videoLock);
+    ASDN::MutexLocker l(_videoLock);
   
-  self.player = nil;
-  self.currentItem = nil;
-  _placeholderImageNode.image = nil;
+    self.player = nil;
+    self.currentItem = nil;
+    _placeholderImageNode.image = nil;
   }
 }
 
@@ -376,7 +376,7 @@ static NSString * const kStatus = @"status";
   
   ASVideoNodePlayerState oldState = _playerState;
   
-  if(oldState == playerState) {
+  if (oldState == playerState) {
     return;
   }
   
@@ -447,7 +447,7 @@ static NSString * const kStatus = @"status";
 - (void)setDelegate:(id<ASVideoNodeDelegate>)delegate
 {
   _delegate = delegate;
-  if(_delegate == nil) {
+  if (_delegate == nil) {
     memset(&_delegateFlags, 0, sizeof(_delegateFlags));
   } else {
     _delegateFlags.delegateVideNodeShouldChangePlayerStateTo = [_delegate respondsToSelector:@selector(videoNode:shouldChangePlayerStateTo:)];
@@ -496,7 +496,7 @@ static NSString * const kStatus = @"status";
 {
   ASDN::MutexLocker l(_videoLock);
   
-  if(![self isStateChangeValid:ASVideoNodePlayerStatePlaying]){
+  if (![self isStateChangeValid:ASVideoNodePlayerStatePlaying]) {
     return;
   }
   
@@ -523,7 +523,7 @@ static NSString * const kStatus = @"status";
   }];
   if (![self ready]) {
     [self showSpinner];
-  }else{
+  } else {
     [self removeSpinner];
     self.playerState = ASVideoNodePlayerStatePlaying;
   }
@@ -555,7 +555,7 @@ static NSString * const kStatus = @"status";
 {
   ASDN::MutexLocker l(_videoLock);
   
-  if(!_spinner) {
+  if (!_spinner) {
     return;
   }
   [_spinner removeFromSupernode];
@@ -565,7 +565,7 @@ static NSString * const kStatus = @"status";
 - (void)pause
 {
   ASDN::MutexLocker l(_videoLock);
-  if(![self isStateChangeValid:ASVideoNodePlayerStatePaused]){
+  if (![self isStateChangeValid:ASVideoNodePlayerStatePaused]) {
     return;
   }
   self.playerState = ASVideoNodePlayerStatePaused;
@@ -586,8 +586,8 @@ static NSString * const kStatus = @"status";
 
 - (BOOL)isStateChangeValid:(ASVideoNodePlayerState)state
 {
-  if(_delegateFlags.delegateVideNodeShouldChangePlayerStateTo){
-    if(![_delegate videoNode:self shouldChangePlayerStateTo:state]){
+  if (_delegateFlags.delegateVideNodeShouldChangePlayerStateTo) {
+    if (![_delegate videoNode:self shouldChangePlayerStateTo:state]) {
       return NO;
     }
   }

--- a/examples/Videos/Sample.xcodeproj/project.pbxproj
+++ b/examples/Videos/Sample.xcodeproj/project.pbxproj
@@ -1,806 +1,377 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>archiveVersion</key>
-	<string>1</string>
-	<key>classes</key>
-	<dict/>
-	<key>objectVersion</key>
-	<string>46</string>
-	<key>objects</key>
-	<dict>
-		<key>0585427F19D4DBE100606EA6</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>image.png</string>
-			<key>name</key>
-			<string>Default-568h@2x.png</string>
-			<key>path</key>
-			<string>../Default-568h@2x.png</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>0585428019D4DBE100606EA6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>0585427F19D4DBE100606EA6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>05E2127819D4DB510098F589</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>05E2128319D4DB510098F589</string>
-				<string>05E2128219D4DB510098F589</string>
-				<string>1A943BF0259746F18D6E423F</string>
-				<string>1AE410B73DA5C3BD087ACDD7</string>
-			</array>
-			<key>indentWidth</key>
-			<string>2</string>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-			<key>tabWidth</key>
-			<string>2</string>
-			<key>usesTabs</key>
-			<string>0</string>
-		</dict>
-		<key>05E2127919D4DB510098F589</key>
-		<dict>
-			<key>attributes</key>
-			<dict>
-				<key>LastUpgradeCheck</key>
-				<string>0600</string>
-				<key>ORGANIZATIONNAME</key>
-				<string>Facebook</string>
-				<key>TargetAttributes</key>
-				<dict>
-					<key>05E2128019D4DB510098F589</key>
-					<dict>
-						<key>CreatedOnToolsVersion</key>
-						<string>6.0.1</string>
-					</dict>
-				</dict>
-			</dict>
-			<key>buildConfigurationList</key>
-			<string>05E2127C19D4DB510098F589</string>
-			<key>compatibilityVersion</key>
-			<string>Xcode 3.2</string>
-			<key>developmentRegion</key>
-			<string>English</string>
-			<key>hasScannedForEncodings</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXProject</string>
-			<key>knownRegions</key>
-			<array>
-				<string>en</string>
-				<string>Base</string>
-			</array>
-			<key>mainGroup</key>
-			<string>05E2127819D4DB510098F589</string>
-			<key>productRefGroup</key>
-			<string>05E2128219D4DB510098F589</string>
-			<key>projectDirPath</key>
-			<string></string>
-			<key>projectReferences</key>
-			<array/>
-			<key>projectRoot</key>
-			<string></string>
-			<key>targets</key>
-			<array>
-				<string>05E2128019D4DB510098F589</string>
-			</array>
-		</dict>
-		<key>05E2127C19D4DB510098F589</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>05E212A219D4DB510098F589</string>
-				<string>05E212A319D4DB510098F589</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>05E2127D19D4DB510098F589</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>05E2128D19D4DB510098F589</string>
-				<string>05E2128A19D4DB510098F589</string>
-				<string>05E2128719D4DB510098F589</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>05E2127E19D4DB510098F589</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>5791C5525B690FA54F26ACE8</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>05E2127F19D4DB510098F589</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>AE8E41191C228A4A00913AC4</string>
-				<string>AED850671C22679200183ED3</string>
-				<string>0585428019D4DBE100606EA6</string>
-				<string>6C2C82AC19EE274300767484</string>
-				<string>AE8E411B1C23634C00913AC4</string>
-				<string>6C2C82AD19EE274300767484</string>
-				<string>AEE1F2C01C293CF1005E0577</string>
-			</array>
-			<key>isa</key>
-			<string>PBXResourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>05E2128019D4DB510098F589</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>05E212A419D4DB510098F589</string>
-			<key>buildPhases</key>
-			<array>
-				<string>E080B80F89C34A25B3488E26</string>
-				<string>05E2127D19D4DB510098F589</string>
-				<string>05E2127E19D4DB510098F589</string>
-				<string>05E2127F19D4DB510098F589</string>
-				<string>F012A6F39E0149F18F564F50</string>
-				<string>93B7780A33739EF25F20366B</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>Sample</string>
-			<key>productName</key>
-			<string>Sample</string>
-			<key>productReference</key>
-			<string>05E2128119D4DB510098F589</string>
-			<key>productType</key>
-			<string>com.apple.product-type.application</string>
-		</dict>
-		<key>05E2128119D4DB510098F589</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.application</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>Sample.app</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>05E2128219D4DB510098F589</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>05E2128119D4DB510098F589</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Products</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>05E2128319D4DB510098F589</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>AED850661C22679200183ED3</string>
-				<string>AEE1F2BF1C293CF1005E0577</string>
-				<string>AE8E41181C228A4A00913AC4</string>
-				<string>AE8E411A1C235A6000913AC4</string>
-				<string>05E2128819D4DB510098F589</string>
-				<string>05E2128919D4DB510098F589</string>
-				<string>05E2128B19D4DB510098F589</string>
-				<string>05E2128C19D4DB510098F589</string>
-				<string>05E2128419D4DB510098F589</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>Sample</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>05E2128419D4DB510098F589</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>0585427F19D4DBE100606EA6</string>
-				<string>6C2C82AA19EE274300767484</string>
-				<string>6C2C82AB19EE274300767484</string>
-				<string>05E2128519D4DB510098F589</string>
-				<string>05E2128619D4DB510098F589</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Supporting Files</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>05E2128519D4DB510098F589</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>05E2128619D4DB510098F589</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>main.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>05E2128719D4DB510098F589</key>
-		<dict>
-			<key>fileRef</key>
-			<string>05E2128619D4DB510098F589</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>05E2128819D4DB510098F589</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>AppDelegate.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>05E2128919D4DB510098F589</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>AppDelegate.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>05E2128A19D4DB510098F589</key>
-		<dict>
-			<key>fileRef</key>
-			<string>05E2128919D4DB510098F589</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>05E2128B19D4DB510098F589</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ViewController.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>05E2128C19D4DB510098F589</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ViewController.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>05E2128D19D4DB510098F589</key>
-		<dict>
-			<key>fileRef</key>
-			<string>05E2128C19D4DB510098F589</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>05E212A219D4DB510098F589</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>gnu++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_MODULES</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN_UNREACHABLE_CODE</key>
-				<string>YES</string>
-				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
-				<string>YES</string>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_DYNAMIC_NO_PIC</key>
-				<string>NO</string>
-				<key>GCC_OPTIMIZATION_LEVEL</key>
-				<string>0</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
-				<string>NO</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES_ERROR</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES_AGGRESSIVE</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>YES</string>
-				<key>ONLY_ACTIVE_ARCH</key>
-				<string>YES</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>05E212A319D4DB510098F589</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>gnu++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_MODULES</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN_UNREACHABLE_CODE</key>
-				<string>YES</string>
-				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
-				<string>YES</string>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>ENABLE_NS_ASSERTIONS</key>
-				<string>NO</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES_ERROR</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES_AGGRESSIVE</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>NO</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>VALIDATE_PRODUCT</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>05E212A419D4DB510098F589</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>05E212A519D4DB510098F589</string>
-				<string>05E212A619D4DB510098F589</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>05E212A519D4DB510098F589</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>CFD6AA1D30516C27DEE5602B</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ASSETCATALOG_COMPILER_APPICON_NAME</key>
-				<string>AppIcon</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Sample/Info.plist</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<string>$(inherited) @executable_path/Frameworks</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>05E212A619D4DB510098F589</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>E51646FF8D3676A1D826A5AE</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ASSETCATALOG_COMPILER_APPICON_NAME</key>
-				<string>AppIcon</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Sample/Info.plist</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<string>$(inherited) @executable_path/Frameworks</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>1A943BF0259746F18D6E423F</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>A2092CAF5607B3863A3700A2</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Frameworks</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>1AE410B73DA5C3BD087ACDD7</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>CFD6AA1D30516C27DEE5602B</string>
-				<string>E51646FF8D3676A1D826A5AE</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Pods</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>5791C5525B690FA54F26ACE8</key>
-		<dict>
-			<key>fileRef</key>
-			<string>A2092CAF5607B3863A3700A2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>6C2C82AA19EE274300767484</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>image.png</string>
-			<key>path</key>
-			<string>Default-667h@2x.png</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-		</dict>
-		<key>6C2C82AB19EE274300767484</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>image.png</string>
-			<key>path</key>
-			<string>Default-736h@3x.png</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-		</dict>
-		<key>6C2C82AC19EE274300767484</key>
-		<dict>
-			<key>fileRef</key>
-			<string>6C2C82AA19EE274300767484</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>6C2C82AD19EE274300767484</key>
-		<dict>
-			<key>fileRef</key>
-			<string>6C2C82AB19EE274300767484</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>93B7780A33739EF25F20366B</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>Embed Pods Frameworks</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>"${SRCROOT}/Pods/Target Support Files/Pods-Sample/Pods-Sample-frameworks.sh"
-</string>
-			<key>showEnvVarsInLog</key>
-			<string>0</string>
-		</dict>
-		<key>A2092CAF5607B3863A3700A2</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>libPods-Sample.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>AE8E41181C228A4A00913AC4</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>image.jpeg</string>
-			<key>path</key>
-			<string>bearacrat@2x.jpg</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AE8E41191C228A4A00913AC4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AE8E41181C228A4A00913AC4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>AE8E411A1C235A6000913AC4</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>file</string>
-			<key>path</key>
-			<string>simon.mp4</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AE8E411B1C23634C00913AC4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AE8E411A1C235A6000913AC4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>AED850661C22679200183ED3</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>image.png</string>
-			<key>path</key>
-			<string>playButton@2x.png</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AED850671C22679200183ED3</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AED850661C22679200183ED3</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>AEE1F2BF1C293CF1005E0577</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>image.png</string>
-			<key>path</key>
-			<string>playButtonSelected@2x.png</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AEE1F2C01C293CF1005E0577</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AEE1F2BF1C293CF1005E0577</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>CFD6AA1D30516C27DEE5602B</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-Sample.debug.xcconfig</string>
-			<key>path</key>
-			<string>Pods/Target Support Files/Pods-Sample/Pods-Sample.debug.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E080B80F89C34A25B3488E26</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>Check Pods Manifest.lock</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>diff "${PODS_ROOT}/../Podfile.lock" "${PODS_ROOT}/Manifest.lock" &gt; /dev/null
-if [[ $? != 0 ]] ; then
-    cat &lt;&lt; EOM
-error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.
-EOM
-    exit 1
-fi
-</string>
-			<key>showEnvVarsInLog</key>
-			<string>0</string>
-		</dict>
-		<key>E51646FF8D3676A1D826A5AE</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-Sample.release.xcconfig</string>
-			<key>path</key>
-			<string>Pods/Target Support Files/Pods-Sample/Pods-Sample.release.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F012A6F39E0149F18F564F50</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>Copy Pods Resources</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>"${SRCROOT}/Pods/Target Support Files/Pods-Sample/Pods-Sample-resources.sh"
-</string>
-			<key>showEnvVarsInLog</key>
-			<string>0</string>
-		</dict>
-	</dict>
-	<key>rootObject</key>
-	<string>05E2127919D4DB510098F589</string>
-</dict>
-</plist>
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		0585428019D4DBE100606EA6 /* Default-568h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 0585427F19D4DBE100606EA6 /* Default-568h@2x.png */; };
+		05E2128719D4DB510098F589 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 05E2128619D4DB510098F589 /* main.m */; };
+		05E2128A19D4DB510098F589 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 05E2128919D4DB510098F589 /* AppDelegate.m */; };
+		05E2128D19D4DB510098F589 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 05E2128C19D4DB510098F589 /* ViewController.m */; };
+		5791C5525B690FA54F26ACE8 /* libPods-Sample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A2092CAF5607B3863A3700A2 /* libPods-Sample.a */; };
+		6C2C82AC19EE274300767484 /* Default-667h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6C2C82AA19EE274300767484 /* Default-667h@2x.png */; };
+		6C2C82AD19EE274300767484 /* Default-736h@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6C2C82AB19EE274300767484 /* Default-736h@3x.png */; };
+		AE8E41191C228A4A00913AC4 /* bearacrat@2x.jpg in Resources */ = {isa = PBXBuildFile; fileRef = AE8E41181C228A4A00913AC4 /* bearacrat@2x.jpg */; };
+		AE8E411B1C23634C00913AC4 /* simon.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = AE8E411A1C235A6000913AC4 /* simon.mp4 */; };
+		AED850671C22679200183ED3 /* playButton@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = AED850661C22679200183ED3 /* playButton@2x.png */; };
+		AEE1F2C01C293CF1005E0577 /* playButtonSelected@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = AEE1F2BF1C293CF1005E0577 /* playButtonSelected@2x.png */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		0585427F19D4DBE100606EA6 /* Default-568h@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "Default-568h@2x.png"; path = "../Default-568h@2x.png"; sourceTree = "<group>"; };
+		05E2128119D4DB510098F589 /* Sample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Sample.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		05E2128519D4DB510098F589 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		05E2128619D4DB510098F589 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		05E2128819D4DB510098F589 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		05E2128919D4DB510098F589 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		05E2128B19D4DB510098F589 /* ViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
+		05E2128C19D4DB510098F589 /* ViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
+		6C2C82AA19EE274300767484 /* Default-667h@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default-667h@2x.png"; sourceTree = SOURCE_ROOT; };
+		6C2C82AB19EE274300767484 /* Default-736h@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default-736h@3x.png"; sourceTree = SOURCE_ROOT; };
+		A2092CAF5607B3863A3700A2 /* libPods-Sample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Sample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		AE8E41181C228A4A00913AC4 /* bearacrat@2x.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = "bearacrat@2x.jpg"; sourceTree = "<group>"; };
+		AE8E411A1C235A6000913AC4 /* simon.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = simon.mp4; sourceTree = "<group>"; };
+		AED850661C22679200183ED3 /* playButton@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "playButton@2x.png"; sourceTree = "<group>"; };
+		AEE1F2BF1C293CF1005E0577 /* playButtonSelected@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "playButtonSelected@2x.png"; sourceTree = "<group>"; };
+		CFD6AA1D30516C27DEE5602B /* Pods-Sample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Sample.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Sample/Pods-Sample.debug.xcconfig"; sourceTree = "<group>"; };
+		E51646FF8D3676A1D826A5AE /* Pods-Sample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Sample.release.xcconfig"; path = "Pods/Target Support Files/Pods-Sample/Pods-Sample.release.xcconfig"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		05E2127E19D4DB510098F589 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5791C5525B690FA54F26ACE8 /* libPods-Sample.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		05E2127819D4DB510098F589 = {
+			isa = PBXGroup;
+			children = (
+				05E2128319D4DB510098F589 /* Sample */,
+				05E2128219D4DB510098F589 /* Products */,
+				1A943BF0259746F18D6E423F /* Frameworks */,
+				1AE410B73DA5C3BD087ACDD7 /* Pods */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		05E2128219D4DB510098F589 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				05E2128119D4DB510098F589 /* Sample.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		05E2128319D4DB510098F589 /* Sample */ = {
+			isa = PBXGroup;
+			children = (
+				AED850661C22679200183ED3 /* playButton@2x.png */,
+				AEE1F2BF1C293CF1005E0577 /* playButtonSelected@2x.png */,
+				AE8E41181C228A4A00913AC4 /* bearacrat@2x.jpg */,
+				AE8E411A1C235A6000913AC4 /* simon.mp4 */,
+				05E2128819D4DB510098F589 /* AppDelegate.h */,
+				05E2128919D4DB510098F589 /* AppDelegate.m */,
+				05E2128B19D4DB510098F589 /* ViewController.h */,
+				05E2128C19D4DB510098F589 /* ViewController.m */,
+				05E2128419D4DB510098F589 /* Supporting Files */,
+			);
+			path = Sample;
+			sourceTree = "<group>";
+		};
+		05E2128419D4DB510098F589 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				0585427F19D4DBE100606EA6 /* Default-568h@2x.png */,
+				6C2C82AA19EE274300767484 /* Default-667h@2x.png */,
+				6C2C82AB19EE274300767484 /* Default-736h@3x.png */,
+				05E2128519D4DB510098F589 /* Info.plist */,
+				05E2128619D4DB510098F589 /* main.m */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		1A943BF0259746F18D6E423F /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				A2092CAF5607B3863A3700A2 /* libPods-Sample.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		1AE410B73DA5C3BD087ACDD7 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				CFD6AA1D30516C27DEE5602B /* Pods-Sample.debug.xcconfig */,
+				E51646FF8D3676A1D826A5AE /* Pods-Sample.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		05E2128019D4DB510098F589 /* Sample */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 05E212A419D4DB510098F589 /* Build configuration list for PBXNativeTarget "Sample" */;
+			buildPhases = (
+				E080B80F89C34A25B3488E26 /* 📦 Check Pods Manifest.lock */,
+				05E2127D19D4DB510098F589 /* Sources */,
+				05E2127E19D4DB510098F589 /* Frameworks */,
+				05E2127F19D4DB510098F589 /* Resources */,
+				F012A6F39E0149F18F564F50 /* 📦 Copy Pods Resources */,
+				93B7780A33739EF25F20366B /* 📦 Embed Pods Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Sample;
+			productName = Sample;
+			productReference = 05E2128119D4DB510098F589 /* Sample.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		05E2127919D4DB510098F589 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0600;
+				ORGANIZATIONNAME = Facebook;
+				TargetAttributes = {
+					05E2128019D4DB510098F589 = {
+						CreatedOnToolsVersion = 6.0.1;
+					};
+				};
+			};
+			buildConfigurationList = 05E2127C19D4DB510098F589 /* Build configuration list for PBXProject "Sample" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 05E2127819D4DB510098F589;
+			productRefGroup = 05E2128219D4DB510098F589 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				05E2128019D4DB510098F589 /* Sample */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		05E2127F19D4DB510098F589 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AE8E41191C228A4A00913AC4 /* bearacrat@2x.jpg in Resources */,
+				AED850671C22679200183ED3 /* playButton@2x.png in Resources */,
+				0585428019D4DBE100606EA6 /* Default-568h@2x.png in Resources */,
+				6C2C82AC19EE274300767484 /* Default-667h@2x.png in Resources */,
+				AE8E411B1C23634C00913AC4 /* simon.mp4 in Resources */,
+				6C2C82AD19EE274300767484 /* Default-736h@3x.png in Resources */,
+				AEE1F2C01C293CF1005E0577 /* playButtonSelected@2x.png in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		93B7780A33739EF25F20366B /* 📦 Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Sample/Pods-Sample-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		E080B80F89C34A25B3488E26 /* 📦 Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		F012A6F39E0149F18F564F50 /* 📦 Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Sample/Pods-Sample-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		05E2127D19D4DB510098F589 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				05E2128D19D4DB510098F589 /* ViewController.m in Sources */,
+				05E2128A19D4DB510098F589 /* AppDelegate.m in Sources */,
+				05E2128719D4DB510098F589 /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		05E212A219D4DB510098F589 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		05E212A319D4DB510098F589 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		05E212A519D4DB510098F589 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = CFD6AA1D30516C27DEE5602B /* Pods-Sample.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				INFOPLIST_FILE = Sample/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		05E212A619D4DB510098F589 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = E51646FF8D3676A1D826A5AE /* Pods-Sample.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				INFOPLIST_FILE = Sample/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		05E2127C19D4DB510098F589 /* Build configuration list for PBXProject "Sample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				05E212A219D4DB510098F589 /* Debug */,
+				05E212A319D4DB510098F589 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		05E212A419D4DB510098F589 /* Build configuration list for PBXNativeTarget "Sample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				05E212A519D4DB510098F589 /* Debug */,
+				05E212A619D4DB510098F589 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 05E2127919D4DB510098F589 /* Project object */;
+}

--- a/examples/Videos/Sample.xcworkspace/contents.xcworkspacedata
+++ b/examples/Videos/Sample.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:Sample.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/examples/Videos/Sample/ViewController.m
+++ b/examples/Videos/Sample/ViewController.m
@@ -12,7 +12,7 @@
 #import "ViewController.h"
 
 @interface ViewController()<ASVideoNodeDelegate>
-@property (nonatomic) ASVideoNode *videoNode;
+@property (nonatomic,strong) ASVideoNode *guitarVideoNode;
 @end
 
 @implementation ViewController
@@ -20,9 +20,8 @@
 - (void)viewWillAppear:(BOOL)animated
 {
   [super viewWillAppear:animated];
-
-  ASVideoNode *guitarVideo = [self guitarVideo];
-  [self.view addSubnode:guitarVideo];
+  
+  [self.view addSubnode:self.guitarVideoNode];
   
   ASVideoNode *nicCageVideo = [self nicCageVideo];
   [self.view addSubnode:nicCageVideo];
@@ -31,19 +30,26 @@
   [self.view addSubnode:simonVideo];
 }
 
-- (ASVideoNode *)guitarVideo;
+- (ASVideoNode *)guitarVideoNode;
 {
-  ASVideoNode *videoNode = [[ASVideoNode alloc] init];
+  if(_guitarVideoNode){
+    return _guitarVideoNode;
+  }
+  _guitarVideoNode = [[ASVideoNode alloc] init];
   
-  videoNode.asset = [AVAsset assetWithURL:[NSURL URLWithString:@"https://files.parsetfss.com/8a8a3b0c-619e-4e4d-b1d5-1b5ba9bf2b42/tfss-3045b261-7e93-4492-b7e5-5d6358376c9f-editedLiveAndDie.mov"]];
+  _guitarVideoNode.asset = [AVAsset assetWithURL:[NSURL URLWithString:@"https://files.parsetfss.com/8a8a3b0c-619e-4e4d-b1d5-1b5ba9bf2b42/tfss-3045b261-7e93-4492-b7e5-5d6358376c9f-editedLiveAndDie.mov"]];
   
-  videoNode.frame = CGRectMake(0, 0, [UIScreen mainScreen].bounds.size.width, [UIScreen mainScreen].bounds.size.height/3);
+  _guitarVideoNode.frame = CGRectMake(0, 0, [UIScreen mainScreen].bounds.size.width, [UIScreen mainScreen].bounds.size.height/3);
   
-  videoNode.gravity = AVLayerVideoGravityResizeAspectFill;
+  _guitarVideoNode.gravity = AVLayerVideoGravityResizeAspectFill;
   
-  videoNode.backgroundColor = [UIColor lightGrayColor];
+  _guitarVideoNode.backgroundColor = [UIColor lightGrayColor];
   
-  return videoNode;
+  _guitarVideoNode.periodicTimeObserverTimescale = 1; //Default is 100
+  
+  _guitarVideoNode.delegate = self;
+  
+  return _guitarVideoNode;
 }
 
 - (ASVideoNode *)nicCageVideo;
@@ -62,7 +68,7 @@
   nicCageVideo.shouldAutorepeat = YES;
   nicCageVideo.shouldAutoplay = YES;
   nicCageVideo.muted = YES;
-
+  
   return nicCageVideo;
 }
 
@@ -80,6 +86,7 @@
   simonVideo.backgroundColor = [UIColor lightGrayColor];
   simonVideo.shouldAutorepeat = YES;
   simonVideo.shouldAutoplay = YES;
+  simonVideo.muted = YES;
   
   return simonVideo;
 }
@@ -94,17 +101,49 @@
   playButton.bounds = CGRectMake(0, 0, playButton.calculatedSize.width, playButton.calculatedSize.height);
   playButton.position = CGPointMake([UIScreen mainScreen].bounds.size.width/4, ([UIScreen mainScreen].bounds.size.height/3)/2);
   [playButton setImage:[UIImage imageNamed:@"playButtonSelected@2x.png"] forState:ASControlStateHighlighted];
-
+  
   return playButton;
 }
 
 - (void)videoNodeWasTapped:(ASVideoNode *)videoNode
 {
+  if(videoNode == self.guitarVideoNode){
+    if(videoNode.playerState == ASVideoNodePlayerStatePlaying){
+      [videoNode pause];
+    }else{
+      [videoNode play];
+    }
+    return;
+  }
   if (videoNode.player.muted == YES) {
     videoNode.player.muted = NO;
   } else {
     videoNode.player.muted = YES;
   }
+}
+
+#pragma mark - ASVideoNodeDelegate
+- (void)videoNode:(ASVideoNode *)videoNode willChangePlayerState:(ASVideoNodePlayerState)state toState:(ASVideoNodePlayerState)toSate{
+  //Ignore nicCageVideo
+  if(videoNode != _guitarVideoNode){
+    return;
+  }
+  
+  if(toSate == ASVideoNodePlayerStatePlaying){
+    NSLog(@"guitarVideoNode is playing");
+  }else if(toSate == ASVideoNodePlayerStateFinished){
+    NSLog(@"guitarVideoNode finished");
+  }else if(toSate == ASVideoNodePlayerStateLoading){
+    NSLog(@"guitarVideoNode is buffering");
+  }
+}
+
+- (void)videoNode:(ASVideoNode *)videoNode didPlayToSecond:(NSTimeInterval)second{
+  if(videoNode != _guitarVideoNode){
+    return;
+  }
+  
+  NSLog(@"guitarVideoNode playback time is: %f",second);
 }
 
 @end

--- a/examples/Videos/Sample/ViewController.m
+++ b/examples/Videos/Sample/ViewController.m
@@ -110,6 +110,8 @@
   if(videoNode == self.guitarVideoNode){
     if(videoNode.playerState == ASVideoNodePlayerStatePlaying){
       [videoNode pause];
+    }else if(videoNode.playerState == ASVideoNodePlayerStateLoading) {
+      [videoNode pause];
     }else{
       [videoNode play];
     }

--- a/examples/Videos/Sample/ViewController.m
+++ b/examples/Videos/Sample/ViewController.m
@@ -12,7 +12,7 @@
 #import "ViewController.h"
 
 @interface ViewController()<ASVideoNodeDelegate>
-@property (nonatomic,strong) ASVideoNode *guitarVideoNode;
+@property (nonatomic, strong) ASVideoNode *guitarVideoNode;
 @end
 
 @implementation ViewController
@@ -32,7 +32,7 @@
 
 - (ASVideoNode *)guitarVideoNode;
 {
-  if(_guitarVideoNode){
+  if (_guitarVideoNode) {
     return _guitarVideoNode;
   }
   _guitarVideoNode = [[ASVideoNode alloc] init];
@@ -107,12 +107,12 @@
 
 - (void)videoNodeWasTapped:(ASVideoNode *)videoNode
 {
-  if(videoNode == self.guitarVideoNode){
-    if(videoNode.playerState == ASVideoNodePlayerStatePlaying){
+  if (videoNode == self.guitarVideoNode) {
+    if (videoNode.playerState == ASVideoNodePlayerStatePlaying) {
       [videoNode pause];
-    }else if(videoNode.playerState == ASVideoNodePlayerStateLoading) {
+    } else if(videoNode.playerState == ASVideoNodePlayerStateLoading) {
       [videoNode pause];
-    }else{
+    } else {
       [videoNode play];
     }
     return;
@@ -125,23 +125,25 @@
 }
 
 #pragma mark - ASVideoNodeDelegate
-- (void)videoNode:(ASVideoNode *)videoNode willChangePlayerState:(ASVideoNodePlayerState)state toState:(ASVideoNodePlayerState)toSate{
+- (void)videoNode:(ASVideoNode *)videoNode willChangePlayerState:(ASVideoNodePlayerState)state toState:(ASVideoNodePlayerState)toSate
+{
   //Ignore nicCageVideo
-  if(videoNode != _guitarVideoNode){
+  if (videoNode != _guitarVideoNode) {
     return;
   }
   
-  if(toSate == ASVideoNodePlayerStatePlaying){
+  if (toSate == ASVideoNodePlayerStatePlaying) {
     NSLog(@"guitarVideoNode is playing");
-  }else if(toSate == ASVideoNodePlayerStateFinished){
+  } else if (toSate == ASVideoNodePlayerStateFinished) {
     NSLog(@"guitarVideoNode finished");
-  }else if(toSate == ASVideoNodePlayerStateLoading){
+  } else if (toSate == ASVideoNodePlayerStateLoading) {
     NSLog(@"guitarVideoNode is buffering");
   }
 }
 
-- (void)videoNode:(ASVideoNode *)videoNode didPlayToSecond:(NSTimeInterval)second{
-  if(videoNode != _guitarVideoNode){
+- (void)videoNode:(ASVideoNode *)videoNode didPlayToSecond:(NSTimeInterval)second
+{
+  if (videoNode != _guitarVideoNode) {
     return;
   }
   


### PR DESCRIPTION
Added new delegate methods : 

##### `videoNode:willChangePlayerState:toState:`
This method is called after each state change. at this moment this states are supported: 
````
typedef enum {
  ASVideoNodePlayerStateUnknown,
  ASVideoNodePlayerStatePlaying,
  ASVideoNodePlayerStateLoading,
  ASVideoNodePlayerStatePaused,
  ASVideoNodePlayerStateFinished
} ASVideoNodePlayerState
````
##### `videoNode:shouldChangePlayerStateTo:`
This method is called before play and pause actions. asks delegate if play and pause are allowed states for ASVideoNode. For example you can disable pause method for some videos.

##### `videoNode:didPlayToSecond:`
This method i called from `periodicTimeObserver` and informs delegate about ASVideoNode playback current time. Can be used for scrubber UI or ads in video. For example you can pause video on 10 second and show some ads. you can control `periodicTimeObserver` timescale by setting `periodicTimeObserverTimescale`

#### ASVideoNodePlayerState
##### ASVideoNodePlayerStatePlaying
Is set from `play` method, when player item status is `AVPlayerItemStatusReadyToPlay` and `_shouldBePlaying` is true.
##### ASVideoNodePlayerStateLoading
Is set when player item status is not equal to `AVPlayerItemStatusReadyToPlay` and spinner is shown
##### ASVideoNodePlayerStatePaused
Is set when `pause` method is called
##### ASVideoNodePlayerStateFinished
Is set when `didPlayToEnd` notification is fired

Will be happy to hear your comments

UPD: 
- added `playbackBufferEmpty` observer to show spinner when buffering; 
- moved show/hide spinner to separate methods