### PR TITLE
[ASDisplayNode] Add automatic measure before layout

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -15,6 +15,8 @@
 #import <AsyncDisplayKit/ASAsciiArtBoxCreator.h>
 #import <AsyncDisplayKit/ASLayoutable.h>
 
+#define ASDisplayNodeLoggingEnabled 0
+
 @class ASDisplayNode;
 
 /**

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -1074,19 +1074,58 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   ASDisplayNodeAssertMainThread();
   ASDN::MutexLocker l(_propertyLock);
   CGRect bounds = self.bounds;
-  if (CGRectEqualToRect(bounds, CGRectZero)) {
-    // Performing layout on a zero-bounds view often results in frame calculations
-    // with negative sizes after applying margins, which will cause
-    // measureWithSizeRange: on subnodes to assert.
+
+  [self measureNodeWithBoundsIfNecessary:bounds];
+
+  // Performing layout on a zero-bounds view often results in frame calculations
+  // with negative sizes after applying margins, which will cause
+  // measureWithSizeRange: on subnodes to assert.
+  if (!CGRectEqualToRect(bounds, CGRectZero)) {
+    _placeholderLayer.frame = bounds;
+    [self layout];
+    [self layoutDidFinish];
+  }
+}
+
+- (void)measureNodeWithBoundsIfNecessary:(CGRect)bounds
+{
+  // Normally measure will be called before layout occurs. If this doesn't happen, nothing is going to call it at all.
+  // We simply call measureWithSizeRange: using a size range equal to whatever bounds were provided to that element or
+  // try to measure the node with the largest size as possible
+  if (self.supernode == nil && !self.supportsRangeManagedInterfaceState && !_flags.isMeasured) {
+    if (CGRectEqualToRect(bounds, CGRectZero)) {
+      // FIXME: Better log to let developers know that the node was not measured before the layout call and no frame was set
+      NSLog(@"Warning: No size given for node before node was trying to layout itself: %@. Please provide a frame for the node.", self);
+    } else {
+      ASSizeRange measureSizeRange = ASSizeRangeMake(CGSizeZero, bounds.size);
+      if ([self shouldMeasureWithSizeRange:measureSizeRange]) {
+        [self measureWithSizeRange:measureSizeRange];
+      }
+    }
+  }
+}
+
+- (void)layout
+{
+  ASDisplayNodeAssertMainThread();
+  
+  if (!_flags.isMeasured) {
     return;
   }
-  _placeholderLayer.frame = bounds;
-  [self layout];
-  [self layoutDidFinish];
+  
+  [self __layoutSublayouts];
+}
+
+- (void)__layoutSublayouts
+{
+  for (ASLayout *subnodeLayout in _layout.immediateSublayouts) {
+    ((ASDisplayNode *)subnodeLayout.layoutableObject).frame = [subnodeLayout frame];
+  }
 }
 
 - (void)layoutDidFinish
 {
+  // Hook for subclasses
 }
 
 - (CATransform3D)_transformToAncestor:(ASDisplayNode *)ancestor
@@ -2366,24 +2405,6 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
   if (self.usesImplicitHierarchyManagement && layoutContext != nil) {
     [layoutContext applySubnodeInsertions];
     [layoutContext applySubnodeRemovals];
-  }
-}
-
-- (void)layout
-{
-  ASDisplayNodeAssertMainThread();
-
-  if (!_flags.isMeasured) {
-    return;
-  }
-  
-  [self __layoutSublayouts];
-}
-
-- (void)__layoutSublayouts
-{
-  for (ASLayout *subnodeLayout in _layout.immediateSublayouts) {
-    ((ASDisplayNode *)subnodeLayout.layoutableObject).frame = [subnodeLayout frame];
   }
 }
 

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -48,8 +48,11 @@ NSString * const ASRenderingEngineDidDisplayNodesScheduledBeforeTimestamp = @"AS
 
 @end
 
-//#define LOG(...) NSLog(__VA_ARGS__)
-#define LOG(...)
+#if ASDisplayNodeLoggingEnabled
+  #define LOG(...) NSLog(__VA_ARGS__)
+#else
+  #define LOG(...)
+#endif
 
 // Conditionally time these scopes to our debug ivars (only exist in debug/profile builds)
 #if TIME_DISPLAYNODE_OPS
@@ -1094,13 +1097,9 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   // try to measure the node with the largest size as possible
   if (self.supernode == nil && !self.supportsRangeManagedInterfaceState && !_flags.isMeasured) {
     if (CGRectEqualToRect(bounds, CGRectZero)) {
-      // FIXME: Better log to let developers know that the node was not measured before the layout call and no frame was set
-      NSLog(@"Warning: No size given for node before node was trying to layout itself: %@. Please provide a frame for the node.", self);
+      LOG(@"Warning: No size given for node before node was trying to layout itself: %@. Please provide a frame for the node.", self);
     } else {
-      ASSizeRange measureSizeRange = ASSizeRangeMake(CGSizeZero, bounds.size);
-      if ([self shouldMeasureWithSizeRange:measureSizeRange]) {
-        [self measureWithSizeRange:measureSizeRange];
-      }
+      [self measureWithSizeRange:ASSizeRangeMake(CGSizeZero, bounds.size)];
     }
   }
 }

--- a/examples/Videos/Sample/ViewController.h
+++ b/examples/Videos/Sample/ViewController.h
@@ -8,8 +8,8 @@
  * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-#import <AsyncDisplayKit/AsyncDisplayKit.h>
-#import <AsyncDisplayKit/ASVideoNode.h>
+
+#include <UIKit/UIKit.h>
 
 @interface ViewController : UIViewController
 

--- a/examples/Videos/Sample/ViewController.m
+++ b/examples/Videos/Sample/ViewController.m
@@ -28,6 +28,7 @@
 
   // Root node for the view controller
   _rootNode = [ASDisplayNode new];
+  _rootNode.frame = self.view.bounds;
   _rootNode.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
   
   ASVideoNode *guitarVideoNode = self.guitarVideoNode;
@@ -52,16 +53,6 @@
     return [ASStaticLayoutSpec staticLayoutSpecWithChildren:@[guitarVideoNode, nicCageVideoNode, simonVideoNode]];
   };
   [self.view addSubnode:_rootNode];
-}
-
-- (void)viewDidLayoutSubviews
-{
-  [super viewDidLayoutSubviews];
-  
-  // After all subviews are layed out we have to measure it and move the root node to the right place
-  CGSize viewSize = self.view.bounds.size;
-  [self.rootNode measureWithSizeRange:ASSizeRangeMake(viewSize, viewSize)];
-  [self.rootNode setNeedsLayout];
 }
 
 #pragma mark - Getter / Setter

--- a/examples/Videos/Sample/ViewController.m
+++ b/examples/Videos/Sample/ViewController.m
@@ -10,8 +10,7 @@
  */
 
 #import "ViewController.h"
-#import "ASLayoutSpec.h"
-#import "ASStaticLayoutSpec.h"
+#import <AsyncDisplayKit/AsyncDisplayKit.h>
 
 @interface ViewController()<ASVideoNodeDelegate>
 @property (nonatomic, strong) ASDisplayNode *rootNode;
@@ -22,10 +21,20 @@
 
 #pragma mark - UIViewController
 
-- (void)viewWillAppear:(BOOL)animated
+- (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
 {
-  [super viewWillAppear:animated];
+  self = [super initWithNibName:nil bundle:nil];
+  if (self) {
 
+    
+  }
+  return self;
+}
+
+- (void)viewDidLoad
+{
+  [super viewDidLoad];
+  
   // Root node for the view controller
   _rootNode = [ASDisplayNode new];
   _rootNode.frame = self.view.bounds;


### PR DESCRIPTION
Normally `measure:` will be called on a `ASDisplayNode` before layout occurs. If this doesn't happen, nothing is going to call it at all.  An experimenting developer probably added a node to the hierarchy directly. We now simply call `measureWithSizeRange:` using a size range equal to whatever bounds were provided to that element. This will make initial experimentation using layoutSpecs much easier.