### PR TITLE
[ASPINRemoteImageDownloader] Allows setting authentication challenge …

### DIFF
--- a/AsyncDisplayKit/Details/ASPINRemoteImageDownloader.h
+++ b/AsyncDisplayKit/Details/ASPINRemoteImageDownloader.h
@@ -8,12 +8,15 @@
 
 #import <Foundation/Foundation.h>
 #import "ASImageProtocols.h"
+#import <PINRemoteImage/PINRemoteImageManager.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface ASPINRemoteImageDownloader : NSObject <ASImageCacheProtocol, ASImageDownloaderProtocol>
 
 + (ASPINRemoteImageDownloader *)sharedDownloader;
+
+- (PINRemoteImageManager *)sharedPINRemoteImageManager;
 
 @end
 


### PR DESCRIPTION
…block

As ASDK creates its own instance of PINRemoteImageManager, It is not possible to just use PINRemoteImageManager sharedInstance to set an authentication challenge block. 

Not sure if this is the best solution, I would love to have any feedback or suggestion.