### PR TITLE
[ASVideoNode] Prevent setting old poster image if the asset was set to nil

### DIFF
--- a/AsyncDisplayKit/ASVideoNode.h
+++ b/AsyncDisplayKit/ASVideoNode.h
@@ -55,7 +55,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign, readwrite) BOOL shouldAggressivelyRecoverFromStall;
 
 @property (nonatomic, assign, readonly) ASVideoNodePlayerState playerState;
-//! Defaults to 100
+//! Defaults to 1000
 @property (nonatomic, assign) int32_t periodicTimeObserverTimescale;
 
 //! Defaults to AVLayerVideoGravityResizeAspect

--- a/AsyncDisplayKit/ASVideoNode.mm
+++ b/AsyncDisplayKit/ASVideoNode.mm
@@ -224,7 +224,7 @@ static NSString * const kStatus = @"status";
 - (void)generatePlaceholderImage
 {
   ASVideoNode * __weak weakSelf = self;
-  AVAsset * __weak asset = self.asset;
+  AVAsset *asset = self.asset;
 
   [self imageAtTime:kCMTimeZero completionHandler:^(UIImage *image) {
     ASPerformBlockOnMainThread(^{


### PR DESCRIPTION
Use a strong reference to the current asset in order to prevent setting a placeholder image if the asset is set to nil while the placeholder image is generating.

Also corrects the documentation of the `periodicTimeObserverTimescale` default.