### PR TITLE
[ASImageNode] Allow configuration of animation runloop

### DIFF
--- a/AsyncDisplayKit/ASImageNode+AnimatedImage.mm
+++ b/AsyncDisplayKit/ASImageNode+AnimatedImage.mm
@@ -85,6 +85,23 @@
   }
 }
 
+- (NSString *)animatedImageRunLoopMode
+{
+  ASDN::MutexLocker l(_displayLinkLock);
+  return _animatedImageRunLoopMode;
+}
+
+- (void)setAnimatedImageRunLoopMode:(NSString *)runLoopMode
+{
+  ASDN::MutexLocker l(_displayLinkLock);
+
+  if (_displayLink != nil) {
+    [_displayLink removeFromRunLoop:[NSRunLoop mainRunLoop] forMode:_animatedImageRunLoopMode];
+    [_displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:runLoopMode];
+  }
+  _animatedImageRunLoopMode = runLoopMode;
+}
+
 - (void)animatedImageFileReady
 {
   ASPerformBlockOnMainThread(^{
@@ -116,7 +133,7 @@
     _displayLink = [CADisplayLink displayLinkWithTarget:[ASWeakProxy weakProxyWithTarget:self] selector:@selector(displayLinkFired:)];
     _displayLink.frameInterval = self.animatedImage.frameInterval;
     
-    [_displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSDefaultRunLoopMode];
+    [_displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:_animatedImageRunLoopMode];
   } else {
     _displayLink.paused = NO;
   }

--- a/AsyncDisplayKit/ASImageNode+AnimatedImage.mm
+++ b/AsyncDisplayKit/ASImageNode+AnimatedImage.mm
@@ -18,6 +18,8 @@
 #import "ASInternalHelpers.h"
 #import "ASWeakProxy.h"
 
+NSString *const ASAnimatedImageDefaultRunLoopMode = NSDefaultRunLoopMode;
+
 @implementation ASImageNode (AnimatedImage)
 
 #pragma mark - GIF support
@@ -94,6 +96,10 @@
 - (void)setAnimatedImageRunLoopMode:(NSString *)runLoopMode
 {
   ASDN::MutexLocker l(_displayLinkLock);
+
+  if (runLoopMode == nil) {
+    runLoopMode = ASAnimatedImageDefaultRunLoopMode;
+  }
 
   if (_displayLink != nil) {
     [_displayLink removeFromRunLoop:[NSRunLoop mainRunLoop] forMode:_animatedImageRunLoopMode];

--- a/AsyncDisplayKit/ASImageNode.h
+++ b/AsyncDisplayKit/ASImageNode.h
@@ -141,6 +141,13 @@ typedef UIImage * _Nullable (^asimagenode_modification_block_t)(UIImage *image);
  */
 @property (atomic, assign) BOOL animatedImagePaused;
 
+/**
+ * @abstract The runloop mode used to animte th image.
+ *
+ * @discussion Defaults to NSDefaultRunLoopMode. Another commonly used mode is NSRunLoopCommonModes.
+ */
+@property (atomic, strong) NSString *animatedImageRunLoopMode;
+
 @end
 
 

--- a/AsyncDisplayKit/ASImageNode.mm
+++ b/AsyncDisplayKit/ASImageNode.mm
@@ -105,7 +105,7 @@
   _cropRect = CGRectMake(0.5, 0.5, 0, 0);
   _cropDisplayBounds = CGRectNull;
   _placeholderColor = ASDisplayNodeDefaultPlaceholderColor();
-  _animatedImageRunLoopMode = NSDefaultRunLoopMode;
+  _animatedImageRunLoopMode = ASAnimatedImageDefaultRunLoopMode;
   
   return self;
 }

--- a/AsyncDisplayKit/ASImageNode.mm
+++ b/AsyncDisplayKit/ASImageNode.mm
@@ -105,6 +105,7 @@
   _cropRect = CGRectMake(0.5, 0.5, 0, 0);
   _cropDisplayBounds = CGRectNull;
   _placeholderColor = ASDisplayNodeDefaultPlaceholderColor();
+  _animatedImageRunLoopMode = NSDefaultRunLoopMode;
   
   return self;
 }

--- a/AsyncDisplayKit/Private/ASImageNode+AnimatedImagePrivate.h
+++ b/AsyncDisplayKit/Private/ASImageNode+AnimatedImagePrivate.h
@@ -14,6 +14,7 @@
   ASDN::Mutex _displayLinkLock;
   id <ASAnimatedImageProtocol> _animatedImage;
   BOOL _animatedImagePaused;
+  NSString *_animatedImageRunLoopMode;
   CADisplayLink *_displayLink;
   
   //accessed on main thread only

--- a/AsyncDisplayKit/Private/ASImageNode+AnimatedImagePrivate.h
+++ b/AsyncDisplayKit/Private/ASImageNode+AnimatedImagePrivate.h
@@ -8,6 +8,8 @@
 
 #import "ASThread.h"
 
+extern NSString *const ASAnimatedImageDefaultRunLoopMode;
+
 @interface ASImageNode ()
 {
   ASDN::RecursiveMutex _animatedImageLock;


### PR DESCRIPTION
`NSDefaultRunLoopMode` suspends while a scrollview is tracking. This causes animated images in the scrollview to pause while scrolling. This behavior is not always desired. So this change enables the configuration of the animation runloop mode.