### PR TITLE
[ASDisplayNode] Improve Transition ID handling

### DIFF
--- a/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
+++ b/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
@@ -93,7 +93,9 @@ FOUNDATION_EXPORT NSString * const ASRenderingEngineDidDisplayNodesScheduledBefo
   ASDisplayNode * __weak _supernode;
 
   ASSentinel *_displaySentinel;
+
   ASSentinel *_transitionSentinel;
+  BOOL _transitionInProgress;
 
   // This is the desired contentsScale, not the scale at which the layer's contents should be displayed
   CGFloat _contentsScaleForDisplay;

--- a/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
+++ b/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
@@ -94,7 +94,7 @@ FOUNDATION_EXPORT NSString * const ASRenderingEngineDidDisplayNodesScheduledBefo
 
   ASSentinel *_displaySentinel;
 
-  ASSentinel *_transitionSentinel;
+  int32_t _transitionID;
   BOOL _transitionInProgress;
 
   // This is the desired contentsScale, not the scale at which the layer's contents should be displayed


### PR DESCRIPTION
Currently in a race condition situation it can happen that subnodes get transition ids from supernodes where the supernodes transition id was reset but the subnode still has the old transition id value. This will trigger an exception although the assignment of the transition id is totally valid. This PR should address this by not reseting the transition id at all for a node and increase the transition id for new transitions.

cc @nguyenhuy @appleguy @levi