### PR TITLE
Fix to text shrinking

### DIFF
--- a/AsyncDisplayKit/TextKit/ASTextKitRenderer.mm
+++ b/AsyncDisplayKit/TextKit/ASTextKitRenderer.mm
@@ -156,7 +156,7 @@ static NSCharacterSet *_defaultAvoidTruncationCharacterSet()
     }];
   }
   
-  [self truncater];
+  [[self truncater] truncate];
   
   // Force glyph generation and layout, which may not have happened yet (and isn't triggered by
   // -usedRectForTextContainer:).

--- a/AsyncDisplayKit/TextKit/ASTextKitRenderer.mm
+++ b/AsyncDisplayKit/TextKit/ASTextKitRenderer.mm
@@ -137,25 +137,30 @@ static NSCharacterSet *_defaultAvoidTruncationCharacterSet()
 
 - (void)_calculateSize
 {
-  [self truncater];
   // if we have no scale factors or an unconstrained width, there is no reason to try to adjust the font size
   if (isinf(_constrainedSize.width) == NO && [_attributes.pointSizeScaleFactors count] > 0) {
     _currentScaleFactor = [[self fontSizeAdjuster] scaleFactor];
   }
   
-  // Force glyph generation and layout, which may not have happened yet (and isn't triggered by
-  // -usedRectForTextContainer:).
   __block NSTextStorage *scaledTextStorage = nil;
   BOOL isScaled = [self isScaled];
-  [[self context] performBlockWithLockedTextKitComponents:^(NSLayoutManager *layoutManager, NSTextStorage *textStorage, NSTextContainer *textContainer) {
-    if (isScaled) {
+  if (isScaled) {
+    // apply the string scale before truncating or else we may truncate the string after we've done the work to shrink it.
+    [[self context] performBlockWithLockedTextKitComponents:^(NSLayoutManager *layoutManager, NSTextStorage *textStorage, NSTextContainer *textContainer) {
       NSMutableAttributedString *scaledString = [[NSMutableAttributedString alloc] initWithAttributedString:textStorage];
       [ASTextKitFontSizeAdjuster adjustFontSizeForAttributeString:scaledString withScaleFactor:_currentScaleFactor];
       scaledTextStorage = [[NSTextStorage alloc] initWithAttributedString:scaledString];
       
       [textStorage removeLayoutManager:layoutManager];
       [scaledTextStorage addLayoutManager:layoutManager];
-    }
+    }];
+  }
+  
+  [self truncater];
+  
+  // Force glyph generation and layout, which may not have happened yet (and isn't triggered by
+  // -usedRectForTextContainer:).
+  [[self context] performBlockWithLockedTextKitComponents:^(NSLayoutManager *layoutManager, NSTextStorage *textStorage, NSTextContainer *textContainer) {
     [layoutManager ensureLayoutForTextContainer:textContainer];
   }];
   

--- a/AsyncDisplayKit/TextKit/ASTextKitTailTruncater.mm
+++ b/AsyncDisplayKit/TextKit/ASTextKitTailTruncater.mm
@@ -30,8 +30,6 @@
     _context = context;
     _truncationAttributedString = truncationAttributedString;
     _avoidTailTruncationSet = avoidTailTruncationSet;
-
-    [self _truncate];
   }
   return self;
 }
@@ -153,7 +151,7 @@
   }
 }
 
-- (void)_truncate
+- (void)truncate
 {
   [_context performBlockWithLockedTextKitComponents:^(NSLayoutManager *layoutManager, NSTextStorage *textStorage, NSTextContainer *textContainer) {
     NSUInteger originalStringLength = textStorage.length;

--- a/AsyncDisplayKit/TextKit/ASTextKitTruncating.h
+++ b/AsyncDisplayKit/TextKit/ASTextKitTruncating.h
@@ -33,4 +33,9 @@
      truncationAttributedString:(NSAttributedString *)truncationAttributedString
          avoidTailTruncationSet:(NSCharacterSet *)avoidTailTruncationSet;
 
+/**
+ *  Actually do the truncation.
+ */
+- (void)truncate;
+
 @end

--- a/AsyncDisplayKitTests/ASTextKitTruncationTests.mm
+++ b/AsyncDisplayKitTests/ASTextKitTruncationTests.mm
@@ -53,6 +53,7 @@
   ASTextKitTailTruncater *tailTruncater = [[ASTextKitTailTruncater alloc] initWithContext:context
                                                                truncationAttributedString:nil
                                                                    avoidTailTruncationSet:nil];
+  [tailTruncater truncate];
   XCTAssert(NSEqualRanges(textKitVisibleRange, tailTruncater.visibleRanges[0]));
 }
 
@@ -71,6 +72,7 @@
   ASTextKitTailTruncater *tailTruncater = [[ASTextKitTailTruncater alloc] initWithContext:context
                                                                truncationAttributedString:[self _simpleTruncationAttributedString]
                                                                    avoidTailTruncationSet:[NSCharacterSet characterSetWithCharactersInString:@""]];
+  [tailTruncater truncate];
   __block NSString *drawnString;
   [context performBlockWithLockedTextKitComponents:^(NSLayoutManager *layoutManager, NSTextStorage *textStorage, NSTextContainer *textContainer) {
     drawnString = textStorage.string;
@@ -95,7 +97,7 @@
   ASTextKitTailTruncater *tailTruncater = [[ASTextKitTailTruncater alloc] initWithContext:context
                                                                truncationAttributedString:[self _simpleTruncationAttributedString]
                                                                    avoidTailTruncationSet:[NSCharacterSet characterSetWithCharactersInString:@"."]];
-  (void)tailTruncater;
+  [tailTruncater truncate];
   __block NSString *drawnString;
   [context performBlockWithLockedTextKitComponents:^(NSLayoutManager *layoutManager, NSTextStorage *textStorage, NSTextContainer *textContainer) {
     drawnString = textStorage.string;
@@ -120,8 +122,7 @@
   ASTextKitTailTruncater *tailTruncater = [[ASTextKitTailTruncater alloc] initWithContext:context
                                                                truncationAttributedString:[self _simpleTruncationAttributedString]
                                                                    avoidTailTruncationSet:[NSCharacterSet characterSetWithCharactersInString:@"."]];
-  // So Xcode doesn't yell at me for an unused var...
-  (void)tailTruncater;
+  [tailTruncater truncate];
   __block NSString *drawnString;
   [context performBlockWithLockedTextKitComponents:^(NSLayoutManager *layoutManager, NSTextStorage *textStorage, NSTextContainer *textContainer) {
     drawnString = textStorage.string;
@@ -144,9 +145,9 @@
                                                            layoutManagerDelegate:nil
                                                         textStorageCreationBlock:nil];
 
-  XCTAssertNoThrow([[ASTextKitTailTruncater alloc] initWithContext:context
+  XCTAssertNoThrow([[[ASTextKitTailTruncater alloc] initWithContext:context
                                         truncationAttributedString:[self _simpleTruncationAttributedString]
-                                            avoidTailTruncationSet:[NSCharacterSet characterSetWithCharactersInString:@"."]]);
+                                            avoidTailTruncationSet:[NSCharacterSet characterSetWithCharactersInString:@"."]] truncate]);
 }
 
 @end


### PR DESCRIPTION
Summary: Previously the first thing we did when calculating the size of text was to truncate it. This could lead to ASFontSizeAdjuster being sent a truncated string which, obviously, never needed to shrink. If we change the order then we first shrink, then truncate if still necessary.

