### PR TITLE
[WIP] Fix custom class drawing methods are not called for ASTextNode and ASImageNode

### DIFF
--- a/AsyncDisplayKit/ASImageNode.mm
+++ b/AsyncDisplayKit/ASImageNode.mm
@@ -24,15 +24,15 @@
 #import "ASInternalHelpers.h"
 #import "ASEqualityHelpers.h"
 
-@interface _ASImageNodeDrawParameters : NSObject
+@interface _ASImageNodeDrawParameters : NSObject<_ASDisplayLayerDelegateForward>
 
-@property (nonatomic, retain) UIImage *image;
+@property (nonatomic, strong) UIImage *image;
 @property (nonatomic, assign) BOOL opaque;
 @property (nonatomic, assign) CGRect bounds;
 @property (nonatomic, assign) CGFloat contentsScale;
 @property (nonatomic, strong) UIColor *backgroundColor;
 @property (nonatomic, assign) UIViewContentMode contentMode;
-
+@property (nonatomic, weak, readonly) id<_ASDisplayLayerDelegate> delegate;
 @end
 
 // TODO: eliminate explicit parameters with a set of keys copied from the node
@@ -44,6 +44,7 @@
                 contentsScale:(CGFloat)contentsScale
               backgroundColor:(UIColor *)backgroundColor
                   contentMode:(UIViewContentMode)contentMode
+                     delegate:(id)delegate
 {
   if (!(self = [self init]))
     return nil;
@@ -54,6 +55,7 @@
   _contentsScale = contentsScale;
   _backgroundColor = backgroundColor;
   _contentMode = contentMode;
+  _delegate = delegate;
 
   return self;
 }
@@ -181,7 +183,8 @@
                                                     opaque:self.opaque
                                              contentsScale:self.contentsScaleForDisplay
                                            backgroundColor:self.backgroundColor
-                                               contentMode:self.contentMode];
+                                               contentMode:self.contentMode
+                                                  delegate:self];
 }
 
 - (NSDictionary *)debugLabelAttributes
