### PR TITLE
[ASDisplayNode] Move constrained size to ASLayout

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -653,10 +653,10 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   // Only generate a new layout if:
   // - The current layout is dirty
   // - The passed constrained size is different than the layout's constrained size
-  return ([self _dirtyLayout] || !ASSizeRangeEqualToSizeRange(constrainedSize, _layout.constrainedSizeRange));
+  return ([self _hasDirtyLayout] || !ASSizeRangeEqualToSizeRange(constrainedSize, _layout.constrainedSizeRange));
 }
 
-- (BOOL)_dirtyLayout
+- (BOOL)_hasDirtyLayout
 {
   return _layout == nil || _layout.isDirty;
 }
@@ -1024,7 +1024,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   ASDisplayNodeAssertThreadAffinity(self);
   ASDN::MutexLocker l(_propertyLock);
   
-  if ([self _dirtyLayout]) {
+  if ([self _hasDirtyLayout]) {
     return;
   }
   
@@ -1100,7 +1100,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   // Normally measure will be called before layout occurs. If this doesn't happen, nothing is going to call it at all.
   // We simply call measureWithSizeRange: using a size range equal to whatever bounds were provided to that element or
   // try to measure the node with the largest size as possible
-  if (self.supernode == nil && !self.supportsRangeManagedInterfaceState && [self _dirtyLayout] == NO) {
+  if (self.supernode == nil && !self.supportsRangeManagedInterfaceState && [self _hasDirtyLayout] == NO) {
     if (CGRectEqualToRect(bounds, CGRectZero)) {
       LOG(@"Warning: No size given for node before node was trying to layout itself: %@. Please provide a frame for the node.", self);
     } else {
@@ -1113,7 +1113,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
 {
   ASDisplayNodeAssertMainThread();
   
-  if ([self _dirtyLayout]) {
+  if ([self _hasDirtyLayout]) {
     return;
   }
   

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -1956,7 +1956,10 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
     // Make sure layoutableObject of the root layout is `self`, so that the flattened layout will be structurally correct.
     if (layout.layoutableObject != self) {
       layout.position = CGPointZero;
-      layout = [ASLayout layoutWithLayoutableObject:self size:layout.size sublayouts:@[layout]];
+      layout = [ASLayout layoutWithLayoutableObject:self
+                               constrainedSizeRange:constrainedSize
+                                               size:layout.size
+                                         sublayouts:@[layout]];
     }
     return [layout flattenedLayoutUsingPredicateBlock:^BOOL(ASLayout *evaluatedLayout) {
       if (self.usesImplicitHierarchyManagement) {
@@ -1969,7 +1972,9 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
     // If neither -layoutSpecThatFits: nor -calculateSizeThatFits: is overridden by subclassses, preferredFrameSize should be used,
     // assume that the default implementation of -calculateSizeThatFits: returns it.
     CGSize size = [self calculateSizeThatFits:constrainedSize.max];
-    return [ASLayout layoutWithLayoutableObject:self size:ASSizeRangeClamp(constrainedSize, size)];
+    return [ASLayout layoutWithLayoutableObject:self
+                           constrainedSizeRange:constrainedSize
+                                           size:ASSizeRangeClamp(constrainedSize, size)];
   }
 }
 

--- a/AsyncDisplayKit/Layout/ASBackgroundLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASBackgroundLayoutSpec.mm
@@ -55,7 +55,10 @@ static NSString * const kBackgroundChildKey = @"kBackgroundChildKey";
   contentsLayout.position = CGPointZero;
   [sublayouts addObject:contentsLayout];
 
-  return [ASLayout layoutWithLayoutableObject:self size:contentsLayout.size sublayouts:sublayouts];
+  return [ASLayout layoutWithLayoutableObject:self
+                         constrainedSizeRange:constrainedSize
+                                         size:contentsLayout.size
+                                   sublayouts:sublayouts];
 }
 
 - (void)setBackground:(id<ASLayoutable>)background

--- a/AsyncDisplayKit/Layout/ASInsetLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASInsetLayoutSpec.mm
@@ -91,7 +91,9 @@ static CGFloat centerInset(CGFloat outer, CGFloat inner)
   
   if (self.child == nil) {
     ASDisplayNodeAssert(NO, @"Inset spec measured without a child. The spec will do nothing.");
-    return [ASLayout layoutWithLayoutableObject:self size:CGSizeZero];
+    return [ASLayout layoutWithLayoutableObject:self
+                           constrainedSizeRange:constrainedSize
+                                           size:CGSizeZero];
   }
   
   ASLayout *sublayout = [self.child measureWithSizeRange:insetConstrainedSize];
@@ -112,7 +114,10 @@ static CGFloat centerInset(CGFloat outer, CGFloat inner)
   
   sublayout.position = CGPointMake(x, y);
   
-  return [ASLayout layoutWithLayoutableObject:self size:computedSize sublayouts:@[sublayout]];
+  return [ASLayout layoutWithLayoutableObject:self
+                         constrainedSizeRange:constrainedSize
+                                         size:computedSize
+                                   sublayouts:@[sublayout]];
 }
 
 @end

--- a/AsyncDisplayKit/Layout/ASLayout.h
+++ b/AsyncDisplayKit/Layout/ASLayout.h
@@ -13,6 +13,7 @@
 #import <UIKit/UIKit.h>
 #import <AsyncDisplayKit/ASAssert.h>
 #import <AsyncDisplayKit/ASLayoutable.h>
+#import <AsyncDisplayKit/ASDimension.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/AsyncDisplayKit/Layout/ASLayout.h
+++ b/AsyncDisplayKit/Layout/ASLayout.h
@@ -21,7 +21,9 @@ extern CGPoint const CGPointNull;
 
 extern BOOL CGPointIsNull(CGPoint point);
 
-/** Represents a computed immutable layout tree. */
+/**
+ * A node in the layout tree that represents the size and position of the object that created it (ASLayoutable).
+ */
 @interface ASLayout : NSObject
 
 /**
@@ -55,6 +57,11 @@ extern BOOL CGPointIsNull(CGPoint point);
  * A list of sublayouts that were not already flattened.
  */
 @property (nonatomic, readonly) NSArray<ASLayout *> *immediateSublayouts;
+
+/**
+ * Mark the layout dirty for future regeneration.
+ */
+@property (nonatomic, getter=isDirty) BOOL dirty;
 
 /**
  * A boolean describing if the current layout has been flattened.

--- a/AsyncDisplayKit/Layout/ASLayout.h
+++ b/AsyncDisplayKit/Layout/ASLayout.h
@@ -41,6 +41,11 @@ extern BOOL CGPointIsNull(CGPoint point);
 @property (nonatomic, readwrite) CGPoint position;
 
 /**
+ * The size range that was use to determine the size of the layout.
+ */
+@property (nonatomic, readonly) ASSizeRange constrainedSizeRange;
+
+/**
  * Array of ASLayouts. Each must have a valid non-null position.
  */
 @property (nonatomic, readonly) NSArray<ASLayout *> *sublayouts;
@@ -67,6 +72,7 @@ extern BOOL CGPointIsNull(CGPoint point);
  * @param sublayouts Sublayouts belong to the new layout.
  */
 + (instancetype)layoutWithLayoutableObject:(id<ASLayoutable>)layoutableObject
+                      constrainedSizeRange:(ASSizeRange)sizeRange
                                       size:(CGSize)size
                                   position:(CGPoint)position
                                 sublayouts:(nullable NSArray<ASLayout *> *)sublayouts
@@ -85,6 +91,7 @@ extern BOOL CGPointIsNull(CGPoint point);
  * @param sublayouts Sublayouts belong to the new layout.
  */
 + (instancetype)layoutWithLayoutableObject:(id<ASLayoutable>)layoutableObject
+                      constrainedSizeRange:(ASSizeRange)sizeRange
                                       size:(CGSize)size
                                 sublayouts:(nullable NSArray<ASLayout *> *)sublayouts;
 
@@ -97,7 +104,9 @@ extern BOOL CGPointIsNull(CGPoint point);
  *
  * @param size The size of this layout.
  */
-+ (instancetype)layoutWithLayoutableObject:(id<ASLayoutable>)layoutableObject size:(CGSize)size;
++ (instancetype)layoutWithLayoutableObject:(id<ASLayoutable>)layoutableObject
+                      constrainedSizeRange:(ASSizeRange)sizeRange
+                                      size:(CGSize)size;
 
 /**
  * Convenience initializer that is flattened and has CGPointNull position.
@@ -109,6 +118,7 @@ extern BOOL CGPointIsNull(CGPoint point);
  * @param sublayouts Sublayouts belong to the new layout.
  */
 + (instancetype)flattenedLayoutWithLayoutableObject:(id<ASLayoutable>)layoutableObject
+                               constrainedSizeRange:(ASSizeRange)sizeRange
                                                size:(CGSize)size
                                          sublayouts:(nullable NSArray<ASLayout *> *)sublayouts;
 

--- a/AsyncDisplayKit/Layout/ASLayout.mm
+++ b/AsyncDisplayKit/Layout/ASLayout.mm
@@ -12,6 +12,7 @@
 #import "ASAssert.h"
 #import "ASLayoutSpecUtilities.h"
 #import "ASInternalHelpers.h"
+#import "ASDimension.h"
 #import <queue>
 
 CGPoint const CGPointNull = {NAN, NAN};

--- a/AsyncDisplayKit/Layout/ASLayout.mm
+++ b/AsyncDisplayKit/Layout/ASLayout.mm
@@ -50,6 +50,7 @@ extern BOOL CGPointIsNull(CGPoint point)
     }
     l->_constrainedSizeRange = sizeRange;
     l->_size = size;
+    l->_dirty = NO;
     
     if (CGPointIsNull(position) == NO) {
       l->_position = CGPointMake(ASCeilPixelValue(position.x), ASCeilPixelValue(position.y));

--- a/AsyncDisplayKit/Layout/ASLayout.mm
+++ b/AsyncDisplayKit/Layout/ASLayout.mm
@@ -24,6 +24,7 @@ extern BOOL CGPointIsNull(CGPoint point)
 @implementation ASLayout
 
 + (instancetype)layoutWithLayoutableObject:(id<ASLayoutable>)layoutableObject
+                      constrainedSizeRange:(ASSizeRange)sizeRange
                                       size:(CGSize)size
                                   position:(CGPoint)position
                                 sublayouts:(NSArray *)sublayouts
@@ -46,6 +47,7 @@ extern BOOL CGPointIsNull(CGPoint point)
     } else {
       size = CGSizeMake(ASCeilPixelValue(size.width), ASCeilPixelValue(size.height));
     }
+    l->_constrainedSizeRange = sizeRange;
     l->_size = size;
     
     if (CGPointIsNull(position) == NO) {
@@ -68,22 +70,39 @@ extern BOOL CGPointIsNull(CGPoint point)
 }
 
 + (instancetype)layoutWithLayoutableObject:(id<ASLayoutable>)layoutableObject
+                      constrainedSizeRange:(ASSizeRange)sizeRange
                                       size:(CGSize)size
                                 sublayouts:(NSArray *)sublayouts
 {
-  return [self layoutWithLayoutableObject:layoutableObject size:size position:CGPointNull sublayouts:sublayouts flattened:NO];
+  return [self layoutWithLayoutableObject:layoutableObject
+                     constrainedSizeRange:sizeRange
+                                     size:size
+                                 position:CGPointNull
+                               sublayouts:sublayouts
+                                flattened:NO];
 }
 
-+ (instancetype)layoutWithLayoutableObject:(id<ASLayoutable>)layoutableObject size:(CGSize)size
++ (instancetype)layoutWithLayoutableObject:(id<ASLayoutable>)layoutableObject
+                      constrainedSizeRange:(ASSizeRange)sizeRange
+                                      size:(CGSize)size
 {
-  return [self layoutWithLayoutableObject:layoutableObject size:size sublayouts:nil];
+  return [self layoutWithLayoutableObject:layoutableObject
+                     constrainedSizeRange:sizeRange
+                                     size:size
+                               sublayouts:nil];
 }
 
 + (instancetype)flattenedLayoutWithLayoutableObject:(id<ASLayoutable>)layoutableObject
+                               constrainedSizeRange:(ASSizeRange)sizeRange
                                                size:(CGSize)size
                                          sublayouts:(nullable NSArray<ASLayout *> *)sublayouts
 {
-  return [self layoutWithLayoutableObject:layoutableObject size:size position:CGPointNull sublayouts:sublayouts flattened:YES];
+  return [self layoutWithLayoutableObject:layoutableObject
+                     constrainedSizeRange:sizeRange
+                                     size:size
+                                 position:CGPointNull
+                               sublayouts:sublayouts
+                                flattened:YES];
 }
 
 - (ASLayout *)flattenedLayoutUsingPredicateBlock:(BOOL (^)(ASLayout *))predicateBlock
@@ -110,6 +129,7 @@ extern BOOL CGPointIsNull(CGPoint point)
       
       if (predicateBlock(context.layout)) {
         [flattenedSublayouts addObject:[ASLayout layoutWithLayoutableObject:context.layout.layoutableObject
+                                                       constrainedSizeRange:context.layout.constrainedSizeRange
                                                                        size:context.layout.size
                                                                    position:context.absolutePosition
                                                                  sublayouts:nil
@@ -124,7 +144,10 @@ extern BOOL CGPointIsNull(CGPoint point)
     }
   }
 
-  return [ASLayout flattenedLayoutWithLayoutableObject:_layoutableObject size:_size sublayouts:flattenedSublayouts];
+  return [ASLayout flattenedLayoutWithLayoutableObject:_layoutableObject
+                                  constrainedSizeRange:_constrainedSizeRange
+                                                  size:_size
+                                            sublayouts:flattenedSublayouts];
 }
 
 - (CGRect)frame

--- a/AsyncDisplayKit/Layout/ASLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASLayoutSpec.mm
@@ -52,7 +52,9 @@
 
 - (ASLayout *)measureWithSizeRange:(ASSizeRange)constrainedSize
 {
-  return [ASLayout layoutWithLayoutableObject:self size:constrainedSize.min];
+  return [ASLayout layoutWithLayoutableObject:self
+                         constrainedSizeRange:constrainedSize
+                                         size:constrainedSize.min];
 }
 
 - (id<ASLayoutable>)finalLayoutable

--- a/AsyncDisplayKit/Layout/ASOverlayLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASOverlayLayoutSpec.mm
@@ -58,7 +58,10 @@ static NSString * const kOverlayChildKey = @"kOverlayChildKey";
     [sublayouts addObject:overlayLayout];
   }
   
-  return [ASLayout layoutWithLayoutableObject:self size:contentsLayout.size sublayouts:sublayouts];
+  return [ASLayout layoutWithLayoutableObject:self
+                         constrainedSizeRange:constrainedSize
+                                         size:contentsLayout.size
+                                   sublayouts:sublayouts];
 }
 
 @end

--- a/AsyncDisplayKit/Layout/ASRatioLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASRatioLayoutSpec.mm
@@ -72,7 +72,10 @@
   const ASSizeRange childRange = (bestSize == sizeOptions.end()) ? constrainedSize : ASSizeRangeMake(*bestSize, *bestSize);
   ASLayout *sublayout = [self.child measureWithSizeRange:childRange];
   sublayout.position = CGPointZero;
-  return [ASLayout layoutWithLayoutableObject:self size:sublayout.size sublayouts:@[sublayout]];
+  return [ASLayout layoutWithLayoutableObject:self
+                         constrainedSizeRange:constrainedSize
+                                         size:sublayout.size
+                                   sublayouts:@[sublayout]];
 }
 
 @end

--- a/AsyncDisplayKit/Layout/ASRelativeLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASRelativeLayoutSpec.mm
@@ -89,7 +89,10 @@
     ASRoundPixelValue((size.height - sublayout.size.height) * yPosition)
   };
   
