### PR TITLE
[ASDataController] Small improvements

### DIFF
--- a/AsyncDisplayKit/Details/ASDataController.mm
+++ b/AsyncDisplayKit/Details/ASDataController.mm
@@ -815,8 +815,7 @@ static void *kASSizingQueueContext = &kASSizingQueueContext;
 
     [_editingTransactionQueue waitUntilAllOperationsAreFinished];
     
-    // sort indexPath in order to avoid messing up the index when deleting
-    // FIXME: Shouldn't deletes be sorted in descending order?
+    // sort indexPath in order to avoid messing up the index when deleting in several batches
     NSArray *sortedIndexPaths = [indexPaths sortedArrayUsingSelector:@selector(compare:)];
 
     [_editingTransactionQueue addOperationWithBlock:^{
@@ -838,14 +837,13 @@ static void *kASSizingQueueContext = &kASSizingQueueContext;
     [self accessDataSourceWithBlock:^{
       NSMutableArray<ASIndexedNodeContext *> *contexts = [[NSMutableArray alloc] initWithCapacity:indexPaths.count];
       
-      // FIXME: This doesn't currently do anything
-      // FIXME: Shouldn't deletes be sorted in descending order?
-      [indexPaths sortedArrayUsingSelector:@selector(compare:)];
+      // sort indexPath to avoid messing up the index when deleting
+      NSArray *sortedIndexPaths = [indexPaths sortedArrayUsingSelector:@selector(compare:)];
       
       id<ASEnvironment> environment = [self.environmentDelegate dataControllerEnvironment];
       ASEnvironmentTraitCollection environmentTraitCollection = environment.environmentTraitCollection;
       
-      for (NSIndexPath *indexPath in indexPaths) {
+      for (NSIndexPath *indexPath in sortedIndexPaths) {
         ASCellNodeBlock nodeBlock = [_dataSource dataController:self nodeBlockAtIndexPath:indexPath];
         ASSizeRange constrainedSize = [self constrainedSizeForNodeOfKind:ASDataControllerRowNodeKind atIndexPath:indexPath];
         [contexts addObject:[[ASIndexedNodeContext alloc] initWithNodeBlock:nodeBlock
@@ -856,7 +854,7 @@ static void *kASSizingQueueContext = &kASSizingQueueContext;
 
       [_editingTransactionQueue addOperationWithBlock:^{
         LOG(@"Edit Transaction - reloadRows: %@", indexPaths);
-        [self _deleteNodesAtIndexPaths:indexPaths withAnimationOptions:animationOptions];
+        [self _deleteNodesAtIndexPaths:sortedIndexPaths withAnimationOptions:animationOptions];
         [self _batchLayoutNodesFromContexts:contexts withAnimationOptions:animationOptions];
       }];
     }];

--- a/AsyncDisplayKit/Details/ASDataController.mm
+++ b/AsyncDisplayKit/Details/ASDataController.mm
@@ -816,9 +816,8 @@ static void *kASSizingQueueContext = &kASSizingQueueContext;
     [_editingTransactionQueue waitUntilAllOperationsAreFinished];
     
     // Sort indexPath in order to avoid messing up the index when deleting in several batches.
-    // When you delete at an index, you invalidate all subsequent indices, and we never want to use an invalid index
-    // in a later delete so we should have the sorted index path's array in descendent order
-    NSArray *sortedIndexPaths = [indexPaths sortedArrayUsingSelector:@selector(asdk_inverseCompare:)];
+    // FIXME: Shouldn't deletes be sorted in descending order?
+    NSArray *sortedIndexPaths = [indexPaths sortedArrayUsingSelector:@selector(compare:)];
 
     [_editingTransactionQueue addOperationWithBlock:^{
       LOG(@"Edit Transaction - deleteRows: %@", indexPaths);
@@ -840,6 +839,7 @@ static void *kASSizingQueueContext = &kASSizingQueueContext;
       NSMutableArray<ASIndexedNodeContext *> *contexts = [[NSMutableArray alloc] initWithCapacity:indexPaths.count];
       
       // Sort indexPath to avoid messing up the index when deleting
+      // FIXME: Shouldn't deletes be sorted in descending order?
       NSArray *sortedIndexPaths = [indexPaths sortedArrayUsingSelector:@selector(compare:)];
       
       id<ASEnvironment> environment = [self.environmentDelegate dataControllerEnvironment];
@@ -854,13 +854,9 @@ static void *kASSizingQueueContext = &kASSizingQueueContext;
                                                  environmentTraitCollection:environmentTraitCollection]];
       }
       
-      // When you delete at an index, you invalidate all subsequent indices, and we never want to use an invalid
-      // index in a later delete so we should have the sorted index path's array in descendent order
-      NSArray *reverseSortedIndexPaths = [[sortedIndexPaths reverseObjectEnumerator] allObjects];
-
       [_editingTransactionQueue addOperationWithBlock:^{
         LOG(@"Edit Transaction - reloadRows: %@", indexPaths);
-        [self _deleteNodesAtIndexPaths:reverseSortedIndexPaths withAnimationOptions:animationOptions];
+        [self _deleteNodesAtIndexPaths:sortedIndexPaths withAnimationOptions:animationOptions];
         [self _batchLayoutNodesFromContexts:contexts withAnimationOptions:animationOptions];
       }];
     }];

--- a/AsyncDisplayKit/Details/ASDataController.mm
+++ b/AsyncDisplayKit/Details/ASDataController.mm
@@ -816,11 +816,9 @@ static void *kASSizingQueueContext = &kASSizingQueueContext;
     [_editingTransactionQueue waitUntilAllOperationsAreFinished];
     
     // Sort indexPath in order to avoid messing up the index when deleting in several batches.
-    NSArray *sortedIndexPaths = [indexPaths sortedArrayUsingSelector:@selector(compare:)];
-    
     // When you delete at an index, you invalidate all subsequent indices, and we never want to use an invalid index
     // in a later delete so we should have the sorted index path's array in descendent order
-    sortedIndexPaths = [[sortedIndexPaths reverseObjectEnumerator] allObjects];
+    NSArray *sortedIndexPaths = [indexPaths sortedArrayUsingSelector:@selector(asdk_inverseCompare:)];
 
     [_editingTransactionQueue addOperationWithBlock:^{
       LOG(@"Edit Transaction - deleteRows: %@", indexPaths);

--- a/AsyncDisplayKit/Details/ASDataController.mm
+++ b/AsyncDisplayKit/Details/ASDataController.mm
@@ -873,7 +873,7 @@ static void *kASSizingQueueContext = &kASSizingQueueContext;
     // (see _layoutNodes:atIndexPaths:withAnimationOptions:).
     [_editingTransactionQueue addOperationWithBlock:^{
       [_mainSerialQueue performBlockOnMainThread:^{
-        for (NSString *kind in [_completedNodes keyEnumerator]) {
+        for (NSString *kind in _completedNodes) {
           [self _relayoutNodesOfKind:kind];
         }
       }];


### PR DESCRIPTION
1. Use NSFastEnumeration directly instead of getting a NSEnumerator for iterating through completedNodes which should improve performance
2. Use the sorted array in `reloadRowsAtIndexPaths:withAnimationOptions:`. Before we just sorted it, but didn't use it :/
3. Remove FIXME about sorting index paths for deleting rows. @Adlai-Holler I saw you added the FIXME, why do you think we should order in descending order before deleting?

cc @appleguy 