### PR TITLE
[ASCollectionView] Repopulate supplementary views on item-level changes

### DIFF
--- a/AsyncDisplayKit/Details/ASCollectionDataController.mm
+++ b/AsyncDisplayKit/Details/ASCollectionDataController.mm
@@ -73,7 +73,6 @@
     [self batchLayoutNodesFromContexts:contexts ofKind:kind completion:^(NSArray<ASCellNode *> *nodes, NSArray<NSIndexPath *> *indexPaths) {
       [self insertNodes:nodes ofKind:kind atIndexPaths:indexPaths completion:nil];
     }];
-
     [_pendingContexts removeObjectForKey:kind];
   }
 }
@@ -102,7 +101,6 @@
     [self batchLayoutNodesFromContexts:contexts ofKind:kind completion:^(NSArray<ASCellNode *> *nodes, NSArray<NSIndexPath *> *indexPaths) {
       [self insertNodes:nodes ofKind:kind atIndexPaths:indexPaths completion:nil];
     }];
-
     [_pendingContexts removeObjectForKey:kind];
   }
 }
@@ -137,7 +135,6 @@
     [self batchLayoutNodesFromContexts:contexts ofKind:kind completion:^(NSArray<ASCellNode *> *nodes, NSArray<NSIndexPath *> *indexPaths) {
       [self insertNodes:nodes ofKind:kind atIndexPaths:indexPaths completion:nil];
     }];
-
     [_pendingContexts removeObjectForKey:kind];
   }
 }
@@ -178,7 +175,6 @@
     [self batchLayoutNodesFromContexts:contexts ofKind:kind completion:^(NSArray<ASCellNode *> *nodes, NSArray<NSIndexPath *> *indexPaths) {
       [self insertNodes:nodes ofKind:kind atIndexPaths:indexPaths completion:nil];
     }];
-
     [_pendingContexts removeObjectForKey:kind];
   }
 }
@@ -205,13 +201,12 @@
   NSArray *keys = _pendingContexts.allKeys;
   for (NSString *kind in keys) {
     NSMutableArray<ASIndexedNodeContext *> *contexts = _pendingContexts[kind];
-    
+
     [self deleteNodesOfKind:kind atIndexPaths:indexPaths completion:nil];
     // reinsert the elements
     [self batchLayoutNodesFromContexts:contexts ofKind:kind completion:^(NSArray<ASCellNode *> *nodes, NSArray<NSIndexPath *> *indexPaths) {
       [self insertNodes:nodes ofKind:kind atIndexPaths:indexPaths completion:nil];
     }];
-    
     [_pendingContexts removeObjectForKey:kind];
   }
 }

--- a/AsyncDisplayKit/Details/ASCollectionDataController.mm
+++ b/AsyncDisplayKit/Details/ASCollectionDataController.mm
@@ -73,6 +73,7 @@
     [self batchLayoutNodesFromContexts:contexts ofKind:kind completion:^(NSArray<ASCellNode *> *nodes, NSArray<NSIndexPath *> *indexPaths) {
       [self insertNodes:nodes ofKind:kind atIndexPaths:indexPaths completion:nil];
     }];
+
     [_pendingContexts removeObjectForKey:kind];
   }
 }
@@ -101,6 +102,7 @@
     [self batchLayoutNodesFromContexts:contexts ofKind:kind completion:^(NSArray<ASCellNode *> *nodes, NSArray<NSIndexPath *> *indexPaths) {
       [self insertNodes:nodes ofKind:kind atIndexPaths:indexPaths completion:nil];
     }];
+
     [_pendingContexts removeObjectForKey:kind];
   }
 }
@@ -135,6 +137,7 @@
     [self batchLayoutNodesFromContexts:contexts ofKind:kind completion:^(NSArray<ASCellNode *> *nodes, NSArray<NSIndexPath *> *indexPaths) {
       [self insertNodes:nodes ofKind:kind atIndexPaths:indexPaths completion:nil];
     }];
+
     [_pendingContexts removeObjectForKey:kind];
   }
 }
