### PR TITLE
[ASImageNode] Fix animated image playback if file is ready

### DIFF
--- a/AsyncDisplayKit/ASImageNode+AnimatedImage.mm
+++ b/AsyncDisplayKit/ASImageNode+AnimatedImage.mm
@@ -39,6 +39,10 @@
       };
     }
     
+    if (animatedImage.playbackReady) {
+      [self animatedImageFileReady];
+    }
+
     animatedImage.playbackReadyCallback = ^{
       [weakSelf animatedImageFileReady];
     };


### PR DESCRIPTION
ASImageNode only starts animating when the animated image's `playbackReadyCallback` is called. If the animate image was ready for playback before it was assigned as ASImageNode's animated image, then `playbackReadyCallback` is never called in the context of ASImageNode. This change checks the playbackReady property, and if it's true, starts playback immediately.