### PR TITLE
[ASEditableTextNode] Fix measurement of ASEditableTextNode

### DIFF
--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -284,6 +284,7 @@
 		68FC85EA1CE29C7D00EDD713 /* ASVisibilityProtocols.h in Headers */ = {isa = PBXBuildFile; fileRef = 68FC85E71CE29C7D00EDD713 /* ASVisibilityProtocols.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		68FC85EB1CE29C7D00EDD713 /* ASVisibilityProtocols.m in Sources */ = {isa = PBXBuildFile; fileRef = 68FC85E81CE29C7D00EDD713 /* ASVisibilityProtocols.m */; };
 		68FC85EC1CE29C7D00EDD713 /* ASVisibilityProtocols.m in Sources */ = {isa = PBXBuildFile; fileRef = 68FC85E81CE29C7D00EDD713 /* ASVisibilityProtocols.m */; };
+		697B315A1CFE4B410049936F /* ASEditableTextNodeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 697B31591CFE4B410049936F /* ASEditableTextNodeTests.m */; };
 		698548631CA9E025008A345F /* ASEnvironment.h in Headers */ = {isa = PBXBuildFile; fileRef = 698548611CA9E025008A345F /* ASEnvironment.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		698548641CA9E025008A345F /* ASEnvironment.h in Headers */ = {isa = PBXBuildFile; fileRef = 698548611CA9E025008A345F /* ASEnvironment.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		698C8B611CAB49FC0052DC3F /* ASLayoutableExtensibility.h in Headers */ = {isa = PBXBuildFile; fileRef = 698C8B601CAB49FC0052DC3F /* ASLayoutableExtensibility.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -813,6 +814,7 @@
 		68FC85E11CE29B7E00EDD713 /* ASTabBarController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASTabBarController.m; sourceTree = "<group>"; };
 		68FC85E71CE29C7D00EDD713 /* ASVisibilityProtocols.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASVisibilityProtocols.h; sourceTree = "<group>"; };
 		68FC85E81CE29C7D00EDD713 /* ASVisibilityProtocols.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASVisibilityProtocols.m; sourceTree = "<group>"; };
+		697B31591CFE4B410049936F /* ASEditableTextNodeTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASEditableTextNodeTests.m; sourceTree = "<group>"; };
 		698548611CA9E025008A345F /* ASEnvironment.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASEnvironment.h; sourceTree = "<group>"; };
 		698C8B601CAB49FC0052DC3F /* ASLayoutableExtensibility.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASLayoutableExtensibility.h; path = AsyncDisplayKit/Layout/ASLayoutableExtensibility.h; sourceTree = "<group>"; };
 		69CB62A91CB8165900024920 /* _ASDisplayViewAccessiblity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _ASDisplayViewAccessiblity.h; sourceTree = "<group>"; };
@@ -1189,6 +1191,7 @@
 				058D0A2F195D057000B7D73C /* ASDisplayNodeTests.m */,
 				058D0A30195D057000B7D73C /* ASDisplayNodeTestsHelper.h */,
 				058D0A31195D057000B7D73C /* ASDisplayNodeTestsHelper.m */,
+				697B31591CFE4B410049936F /* ASEditableTextNodeTests.m */,
 				052EE0651A159FEF002C6279 /* ASMultiplexImageNodeTests.m */,
 				058D0A32195D057000B7D73C /* ASMutableAttributedStringBuilderTests.m */,
 				3C9C128419E616EF00E942A0 /* ASTableViewTests.m */,
@@ -2165,6 +2168,7 @@
 				CC7FD9E11BB5F750005CCB2B /* ASPhotosFrameworkImageRequestTests.m in Sources */,
 				052EE0661A159FEF002C6279 /* ASMultiplexImageNodeTests.m in Sources */,
 				058D0A3C195D057000B7D73C /* ASMutableAttributedStringBuilderTests.m in Sources */,
+				697B315A1CFE4B410049936F /* ASEditableTextNodeTests.m in Sources */,
 				ACF6ED611B178DC700DA7C62 /* ASOverlayLayoutSpecSnapshotTests.mm in Sources */,
 				ACF6ED621B178DC700DA7C62 /* ASRatioLayoutSpecSnapshotTests.mm in Sources */,
 				7AB338691C55B97B0055FDE8 /* ASRelativeLayoutSpecSnapshotTests.mm in Sources */,

--- a/AsyncDisplayKit/ASEditableTextNode.mm
+++ b/AsyncDisplayKit/ASEditableTextNode.mm
@@ -191,7 +191,7 @@
   ASTextKitComponents *displayedComponents = [self isDisplayingPlaceholder] ? _placeholderTextKitComponents : _textKitComponents;
   CGSize textSize = [displayedComponents sizeForConstrainedWidth:constrainedSize.width];
   textSize = ceilSizeValue(textSize);
-  return CGSizeMake(constrainedSize.width, fminf(textSize.height, constrainedSize.height));
+  return CGSizeMake(fminf(textSize.width, constrainedSize.width), fminf(textSize.height, constrainedSize.height));
 }
 
 - (void)layout

--- a/AsyncDisplayKitTests/ASEditableTextNodeTests.m
+++ b/AsyncDisplayKitTests/ASEditableTextNodeTests.m
@@ -1,0 +1,103 @@
+//
+//  ASEditableTextNodeTests.m
+//  AsyncDisplayKit
+//
+//  Created by Michael Schneider on 5/31/16.
+//  Copyright © 2016 Facebook. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import <AsyncDisplayKit/ASEditableTextNode.h>
+
+static BOOL CGSizeEqualToSizeWithIn(CGSize size1, CGSize size2, CGFloat delta)
+{
+  return fabs(size1.width - size2.width) < delta && fabs(size1.height - size2.height) < delta;
+}
+
+@interface ASEditableTextNodeTests : XCTestCase
+@property (nonatomic, readwrite, strong) ASEditableTextNode *editableTextNode;
+@property (nonatomic, readwrite, copy) NSAttributedString *attributedText;
+@end
+
+@implementation ASEditableTextNodeTests
+
+- (void)setUp
+{
+  [super setUp];
+  
+  _editableTextNode = [[ASEditableTextNode alloc] init];
+  
+  NSMutableAttributedString *mas = [[NSMutableAttributedString alloc] initWithString:@"Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."];
+  NSMutableParagraphStyle *para = [NSMutableParagraphStyle new];
+  para.alignment = NSTextAlignmentCenter;
+  para.lineSpacing = 1.0;
+  [mas addAttribute:NSParagraphStyleAttributeName value:para
+              range:NSMakeRange(0, mas.length - 1)];
+  
+  // Vary the linespacing on the last line
+  NSMutableParagraphStyle *lastLinePara = [NSMutableParagraphStyle new];
+  lastLinePara.alignment = para.alignment;
+  lastLinePara.lineSpacing = 5.0;
+  [mas addAttribute:NSParagraphStyleAttributeName value:lastLinePara
+              range:NSMakeRange(mas.length - 1, 1)];
+  
+  _attributedText = mas;
+  _editableTextNode.attributedText = _attributedText;
+
+}
+
+#pragma mark - ASEditableTextNode
+
+- (void)testAllocASEditableTextNode
+{
+  ASEditableTextNode *node = [[ASEditableTextNode alloc] init];
+  XCTAssertTrue([[node class] isSubclassOfClass:[ASEditableTextNode class]], @"ASTextNode alloc should return an instance of ASTextNode, instead returned %@", [node class]);
+}
+
+#pragma mark - ASEditableTextNode
+
+- (void)testSetPreferredFrameSize
+{
+  CGSize preferredFrameSize = CGSizeMake(100, 100);
+  _editableTextNode.preferredFrameSize = preferredFrameSize;
+  
+  CGSize calculatedSize = [_editableTextNode measure:CGSizeZero];
+  XCTAssertTrue(calculatedSize.width != preferredFrameSize.width, @"Calculated width (%f) should be equal than preferred width (%f)", calculatedSize.width, preferredFrameSize.width);
+  XCTAssertTrue(calculatedSize.width != preferredFrameSize.width, @"Calculated height (%f) should be equal than preferred height (%f)", calculatedSize.width, preferredFrameSize.width);
+  
+  _editableTextNode.preferredFrameSize = CGSizeZero;
+}
+
+- (void)testCalculatedSizeIsGreaterThanOrEqualToConstrainedSize
+{
+  for (NSInteger i = 10; i < 500; i += 50) {
+    CGSize constrainedSize = CGSizeMake(i, i);
+    CGSize calculatedSize = [_editableTextNode measure:constrainedSize];
+    XCTAssertTrue(calculatedSize.width <= constrainedSize.width, @"Calculated width (%f) should be less than or equal to constrained width (%f)", calculatedSize.width, constrainedSize.width);
+    XCTAssertTrue(calculatedSize.height <= constrainedSize.height, @"Calculated height (%f) should be less than or equal to constrained height (%f)", calculatedSize.height, constrainedSize.height);
+  }
+}
+
+- (void)testRecalculationOfSizeIsSameAsOriginallyCalculatedSize
+{
+  for (NSInteger i = 10; i < 500; i += 50) {
+    CGSize constrainedSize = CGSizeMake(i, i);
+    CGSize calculatedSize = [_editableTextNode measure:constrainedSize];
+    CGSize recalculatedSize = [_editableTextNode measure:calculatedSize];
+    
+    XCTAssertTrue(CGSizeEqualToSizeWithIn(calculatedSize, recalculatedSize, 4.0), @"Recalculated size %@ should be same as original size %@", NSStringFromCGSize(recalculatedSize), NSStringFromCGSize(calculatedSize));
+  }
+}
+
+- (void)testRecalculationOfSizeIsSameAsOriginallyCalculatedFloatingPointSize
+{
+  for (CGFloat i = 10; i < 500; i *= 1.3) {
+    CGSize constrainedSize = CGSizeMake(i, i);
+    CGSize calculatedSize = [_editableTextNode measure:constrainedSize];
+    CGSize recalculatedSize = [_editableTextNode measure:calculatedSize];
+
+    XCTAssertTrue(CGSizeEqualToSizeWithIn(calculatedSize, recalculatedSize, 11.0), @"Recalculated size %@ should be same as original size %@", NSStringFromCGSize(recalculatedSize), NSStringFromCGSize(calculatedSize));
+  }
+}
+
+@end


### PR DESCRIPTION
- Add ability to measure the ASEditableTextNode based on the content now by calling `measure:`
- ASEditableTextNode considers `preferredFrameSize` now
- Fix crash if ASEditableTextNode is included in a horizontal stack
- Add tests for ASEditableTextNode

Addresses: #1701