### PR TITLE
WIP - Two different approaches to trigger an update to nodes constrained size

### DIFF
--- a/AsyncDisplayKit/ASCellNode+Internal.h
+++ b/AsyncDisplayKit/ASCellNode+Internal.h
@@ -23,6 +23,15 @@
  */
 - (void)nodeDidRelayout:(ASCellNode *)node sizeChanged:(BOOL)sizeChanged;
 
+/**
+ * Notifies the delegate that the specified cell node has a new constrained size.
+ * The notification is done on main thread.
+ *
+ * @param cellNode A node informing the delegate about the it's size.
+ * @param oldConstrainedSize The previous constrained size of the node.
+ */
+- (ASSizeRange)cellNode:(ASCellNode *)node constrainedSizeForLayoutWithOldConstrainedSize:(ASSizeRange)oldConstrainedSize;
+
 @end
 
 @interface ASCellNode ()

--- a/AsyncDisplayKit/ASCellNode.mm
+++ b/AsyncDisplayKit/ASCellNode.mm
@@ -121,6 +121,11 @@
   ASDisplayNodeAssert(!layerBacked, @"ASCellNode does not support layer-backing.");
 }
 
+-(ASSizeRange)__constrainedSizeForLayout
+{
+  return [_layoutDelegate cellNode:self constrainedSizeForLayoutWithOldConstrainedSize:_constrainedSize];
+}
+
 - (void)__setNeedsLayout
 {
   CGSize oldSize = self.calculatedSize;

--- a/AsyncDisplayKit/ASCollectionView.h
+++ b/AsyncDisplayKit/ASCollectionView.h
@@ -168,7 +168,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Triggers a relayout of all nodes.
  *
  */
-- (void)relayoutAllNodes;
+- (void)relayoutItems;
 
 /**
  *  Blocks execution of the main thread until all section and row updates are committed. This method must be called from the main thread.

--- a/AsyncDisplayKit/ASCollectionView.h
+++ b/AsyncDisplayKit/ASCollectionView.h
@@ -165,6 +165,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)reloadDataImmediately;
 
 /**
+ * Triggers a relayout of all nodes.
+ *
+ */
+- (void)relayoutAllNodes;
+
+/**
  *  Blocks execution of the main thread until all section and row updates are committed. This method must be called from the main thread.
  */
 - (void)waitUntilAllUpdatesAreCommitted;

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -313,7 +313,7 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   [super reloadData];
 }
 
-- (void)relayoutAllNodes
+- (void)relayoutItems
 {
   [_dataController relayoutAllNodes];
 }

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -1118,6 +1118,12 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
 
 #pragma mark - ASCellNodeDelegate
 
+- (ASSizeRange)cellNode:(ASCellNode *)node constrainedSizeForLayoutWithOldConstrainedSize:(ASSizeRange)oldConstrainedSize
+{
+  NSIndexPath *indexPath = [self indexPathForNode:node];
+  return [_asyncDataSource collectionView:self constrainedSizeForNodeAtIndexPath:indexPath];
+}
+
 - (void)nodeDidRelayout:(ASCellNode *)node sizeChanged:(BOOL)sizeChanged
 {
   ASDisplayNodeAssertMainThread();

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -313,6 +313,11 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   [super reloadData];
 }
 
+- (void)relayoutAllNodes
+{
+  [_dataController relayoutAllNodes];
+}
+
 - (void)waitUntilAllUpdatesAreCommitted
 {
   ASDisplayNodeAssertMainThread();

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -1016,6 +1016,11 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   [self displayImmediately];
 }
 
+- (ASSizeRange)__constrainedSizeForLayout
+{
+  return _constrainedSize;
+}
+
 - (void)__setNeedsLayout
 {
   ASDisplayNodeAssertThreadAffinity(self);
@@ -1025,7 +1030,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
     return;
   }
   
-  ASSizeRange oldConstrainedSize = _constrainedSize;
+  ASSizeRange oldConstrainedSize = [self __constrainedSizeForLayout];
   [self invalidateCalculatedLayout];
   
   if (_supernode) {

--- a/AsyncDisplayKit/ASTableView.h
+++ b/AsyncDisplayKit/ASTableView.h
@@ -135,6 +135,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)reloadDataImmediately;
 
 /**
+ * Triggers a relayout of all nodes.
+ *
+ */
+- (void)relayoutItems;
+
+/**
  *  begins a batch of insert, delete reload and move operations. This method must be called from the main thread.
  */
 - (void)beginUpdates;

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -1126,6 +1126,12 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
 
 #pragma mark - ASCellNodeLayoutDelegate
 
+-(ASSizeRange)cellNode:(ASCellNode *)node constrainedSizeForLayoutWithOldConstrainedSize:(ASSizeRange)oldConstrainedSize
+{
+  NSIndexPath *indexPath = [self indexPathForNode:node];
+  return [self dataController:_dataController constrainedSizeForNodeAtIndexPath:indexPath];
+}
+
 - (void)nodeDidRelayout:(ASCellNode *)node sizeChanged:(BOOL)sizeChanged
 {
   ASDisplayNodeAssertMainThread();

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -354,6 +354,11 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
   [super reloadData];
 }
 
+- (void)relayoutItems
+{
+  [_dataController relayoutAllNodes];
+}
+
 - (void)setTuningParameters:(ASRangeTuningParameters)tuningParameters forRangeType:(ASLayoutRangeType)rangeType
 {
   [_layoutController setTuningParameters:tuningParameters forRangeMode:ASLayoutRangeModeFull rangeType:rangeType];


### PR DESCRIPTION
The purpose of this PR is to explore approaches to invalidating and remeasuring a cell node's constrained size. Particularly useful during an interactive transition where cells are resized by some type of gesture.

Approach 1: 
- expose `- (void)relayoutAllNodes` in `ASCollectionDataController` to `ASCollectionView` and `ASTableView`
-  call `relayoutItems()` in `ASCollectionView` to trigger all nodes to force their size to invalidate and remeasure

Approach 2: 
- in `ASDisplayNode`, modify `__setNeedsLayout` so `oldConstrainedSize` checks new `[self __constrainedSizeForLayout]`
- in `ASDisplayNode` private `__constrainedSizeForLayout` returns default `_constrainedSize`
- in `ASCellNode` we override `__constrainedSizeForLayout` to return new `ASSizeRange` calling new `constrainedSizeForLayoutWithOldConstrainedSize` delegate method in `ASCellNodeDelegate`
- `ASCollectionView` implements `ASCellNodeDelegate` `constrainedSizeForLayoutWithOldConstrainedSize` delegate method and returns `_asyncDataSource` `constrainedSizeForNodeAtIndexPath` effectively getting the new constrained size from the user's `collectionView` `constrainedSizeForNodeAtIndexPath` `ASCollectionDataSource` delegate implementation 
- User just needs to call `setNeedsLayout()` on any `ASCellNode` to force it's size to invalidate and remeasure

Findings so far:
Approach 1 works well, but may be a bit coarse a solution and perhaps more expensive than it needs to be.
Approach 2 _almost_ works, and is a more elegant solution but it appears to be fighting something else listening to the invalidation, that is getting it wrong. More research to do here.

Demo:
Points to my ASDK fork with these changes.
git@github.com:the-grid/zoom-demo.git
Branch `relayoutAllNodes` uses approach 1
Branch `setNeedsLayout` uses approach 2

cc/ @nguyenhuy @appleguy for all the guidance. I think we are getting close here.