### PR TITLE
[ASMultiplexImageNode] Do Not Request Already-Loaded Images From Data Source

### DIFF
--- a/AsyncDisplayKit/ASMultiplexImageNode.mm
+++ b/AsyncDisplayKit/ASMultiplexImageNode.mm
@@ -436,8 +436,12 @@ typedef void(^ASMultiplexImageLoadCompletionBlock)(UIImage *image, id imageIdent
   }
 
   // Grab the best available image from the data source.
+  UIImage *existingImage = self.image;
   for (id imageIdentifier in _imageIdentifiers) {
-    UIImage *image = [_dataSource multiplexImageNode:self imageForImageIdentifier:imageIdentifier];
+    // If this image is already loaded, don't request it from the data source again because
+    // the data source may generate a new instance of UIImage that returns NO for isEqual:
+    // and we'll end up in an infinite loading loop.
+    UIImage *image = ASObjectIsEqual(imageIdentifier, _loadedImageIdentifier) ? existingImage : [_dataSource multiplexImageNode:self imageForImageIdentifier:imageIdentifier];
     if (image) {
       if (imageIdentifierOut) {
         *imageIdentifierOut = imageIdentifier;


### PR DESCRIPTION
In a recent update to PINRemoteImage, its memory cache went from storing UIImage instances to containers of NSData which are used to generate a UIImage instance on demand. Unfortunately, these UIImage instances show `isEqual: NO` compared to one another.

Since the images appear to be different, if you wire `ASMultiplexImageNodeDataSource.imageForImageIdentifier` up to synchronously retrieve an image from the PINRemoteImageManager instance, the image will change every time, which will call setNeedsDisplay, which will call displayWillStart, which will call fetchData, which will generate a new UIImage instance.

To break this cycle, this patch avoids requesting the image for an already-loaded image identifier from the multiplex node's data source. The only issue I can see with this is, if you load an image into a multiplex node and then manually set `image` on the multiplex image node (sidestepping the image loading mechanism), the node may continue using that image rather than attempting to refetch. It's not ideal, but I can't imagine a use case for that.

@garrettmoon @appleguy 

As a separate issue, `ASPINRemoteImageDownloader` uses a private image manager instance which completely surprised me. I think this behavior is pretty misleading; for instance if I want to clear the memory/disk cache, or print the disk cache size for diagnostics, I couldn't and most users probably wouldn't even know that there were two PINRemoteImageManager instances.