### PR TITLE
remove exclusive => true due to CocoaPods 1.0.0 changes

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -2,7 +2,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 
 platform :ios, '7.0'
 
-target :'AsyncDisplayKitTests', :exclusive => true do
+target :'AsyncDisplayKitTests' do
   pod 'OCMock', '~> 2.2'
   pod 'FBSnapshotTestCase', '~> 1.8.1'
 end


### PR DESCRIPTION
Resolves the following error with `pod install`
Will resolve https://github.com/facebook/AsyncDisplayKit/issues/1690
```
[!] Invalid `Podfile` file: [!] Unsupported options `{:exclusive=>true}` for target `AsyncDisplayKitTests`..

 #  from /Documents/AsyncDisplayKit/Podfile:5
 #  -------------------------------------------
 #  
 >  target :'AsyncDisplayKitTests', :exclusive => true do
 #    pod 'OCMock', '~> 2.2'
 #  -------------------------------------------
```