@@ -172,7 +175,6 @@
     [self batchLayoutNodesFromContexts:contexts ofKind:kind completion:^(NSArray<ASCellNode *> *nodes, NSArray<NSIndexPath *> *indexPaths) {
     [self insertNodes:nodes ofKind:kind atIndexPaths:indexPaths completion:nil];
     }];
-    [_pendingContexts removeObjectForKey:kind];
   }];
 }
 
@@ -201,7 +203,6 @@
     [self batchLayoutNodesFromContexts:contexts ofKind:kind completion:^(NSArray<ASCellNode *> *nodes, NSArray<NSIndexPath *> *indexPaths) {
       [self insertNodes:nodes ofKind:kind atIndexPaths:indexPaths completion:nil];
     }];
-    [_pendingContexts removeObjectForKey:kind];
   }];
 }
 
@@ -216,12 +217,7 @@
     NSUInteger rowCount = [self.collectionDataSource dataController:self supplementaryNodesOfKind:kind inSection:i];
     for (NSUInteger j = 0; j < rowCount; j++) {
       NSIndexPath *indexPath = [sectionIndexPath indexPathByAddingIndex:j];
-      [self _populateSupplementaryNodeOfKind:kind atIndexPath:indexPath mutableContexts:contexts];
-
-
-
-
-
+      [self _populateSupplementaryNodeOfKind:kind atIndexPath:indexPath mutableContexts:contexts environmentTraitCollection:environmentTraitCollection];
     }
   }
 }
@@ -236,13 +232,16 @@
     NSIndexPath *sectionIndex = [[NSIndexPath alloc] initWithIndex:idx];
     for (NSUInteger i = 0; i < rowNum; i++) {
       NSIndexPath *indexPath = [sectionIndex indexPathByAddingIndex:i];
-      [self _populateSupplementaryNodeOfKind:kind atIndexPath:indexPath mutableContexts:contexts];
+      [self _populateSupplementaryNodeOfKind:kind atIndexPath:indexPath mutableContexts:contexts environmentTraitCollection:environmentTraitCollection];
     }
   }];
 }
 
 - (void)_populateSupplementaryNodesOfKind:(NSString *)kind atIndexPaths:(NSArray<NSIndexPath *> *)indexPaths mutableContexts:(NSMutableArray<ASIndexedNodeContext *> *)contexts
 {
+  id<ASEnvironment> environment = [self.environmentDelegate dataControllerEnvironment];
+  ASEnvironmentTraitCollection environmentTraitCollection = environment.environmentTraitCollection;
+
   NSMutableIndexSet *sections = [NSMutableIndexSet indexSet];
   for (NSIndexPath *indexPath in indexPaths) {
     [sections addIndex:indexPath.section];
@@ -253,12 +252,12 @@
     NSIndexPath *sectionIndex = [[NSIndexPath alloc] initWithIndex:idx];
     for (NSUInteger i = 0; i < rowNum; i++) {
       NSIndexPath *indexPath = [sectionIndex indexPathByAddingIndex:i];
-      [self _populateSupplementaryNodeOfKind:kind atIndexPath:indexPath mutableContexts:contexts];
+      [self _populateSupplementaryNodeOfKind:kind atIndexPath:indexPath mutableContexts:contexts environmentTraitCollection:environmentTraitCollection];
     }
   }];
 }
 
