### PR TITLE
[ASLayoutSpec] Remove cached ASTraitCollection

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -1901,7 +1901,10 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
   if ((_methodOverrides & ASDisplayNodeMethodOverrideLayoutSpecThatFits) || _layoutSpecBlock != NULL) {
     ASLayoutSpec *layoutSpec = [self layoutSpecThatFits:constrainedSize];
     layoutSpec.parent = self; // This causes upward propogation of any non-default layoutable values.
-    layoutSpec.traitCollection = self.asyncTraitCollection;
+    
+    // manually propagate the trait collection here so that any layoutSpec children of layoutSpec will get a traitCollection
+    ASEnvironmentStatePropagateDown(layoutSpec, self.environmentTraitCollection);
+    
     layoutSpec.isMutable = NO;
     ASLayout *layout = [layoutSpec measureWithSizeRange:constrainedSize];
     // Make sure layoutableObject of the root layout is `self`, so that the flattened layout will be structurally correct.

--- a/AsyncDisplayKit/Layout/ASLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASLayoutSpec.h
@@ -11,8 +11,6 @@
 #import <AsyncDisplayKit/ASLayoutable.h>
 #import <AsyncDisplayKit/ASAsciiArtBoxCreator.h>
 
-@class ASTraitCollection;
-
 NS_ASSUME_NONNULL_BEGIN
 
 /** A layout spec is an immutable object that describes a layout, loosely inspired by React. */
@@ -24,8 +22,6 @@ NS_ASSUME_NONNULL_BEGIN
  * set to NO and any further mutations will cause an assert.
  */
 @property (nonatomic, assign) BOOL isMutable;
-
-@property (nonatomic, strong, nullable) ASTraitCollection *traitCollection;
 
 - (instancetype)init;
 

--- a/AsyncDisplayKit/Layout/ASLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASLayoutSpec.mm
@@ -185,14 +185,6 @@
   return _children;
 }
 
-- (void)setTraitCollection:(ASTraitCollection *)traitCollection
-{
-  if ([traitCollection isEqualToTraitCollection:self.traitCollection] == NO) {
-    _traitCollection = traitCollection;
-    ASEnvironmentStatePropagateDown(self, [traitCollection environmentTraitCollection]);
-  }
-}
-
 #pragma mark - ASEnvironment
 
 - (ASEnvironmentState)environmentState


### PR DESCRIPTION
If a layoutSpec is asked for its `asyncTraitCollection`, it creates it on demand.