### PR TITLE
[ASVideoNode] Allow playback to continue sooner, even if another re-buffering pause will be required.

### DIFF
--- a/AsyncDisplayKit/ASVideoNode.mm
+++ b/AsyncDisplayKit/ASVideoNode.mm
@@ -318,8 +318,11 @@ static NSString * const kStatus = @"status";
       }
     }
   } else if ([keyPath isEqualToString:kPlaybackLikelyToKeepUpKey]) {
-    if (_shouldBePlaying && [change[NSKeyValueChangeNewKey] boolValue] == true && ASInterfaceStateIncludesVisible(self.interfaceState)) {
-      [self play]; // autoresume after buffer catches up
+    /* Predicts whether the current loading rate and playback buffer status is sufficient to play from the AVPlayerItem.CurrentTime to the end without requiring a buffering pause
+     * We want to resume the video playback even when the loading rate isn't sufficient to play until the end and further re-buffering is needed.
+     */
+    if (_shouldBePlaying && ASInterfaceStateIncludesVisible(self.interfaceState)) {
+      [self play]; 
     }
   } else if ([keyPath isEqualToString:kplaybackBufferEmpty]) {
     if (_shouldBePlaying && [change[NSKeyValueChangeNewKey] boolValue] == true && ASInterfaceStateIncludesVisible(self.interfaceState)) {


### PR DESCRIPTION
Resume video playback even when playbackLikelyToKeepUp is NO.  Main reason for that is in cases where the loading rate is always less than the bitrate of the video in a poor network condition, the video will never be resumed once enough contents have been buffered until close to the entire video is loaded.  Instead of that, we want to resume playback even though further re-buffering is needed.