### PR TITLE
Revert "[ASCollectionView] Add a "Null Object" for a layout inspector if custom layout is given but no layout inspector"

### DIFF
--- a/AsyncDisplayKit/Details/ASCollectionViewFlowLayoutInspector.h
+++ b/AsyncDisplayKit/Details/ASCollectionViewFlowLayoutInspector.h
@@ -47,17 +47,6 @@
 
 @end
 
-/**
- * Simple "Null Object" inspector for non-flow layouts that does not implement a custom inspector, provides a zero
- * constrained size and throws an exception if methods are called from <ASCollectionViewLayoutInspecting>
- */
-@interface ASCollectionViewCustomLayoutInspector : NSObject <ASCollectionViewLayoutInspecting>
-
-@end
-
-/**
- * A layout inspector implementation specific for the sizing behavior of UICollectionViewFlowLayouts
- */
 @interface ASCollectionViewFlowLayoutInspector : NSObject <ASCollectionViewLayoutInspecting>
 
 @property (nonatomic, weak) UICollectionViewFlowLayout *layout;

--- a/AsyncDisplayKit/Details/ASCollectionViewFlowLayoutInspector.m
+++ b/AsyncDisplayKit/Details/ASCollectionViewFlowLayoutInspector.m
@@ -13,35 +13,6 @@
 #import "ASAssert.h"
 #import "ASEqualityHelpers.h"
 
-
-
-@implementation ASCollectionViewCustomLayoutInspector
-
-- (ASSizeRange)collectionView:(ASCollectionView *)collectionView constrainedSizeForNodeAtIndexPath:(NSIndexPath *)indexPath
-{
-  return ASSizeRangeMake(CGSizeZero, CGSizeZero);
-}
-
-- (ASSizeRange)collectionView:(ASCollectionView *)collectionView constrainedSizeForSupplementaryNodeOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath
-{
-  ASDisplayNodeAssert(NO, @"To support supplementary nodes in ASCollectionView, it must have a layoutDelegate for layout inspection. (See ASCollectionViewFlowLayoutInspector for an example.)");
-  return ASSizeRangeMake(CGSizeZero, CGSizeZero);
-}
-
-- (NSUInteger)collectionView:(ASCollectionView *)collectionView numberOfSectionsForSupplementaryNodeOfKind:(NSString *)kind
-{
-  ASDisplayNodeAssert(NO, @"To support supplementary nodes in ASCollectionView, it must have a layoutDelegate for layout inspection. (See ASCollectionViewFlowLayoutInspector for an example.)");
-  return 0;
-}
-
-- (NSUInteger)collectionView:(ASCollectionView *)collectionView supplementaryNodesOfKind:(NSString *)kind inSection:(NSUInteger)section
-{
-  ASDisplayNodeAssert(NO, @"To support supplementary nodes in ASCollectionView, it must have a layoutDelegate for layout inspection. (See ASCollectionViewFlowLayoutInspector for an example.)");
-  return 0;
-}
-
-@end
- 
 @implementation ASCollectionViewFlowLayoutInspector {
   BOOL _delegateImplementsReferenceSizeForHeader;
   BOOL _delegateImplementsReferenceSizeForFooter;
@@ -79,11 +50,8 @@
 
 - (ASSizeRange)collectionView:(ASCollectionView *)collectionView constrainedSizeForNodeAtIndexPath:(NSIndexPath *)indexPath
 {
-  if ([collectionView.asyncDataSource respondsToSelector:@selector(collectionView:constrainedSizeForNodeAtIndexPath:)]) {
-    return [collectionView.asyncDataSource collectionView:collectionView constrainedSizeForNodeAtIndexPath:indexPath];
-  } else {
-    return ASSizeRangeMake(_layout.itemSize, _layout.itemSize);
-  }
+  // TODO: Provide constrained size for flow layout item nodes
+  return ASSizeRangeMake(CGSizeZero, CGSizeZero);
 }
 
 - (ASSizeRange)collectionView:(ASCollectionView *)collectionView constrainedSizeForSupplementaryNodeOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath

--- a/AsyncDisplayKitTests/ASCollectionViewTests.m
+++ b/AsyncDisplayKitTests/ASCollectionViewTests.m
@@ -108,10 +108,7 @@
 {
   UICollectionViewLayout *layout = [[UICollectionViewLayout alloc] init];
   ASCollectionView *collectionView = [[ASCollectionView alloc] initWithFrame:CGRectZero collectionViewLayout:layout];
-  XCTAssert(collectionView.layoutInspector != nil, @"should automatically set a layout delegate for custom layouts");
-  XCTAssert([collectionView.layoutInspector isKindOfClass:[ASCollectionViewCustomLayoutInspector class]], @"should have a internal custom layout inspector by default");
-  XCTAssert(ASSizeRangeEqualToSizeRange([collectionView.layoutInspector collectionView:collectionView constrainedSizeForNodeAtIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]], ASSizeRangeMake(CGSizeZero, CGSizeZero)), @"should return a zero constrainted size range in internal custom layout inspector");
-  XCTAssertThrows([collectionView.layoutInspector collectionView:collectionView supplementaryNodesOfKind:UICollectionElementKindSectionHeader inSection:0], @"should throw an exception for <ASCollectionViewLayoutInspecting> methods");
+  XCTAssert(collectionView.layoutInspector == nil, @"should not set a layout delegate for custom layouts");
 }
 
 - (void)testThatRegisteringASupplementaryNodeStoresItForIntrospection


### PR DESCRIPTION
Reverts facebook/AsyncDisplayKit#1674

@maicki some careful bisecting discovered that this caused a layout regression in the Pinterest feed, so I need to revert it for now.  Looking forward to re-landing once fixed.  Fortunately the issue reproduces every time.

![img_0104](https://cloud.githubusercontent.com/assets/565251/15803836/832e42b2-2aa6-11e6-85f9-19eed092bf29.PNG)
![img_0105](https://cloud.githubusercontent.com/assets/565251/15803837/834c0978-2aa6-11e6-8ff0-13c2825199de.PNG)
