### PR TITLE
Replace Framework-Style Imports with Direct Imports

### DIFF
--- a/AsyncDisplayKit/ASButtonNode.h
+++ b/AsyncDisplayKit/ASButtonNode.h
@@ -6,8 +6,8 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <AsyncDisplayKit/ASTextNode.h>
-#import <AsyncDisplayKit/ASImageNode.h>
+#import "ASTextNode.h"
+#import "ASImageNode.h"
 
 @interface ASButtonNode : ASControlNode
 

--- a/AsyncDisplayKit/ASCellNode.h
+++ b/AsyncDisplayKit/ASCellNode.h
@@ -6,7 +6,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <AsyncDisplayKit/ASDisplayNode.h>
+#import "ASDisplayNode.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/AsyncDisplayKit/ASCellNode.mm
+++ b/AsyncDisplayKit/ASCellNode.mm
@@ -11,14 +11,14 @@
 #import "ASInternalHelpers.h"
 #import "ASEqualityHelpers.h"
 #import "ASDisplayNodeInternal.h"
-#import <AsyncDisplayKit/_ASDisplayView.h>
-#import <AsyncDisplayKit/ASDisplayNode+Subclasses.h>
-#import <AsyncDisplayKit/ASDisplayNode+Beta.h>
-#import <AsyncDisplayKit/ASTextNode.h>
+#import "_ASDisplayView.h"
+#import "ASDisplayNode+Subclasses.h"
+#import "ASDisplayNode+Beta.h"
+#import "ASTextNode.h"
 
-#import <AsyncDisplayKit/ASViewController.h>
-#import <AsyncDisplayKit/ASInsetLayoutSpec.h>
-#import <AsyncDisplayKit/ASLayout.h>
+#import "ASViewController.h"
+#import "ASInsetLayoutSpec.h"
+#import "ASLayout.h"
 
 #pragma mark -
 #pragma mark ASCellNode

--- a/AsyncDisplayKit/ASCollectionNode.h
+++ b/AsyncDisplayKit/ASCollectionNode.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 Facebook. All rights reserved.
 //
 
-#import <AsyncDisplayKit/ASCollectionView.h>
+#import "ASCollectionView.h"
 
 @protocol ASCollectionViewLayoutFacilitatorProtocol;
 

--- a/AsyncDisplayKit/ASCollectionView.h
+++ b/AsyncDisplayKit/ASCollectionView.h
@@ -8,12 +8,12 @@
 
 #import <UIKit/UIKit.h>
 
-#import <AsyncDisplayKit/ASRangeController.h>
-#import <AsyncDisplayKit/ASCollectionViewProtocols.h>
-#import <AsyncDisplayKit/ASBaseDefines.h>
-#import <AsyncDisplayKit/ASBatchContext.h>
-#import <AsyncDisplayKit/ASCollectionViewFlowLayoutInspector.h>
-#import <AsyncDisplayKit/ASCollectionViewLayoutFacilitatorProtocol.h>
+#import "ASRangeController.h"
+#import "ASCollectionViewProtocols.h"
+#import "ASBaseDefines.h"
+#import "ASBatchContext.h"
+#import "ASCollectionViewFlowLayoutInspector.h"
+#import "ASCollectionViewLayoutFacilitatorProtocol.h"
 
 @class ASCellNode;
 @class ASCollectionNode;

--- a/AsyncDisplayKit/ASContextTransitioning.h
+++ b/AsyncDisplayKit/ASContextTransitioning.h
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Facebook. All rights reserved.
 //
 
-#import <AsyncDisplayKit/ASDisplayNode.h>
+#import "ASDisplayNode.h"
 
 extern NSString * const ASTransitionContextFromLayoutKey;
 extern NSString * const ASTransitionContextToLayoutKey;

--- a/AsyncDisplayKit/ASControlNode+tvOS.h
+++ b/AsyncDisplayKit/ASControlNode+tvOS.h
@@ -7,7 +7,7 @@
 //
 
 #if TARGET_OS_TV
-#import <AsyncDisplayKit/AsyncDisplayKit.h>
+#import "AsyncDisplayKit.h"
 
 @interface ASControlNode (tvOS)
 

--- a/AsyncDisplayKit/ASControlNode.h
+++ b/AsyncDisplayKit/ASControlNode.h
@@ -6,7 +6,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <AsyncDisplayKit/ASDisplayNode.h>
+#import "ASDisplayNode.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/AsyncDisplayKit/ASDisplayNode+Subclasses.h
+++ b/AsyncDisplayKit/ASDisplayNode+Subclasses.h
@@ -8,10 +8,10 @@
 
 #import <pthread.h>
 
-#import <AsyncDisplayKit/_ASDisplayLayer.h>
-#import <AsyncDisplayKit/ASAssert.h>
-#import <AsyncDisplayKit/ASDisplayNode.h>
-#import <AsyncDisplayKit/ASThread.h>
+#import "_ASDisplayLayer.h"
+#import "ASAssert.h"
+#import "ASDisplayNode.h"
+#import "ASThread.h"
 
 @class ASLayoutSpec;
 

