### PR TITLE
[Table / Collection] Trigger new batch fetch after programmatic scrolls, or layout transitions.

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -1003,10 +1003,6 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
 {
   ASDisplayNodeAssertMainThread();
   
-  // We must re-check the batch measurement range when additional cells enter the same visual area
-  // Use case is - User has 10 items visible, and wants to trigger batch updates at 2x visible screen size, so 20 records need to be fetched. User modifies the collection view (by pinch or other means) and it results in 15 items in the visible space. In order to achieve the 2x batch promise, we now need 30 records. This accounts for that by triggering a remeasurement at the appropriate time.
-  [self _checkForBatchFetching];
-  
   // Calling visibleNodeIndexPathsForRangeController: will trigger UIKit to call reloadData if it never has, which can result
   // in incorrect layout if performed at zero size.  We can use the fact that nothing can be visible at zero size to return fast.
   BOOL isZeroSized = CGRectEqualToRect(self.bounds, CGRectZero);
@@ -1068,6 +1064,11 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   
   [_batchUpdateBlocks removeAllObjects];
   _performingBatchUpdates = NO;
+}
+
+- (void)didCompleteUpdatesInRangeController:(ASRangeController *)rangeController
+{
+  [self _checkForBatchFetching];
 }
 
 - (void)rangeController:(ASRangeController *)rangeController didInsertNodes:(NSArray *)nodes atIndexPaths:(NSArray *)indexPaths withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -1002,6 +1002,11 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
 - (NSArray *)visibleNodeIndexPathsForRangeController:(ASRangeController *)rangeController
 {
   ASDisplayNodeAssertMainThread();
+  
+  // We must re-check the batch measurement range when additional cells enter the same visual area
+  // Use case is - User has 10 items visible, and wants to trigger batch updates at 2x visible screen size, so 20 records need to be fetched. User modifies the collection view (by pinch or other means) and it results in 15 items in the visible space. In order to achieve the 2x batch promise, we now need 30 records. This accounts for that by triggering a remeasurement at the appropriate time.
+  [self _checkForBatchFetching];
+  
   // Calling visibleNodeIndexPathsForRangeController: will trigger UIKit to call reloadData if it never has, which can result
   // in incorrect layout if performed at zero size.  We can use the fact that nothing can be visible at zero size to return fast.
   BOOL isZeroSized = CGRectEqualToRect(self.bounds, CGRectZero);

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -968,6 +968,11 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
   }
 }
 
+- (void)didCompleteUpdatesInRangeController:(ASRangeController *)rangeController
+{
+  [self _checkForBatchFetching];
+}
+
 - (void)rangeController:(ASRangeController *)rangeController didInsertNodes:(NSArray *)nodes atIndexPaths:(NSArray *)indexPaths withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions
 {
   ASDisplayNodeAssertMainThread();

--- a/AsyncDisplayKit/Details/ASRangeController.h
+++ b/AsyncDisplayKit/Details/ASRangeController.h
@@ -147,6 +147,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)rangeController:(ASRangeController * )rangeController didEndUpdatesAnimated:(BOOL)animated completion:(void (^)(BOOL))completion;
 
 /**
+ * Completed updates to cell node addition and removal.
+ *
+ * @param rangeController Sender.
+ */
+- (void)didCompleteUpdatesInRangeController:(ASRangeController *)rangeController;
+
+/**
  * Called for nodes insertion.
  *
  * @param rangeController Sender.

--- a/AsyncDisplayKit/Details/ASRangeController.mm
+++ b/AsyncDisplayKit/Details/ASRangeController.mm
@@ -333,6 +333,7 @@ static UIApplicationState __ApplicationState = UIApplicationStateActive;
   [modifiedIndexPaths sortUsingSelector:@selector(compare:)];
   NSLog(@"Range update complete; modifiedIndexPaths: %@", [self descriptionWithIndexPaths:modifiedIndexPaths]);
 #endif
+  [_delegate didCompleteUpdatesInRangeController:self];
 }
 
 #pragma mark - Notification observers


### PR DESCRIPTION
During various layout changes that trigger content size changes, batch fetching needs to recalulate it's number of screens left to scroll before the delegate -collectionView:beginBatchFetchingWithContext: is called. 

Just exposes `[self _checkForBatchFetching];`

**UPDATE:**
Due to conversations with @appleguy the approach has changed to triggering `[self _checkForBatchFetching];`internally, at the appropriate times.

After some digging, it appears triggering this on `- (NSArray *)visibleNodeIndexPathsForRangeController:(ASRangeController *)rangeController` exhibits the least amount of additional calculations, but covers a range of use cases that require a batch fetch re-measurement.

From the code comments:
> // We must re-check the batch measurement range when additional cells enter the same visual area
  // Use case is - User has 10 items visible, and wants to trigger batch updates at 2x visible screen size, so 20 records need to be fetched. User modifies the collection view (by pinch or other means) and it results in 15 items in the visible space. In order to achieve the 2x batch promise, we now need 30 records. This accounts for that by triggering a remeasurement at the appropriate time.