-  return [ASLayout layoutWithLayoutableObject:self size:size sublayouts:@[sublayout]];
+  return [ASLayout layoutWithLayoutableObject:self
+                         constrainedSizeRange:constrainedSize
+                                         size:size
+                                   sublayouts:@[sublayout]];
 }
 
 - (CGFloat)proportionOfAxisForAxisPosition:(ASRelativeLayoutSpecPosition)position

--- a/AsyncDisplayKit/Layout/ASStackLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASStackLayoutSpec.mm
@@ -124,7 +124,9 @@
 - (ASLayout *)measureWithSizeRange:(ASSizeRange)constrainedSize
 {
   if (self.children.count == 0) {
-    return [ASLayout layoutWithLayoutableObject:self size:constrainedSize.min];
+    return [ASLayout layoutWithLayoutableObject:self
+                           constrainedSizeRange:constrainedSize
+                                           size:constrainedSize.min];
   }
   
   ASStackLayoutSpecStyle style = {.direction = _direction, .spacing = _spacing, .justifyContent = _justifyContent, .alignItems = _alignItems, .baselineRelativeArrangement = _baselineRelativeArrangement};
@@ -163,6 +165,7 @@
   }
   
   return [ASLayout layoutWithLayoutableObject:self
+                         constrainedSizeRange:constrainedSize
                                          size:ASSizeRangeClamp(constrainedSize, finalSize)
                                    sublayouts:sublayouts];
 }