--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -8,12 +8,12 @@
 
 #import <UIKit/UIKit.h>
 
-#import <AsyncDisplayKit/_ASAsyncTransactionContainer.h>
-#import <AsyncDisplayKit/ASBaseDefines.h>
-#import <AsyncDisplayKit/ASDealloc2MainObject.h>
-#import <AsyncDisplayKit/ASDimension.h>
-#import <AsyncDisplayKit/ASAsciiArtBoxCreator.h>
-#import <AsyncDisplayKit/ASLayoutable.h>
+#import "_ASAsyncTransactionContainer.h"
+#import "ASBaseDefines.h"
+#import "ASDealloc2MainObject.h"
+#import "ASDimension.h"
+#import "ASAsciiArtBoxCreator.h"
+#import "ASLayoutable.h"
 
 @class ASDisplayNode;
 

--- a/AsyncDisplayKit/ASDisplayNodeExtras.h
+++ b/AsyncDisplayKit/ASDisplayNodeExtras.h
@@ -9,8 +9,8 @@
 #import <QuartzCore/QuartzCore.h>
 #import <UIKit/UIKit.h>
 
-#import <AsyncDisplayKit/ASBaseDefines.h>
-#import <AsyncDisplayKit/ASDisplayNode.h>
+#import "ASBaseDefines.h"
+#import "ASDisplayNode.h"
 
 // Because inline methods can't be extern'd and need to be part of the translation unit of code
 // that compiles with them to actually inline, we both declare and define these in the header.

--- a/AsyncDisplayKit/ASEditableTextNode.h
+++ b/AsyncDisplayKit/ASEditableTextNode.h
@@ -6,8 +6,8 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <AsyncDisplayKit/ASDisplayNode.h>
-#import <AsyncDisplayKit/ASTextKitComponents.h>
+#import "ASDisplayNode.h"
+#import "ASTextKitComponents.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/AsyncDisplayKit/ASImageNode+tvOS.h
+++ b/AsyncDisplayKit/ASImageNode+tvOS.h
@@ -7,7 +7,7 @@
 //
 
 #if TARGET_OS_TV
-#import <AsyncDisplayKit/AsyncDisplayKit.h>
+#import "AsyncDisplayKit.h"
 
 @interface ASImageNode (tvOS)
 @end

--- a/AsyncDisplayKit/ASImageNode.h
+++ b/AsyncDisplayKit/ASImageNode.h
@@ -6,7 +6,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <AsyncDisplayKit/ASControlNode.h>
+#import "ASControlNode.h"
 
 #import "ASImageProtocols.h"
 

--- a/AsyncDisplayKit/ASImageNode.mm
+++ b/AsyncDisplayKit/ASImageNode.mm
@@ -8,15 +8,15 @@
 
 #import "ASImageNode.h"
 
-#import <AsyncDisplayKit/_ASCoreAnimationExtras.h>
-#import <AsyncDisplayKit/_ASDisplayLayer.h>
-#import <AsyncDisplayKit/ASAssert.h>
-#import <AsyncDisplayKit/ASDisplayNode+Subclasses.h>
-#import <AsyncDisplayKit/ASDisplayNodeInternal.h>
-#import <AsyncDisplayKit/ASDisplayNodeExtras.h>
-#import <AsyncDisplayKit/ASDisplayNode+Beta.h>
-#import <AsyncDisplayKit/ASTextNode.h>
-#import <AsyncDisplayKit/ASImageNode+AnimatedImagePrivate.h>
+#import "_ASCoreAnimationExtras.h"
+#import "_ASDisplayLayer.h"
+#import "ASAssert.h"
+#import "ASDisplayNode+Subclasses.h"
+#import "ASDisplayNodeInternal.h"
+#import "ASDisplayNodeExtras.h"
+#import "ASDisplayNode+Beta.h"
+#import "ASTextNode.h"
+#import "ASImageNode+AnimatedImagePrivate.h"
 
 #import "ASImageNode+CGExtras.h"
 #import "AsyncDisplayKit+Debug.h"

--- a/AsyncDisplayKit/ASMapNode.h
+++ b/AsyncDisplayKit/ASMapNode.h
@@ -6,7 +6,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <AsyncDisplayKit/ASImageNode.h>
+#import "ASImageNode.h"
 #if TARGET_OS_IOS
 #import <MapKit/MapKit.h>
 

--- a/AsyncDisplayKit/ASMapNode.mm
+++ b/AsyncDisplayKit/ASMapNode.mm
@@ -8,13 +8,13 @@
 
 #if TARGET_OS_IOS
 #import "ASMapNode.h"
