### PR TITLE
Change ASTableView's visibleNodes interface to return array of ASCellNodes

### DIFF
--- a/AsyncDisplayKit/ASTableView.h
+++ b/AsyncDisplayKit/ASTableView.h
@@ -285,9 +285,9 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Similar to -visibleCells.
  *
- * @returns an array containing the nodes being displayed on screen.
+ * @returns an array containing the cell nodes being displayed on screen.
  */
-- (NSArray<ASDisplayNode *> *)visibleNodes;
+- (NSArray<ASCellNode *> *)visibleNodes;
 
 /**
  * YES to automatically adjust the contentOffset when cells are inserted or deleted "before"

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -389,11 +389,11 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
   return [_dataController indexPathForNode:cellNode];
 }
 
-- (NSArray *)visibleNodes
+- (NSArray<ASCellNode *> *)visibleNodes
 {
   NSArray *indexPaths = [self visibleNodeIndexPathsForRangeController:_rangeController];
   
-  NSMutableArray *visibleNodes = [NSMutableArray array];
+  NSMutableArray<ASCellNode *> *visibleNodes = [NSMutableArray array];
   for (NSIndexPath *indexPath in indexPaths) {
     ASCellNode *node = [self nodeForRowAtIndexPath:indexPath];
     if (node) {


### PR DESCRIPTION
It is known that the visible nodes of an `ASTableView` are `ASCellNode`s. This diff specialize the `visibleNodes` method in `ASTableView` to return an array of `ASCellNode`s instead of an array of `ASDisplayNode`s. This way, it is both clearer of what the objects of that array truly are and also avoids unnecessary casts when using this method.