--- a/AsyncDisplayKit/Layout/ASStaticLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASStaticLayoutSpec.mm
@@ -68,6 +68,7 @@
   }
 
   return [ASLayout layoutWithLayoutableObject:self
+                         constrainedSizeRange:constrainedSize
                                          size:ASSizeRangeClamp(constrainedSize, size)
                                    sublayouts:sublayouts];
 }

--- a/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
+++ b/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
@@ -82,7 +82,6 @@ FOUNDATION_EXPORT NSString * const ASRenderingEngineDidDisplayNodesScheduledBefo
     unsigned implementsDrawParameters:1;
 
     // internal state
-    unsigned isMeasured:1;
     unsigned isEnteringHierarchy:1;
     unsigned isExitingHierarchy:1;
     unsigned isInHierarchy:1;

--- a/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
+++ b/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
@@ -103,8 +103,6 @@ FOUNDATION_EXPORT NSString * const ASRenderingEngineDidDisplayNodesScheduledBefo
   ASEnvironmentState _environmentState;
   ASLayout *_layout;
 
-  ASSizeRange _constrainedSize;
-
   UIEdgeInsets _hitTestSlop;
   NSMutableArray *_subnodes;
   

--- a/AsyncDisplayKit/Private/ASLayoutTransition.h
+++ b/AsyncDisplayKit/Private/ASLayoutTransition.h
@@ -16,15 +16,11 @@
 
 @property (nonatomic, readonly, weak) ASDisplayNode *node;
 @property (nonatomic, readonly, strong) ASLayout *pendingLayout;
