### PR TITLE
[Swift] Add missing nullability annotations to transition methods

### DIFF
--- a/AsyncDisplayKit/ASContextTransitioning.h
+++ b/AsyncDisplayKit/ASContextTransitioning.h
@@ -8,6 +8,8 @@
 
 #import <AsyncDisplayKit/ASDisplayNode.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 extern NSString * const ASTransitionContextFromLayoutKey;
 extern NSString * const ASTransitionContextToLayoutKey;
 
@@ -21,7 +23,7 @@ extern NSString * const ASTransitionContextToLayoutKey;
 /**
  * @abstract Retrieve either the "from" or "to" layout
  */
-- (ASLayout *)layoutForKey:(NSString *)key;
+- (nullable ASLayout *)layoutForKey:(NSString *)key;
 
 /**
  * @abstract Retrieve either the "from" or "to" constrainedSize
@@ -62,3 +64,5 @@ extern NSString * const ASTransitionContextToLayoutKey;
 - (void)completeTransition:(BOOL)didComplete;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/AsyncDisplayKit/ASDisplayNode+Beta.h
+++ b/AsyncDisplayKit/ASDisplayNode+Beta.h
@@ -8,6 +8,8 @@
 
 #import "ASContextTransitioning.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 ASDISPLAYNODE_EXTERN_C_BEGIN
 void ASPerformBlockOnMainThread(void (^block)());
 void ASPerformBlockOnBackgroundThread(void (^block)()); // DISPATCH_QUEUE_PRIORITY_DEFAULT
@@ -35,12 +37,12 @@ ASDISPLAYNODE_EXTERN_C_END
  * restoring context if necessary. Restoring can be done in contextDidDisplayNodeContent
  * This block can be called from *any* thread and it is unsafe to access any UIKit main thread properties from it.
  */
-@property (nonatomic, strong) ASDisplayNodeContextModifier willDisplayNodeContentWithRenderingContext;
+@property (nonatomic, copy, nullable) ASDisplayNodeContextModifier willDisplayNodeContentWithRenderingContext;
 
 /**
  * @abstract allow modification of a context after the node's content is drawn
  */
-@property (nonatomic, strong) ASDisplayNodeContextModifier didDisplayNodeContentWithRenderingContext;
+@property (nonatomic, copy, nullable) ASDisplayNodeContextModifier didDisplayNodeContentWithRenderingContext;
 
 /** @name Layout Transitioning */
 
@@ -73,7 +75,7 @@ ASDISPLAYNODE_EXTERN_C_END
 - (void)transitionLayoutWithSizeRange:(ASSizeRange)constrainedSize
                              animated:(BOOL)animated
                    shouldMeasureAsync:(BOOL)shouldMeasureAsync
-                measurementCompletion:(void(^)())completion;
+                measurementCompletion:(nullable void(^)())completion;
 
 /**
  * @abstract Invalidates the current layout and begins a relayout of the node with the current `constrainedSize`. Must be called on main thread.
@@ -88,8 +90,8 @@ ASDISPLAYNODE_EXTERN_C_END
  * @see animateLayoutTransition:
  */
 - (void)transitionLayoutWithAnimation:(BOOL)animated
-                         shouldMeasureAsync:(BOOL)shouldMeasureAsync
-                      measurementCompletion:(void(^)())completion;
+                   shouldMeasureAsync:(BOOL)shouldMeasureAsync
+                measurementCompletion:(nullable void(^)())completion;
 
 
 /**
@@ -113,3 +115,5 @@ ASDISPLAYNODE_EXTERN_C_END
 - (void)hierarchyDisplayDidFinish;
 
 @end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
There may be more public headers missing nullability annotations, but these are the ones I noticed while using them.