### PR TITLE
[ASNetworkImageNode] Support loading local animated images

### DIFF
--- a/AsyncDisplayKit/ASNetworkImageNode.mm
+++ b/AsyncDisplayKit/ASNetworkImageNode.mm
@@ -457,26 +457,27 @@ static const CGSize kMinReleaseImageOnBackgroundSize = {20.0, 20.0};
           } else {
             // First try to load the path directly, for efficiency assuming a developer who
             // doesn't want caching is trying to be as minimal as possible.
-            NSData *data = [NSData dataWithContentsOfURL:_URL];
-            if (data == nil) {
+            UIImage *nonAnimatedImage = [UIImage imageWithContentsOfFile:_URL.path];
+            if (nonAnimatedImage == nil) {
               // If we couldn't find it, execute an -imageNamed:-like search so we can find resources even if the
               // extension is not provided in the path.  This allows the same path to work regardless of shouldCacheImage.
               NSString *filename = [[NSBundle mainBundle] pathForResource:_URL.path.lastPathComponent ofType:nil];
               if (filename != nil) {
-                data = [NSData dataWithContentsOfFile:filename];
+                nonAnimatedImage = [UIImage imageWithContentsOfFile:filename];
               }
             }
 
             // If the file may be an animated gif and then created an animated image.
             id<ASAnimatedImageProtocol> animatedImage = nil;
-            if (_downloaderImplementsAnimatedImage && data != nil && [_URL.pathExtension isEqualToString:@"gif"]) {
+            if (_downloaderImplementsAnimatedImage && [_URL.pathExtension isEqualToString:@"gif"]) {
+              NSData *data = [NSData dataWithContentsOfURL:_URL];
               animatedImage = [_downloader animatedImageWithData:data];
             }
 
             if (animatedImage != nil) {
               self.animatedImage = animatedImage;
             } else {
-              self.image = [UIImage imageWithData:data];
+              self.image = nonAnimatedImage;
             }
           }
 

--- a/AsyncDisplayKit/ASNetworkImageNode.mm
+++ b/AsyncDisplayKit/ASNetworkImageNode.mm
@@ -469,9 +469,13 @@ static const CGSize kMinReleaseImageOnBackgroundSize = {20.0, 20.0};
 
             // If the file may be an animated gif and then created an animated image.
             id<ASAnimatedImageProtocol> animatedImage = nil;
-            if (_downloaderImplementsAnimatedImage && [_URL.pathExtension isEqualToString:@"gif"]) {
+            if (_downloaderImplementsAnimatedImage) {
               NSData *data = [NSData dataWithContentsOfURL:_URL];
               animatedImage = [_downloader animatedImageWithData:data];
+
+              if ([animatedImage respondsToSelector:@selector(isDataSupported:)] && [animatedImage isDataSupported:data] == NO) {
+                animatedImage = nil;
+              }
             }
 
             if (animatedImage != nil) {

--- a/AsyncDisplayKit/ASNetworkImageNode.mm
+++ b/AsyncDisplayKit/ASNetworkImageNode.mm
@@ -457,14 +457,26 @@ static const CGSize kMinReleaseImageOnBackgroundSize = {20.0, 20.0};
           } else {
             // First try to load the path directly, for efficiency assuming a developer who
             // doesn't want caching is trying to be as minimal as possible.
-            self.image = [UIImage imageWithContentsOfFile:_URL.path];
-            if (!self.image) {
+            NSData *data = [NSData dataWithContentsOfURL:_URL];
+            if (data == nil) {
               // If we couldn't find it, execute an -imageNamed:-like search so we can find resources even if the
               // extension is not provided in the path.  This allows the same path to work regardless of shouldCacheImage.
               NSString *filename = [[NSBundle mainBundle] pathForResource:_URL.path.lastPathComponent ofType:nil];
-              if (filename) {
-                self.image = [UIImage imageWithContentsOfFile:filename];
+              if (filename != nil) {
+                data = [NSData dataWithContentsOfFile:filename];
               }
+            }
+
+            // If the file may be an animated gif and then created an animated image.
+            id<ASAnimatedImageProtocol> animatedImage = nil;
+            if (_downloaderImplementsAnimatedImage && data != nil && [_URL.pathExtension isEqualToString:@"gif"]) {
+              animatedImage = [_downloader animatedImageWithData:data];
+            }
+
+            if (animatedImage != nil) {
+              self.animatedImage = animatedImage;
+            } else {
+              self.image = [UIImage imageWithData:data];
             }
           }
 

--- a/AsyncDisplayKit/Details/ASImageProtocols.h
+++ b/AsyncDisplayKit/Details/ASImageProtocols.h
@@ -142,11 +142,20 @@ withDownloadIdentifier:(id)downloadIdentifier;
 
 @protocol ASAnimatedImageProtocol <NSObject>
 
+@optional
+
 /**
  @abstract Should be called when the objects cover image is ready.
  @param coverImageReadyCallback a block which receives the cover image.
  */
 @property (nonatomic, strong, readwrite) void (^coverImageReadyCallback)(UIImage *coverImage);
+
+/**
+ @abstract Returns whether the supplied data contains a supported animated image format.
+ @param data the data to check if contains a supported animated image.
+ */
+- (BOOL)isDataSupported:(NSData *)data;
+
 
 @required
 

--- a/AsyncDisplayKit/Details/ASPINRemoteImageDownloader.m
+++ b/AsyncDisplayKit/Details/ASPINRemoteImageDownloader.m
@@ -56,6 +56,11 @@
   return self.fileReady;
 }
 
+- (BOOL)isDataSupported:(NSData *)data
+{
+  return [data pin_isGIF];
+}
+
 @end
 #endif
 


### PR DESCRIPTION
Previously, animated images would only work if the URL is to a remote location. This change adds support to file system URLs. 

I'm not keen on the path extension check. Please let me know if there's a better way to ensure URLs to non-animated images aren't treated as if they are animated.