-- (void)_populateSupplementaryNodeOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath mutableContexts:(NSMutableArray<ASIndexedNodeContext *> *)contexts
+- (void)_populateSupplementaryNodeOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath mutableContexts:(NSMutableArray<ASIndexedNodeContext *> *)contexts environmentTraitCollection:(ASEnvironmentTraitCollection)environmentTraitCollection
 {
       ASCellNodeBlock supplementaryCellBlock;
       if (_dataSourceImplementsSupplementaryNodeBlockOfKindAtIndexPath) {

--- a/AsyncDisplayKit/Details/ASCollectionDataController.mm
+++ b/AsyncDisplayKit/Details/ASCollectionDataController.mm
@@ -161,9 +161,7 @@
   for (NSString *kind in [self supplementaryKinds]) {
     LOG(@"Populating elements of kind: %@, for index paths: %@", kind, indexPaths);
     NSMutableArray<ASIndexedNodeContext *> *contexts = [NSMutableArray array];
-    for (NSIndexPath *indexPath in indexPaths) {
-      [self _populateSupplementaryNodeOfKind:kind atIndexPath:indexPath mutableContexts:contexts];
-    }
+    [self _populateSupplementaryNodesOfKind:kind atIndexPaths:indexPaths mutableContexts:contexts];
     _pendingContexts[kind] = contexts;
   }
 }
@@ -190,9 +188,7 @@
 {
   for (NSString *kind in [self supplementaryKinds]) {
     NSMutableArray<ASIndexedNodeContext *> *contexts = [NSMutableArray array];
-    for (NSIndexPath *indexPath in indexPaths) {
-      [self _populateSupplementaryNodeOfKind:kind atIndexPath:indexPath mutableContexts:contexts];
-    }
+    [self _populateSupplementaryNodesOfKind:kind atIndexPaths:indexPaths mutableContexts:contexts];
     _pendingContexts[kind] = contexts;
   }
 }
@@ -235,6 +231,23 @@
   id<ASEnvironment> environment = [self.environmentDelegate dataControllerEnvironment];
   ASEnvironmentTraitCollection environmentTraitCollection = environment.environmentTraitCollection;
   
+  [sections enumerateIndexesUsingBlock:^(NSUInteger idx, BOOL *stop) {
+    NSUInteger rowNum = [self.collectionDataSource dataController:self supplementaryNodesOfKind:kind inSection:idx];
+    NSIndexPath *sectionIndex = [[NSIndexPath alloc] initWithIndex:idx];
+    for (NSUInteger i = 0; i < rowNum; i++) {
+      NSIndexPath *indexPath = [sectionIndex indexPathByAddingIndex:i];
+      [self _populateSupplementaryNodeOfKind:kind atIndexPath:indexPath mutableContexts:contexts];
+    }
+  }];
+}
+
+- (void)_populateSupplementaryNodesOfKind:(NSString *)kind atIndexPaths:(NSArray<NSIndexPath *> *)indexPaths mutableContexts:(NSMutableArray<ASIndexedNodeContext *> *)contexts
+{
+  NSMutableIndexSet *sections = [NSMutableIndexSet indexSet];
+  for (NSIndexPath *indexPath in indexPaths) {
+    [sections addIndex:indexPath.section];
+  }
+
   [sections enumerateIndexesUsingBlock:^(NSUInteger idx, BOOL *stop) {
     NSUInteger rowNum = [self.collectionDataSource dataController:self supplementaryNodesOfKind:kind inSection:idx];
     NSIndexPath *sectionIndex = [[NSIndexPath alloc] initWithIndex:idx];

--- a/AsyncDisplayKit/Details/ASCollectionDataController.mm
+++ b/AsyncDisplayKit/Details/ASCollectionDataController.mm
@@ -171,11 +171,16 @@
 
 - (void)willInsertRowsAtIndexPaths:(NSArray<NSIndexPath *> *)indexPaths
 {
-  [_pendingContexts enumerateKeysAndObjectsUsingBlock:^(NSString *kind, NSMutableArray<ASIndexedNodeContext *> *contexts, BOOL *stop) {
+  NSArray *keys = _pendingContexts.allKeys;
+  for (NSString *kind in keys) {
+    NSMutableArray<ASIndexedNodeContext *> *contexts = _pendingContexts[kind];
+
     [self batchLayoutNodesFromContexts:contexts ofKind:kind completion:^(NSArray<ASCellNode *> *nodes, NSArray<NSIndexPath *> *indexPaths) {
-    [self insertNodes:nodes ofKind:kind atIndexPaths:indexPaths completion:nil];
+      [self insertNodes:nodes ofKind:kind atIndexPaths:indexPaths completion:nil];
     }];
-  }];
+
+    [_pendingContexts removeObjectForKey:kind];
+  }
 }
 
 - (void)willDeleteRowsAtIndexPaths:(NSArray<NSIndexPath *> *)indexPaths
@@ -197,13 +202,18 @@
 
 - (void)willReloadRowsAtIndexPaths:(NSArray<NSIndexPath *> *)indexPaths
 {
-  [_pendingContexts enumerateKeysAndObjectsUsingBlock:^(NSString *kind, NSMutableArray<ASIndexedNodeContext *> *contexts, BOOL *stop) {
+  NSArray *keys = _pendingContexts.allKeys;
+  for (NSString *kind in keys) {
+    NSMutableArray<ASIndexedNodeContext *> *contexts = _pendingContexts[kind];
+    
     [self deleteNodesOfKind:kind atIndexPaths:indexPaths completion:nil];
     // reinsert the elements
     [self batchLayoutNodesFromContexts:contexts ofKind:kind completion:^(NSArray<ASCellNode *> *nodes, NSArray<NSIndexPath *> *indexPaths) {
       [self insertNodes:nodes ofKind:kind atIndexPaths:indexPaths completion:nil];
     }];
-  }];
+    
+    [_pendingContexts removeObjectForKey:kind];
+  }
 }
 
 - (void)_populateSupplementaryNodesOfKind:(NSString *)kind withMutableContexts:(NSMutableArray<ASIndexedNodeContext *> *)contexts

--- a/AsyncDisplayKit/Details/ASDataController+Subclasses.h
+++ b/AsyncDisplayKit/Details/ASDataController+Subclasses.h
@@ -160,4 +160,70 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCellNode *> *nodes, NS
  */
 - (void)willMoveSection:(NSInteger)section toSection:(NSInteger)newSection;
 
+/**
+ * Notifies the subclass to perform setup before rows are inserted in the data controller.
+ *
+ * @discussion This method will be performed before the data controller enters its editing queue.
+ * The data source is locked at this point and accessing it is safe. Use this method to set up any nodes or
+ * data stores before entering into editing the backing store on a background thread.
+ *
+ * @param indexPaths Index paths for the rows to be inserted.
+ */
+- (void)prepareForInsertRowsAtIndexPaths:(NSArray<NSIndexPath *> *)indexPaths;
+
+/**
+ * Notifies the subclass that the data controller will insert new rows at the given index paths.
+ *
+ * @discussion This method will be performed on the data controller's editing background queue before the parent's
+ * concrete implementation. This is a great place to perform any additional transformations like supplementary views
+ * or header/footer nodes.
+ *
+ * @param indexPaths Index paths for the rows to be inserted.
+ */
+- (void)willInsertRowsAtIndexPaths:(NSArray<NSIndexPath *> *)indexPaths;
+
+/**
+ * Notifies the subclass to perform setup before rows are deleted in the data controller.
+ *
+ * @discussion This method will be performed before the data controller enters its editing queue.
+ * The data source is locked at this point and accessing it is safe. Use this method to set up any nodes or
+ * data stores before entering into editing the backing store on a background thread.
+ *
+ * @param indexPaths Index paths for the rows to be deleted.
+ */
+- (void)prepareForDeleteRowsAtIndexPaths:(NSArray<NSIndexPath *> *)indexPaths;
+
+/**
+ * Notifies the subclass that the data controller will delete rows at the given index paths.
+ *
+ * @discussion This method will be performed before the data controller enters its editing queue.
+ * The data source is locked at this point and accessing it is safe. Use this method to set up any nodes or
+ * data stores before entering into editing the backing store on a background thread.
+ *
+ * @param indexPaths Index paths for the rows to be deleted.
+ */
+- (void)willDeleteRowsAtIndexPaths:(NSArray<NSIndexPath *> *)indexPaths;
+
+/**
+ * Notifies the subclass to perform any work needed before the given rows will be reloaded.
+ *
+ * @discussion This method will be performed before the data controller enters its editing queue, usually on the main
+ * thread. The data source is locked at this point and accessing it is safe. Use this method to set up any nodes or
+ * data stores before entering into editing the backing store on a background thread.
+ *
+ * @param indexPaths Index paths for the rows to be reloaded.
+ */
+- (void)prepareForReloadRowsAtIndexPaths:(NSArray<NSIndexPath *> *)indexPaths;
+
+/**
+ * Notifies the subclass that the data controller will reload the rows at the given index paths.
+ *
+ * @discussion This method will be performed on the data controller's editing background queue before the parent's
+ * concrete implementation. This is a great place to perform any additional transformations like supplementary views
+ * or header/footer nodes.
+ *
+ * @param indexPaths Index paths for the rows to be reloaded.
+ */
+- (void)willReloadRowsAtIndexPaths:(NSArray<NSIndexPath *> *)indexPaths;
+
 @end

--- a/AsyncDisplayKit/Details/ASDataController.mm
+++ b/AsyncDisplayKit/Details/ASDataController.mm
@@ -772,6 +772,36 @@ static void *kASSizingQueueContext = &kASSizingQueueContext;
   // Optional template hook for subclasses (See ASDataController+Subclasses.h)
 }
 
+- (void)prepareForInsertRowsAtIndexPaths:(NSArray<NSIndexPath *> *)indexPaths
+{
+  // Optional template hook for subclasses (See ASDataController+Subclasses.h)
+}
+
+- (void)willInsertRowsAtIndexPaths:(NSArray<NSIndexPath *> *)indexPaths
+{
+  // Optional template hook for subclasses (See ASDataController+Subclasses.h)
+}
+
+- (void)prepareForDeleteRowsAtIndexPaths:(NSArray<NSIndexPath *> *)indexPaths
+{
+  // Optional template hook for subclasses (See ASDataController+Subclasses.h)
+}
+
+- (void)willDeleteRowsAtIndexPaths:(NSArray<NSIndexPath *> *)indexPaths
+{
+  // Optional template hook for subclasses (See ASDataController+Subclasses.h)
+}
+
+- (void)prepareForReloadRowsAtIndexPaths:(NSArray<NSIndexPath *> *)indexPaths
+{
+  // Optional template hook for subclasses (See ASDataController+Subclasses.h)
+}
+
+- (void)willReloadRowsAtIndexPaths:(NSArray<NSIndexPath *> *)indexPaths
+{
+  // Optional template hook for subclasses (See ASDataController+Subclasses.h)
+}
+
 #pragma mark - Row Editing (External API)
 
 - (void)insertRowsAtIndexPaths:(NSArray *)indexPaths withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions
@@ -799,7 +829,11 @@ static void *kASSizingQueueContext = &kASSizingQueueContext;
                                                  environmentTraitCollection:environmentTraitCollection]];
       }
 
