### PR TITLE
[ASLayoutSpec] Remove use of dictionary to hold children

### DIFF
--- a/AsyncDisplayKit/Layout/ASBackgroundLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASBackgroundLayoutSpec.mm
@@ -14,7 +14,8 @@
 #import "ASBaseDefines.h"
 #import "ASLayout.h"
 
-static NSString * const kBackgroundChildKey = @"kBackgroundChildKey";
+static NSUInteger const kForegroundChildIndex = 0;
+static NSUInteger const kBackgroundChildIndex = 1;
 
 @interface ASBackgroundLayoutSpec ()
 @end
@@ -28,7 +29,7 @@ static NSString * const kBackgroundChildKey = @"kBackgroundChildKey";
   }
   
   ASDisplayNodeAssertNotNil(child, @"Child cannot be nil");
-  [self setChild:child];
+  [self setChild:child forIndex:kForegroundChildIndex];
   self.background = background;
   return self;
 }
@@ -63,12 +64,12 @@ static NSString * const kBackgroundChildKey = @"kBackgroundChildKey";
 
 - (void)setBackground:(id<ASLayoutable>)background
 {
-  [super setChild:background forIdentifier:kBackgroundChildKey];
+  [super setChild:background forIndex:kBackgroundChildIndex];
 }
 
 - (id<ASLayoutable>)background
 {
-  return [super childForIdentifier:kBackgroundChildKey];
+  return [super childForIndex:kBackgroundChildIndex];
 }
 
 @end

--- a/AsyncDisplayKit/Layout/ASLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASLayoutSpec.h
@@ -40,10 +40,9 @@ NS_ASSUME_NONNULL_BEGIN
  * only require a single child.
  *
  * For layout specs that require a known number of children (ASBackgroundLayoutSpec, for example)
- * a subclass should use this method to set the "primary" child. It can then use setChild:forIdentifier:
- * to set any other required children. Ideally a subclass would hide this from the user, and use the
- * setChild:forIdentifier: internally. For example, ASBackgroundLayoutSpec exposes a backgroundChild
- * property that behind the scenes is calling setChild:forIdentifier:.
+ * a subclass should use this method to set the "primary" child. This is actually the same as calling 
+ * setChild:forIdentifier:0. All other children should be set by defining convenience methods
+ * that call setChild:forIdentifier behind the scenes.
  */
 - (void)setChild:(id<ASLayoutable>)child;
 

--- a/AsyncDisplayKit/Layout/ASLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASLayoutSpec.h
@@ -52,19 +52,19 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @param child A child to be added.
  *
- * @param identifier An identifier associated with the child.
+ * @param index An index associated with the child.
  *
  * @discussion Every ASLayoutSpec must act on at least one child. The ASLayoutSpec base class takes the
  * responsibility of holding on to the spec children. Some layout specs, like ASInsetLayoutSpec,
  * only require a single child.
  *
  * For layout specs that require a known number of children (ASBackgroundLayoutSpec, for example)
- * a subclass should use the setChild method to set the "primary" child. It can then use this method
+ * a subclass can use the setChild method to set the "primary" child. It should then use this method
  * to set any other required children. Ideally a subclass would hide this from the user, and use the
- * setChild:forIdentifier: internally. For example, ASBackgroundLayoutSpec exposes a backgroundChild
- * property that behind the scenes is calling setChild:forIdentifier:.
+ * setChild:forIndex: internally. For example, ASBackgroundLayoutSpec exposes a backgroundChild
+ * property that behind the scenes is calling setChild:forIndex:.
  */
-- (void)setChild:(id<ASLayoutable>)child forIdentifier:(NSString *)identifier;
+- (void)setChild:(id<ASLayoutable>)child forIndex:(NSUInteger)index;
 
 /**
  * Adds childen to this layout spec.
@@ -94,11 +94,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable id<ASLayoutable>)child;
 
 /**
- * Returns the child added to this layout spec using the given identifier.
+ * Returns the child added to this layout spec using the given index.
  *
- * @param identifier An identifier associated withe the child.
+ * @param index An identifier associated withe the child.
  */
-- (nullable id<ASLayoutable>)childForIdentifier:(NSString *)identifier;
+- (nullable id<ASLayoutable>)childForIndex:(NSUInteger)index;
 
 /**
  * Returns all children added to this layout spec.

--- a/AsyncDisplayKit/Layout/ASLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASLayoutSpec.mm
@@ -121,7 +121,7 @@ typedef std::map<unsigned long, id<ASLayoutable>, std::less<unsigned long>> ASCh
       _children[0] = finalLayoutable;
       [self propagateUpLayoutable:finalLayoutable];
     }
-  } else if (_children.size() > 0) {
+  } else {
     _children.erase(0);
   }
 }

--- a/AsyncDisplayKit/Layout/ASOverlayLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASOverlayLayoutSpec.mm
@@ -14,7 +14,8 @@
 #import "ASBaseDefines.h"
 #import "ASLayout.h"
 
-static NSString * const kOverlayChildKey = @"kOverlayChildKey";
+static NSUInteger const kUnderlayChildIndex = 0;
+static NSUInteger const kOverlayChildIndex = 1;
 
 @implementation ASOverlayLayoutSpec
 
@@ -25,7 +26,7 @@ static NSString * const kOverlayChildKey = @"kOverlayChildKey";
   }
   ASDisplayNodeAssertNotNil(child, @"Child that will be overlayed on shouldn't be nil");
   self.overlay = overlay;
-  [self setChild:child];
+  [self setChild:child forIndex:kUnderlayChildIndex];
   return self;
 }
 
@@ -36,12 +37,12 @@ static NSString * const kOverlayChildKey = @"kOverlayChildKey";
 
 - (void)setOverlay:(id<ASLayoutable>)overlay
 {
-  [super setChild:overlay forIdentifier:kOverlayChildKey];
+  [super setChild:overlay forIndex:kOverlayChildIndex];
 }
 
 - (id<ASLayoutable>)overlay
 {
-  return [super childForIdentifier:kOverlayChildKey];
+  return [super childForIndex:kOverlayChildIndex];
 }
 
 /**


### PR DESCRIPTION
Converted the backing store of children to a std::vector. Subclass now have defined indexes instead of string keys to add children.