-#import <AsyncDisplayKit/ASDisplayNode+Subclasses.h>
-#import <AsyncDisplayKit/ASDisplayNodeExtras.h>
-#import <AsyncDisplayKit/ASInsetLayoutSpec.h>
-#import <AsyncDisplayKit/ASCenterLayoutSpec.h>
-#import <AsyncDisplayKit/ASThread.h>
-#import <AsyncDisplayKit/ASInternalHelpers.h>
-#import <AsyncDisplayKit/ASLayout.h>
+#import "ASDisplayNode+Subclasses.h"
+#import "ASDisplayNodeExtras.h"
+#import "ASInsetLayoutSpec.h"
+#import "ASCenterLayoutSpec.h"
+#import "ASThread.h"
+#import "ASInternalHelpers.h"
+#import "ASLayout.h"
 
 @interface ASMapNode()
 {

--- a/AsyncDisplayKit/ASMultiplexImageNode.h
+++ b/AsyncDisplayKit/ASMultiplexImageNode.h
@@ -8,8 +8,8 @@
 
 #if TARGET_OS_IOS
 
-#import <AsyncDisplayKit/ASImageNode.h>
-#import <AsyncDisplayKit/ASImageProtocols.h>
+#import "ASImageNode.h"
+#import "ASImageProtocols.h"
 #import <Photos/Photos.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/AsyncDisplayKit/ASNetworkImageNode.h
+++ b/AsyncDisplayKit/ASNetworkImageNode.h
@@ -6,8 +6,8 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <AsyncDisplayKit/ASImageNode.h>
-#import <AsyncDisplayKit/ASImageProtocols.h>
+#import "ASImageNode.h"
+#import "ASImageProtocols.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/AsyncDisplayKit/ASPagerNode.h
+++ b/AsyncDisplayKit/ASPagerNode.h
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Facebook. All rights reserved.
 //
 
-#import <AsyncDisplayKit/ASCollectionNode.h>
+#import "ASCollectionNode.h"
 
 @class ASPagerNode;
 @class ASPagerFlowLayout;

--- a/AsyncDisplayKit/ASScrollNode.h
+++ b/AsyncDisplayKit/ASScrollNode.h
@@ -8,7 +8,7 @@
 
 #import <UIKit/UIKit.h>
 
-#import <AsyncDisplayKit/ASDisplayNode.h>
+#import "ASDisplayNode.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/AsyncDisplayKit/ASTableNode.h
+++ b/AsyncDisplayKit/ASTableNode.h
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Facebook. All rights reserved.
 //
 
-#import <AsyncDisplayKit/ASTableView.h>
+#import "ASTableView.h"
 
 /**
  * ASTableNode is a node based class that wraps an ASTableView. It can be used

--- a/AsyncDisplayKit/ASTableView.h
+++ b/AsyncDisplayKit/ASTableView.h
@@ -7,10 +7,10 @@
  */
 
 #import <UIKit/UIKit.h>
-#import <AsyncDisplayKit/ASRangeController.h>
-#import <AsyncDisplayKit/ASTableViewProtocols.h>
-#import <AsyncDisplayKit/ASBaseDefines.h>
-#import <AsyncDisplayKit/ASBatchContext.h>
+#import "ASRangeController.h"
+#import "ASTableViewProtocols.h"
+#import "ASBaseDefines.h"
+#import "ASBatchContext.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/AsyncDisplayKit/ASTextNode.h
+++ b/AsyncDisplayKit/ASTextNode.h
@@ -6,7 +6,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <AsyncDisplayKit/ASControlNode.h>
+#import "ASControlNode.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/AsyncDisplayKit/ASTextNode.mm
+++ b/AsyncDisplayKit/ASTextNode.mm
@@ -9,12 +9,12 @@
 #import "ASTextNode.h"
 #import "ASTextNode+Beta.h"
 
-#import <AsyncDisplayKit/_ASDisplayLayer.h>
-#import <AsyncDisplayKit/ASAssert.h>
-#import <AsyncDisplayKit/ASDisplayNode+Subclasses.h>
-#import <AsyncDisplayKit/ASDisplayNodeInternal.h>
-#import <AsyncDisplayKit/ASHighlightOverlayLayer.h>
-#import <AsyncDisplayKit/ASDisplayNodeExtras.h>
+#import "_ASDisplayLayer.h"
+#import "ASAssert.h"
+#import "ASDisplayNode+Subclasses.h"
+#import "ASDisplayNodeInternal.h"
+#import "ASHighlightOverlayLayer.h"
+#import "ASDisplayNodeExtras.h"
 
 #import "ASTextKitCoreTextAdditions.h"
 #import "ASTextKitComponents.h"

--- a/AsyncDisplayKit/ASVideoNode.h
+++ b/AsyncDisplayKit/ASVideoNode.h
@@ -7,7 +7,7 @@
  */
 
 #if TARGET_OS_IOS
-#import <AsyncDisplayKit/ASButtonNode.h>
+#import "ASButtonNode.h"
 
 @class AVAsset, AVPlayer, AVPlayerItem;
 @protocol ASVideoNodeDelegate;

--- a/AsyncDisplayKit/ASViewController.h
+++ b/AsyncDisplayKit/ASViewController.h
@@ -7,8 +7,8 @@
 //
 
 #import <UIKit/UIKit.h>
-#import <AsyncDisplayKit/ASDisplayNode.h>
-#import <AsyncDisplayKit/ASVisibilityProtocols.h>
+#import "ASDisplayNode.h"
+#import "ASVisibilityProtocols.h"
 
 @class ASTraitCollection;
 

--- a/AsyncDisplayKit/AsyncDisplayKit.h
+++ b/AsyncDisplayKit/AsyncDisplayKit.h
@@ -6,82 +6,82 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <AsyncDisplayKit/ASDisplayNode.h>
-#import <AsyncDisplayKit/ASDisplayNodeExtras.h>
+#import "ASDisplayNode.h"
+#import "ASDisplayNodeExtras.h"
 
-#import <AsyncDisplayKit/ASControlNode.h>
-#import <AsyncDisplayKit/ASImageNode.h>
-#import <AsyncDisplayKit/ASTextNode.h>
-#import <AsyncDisplayKit/ASButtonNode.h>
-#import <AsyncDisplayKit/ASMapNode.h>
-#import <AsyncDisplayKit/ASVideoNode.h>
-#import <AsyncDisplayKit/ASEditableTextNode.h>
+#import "ASControlNode.h"
+#import "ASImageNode.h"
+#import "ASTextNode.h"
+#import "ASButtonNode.h"
+#import "ASMapNode.h"
+#import "ASVideoNode.h"
+#import "ASEditableTextNode.h"
 
-#import <AsyncDisplayKit/ASBasicImageDownloader.h>
-#import <AsyncDisplayKit/ASMultiplexImageNode.h>
-#import <AsyncDisplayKit/ASNetworkImageNode.h>
-#import <AsyncDisplayKit/ASPhotosFrameworkImageRequest.h>
+#import "ASBasicImageDownloader.h"
+#import "ASMultiplexImageNode.h"
+#import "ASNetworkImageNode.h"
+#import "ASPhotosFrameworkImageRequest.h"
 
-#import <AsyncDisplayKit/ASTableView.h>
-#import <AsyncDisplayKit/ASTableNode.h>
-#import <AsyncDisplayKit/ASCollectionView.h>
-#import <AsyncDisplayKit/ASCollectionNode.h>
-#import <AsyncDisplayKit/ASCellNode.h>
+#import "ASTableView.h"
+#import "ASTableNode.h"
+#import "ASCollectionView.h"
+#import "ASCollectionNode.h"
+#import "ASCellNode.h"
 
-#import <AsyncDisplayKit/ASScrollNode.h>
+#import "ASScrollNode.h"
 
-#import <AsyncDisplayKit/ASPagerFlowLayout.h>
-#import <AsyncDisplayKit/ASPagerNode.h>
+#import "ASPagerFlowLayout.h"
+#import "ASPagerNode.h"
 
-#import <AsyncDisplayKit/ASViewController.h>
-#import <AsyncDisplayKit/ASNavigationController.h>
-#import <AsyncDisplayKit/ASTabBarController.h>
-#import <AsyncDisplayKit/ASRangeControllerUpdateRangeProtocol+Beta.h>
+#import "ASViewController.h"
+#import "ASNavigationController.h"
+#import "ASTabBarController.h"
+#import "ASRangeControllerUpdateRangeProtocol+Beta.h"
 
-#import <AsyncDisplayKit/ASChangeSetDataController.h>
+#import "ASChangeSetDataController.h"
 
-#import <AsyncDisplayKit/ASLayout.h>
-#import <AsyncDisplayKit/ASDimension.h>
-#import <AsyncDisplayKit/ASEnvironment.h>
-#import <AsyncDisplayKit/ASLayoutable.h>
-#import <AsyncDisplayKit/ASLayoutSpec.h>
-#import <AsyncDisplayKit/ASBackgroundLayoutSpec.h>
-#import <AsyncDisplayKit/ASCenterLayoutSpec.h>
-#import <AsyncDisplayKit/ASRelativeLayoutSpec.h>
-#import <AsyncDisplayKit/ASInsetLayoutSpec.h>
-#import <AsyncDisplayKit/ASOverlayLayoutSpec.h>
-#import <AsyncDisplayKit/ASRatioLayoutSpec.h>
-#import <AsyncDisplayKit/ASStaticLayoutSpec.h>
-#import <AsyncDisplayKit/ASStackLayoutDefines.h>
-#import <AsyncDisplayKit/ASStackLayoutSpec.h>
+#import "ASLayout.h"
+#import "ASDimension.h"
+#import "ASEnvironment.h"
+#import "ASLayoutable.h"
+#import "ASLayoutSpec.h"
+#import "ASBackgroundLayoutSpec.h"
+#import "ASCenterLayoutSpec.h"
+#import "ASRelativeLayoutSpec.h"
+#import "ASInsetLayoutSpec.h"
+#import "ASOverlayLayoutSpec.h"
+#import "ASRatioLayoutSpec.h"
+#import "ASStaticLayoutSpec.h"
+#import "ASStackLayoutDefines.h"
+#import "ASStackLayoutSpec.h"
 
-#import <AsyncDisplayKit/_ASAsyncTransaction.h>
-#import <AsyncDisplayKit/_ASAsyncTransactionGroup.h>
-#import <AsyncDisplayKit/_ASDisplayView.h>
-#import <AsyncDisplayKit/ASDisplayNode+Beta.h>
-#import <AsyncDisplayKit/ASTextNode+Beta.h>
-#import <AsyncDisplayKit/ASTextNodeTypes.h>
-#import <AsyncDisplayKit/ASAvailability.h>
-#import <AsyncDisplayKit/ASCollectionViewLayoutController.h>
-#import <AsyncDisplayKit/ASContextTransitioning.h>
-#import <AsyncDisplayKit/ASControlNode+Subclasses.h>
-#import <AsyncDisplayKit/ASDisplayNode+Subclasses.h>
-#import <AsyncDisplayKit/ASEqualityHelpers.h>
-#import <AsyncDisplayKit/ASHighlightOverlayLayer.h>
-#import <AsyncDisplayKit/ASIndexPath.h>
-#import <AsyncDisplayKit/ASImageContainerProtocolCategories.h>
-#import <AsyncDisplayKit/ASLog.h>
-#import <AsyncDisplayKit/ASMutableAttributedStringBuilder.h>
-#import <AsyncDisplayKit/ASThread.h>
-#import <AsyncDisplayKit/CGRect+ASConvenience.h>
-#import <AsyncDisplayKit/NSMutableAttributedString+TextKitAdditions.h>
-#import <AsyncDisplayKit/UICollectionViewLayout+ASConvenience.h>
-#import <AsyncDisplayKit/UIView+ASConvenience.h>
-#import <AsyncDisplayKit/ASRunLoopQueue.h>
-#import <AsyncDisplayKit/ASTextKitComponents.h>
-#import <AsyncDisplayKit/ASTraitCollection.h>
-#import <AsyncDisplayKit/ASVisibilityProtocols.h>
+#import "_ASAsyncTransaction.h"
+#import "_ASAsyncTransactionGroup.h"
+#import "_ASDisplayView.h"
+#import "ASDisplayNode+Beta.h"
+#import "ASTextNode+Beta.h"
+#import "ASTextNodeTypes.h"
+#import "ASAvailability.h"
+#import "ASCollectionViewLayoutController.h"
+#import "ASContextTransitioning.h"
+#import "ASControlNode+Subclasses.h"
+#import "ASDisplayNode+Subclasses.h"
+#import "ASEqualityHelpers.h"
+#import "ASHighlightOverlayLayer.h"
+#import "ASIndexPath.h"
+#import "ASImageContainerProtocolCategories.h"
+#import "ASLog.h"
+#import "ASMutableAttributedStringBuilder.h"
+#import "ASThread.h"
+#import "CGRect+ASConvenience.h"
+#import "NSMutableAttributedString+TextKitAdditions.h"
+#import "UICollectionViewLayout+ASConvenience.h"
+#import "UIView+ASConvenience.h"
+#import "ASRunLoopQueue.h"
+#import "ASTextKitComponents.h"
+#import "ASTraitCollection.h"
+#import "ASVisibilityProtocols.h"
 
-#import <AsyncDisplayKit/AsyncDisplayKit+Debug.h>
+#import "AsyncDisplayKit+Debug.h"
 
-#import <AsyncDisplayKit/ASCollectionNode+Beta.h>
+#import "ASCollectionNode+Beta.h"

--- a/AsyncDisplayKit/Details/ASAbstractLayoutController.h
+++ b/AsyncDisplayKit/Details/ASAbstractLayoutController.h
@@ -6,8 +6,8 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <AsyncDisplayKit/ASLayoutController.h>
-#import <AsyncDisplayKit/ASBaseDefines.h>
+#import "ASLayoutController.h"
+#import "ASBaseDefines.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/AsyncDisplayKit/Details/ASBasicImageDownloader.h
+++ b/AsyncDisplayKit/Details/ASBasicImageDownloader.h
@@ -6,7 +6,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <AsyncDisplayKit/ASImageProtocols.h>
+#import "ASImageProtocols.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/AsyncDisplayKit/Details/ASChangeSetDataController.h
+++ b/AsyncDisplayKit/Details/ASChangeSetDataController.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 Facebook. All rights reserved.
 //
 
-#import <AsyncDisplayKit/ASDataController.h>
+#import "ASDataController.h"
 
 /**
  * @abstract Subclass of ASDataController that simulates ordering of operations in batch updates defined in UITableView and UICollectionView.

--- a/AsyncDisplayKit/Details/ASCollectionDataController.h
+++ b/AsyncDisplayKit/Details/ASCollectionDataController.h
@@ -8,8 +8,8 @@
 
 #import <UIKit/UIKit.h>
 
-#import <AsyncDisplayKit/ASChangeSetDataController.h>
-#import <AsyncDisplayKit/ASDimension.h>
+#import "ASChangeSetDataController.h"
+#import "ASDimension.h"
 
 @class ASDisplayNode;
 @class ASCollectionDataController;

--- a/AsyncDisplayKit/Details/ASCollectionViewFlowLayoutInspector.h
+++ b/AsyncDisplayKit/Details/ASCollectionViewFlowLayoutInspector.h
@@ -9,7 +9,7 @@
 #pragma once
 
 #import <Foundation/Foundation.h>
-#import <AsyncDisplayKit/ASDimension.h>
+#import "ASDimension.h"
 
 @class ASCollectionView;
 @protocol ASCollectionDelegate;

--- a/AsyncDisplayKit/Details/ASCollectionViewLayoutController.h
+++ b/AsyncDisplayKit/Details/ASCollectionViewLayoutController.h
@@ -6,8 +6,8 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <AsyncDisplayKit/ASAbstractLayoutController.h>
-#import <AsyncDisplayKit/ASBaseDefines.h>
+#import "ASAbstractLayoutController.h"
+#import "ASBaseDefines.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/AsyncDisplayKit/Details/ASDataController.h
+++ b/AsyncDisplayKit/Details/ASDataController.h
@@ -9,9 +9,9 @@
 #pragma once
 
 #import <UIKit/UIKit.h>
-#import <AsyncDisplayKit/ASDealloc2MainObject.h>
-#import <AsyncDisplayKit/ASDimension.h>
-#import <AsyncDisplayKit/ASFlowLayoutController.h>
+#import "ASDealloc2MainObject.h"
+#import "ASDimension.h"
+#import "ASFlowLayoutController.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/AsyncDisplayKit/Details/ASEnvironment.mm
+++ b/AsyncDisplayKit/Details/ASEnvironment.mm
@@ -10,7 +10,7 @@
 
 #import "ASEnvironment.h"
 #import "ASEnvironmentInternal.h"
-#import <AsyncDisplayKit/ASAvailability.h>
+#import "ASAvailability.h"
 
 ASEnvironmentLayoutOptionsState _ASEnvironmentLayoutOptionsStateMakeDefault()
 {

--- a/AsyncDisplayKit/Details/ASFlowLayoutController.h
+++ b/AsyncDisplayKit/Details/ASFlowLayoutController.h
@@ -6,8 +6,8 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <AsyncDisplayKit/ASAbstractLayoutController.h>
-#import <AsyncDisplayKit/ASBaseDefines.h>
+#import "ASAbstractLayoutController.h"
+#import "ASBaseDefines.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/AsyncDisplayKit/Details/ASImageProtocols.h
+++ b/AsyncDisplayKit/Details/ASImageProtocols.h
@@ -7,7 +7,7 @@
  */
 
 #import <UIKit/UIKit.h>
-#import <AsyncDisplayKit/ASBaseDefines.h>
+#import "ASBaseDefines.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/AsyncDisplayKit/Details/ASIndexPath.h
+++ b/AsyncDisplayKit/Details/ASIndexPath.h
@@ -6,7 +6,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <AsyncDisplayKit/ASBaseDefines.h>
+#import "ASBaseDefines.h"
 #import <Foundation/Foundation.h>
 
 typedef struct {

--- a/AsyncDisplayKit/Details/ASIndexedNodeContext.h
+++ b/AsyncDisplayKit/Details/ASIndexedNodeContext.h
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Facebook. All rights reserved.
 //
 
-#import <AsyncDisplayKit/ASDataController.h>
+#import "ASDataController.h"
 
 @interface ASIndexedNodeContext : NSObject
 

--- a/AsyncDisplayKit/Details/ASLayoutController.h
+++ b/AsyncDisplayKit/Details/ASLayoutController.h
@@ -8,9 +8,9 @@
 
 #import <UIKit/UIKit.h>
 
-#import <AsyncDisplayKit/ASBaseDefines.h>
-#import <AsyncDisplayKit/ASLayoutRangeType.h>
-#import <AsyncDisplayKit/ASScrollDirection.h>
+#import "ASBaseDefines.h"
+#import "ASLayoutRangeType.h"
+#import "ASScrollDirection.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/AsyncDisplayKit/Details/ASRangeController.h
+++ b/AsyncDisplayKit/Details/ASRangeController.h
@@ -8,10 +8,10 @@
 
 #import <Foundation/Foundation.h>
 
-#import <AsyncDisplayKit/ASCellNode.h>
-#import <AsyncDisplayKit/ASDataController.h>
-#import <AsyncDisplayKit/ASLayoutController.h>
-#import <AsyncDisplayKit/ASLayoutRangeType.h>
+#import "ASCellNode.h"
+#import "ASDataController.h"
+#import "ASLayoutController.h"
+#import "ASLayoutRangeType.h"
 
 #define ASRangeControllerLoggingEnabled 0
 

--- a/AsyncDisplayKit/Details/ASThread.h
+++ b/AsyncDisplayKit/Details/ASThread.h
@@ -15,8 +15,8 @@
 
 #import <libkern/OSAtomic.h>
 
-#import <AsyncDisplayKit/ASAssert.h>
-#import <AsyncDisplayKit/ASBaseDefines.h>
+#import "ASAssert.h"
+#import "ASBaseDefines.h"
 
 
 static inline BOOL ASDisplayNodeThreadIsMain()

--- a/AsyncDisplayKit/Details/ASTraitCollection.h
+++ b/AsyncDisplayKit/Details/ASTraitCollection.h
@@ -9,7 +9,7 @@
  */
 
 #import <UIKit/UIKit.h>
-#import <AsyncDisplayKit/ASEnvironment.h>
+#import "ASEnvironment.h"
 
 @interface ASTraitCollection : NSObject
 

--- a/AsyncDisplayKit/Details/ASTraitCollection.m
+++ b/AsyncDisplayKit/Details/ASTraitCollection.m
@@ -7,8 +7,8 @@
 //
 
 #import "ASTraitCollection.h"
-#import <AsyncDisplayKit/ASAssert.h>
-#import <AsyncDisplayKit/ASAvailability.h>
+#import "ASAssert.h"
+#import "ASAvailability.h"
 
 @implementation ASTraitCollection
 

--- a/AsyncDisplayKit/Details/Transactions/_ASAsyncTransactionContainer+Private.h
+++ b/AsyncDisplayKit/Details/Transactions/_ASAsyncTransactionContainer+Private.h
@@ -6,7 +6,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <AsyncDisplayKit/_ASAsyncTransactionContainer.h>
+#import "_ASAsyncTransactionContainer.h"
 
 
 @interface CALayer (ASAsyncTransactionContainerTransactions)

--- a/AsyncDisplayKit/Layout/ASBackgroundLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASBackgroundLayoutSpec.h
@@ -8,7 +8,7 @@
  *
  */
 
-#import <AsyncDisplayKit/ASLayoutSpec.h>
+#import "ASLayoutSpec.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/AsyncDisplayKit/Layout/ASCenterLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASCenterLayoutSpec.h
@@ -8,7 +8,7 @@
  *
  */
 
-#import <AsyncDisplayKit/ASRelativeLayoutSpec.h>
+#import "ASRelativeLayoutSpec.h"
 
 /** How the child is centered within the spec. */
 typedef NS_OPTIONS(NSUInteger, ASCenterLayoutSpecCenteringOptions) {

--- a/AsyncDisplayKit/Layout/ASDimension.h
+++ b/AsyncDisplayKit/Layout/ASDimension.h
@@ -10,7 +10,7 @@
 
 #pragma once
 #import <UIKit/UIKit.h>
-#import <AsyncDisplayKit/ASBaseDefines.h>
+#import "ASBaseDefines.h"
 
 /**
  A dimension relative to constraints to be provided in the future.

--- a/AsyncDisplayKit/Layout/ASInsetLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASInsetLayoutSpec.h
@@ -8,7 +8,7 @@
  *
  */
 
-#import <AsyncDisplayKit/ASLayoutSpec.h>
+#import "ASLayoutSpec.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/AsyncDisplayKit/Layout/ASLayout.h
+++ b/AsyncDisplayKit/Layout/ASLayout.h
@@ -11,8 +11,8 @@
 #pragma once
 
 #import <UIKit/UIKit.h>
-#import <AsyncDisplayKit/ASAssert.h>
-#import <AsyncDisplayKit/ASLayoutable.h>
+#import "ASAssert.h"
+#import "ASLayoutable.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/AsyncDisplayKit/Layout/ASLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASLayoutSpec.h
@@ -8,8 +8,8 @@
  *
  */
 
-#import <AsyncDisplayKit/ASLayoutable.h>
-#import <AsyncDisplayKit/ASAsciiArtBoxCreator.h>
+#import "ASLayoutable.h"
+#import "ASAsciiArtBoxCreator.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/AsyncDisplayKit/Layout/ASLayoutable.h
+++ b/AsyncDisplayKit/Layout/ASLayoutable.h
@@ -8,15 +8,15 @@
  *
  */
 
-#import <AsyncDisplayKit/ASDimension.h>
-#import <AsyncDisplayKit/ASRelativeSize.h>
-#import <AsyncDisplayKit/ASStackLayoutDefines.h>
-#import <AsyncDisplayKit/ASStackLayoutable.h>
-#import <AsyncDisplayKit/ASStaticLayoutable.h>
+#import "ASDimension.h"
+#import "ASRelativeSize.h"
+#import "ASStackLayoutDefines.h"
+#import "ASStackLayoutable.h"
+#import "ASStaticLayoutable.h"
 
-#import <AsyncDisplayKit/ASLayoutablePrivate.h>
-#import <AsyncDisplayKit/ASEnvironment.h>
-#import <AsyncDisplayKit/ASLayoutableExtensibility.h>
+#import "ASLayoutablePrivate.h"
+#import "ASEnvironment.h"
+#import "ASLayoutableExtensibility.h"
 
 @class ASLayout;
 @class ASLayoutSpec;

--- a/AsyncDisplayKit/Layout/ASOverlayLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASOverlayLayoutSpec.h
@@ -8,7 +8,7 @@
  *
  */
 
-#import <AsyncDisplayKit/ASLayoutSpec.h>
+#import "ASLayoutSpec.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/AsyncDisplayKit/Layout/ASRatioLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASRatioLayoutSpec.h
@@ -8,8 +8,8 @@
  *
  */
 
-#import <AsyncDisplayKit/ASLayoutSpec.h>
-#import <AsyncDisplayKit/ASLayoutable.h>
+#import "ASLayoutSpec.h"
+#import "ASLayoutable.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/AsyncDisplayKit/Layout/ASRelativeLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASRelativeLayoutSpec.h
@@ -5,7 +5,7 @@
 //  Created by Samuel Stow on 12/31/15.
 //
 
-#import <AsyncDisplayKit/ASLayoutSpec.h>
+#import "ASLayoutSpec.h"
 
 /** How the child is positioned within the spec. */
 typedef NS_OPTIONS(NSUInteger, ASRelativeLayoutSpecPosition) {

--- a/AsyncDisplayKit/Layout/ASRelativeSize.h
+++ b/AsyncDisplayKit/Layout/ASRelativeSize.h
@@ -9,8 +9,8 @@
  */
 
 #import <UIKit/UIKit.h>
-#import <AsyncDisplayKit/ASBaseDefines.h>
-#import <AsyncDisplayKit/ASDimension.h>
+#import "ASBaseDefines.h"
+#import "ASDimension.h"
 
 /** 
  Expresses a size with relative dimensions.

--- a/AsyncDisplayKit/Layout/ASStackLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASStackLayoutSpec.h
@@ -8,8 +8,8 @@
  *
  */
 
-#import <AsyncDisplayKit/ASLayoutSpec.h>
-#import <AsyncDisplayKit/ASStackLayoutDefines.h>
+#import "ASLayoutSpec.h"
+#import "ASStackLayoutDefines.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/AsyncDisplayKit/Layout/ASStackLayoutable.h
+++ b/AsyncDisplayKit/Layout/ASStackLayoutable.h
@@ -8,8 +8,8 @@
  *
  */
 
-#import <AsyncDisplayKit/ASDimension.h>
-#import <AsyncDisplayKit/ASStackLayoutDefines.h>
+#import "ASDimension.h"
+#import "ASStackLayoutDefines.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/AsyncDisplayKit/Layout/ASStaticLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASStaticLayoutSpec.h
@@ -8,8 +8,8 @@
  *
  */
 
-#import <AsyncDisplayKit/ASLayoutSpec.h>
-#import <AsyncDisplayKit/ASRelativeSize.h>
+#import "ASLayoutSpec.h"
+#import "ASRelativeSize.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/AsyncDisplayKit/Layout/ASStaticLayoutable.h
+++ b/AsyncDisplayKit/Layout/ASStaticLayoutable.h
@@ -8,7 +8,7 @@
  *
  */
 
-#import <AsyncDisplayKit/ASRelativeSize.h>
+#import "ASRelativeSize.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/AsyncDisplayKit/Private/ASDefaultPlayButton.h
+++ b/AsyncDisplayKit/Private/ASDefaultPlayButton.h
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Facebook. All rights reserved.
 //
 
-#import <AsyncDisplayKit/AsyncDisplayKit.h>
+#import "AsyncDisplayKit.h"
 
 @interface ASDefaultPlayButton : ASButtonNode
 

--- a/AsyncDisplayKit/Private/ASDisplayNode+DebugTiming.h
+++ b/AsyncDisplayKit/Private/ASDisplayNode+DebugTiming.h
@@ -6,7 +6,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <AsyncDisplayKit/ASDisplayNode.h>
+#import "ASDisplayNode.h"
 
 @interface ASDisplayNode (DebugTiming)
 

--- a/AsyncDisplayKit/Private/ASImageNode+CGExtras.h
+++ b/AsyncDisplayKit/Private/ASImageNode+CGExtras.h
@@ -6,7 +6,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <AsyncDisplayKit/ASBaseDefines.h>
+#import "ASBaseDefines.h"
 
 #include <UIKit/UIKit.h>
 

--- a/AsyncDisplayKit/Private/ASMultidimensionalArrayUtils.h
+++ b/AsyncDisplayKit/Private/ASMultidimensionalArrayUtils.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import <AsyncDisplayKit/ASBaseDefines.h>
+#import "ASBaseDefines.h"
 
 
 /**

--- a/AsyncDisplayKit/Private/_ASHierarchyChangeSet.h
+++ b/AsyncDisplayKit/Private/_ASHierarchyChangeSet.h
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <AsyncDisplayKit/ASInternalHelpers.h>
+#import "ASInternalHelpers.h"
 
 typedef NSUInteger ASDataControllerAnimationOptions;
 

--- a/AsyncDisplayKit/TextKit/ASTextKitComponents.h
+++ b/AsyncDisplayKit/TextKit/ASTextKitComponents.h
@@ -7,7 +7,7 @@
  */
 
 #import <UIKit/UIKit.h>
-#import <AsyncDisplayKit/ASBaseDefines.h>
+#import "ASBaseDefines.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/AsyncDisplayKit/TextKit/ASTextKitCoreTextAdditions.h
+++ b/AsyncDisplayKit/TextKit/ASTextKitCoreTextAdditions.h
@@ -9,7 +9,7 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
-#import <AsyncDisplayKit/ASBaseDefines.h>
+#import "ASBaseDefines.h"
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
CocoaPods was having trouble building ASDK as a dependency of an extension pod I made, and this fixed it right up. 

This fixes https://github.com/CocoaPods/CocoaPods/issues/5230 and probably also #431 . @appleguy @maicki thoughts?