+      [self prepareForInsertRowsAtIndexPaths:indexPaths];
+
       [_editingTransactionQueue addOperationWithBlock:^{
+        [self willInsertRowsAtIndexPaths:indexPaths];
+
         LOG(@"Edit Transaction - insertRows: %@", indexPaths);
         [self _batchLayoutNodesFromContexts:contexts withAnimationOptions:animationOptions];
       }];
@@ -819,7 +853,11 @@ static void *kASSizingQueueContext = &kASSizingQueueContext;
     // FIXME: Shouldn't deletes be sorted in descending order?
     NSArray *sortedIndexPaths = [indexPaths sortedArrayUsingSelector:@selector(compare:)];
 
+    [self prepareForDeleteRowsAtIndexPaths:sortedIndexPaths];
+
     [_editingTransactionQueue addOperationWithBlock:^{
+      [self willDeleteRowsAtIndexPaths:sortedIndexPaths];
+
       LOG(@"Edit Transaction - deleteRows: %@", indexPaths);
       [self _deleteNodesAtIndexPaths:sortedIndexPaths withAnimationOptions:animationOptions];
     }];
@@ -853,8 +891,12 @@ static void *kASSizingQueueContext = &kASSizingQueueContext;
                                                             constrainedSize:constrainedSize
                                                  environmentTraitCollection:environmentTraitCollection]];
       }