-@property (nonatomic, readonly, assign) ASSizeRange pendingConstrainedSize;
 @property (nonatomic, readonly, strong) ASLayout *previousLayout;
-@property (nonatomic, readonly, assign) ASSizeRange previousConstrainedSize;
 
 - (instancetype)initWithNode:(ASDisplayNode *)node
                pendingLayout:(ASLayout *)pendingLayout
-      pendingConstrainedSize:(ASSizeRange)pendingConstrainedSize
-              previousLayout:(ASLayout *)previousLayout
-     previousConstrainedSize:(ASSizeRange)previousConstrainedSize;
+              previousLayout:(ASLayout *)previousLayout;
 
 - (void)applySubnodeInsertions;
 

--- a/AsyncDisplayKit/Private/ASLayoutTransition.mm
+++ b/AsyncDisplayKit/Private/ASLayoutTransition.mm
@@ -29,17 +29,13 @@
 
 - (instancetype)initWithNode:(ASDisplayNode *)node
                pendingLayout:(ASLayout *)pendingLayout
-      pendingConstrainedSize:(ASSizeRange)pendingConstrainedSize
               previousLayout:(ASLayout *)previousLayout
-     previousConstrainedSize:(ASSizeRange)previousConstrainedSize
 {
   self = [super init];
   if (self) {
     _node = node;
     _pendingLayout = pendingLayout;
-    _pendingConstrainedSize = pendingConstrainedSize;
     _previousLayout = previousLayout;
-    _previousConstrainedSize = previousConstrainedSize;
   }
   return self;
 }