@@ -192,6 +195,8 @@
 
 - (UIImage *)displayWithParameters:(_ASImageNodeDrawParameters *)parameters isCancelled:(asdisplaynode_iscancelled_block_t)isCancelled
 {
+  ASDisplayNodeAssert([parameters isKindOfClass:[_ASImageNodeDrawParameters class]], @"Calling super for displayWithParameters:isCancelled: in a ASImageNode subclass must pass in the original parameters to superclass implementation.");
+  
   UIImage *image = parameters.image;
   if (!image) {
     return nil;

--- a/AsyncDisplayKit/ASTextNode.mm
+++ b/AsyncDisplayKit/ASTextNode.mm
@@ -33,22 +33,24 @@ static const CGFloat ASTextNodeHighlightLightOpacity = 0.11;
 static const CGFloat ASTextNodeHighlightDarkOpacity = 0.22;
 static NSString *ASTextNodeTruncationTokenAttributeName = @"ASTextNodeTruncationAttribute";
 
-@interface ASTextNodeDrawParameters : NSObject
+@interface _ASTextNodeDrawParameters : NSObject<_ASDisplayLayerDelegateForward>
 
 @property (nonatomic, assign, readonly) CGRect bounds;
-
 @property (nonatomic, strong, readonly) UIColor *backgroundColor;
+@property (nonatomic, weak, readonly) id<_ASDisplayLayerDelegate> delegate;
 
 @end
 
-@implementation ASTextNodeDrawParameters
+@implementation _ASTextNodeDrawParameters
 
 - (instancetype)initWithBounds:(CGRect)bounds
                backgroundColor:(UIColor *)backgroundColor
+                      delegate:(id)delegate
 {
   if (self = [super init]) {
     _bounds = bounds;
     _backgroundColor = backgroundColor;
+    _delegate = delegate;
   }
   return self;
 }
@@ -413,8 +415,10 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
 
 #pragma mark - Drawing
 
-- (void)drawRect:(CGRect)bounds withParameters:(ASTextNodeDrawParameters *)parameters isCancelled:(asdisplaynode_iscancelled_block_t)isCancelledBlock isRasterizing:(BOOL)isRasterizing
+- (void)drawRect:(CGRect)bounds withParameters:(_ASTextNodeDrawParameters *)parameters isCancelled:(asdisplaynode_iscancelled_block_t)isCancelledBlock isRasterizing:(BOOL)isRasterizing
 {
+  ASDisplayNodeAssert([parameters isKindOfClass:[_ASTextNodeDrawParameters class]], @"Calling super for drawRect:withParameters:isCancelled:isRasterizing: in a ASTextNode subclass must pass in the original parameters to superclass implementation.");
+  
   CGContextRef context = UIGraphicsGetCurrentContext();
   ASDisplayNodeAssert(context, @"This is no good without a context.");
   
@@ -446,7 +450,9 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
 
 - (NSObject *)drawParametersForAsyncLayer:(_ASDisplayLayer *)layer
 {
-  return [[ASTextNodeDrawParameters alloc] initWithBounds:self.threadSafeBounds backgroundColor:self.backgroundColor];
+  return [[_ASTextNodeDrawParameters alloc] initWithBounds:self.threadSafeBounds
+                                           backgroundColor:self.backgroundColor
+                                                  delegate:self];
 }
 
 #pragma mark - Attributes

--- a/AsyncDisplayKit/Details/_ASDisplayLayer.h
+++ b/AsyncDisplayKit/Details/_ASDisplayLayer.h
@@ -134,3 +134,9 @@ typedef BOOL(^asdisplaynode_iscancelled_block_t)(void);
 - (void)cancelDisplayAsyncLayer:(_ASDisplayLayer *)asyncLayer;
 
 @end
+
+@protocol _ASDisplayLayerDelegateForward <NSObject>
+
+- (id<_ASDisplayLayerDelegate>) delegate;
+   
+@end

--- a/AsyncDisplayKit/Private/ASDisplayNode+AsyncDisplay.mm
+++ b/AsyncDisplayKit/Private/ASDisplayNode+AsyncDisplay.mm
@@ -83,6 +83,34 @@ static void __ASDisplayLayerDecrementConcurrentDisplayCount(BOOL displayIsAsync,
   return nil;
 }
 
++ (void)drawRect:(CGRect)bounds withParameters:(id <_ASDisplayLayerDelegateForward>)parameters isCancelled:(asdisplaynode_iscancelled_block_t)isCancelledBlock isRasterizing:(BOOL)isRasterizing
+{
+  ASDisplayNodeAssert([parameters conformsToProtocol:@protocol(_ASDisplayLayerDelegateForward)], @"Calling super for drawRect:withParameters:isCancelled:isRasterizing: must pass in the original parameters to superclass implementation.");
+  
+  if ([parameters conformsToProtocol:@protocol(_ASDisplayLayerDelegateForward)]) {
+    id <_ASDisplayLayerDelegateForward> internalParameters = (id <_ASDisplayLayerDelegateForward>)parameters;
+    id<_ASDisplayLayerDelegate> delegate = internalParameters.delegate;
+    if (delegate != nil) {
+      [delegate drawRect:bounds withParameters:parameters isCancelled:isCancelledBlock isRasterizing:isRasterizing];
+    }
+  }
+}
+
++ (UIImage *)displayWithParameters:(id <NSObject>)parameters isCancelled:(asdisplaynode_iscancelled_block_t)isCancelledBlock
+{
+  ASDisplayNodeAssert([parameters conformsToProtocol:@protocol(_ASDisplayLayerDelegateForward)], @"Calling super for displayWithParameters:isCancelled: must pass in the original parameters to superclass implementation.");
+  
+  if ([parameters conformsToProtocol:@protocol(_ASDisplayLayerDelegateForward)]) {
+    id <_ASDisplayLayerDelegateForward> internalParameters = (id <_ASDisplayLayerDelegateForward>)parameters;
+    id<_ASDisplayLayerDelegate> delegate = internalParameters.delegate;
+    if (delegate != nil) {
+      return [delegate displayWithParameters:parameters isCancelled:isCancelledBlock];
+    }
+  }
+
+  return nil;
+}
+
 - (void)_recursivelyRasterizeSelfAndSublayersWithIsCancelledBlock:(asdisplaynode_iscancelled_block_t)isCancelledBlock displayBlocks:(NSMutableArray *)displayBlocks
 {
   // Skip subtrees that are hidden or zero alpha.
@@ -239,12 +267,12 @@ static void __ASDisplayLayerDecrementConcurrentDisplayCount(BOOL displayIsAsync,
       ASDN_DELAY_FOR_DISPLAY();
       
       UIImage *result = nil;
-      //We can't call _willDisplayNodeContentWithRenderingContext or _didDisplayNodeContentWithRenderingContext because we don't
-      //have a context. We rely on implementors of displayWithParameters:isCancelled: to call
-      if (_flags.implementsInstanceImageDisplay) {
-        result = [self displayWithParameters:drawParameters isCancelled:isCancelledBlock];
-      } else {
+      // We can't call _willDisplayNodeContentWithRenderingContext or _didDisplayNodeContentWithRenderingContext because we don't
+      // have a context. We rely on implementors of displayWithParameters:isCancelled: to call
+      if (_flags.implementsImageDisplay) {
         result = [[self class] displayWithParameters:drawParameters isCancelled:isCancelledBlock];
+      } else {
+        result = [self displayWithParameters:drawParameters isCancelled:isCancelledBlock];
       }
       __ASDisplayLayerDecrementConcurrentDisplayCount(asynchronous, rasterizing);
       return result;
@@ -280,11 +308,12 @@ static void __ASDisplayLayerDecrementConcurrentDisplayCount(BOOL displayIsAsync,
         _willDisplayNodeContentWithRenderingContext(currentContext);
       }
       
-      if (_flags.implementsInstanceDrawRect) {
-        [self drawRect:bounds withParameters:drawParameters isCancelled:isCancelledBlock isRasterizing:rasterizing];
-      } else {
+      if (_flags.implementsDrawRect) {
         [[self class] drawRect:bounds withParameters:drawParameters isCancelled:isCancelledBlock isRasterizing:rasterizing];
+      } else {
+        [self drawRect:bounds withParameters:drawParameters isCancelled:isCancelledBlock isRasterizing:rasterizing];
       }
+      
       
       if (currentContext && _didDisplayNodeContentWithRenderingContext) {
         _didDisplayNodeContentWithRenderingContext(currentContext);

--- a/examples_extra/Placeholders/Sample/PostNode.m
+++ b/examples_extra/Placeholders/Sample/PostNode.m
@@ -43,6 +43,7 @@
   _textNode = [[SlowpokeTextNode alloc] init];
   _textNode.placeholderInsets = UIEdgeInsetsMake(3.0, 0.0, 3.0, 0.0);
   _textNode.placeholderEnabled = YES;
+  _textNode.placeholderFadeDuration = 0.2;
 
   NSString *text = @"Etiam porta sem malesuada magna mollis euismod. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Etiam porta sem malesuada magna mollis euismod. Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh.";
   NSDictionary *attributes = @{ NSFontAttributeName: [UIFont systemFontOfSize:17.0] };

--- a/examples_extra/Placeholders/Sample/SlowpokeImageNode.m
+++ b/examples_extra/Placeholders/Sample/SlowpokeImageNode.m
@@ -22,7 +22,7 @@ static CGFloat const kASDKLogoAspectRatio = 2.79;
 
 @implementation SlowpokeImageNode
 
-- (UIImage *)displayWithParameters:(id<NSObject>)parameters isCancelled:(asdisplaynode_iscancelled_block_t)isCancelledBlock
++ (UIImage *)displayWithParameters:(id<NSObject>)parameters isCancelled:(asdisplaynode_iscancelled_block_t)isCancelledBlock
 {
   usleep( (long)(0.5 * USEC_PER_SEC) ); // artificial delay of 0.5s
   

--- a/examples_extra/Placeholders/Sample/SlowpokeTextNode.m
+++ b/examples_extra/Placeholders/Sample/SlowpokeTextNode.m
@@ -11,20 +11,23 @@
 
 #import "SlowpokeTextNode.h"
 
-#import <AsyncDisplayKit/ASDisplayNode+Subclasses.h>
-
-@interface ASTextNode (ForwardWorkaround)
-// This is a workaround until subclass overriding of custom drawing class methods is fixed
-- (void)drawRect:(CGRect)bounds withParameters:(id<NSObject>)parameters isCancelled:(asdisplaynode_iscancelled_block_t)isCancelledBlock isRasterizing:(BOOL)isRasterizing;
-@end
-
 @implementation SlowpokeTextNode
 
-- (void)drawRect:(CGRect)bounds withParameters:(id<NSObject>)parameters isCancelled:(asdisplaynode_iscancelled_block_t)isCancelledBlock isRasterizing:(BOOL)isRasterizing
+- (NSObject *)drawParametersForAsyncLayer:(_ASDisplayLayer *)layer
 {
-  usleep( (long)(1.0 * USEC_PER_SEC) ); // artificial delay of 1.0
+  id original = [super drawParametersForAsyncLayer:layer];
+  return @{
+    @"original" : original,
+    @"delay" : @(1.0)
+  };
+}
 
-  [super drawRect:bounds withParameters:parameters isCancelled:isCancelledBlock isRasterizing:isRasterizing];
++ (void)drawRect:(CGRect)bounds withParameters:(NSDictionary *)parameters isCancelled:(asdisplaynode_iscancelled_block_t)isCancelledBlock isRasterizing:(BOOL)isRasterizing
+{
+  usleep( (long)([parameters[@"delay"] floatValue] * USEC_PER_SEC) ); // artificial delay of 1.0
+  
+  id originalParameter = parameters[@"original"];
+  [super drawRect:bounds withParameters:originalParameter isCancelled:isCancelledBlock isRasterizing:isRasterizing];
 }
 
 @end


### PR DESCRIPTION
ASTextNode and ASImageNode currently implement drawing methods as instance methods. This breaks the custom class drawing methods. They will never be called for a subclass. Fixing it by adding a delegate object to the text / image node drawing methods to be able to dispatch the call to the instance method in ASDisplayNode.

To be able to work this way the original parameters needs to be passed to the superclass if a subclass calls the superclasses class drawing method.

cc @appleguy As we talked about this is a first proposal how we could tackle the broken custom class drawing methods. As also said we need to look into the locking issue that is already happening and likely still happening with this solution.