### PR TITLE
[ASDisplayNode] Fix placeholder image is not appearing if size of node changed after initial placement

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -1088,7 +1088,13 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   // with negative sizes after applying margins, which will cause
   // measureWithSizeRange: on subnodes to assert.
   if (!CGRectEqualToRect(bounds, CGRectZero)) {
+    // Handle placeholder layer creation in case the size of the node changed after the initial placeholder layer
+    // was created
+    if ([self _shouldHavePlaceholderLayer]) {
+      [self _setupPlaceholderLayerIfNeeded];
+    }
     _placeholderLayer.frame = bounds;
+  
     [self layout];
     [self layoutDidFinish];
   }

--- a/examples_extra/Placeholders/Sample/PostNode.m
+++ b/examples_extra/Placeholders/Sample/PostNode.m
@@ -60,6 +60,10 @@
 - (UIImage *)placeholderImage
 {
   CGSize size = self.calculatedSize;
+  if (CGSizeEqualToSize(size, CGSizeZero)) {
+    return nil;
+  }
+  
   UIGraphicsBeginImageContext(size);
   [[UIColor colorWithWhite:0.9 alpha:1] setFill];
   UIRectFill((CGRect){CGPointZero, size});
@@ -78,6 +82,8 @@
 
 - (void)layout
 {
+  [super layout];
+  
   CGSize textSize = _textNode.calculatedSize;
   CGSize needyChildSize = _needyChildNode.calculatedSize;
 

--- a/examples_extra/Placeholders/Sample/SlowpokeImageNode.m
+++ b/examples_extra/Placeholders/Sample/SlowpokeImageNode.m
@@ -15,9 +15,14 @@
 
 static CGFloat const kASDKLogoAspectRatio = 2.79;
 
+@interface ASImageNode (ForwardWorkaround)
+// This is a workaround until subclass overwritting of custom drawing class methods is fixed
+- (UIImage *)displayWithParameters:(id<NSObject>)parameters isCancelled:(asdisplaynode_iscancelled_block_t)isCancelledBlock;
+@end
+
 @implementation SlowpokeImageNode
 
-+ (UIImage *)displayWithParameters:(id<NSObject>)parameters isCancelled:(asdisplaynode_iscancelled_block_t)isCancelledBlock
+- (UIImage *)displayWithParameters:(id<NSObject>)parameters isCancelled:(asdisplaynode_iscancelled_block_t)isCancelledBlock
 {
   usleep( (long)(0.5 * USEC_PER_SEC) ); // artificial delay of 0.5s
   
@@ -46,6 +51,10 @@ static CGFloat const kASDKLogoAspectRatio = 2.79;
 - (UIImage *)placeholderImage
 {
   CGSize size = self.calculatedSize;
+  if (CGSizeEqualToSize(size, CGSizeZero)) {
+    return nil;
+  }
+
   UIGraphicsBeginImageContext(size);
   [[UIColor whiteColor] setFill];
   [[UIColor colorWithWhite:0.9 alpha:1] setStroke];

--- a/examples_extra/Placeholders/Sample/SlowpokeImageNode.m
+++ b/examples_extra/Placeholders/Sample/SlowpokeImageNode.m
@@ -16,7 +16,7 @@
 static CGFloat const kASDKLogoAspectRatio = 2.79;
 
 @interface ASImageNode (ForwardWorkaround)
-// This is a workaround until subclass overwritting of custom drawing class methods is fixed
+// This is a workaround until subclass overriding of custom drawing class methods is fixed
 - (UIImage *)displayWithParameters:(id<NSObject>)parameters isCancelled:(asdisplaynode_iscancelled_block_t)isCancelledBlock;
 @end
 

--- a/examples_extra/Placeholders/Sample/SlowpokeTextNode.m
+++ b/examples_extra/Placeholders/Sample/SlowpokeTextNode.m
@@ -13,9 +13,14 @@
 
 #import <AsyncDisplayKit/ASDisplayNode+Subclasses.h>
 
+@interface ASTextNode (ForwardWorkaround)
+// This is a workaround until subclass overwritting of custom drawing class methods is fixed
+- (void)drawRect:(CGRect)bounds withParameters:(id<NSObject>)parameters isCancelled:(asdisplaynode_iscancelled_block_t)isCancelledBlock isRasterizing:(BOOL)isRasterizing;
+@end
+
 @implementation SlowpokeTextNode
 
-+ (void)drawRect:(CGRect)bounds withParameters:(id<NSObject>)parameters isCancelled:(asdisplaynode_iscancelled_block_t)isCancelledBlock isRasterizing:(BOOL)isRasterizing
+- (void)drawRect:(CGRect)bounds withParameters:(id<NSObject>)parameters isCancelled:(asdisplaynode_iscancelled_block_t)isCancelledBlock isRasterizing:(BOOL)isRasterizing
 {
   usleep( (long)(1.0 * USEC_PER_SEC) ); // artificial delay of 1.0
 

--- a/examples_extra/Placeholders/Sample/SlowpokeTextNode.m
+++ b/examples_extra/Placeholders/Sample/SlowpokeTextNode.m
@@ -14,7 +14,7 @@
 #import <AsyncDisplayKit/ASDisplayNode+Subclasses.h>
 
 @interface ASTextNode (ForwardWorkaround)
-// This is a workaround until subclass overwritting of custom drawing class methods is fixed
+// This is a workaround until subclass overriding of custom drawing class methods is fixed
 - (void)drawRect:(CGRect)bounds withParameters:(id<NSObject>)parameters isCancelled:(asdisplaynode_iscancelled_block_t)isCancelledBlock isRasterizing:(BOOL)isRasterizing;
 @end
 


### PR DESCRIPTION
Placeholder are not appearing if a node is measured after the initial placeholder was set. This should fix this behavior by creating the placeholder layer and the placeholder image in the right size while layout happens. 

Furthermore put in a workaround for the Placeholder example that was broken. But would be reproducible by running the Placeholder example and comment out the fix in `ASDisplayNode`.