@@ -129,9 +125,9 @@
 {
   ASDN::MutexLocker l(_propertyLock);
   if ([key isEqualToString:ASTransitionContextFromLayoutKey]) {
-    return _previousConstrainedSize;
+    return _previousLayout.constrainedSizeRange;
   } else if ([key isEqualToString:ASTransitionContextToLayoutKey]) {
-    return _pendingConstrainedSize;
+    return _pendingLayout.constrainedSizeRange;
   } else {
     return ASSizeRangeMake(CGSizeZero, CGSizeZero);
   }

--- a/AsyncDisplayKit/Private/ASStackUnpositionedLayout.mm
+++ b/AsyncDisplayKit/Private/ASStackUnpositionedLayout.mm
@@ -303,7 +303,7 @@ static std::vector<ASStackUnpositionedItem> layoutChildrenAlongUnconstrainedStac
     const CGFloat exactStackDimension = ASRelativeDimensionResolve(flexBasis, stackDimension(style.direction, size));
 
     if (useOptimizedFlexing && isFlexibleInBothDirections(child)) {
-      return { child, [ASLayout layoutWithLayoutableObject:child size:{0, 0}] };
+      return { child, [ASLayout layoutWithLayoutableObject:child constrainedSizeRange:sizeRange size:{0, 0}] };
     } else {
       return {
         child,

--- a/AsyncDisplayKitTests/ASLayoutSpecSnapshotTestsHelper.m
+++ b/AsyncDisplayKitTests/ASLayoutSpecSnapshotTestsHelper.m
@@ -55,7 +55,10 @@
 {
   ASLayout *layout = [layoutSpecUnderTest measureWithSizeRange:sizeRange];
   layout.position = CGPointZero;
-  layout = [ASLayout layoutWithLayoutableObject:self size:layout.size sublayouts:@[layout]];
+  layout = [ASLayout layoutWithLayoutableObject:self
+                           constrainedSizeRange:sizeRange
+                                           size:layout.size
+                                     sublayouts:@[layout]];
   _layoutUnderTest = [layout flattenedLayoutUsingPredicateBlock:^BOOL(ASLayout *evaluatedLayout) {
     return [self.subnodes containsObject:(ASDisplayNode *)evaluatedLayout.layoutableObject];
   }];

--- a/examples/AsyncDisplayKitOverview/Sample/Node Containers/OverviewASPagerNode.m
+++ b/examples/AsyncDisplayKitOverview/Sample/Node Containers/OverviewASPagerNode.m
@@ -26,7 +26,9 @@ static UIColor *OverViewASPagerNodeRandomColor() {
 
 - (ASLayout *)calculateLayoutThatFits:(ASSizeRange)constrainedSize
 {
-    return [ASLayout layoutWithLayoutableObject:self size:constrainedSize.max];
+    return [ASLayout layoutWithLayoutableObject:self
+                           constrainedSizeRange:constrainedSize
+                                           size:constrainedSize.max];
 }
 
 @end

--- a/examples/PagerNode/Sample/PageNode.m
+++ b/examples/PagerNode/Sample/PageNode.m
@@ -12,7 +12,9 @@
 
 - (ASLayout *)calculateLayoutThatFits:(ASSizeRange)constrainedSize
 {
-  return [ASLayout layoutWithLayoutableObject:self size:constrainedSize.max];
+  return [ASLayout layoutWithLayoutableObject:self 
+                         constrainedSizeRange:constrainedSize
+                                         size:constrainedSize.max];
 }
 
 - (void)fetchData


### PR DESCRIPTION
I have this grand master plan of turning our use of ASLayouts into something like a browser render tree, a tree that every node queries when it wants to know its own size and position on screen. This is a change to move into that direction, as constrainedSize ultimately belongs in ASLayout because ASLayoutables (objects that create ASLayouts) all pass a constrainedSize when they generate a layout.

Moreover, I've removed the legacy concept of a node being "measured". Instead, ASLayouts can now be marked as dirty, which then is used to replace the `isMeasured` bit flag. As we mature the underlying ASLayout tree structure, we should move away from "measurement" and begin to use nomenclature that describes generating layouts and rendering nodes.