+
+      [self prepareForReloadRowsAtIndexPaths:indexPaths];
       
       [_editingTransactionQueue addOperationWithBlock:^{
+        [self willReloadRowsAtIndexPaths:indexPaths];
+
         LOG(@"Edit Transaction - reloadRows: %@", indexPaths);
         [self _deleteNodesAtIndexPaths:sortedIndexPaths withAnimationOptions:animationOptions];
         [self _batchLayoutNodesFromContexts:contexts withAnimationOptions:animationOptions];

--- a/AsyncDisplayKit/Private/ASMultidimensionalArrayUtils.h
+++ b/AsyncDisplayKit/Private/ASMultidimensionalArrayUtils.h
@@ -47,7 +47,12 @@ extern NSArray *ASFindElementsInMultidimensionalArrayAtIndexPaths(NSMutableArray
 /**
  * Return all the index paths of mutable multidimensional array at given index set, in ascending order.
  */
-extern NSArray *ASIndexPathsForMultidimensionalArrayAtIndexSet(NSArray *MultidimensionalArray, NSIndexSet *indexSet);
+extern NSArray *ASIndexPathsForMultidimensionalArrayAtIndexSet(NSArray *multidimensionalArray, NSIndexSet *indexSet);
+
+/**
+ * Return the index paths of the given multidimensional array that are present in the given index paths array.
+ */
+extern NSArray<NSIndexPath *> *ASIndexPathsInMultidimensionalArrayIntersectingIndexPaths(NSArray *multidimensionalArray, NSArray<NSIndexPath *> *indexPaths);
 
 /**
  * Return all the index paths of a two-dimensional array, in ascending order.

--- a/AsyncDisplayKit/Private/ASMultidimensionalArrayUtils.mm
+++ b/AsyncDisplayKit/Private/ASMultidimensionalArrayUtils.mm
@@ -53,11 +53,11 @@ static void ASRecursivelyFindIndexPathsForMultidimensionalArray(NSObject *obj, N
   }
 }
 
-static BOOL ASElementExistsAtIndexPath(NSMutableArray *mutableArray, NSIndexPath *indexPath) {
+static BOOL ASElementExistsAtIndexPathForMultidimensionalArray(NSArray *array, NSIndexPath *indexPath) {
   NSUInteger indexLength = indexPath.length;
   ASDisplayNodeCAssert(indexLength != 0, @"Must have a non-zero indexPath length");
   NSUInteger firstIndex = [indexPath indexAtPosition:0];
-  BOOL elementExists = firstIndex < mutableArray.count;
+  BOOL elementExists = firstIndex < array.count;
 
   if (indexLength == 1) {
     return elementExists;
@@ -67,7 +67,7 @@ static BOOL ASElementExistsAtIndexPath(NSMutableArray *mutableArray, NSIndexPath
     return NO;
   }
 
-  return ASElementExistsAtIndexPath(mutableArray[firstIndex], [indexPath indexPathByRemovingLastIndex]);
+  return ASElementExistsAtIndexPathForMultidimensionalArray(array[firstIndex], [indexPath indexPathByRemovingLastIndex]);
 }
 
 #pragma mark - Public Methods
@@ -163,7 +163,7 @@ NSArray<NSIndexPath *> *ASIndexPathsInMultidimensionalArrayIntersectingIndexPath
 {
   NSMutableArray *res = [NSMutableArray array];
   for (NSIndexPath *indexPath in indexPaths) {
-    if (ASElementExistsAtIndexPath(multidimensionalArray, indexPath)) {
+    if (ASElementExistsAtIndexPathForMultidimensionalArray(multidimensionalArray, indexPath)) {
       [res addObject:indexPath];
     }
   }

--- a/AsyncDisplayKit/Private/ASMultidimensionalArrayUtils.mm
+++ b/AsyncDisplayKit/Private/ASMultidimensionalArrayUtils.mm
@@ -53,6 +53,23 @@ static void ASRecursivelyFindIndexPathsForMultidimensionalArray(NSObject *obj, N
   }
 }
 
+static BOOL ASElementExistsAtIndexPath(NSMutableArray *mutableArray, NSIndexPath *indexPath) {
+  NSUInteger indexLength = indexPath.length;
+  ASDisplayNodeCAssert(indexLength != 0, @"Must have a non-zero indexPath length");
+  NSUInteger firstIndex = [indexPath indexAtPosition:0];
+  BOOL elementExists = firstIndex < mutableArray.count;
+
+  if (indexLength == 1) {
+    return elementExists;
+  }
+
+  if (!elementExists) {
+    return NO;
+  }
+
+  return ASElementExistsAtIndexPath(mutableArray[firstIndex], [indexPath indexPathByRemovingLastIndex]);
+}
+
 #pragma mark - Public Methods
 
 NSObject<NSCopying> *ASMultidimensionalArrayDeepMutableCopy(NSObject<NSCopying> *obj)
@@ -138,6 +155,18 @@ NSArray *ASIndexPathsForMultidimensionalArrayAtIndexSet(NSArray *multidimensiona
   [indexSet enumerateIndexesUsingBlock:^(NSUInteger idx, BOOL *stop) {
     ASRecursivelyFindIndexPathsForMultidimensionalArray(multidimensionalArray[idx], [NSIndexPath indexPathWithIndex:idx], res);
   }];
+
+  return res;
+}
+
+NSArray<NSIndexPath *> *ASIndexPathsInMultidimensionalArrayIntersectingIndexPaths(NSArray *multidimensionalArray, NSArray<NSIndexPath *> *indexPaths)
+{
+  NSMutableArray *res = [NSMutableArray array];
+  for (NSIndexPath *indexPath in indexPaths) {
+    if (ASElementExistsAtIndexPath(multidimensionalArray, indexPath)) {
+      [res addObject:indexPath];
+    }
+  }
 
   return res;
 }

--- a/AsyncDisplayKit/Private/ASMultidimensionalArrayUtils.mm
+++ b/AsyncDisplayKit/Private/ASMultidimensionalArrayUtils.mm
@@ -67,7 +67,12 @@ static BOOL ASElementExistsAtIndexPathForMultidimensionalArray(NSArray *array, N
     return NO;
   }
 
-  return ASElementExistsAtIndexPathForMultidimensionalArray(array[firstIndex], [indexPath indexPathByRemovingLastIndex]);
+  NSUInteger indexesLength = indexLength - 1;
+  NSUInteger indexes[indexesLength];
+  [indexPath getIndexes:indexes range:NSMakeRange(1, indexesLength)];
+  NSIndexPath *indexPathByRemovingFirstIndex = [NSIndexPath indexPathWithIndexes:indexes length:indexesLength];
+
+  return ASElementExistsAtIndexPathForMultidimensionalArray(array[firstIndex], indexPathByRemovingFirstIndex);
 }
 
 #pragma mark - Public Methods


### PR DESCRIPTION
Currently within `ASCollectionView`, there is an assumption that there will always be a static number of supplementary views per section—even when additional items are added or removed from that section. This is evidenced by the fact that when you invoke -[ASCollectionView insertItemsAtIndexPaths:], the data source method -[ASCollectionDataSource collectionView:nodeForSupplementaryElementOfKind:atIndexPath:] is not invoked, preventing consumers from specifying a new number of supplementary nodes for the new set of items.

With this change, the set of supplementary nodes for a section is now recalculated not only on section-level mutations, but also on item-level mutations as well. This adds item-level counterparts to the section-level `-prepareFor...` subclassing hooks in `ASDataController+Subclasses.h` to make this possible.

This should fix #1278 and #1322

This has been tested in my project and seems to fix the assertion. Open to suggestions on how to test in a more universal way.