### PR TITLE
[ASLayout] Clean up flattening process of ASLayout

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -62,7 +62,9 @@ NSString * const ASRenderingEngineDidDisplayNodesScheduledBeforeTimestamp = @"AS
 @implementation ASDisplayNode
 
 // these dynamic properties all defined in ASLayoutOptionsPrivate.m
-@dynamic spacingAfter, spacingBefore, flexGrow, flexShrink, flexBasis, alignSelf, ascender, descender, sizeRange, layoutPosition;
+@dynamic spacingAfter, spacingBefore, flexGrow, flexShrink, flexBasis,
+         alignSelf, ascender, descender, sizeRange, layoutPosition, layoutableType;
+
 @synthesize name = _name;
 @synthesize preferredFrameSize = _preferredFrameSize;
 @synthesize isFinalLayoutable = _isFinalLayoutable;
@@ -657,6 +659,11 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
 - (BOOL)_hasDirtyLayout
 {
   return _layout == nil || _layout.isDirty;
+}
+
+- (ASLayoutableType)layoutableType
+{
+  return ASLayoutableTypeDisplayNode;
 }
 
 #pragma mark - Layout Transition

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -1916,13 +1916,7 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
       ASLayoutableValidateLayout(layout);
 #endif
     }
-    return [layout flattenedLayoutUsingPredicateBlock:^BOOL(ASLayout *evaluatedLayout) {
-      if (self.usesImplicitHierarchyManagement) {
-        return ASObjectIsEqual(layout, evaluatedLayout) == NO && [evaluatedLayout.layoutableObject isKindOfClass:[ASDisplayNode class]];
-      } else {
-        return [_subnodes containsObject:evaluatedLayout.layoutableObject];
-      }
-    }];
+    return [layout filteredNodeLayoutTree];
   } else {
     // If neither -layoutSpecThatFits: nor -calculateSizeThatFits: is overridden by subclassses, preferredFrameSize should be used,
     // assume that the default implementation of -calculateSizeThatFits: returns it.
@@ -2390,7 +2384,7 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
 
 - (void)__layoutSublayouts
 {
-  for (ASLayout *subnodeLayout in _layout.immediateSublayouts) {
+  for (ASLayout *subnodeLayout in _layout.sublayouts) {
     ((ASDisplayNode *)subnodeLayout.layoutableObject).frame = [subnodeLayout frame];
   }
 }

--- a/AsyncDisplayKit/Layout/ASLayout.h
+++ b/AsyncDisplayKit/Layout/ASLayout.h
@@ -54,19 +54,9 @@ extern BOOL CGPointIsNull(CGPoint point);
 @property (nonatomic, readonly) NSArray<ASLayout *> *sublayouts;
 
 /**
- * A list of sublayouts that were not already flattened.
- */
-@property (nonatomic, readonly) NSArray<ASLayout *> *immediateSublayouts;
-
-/**
  * Mark the layout dirty for future regeneration.
  */
 @property (nonatomic, getter=isDirty) BOOL dirty;
-
-/**
- * A boolean describing if the current layout has been flattened.
- */
-@property (nonatomic, readonly, getter=isFlattened) BOOL flattened;
 
 /**
  * @abstract Returns a valid frame for the current layout computed with the size and position.
@@ -75,22 +65,27 @@ extern BOOL CGPointIsNull(CGPoint point);
 @property (nonatomic, readonly) CGRect frame;
 
 /**
- * Initializer.
+ * Designated initializer
+ */
+- (instancetype)initWithLayoutableObject:(id<ASLayoutable>)layoutableObject
+                    constrainedSizeRange:(ASSizeRange)sizeRange
+                                    size:(CGSize)size
+                                position:(CGPoint)position
+                              sublayouts:(NSArray *)sublayouts NS_DESIGNATED_INITIALIZER;
+
+/**
+ * Convenience class initializer for layout construction.
  *
  * @param layoutableObject The backing ASLayoutable object.
- *
- * @param size The size of this layout.
- *
- * @param position The position of this layout within its parent (if available).
- *
- * @param sublayouts Sublayouts belong to the new layout.
+ * @param size             The size of this layout.
+ * @param position         The position of this layout within its parent (if available).
+ * @param sublayouts       Sublayouts belong to the new layout.
  */
 + (instancetype)layoutWithLayoutableObject:(id<ASLayoutable>)layoutableObject
                       constrainedSizeRange:(ASSizeRange)sizeRange
                                       size:(CGSize)size
                                   position:(CGPoint)position
-                                sublayouts:(nullable NSArray<ASLayout *> *)sublayouts
-                                 flattened:(BOOL)flattened;
+                                sublayouts:(nullable NSArray<ASLayout *> *)sublayouts;
 
 /**
  * Convenience initializer that has CGPointNull position.
@@ -99,9 +94,7 @@ extern BOOL CGPointIsNull(CGPoint point);
  * or for creating a sublayout of which the position is yet to be determined.
  *
  * @param layoutableObject The backing ASLayoutable object.
- *
  * @param size The size of this layout.
- *
  * @param sublayouts Sublayouts belong to the new layout.
  */
 + (instancetype)layoutWithLayoutableObject:(id<ASLayoutable>)layoutableObject
@@ -115,7 +108,6 @@ extern BOOL CGPointIsNull(CGPoint point);
  * or a sublayout of which the position is yet to be determined.
  *
  * @param layoutableObject The backing ASLayoutable object.
- *
  * @param size The size of this layout.
  */
 + (instancetype)layoutWithLayoutableObject:(id<ASLayoutable>)layoutableObject
@@ -126,9 +118,7 @@ extern BOOL CGPointIsNull(CGPoint point);
  * Convenience initializer that is flattened and has CGPointNull position.
  *
  * @param layoutableObject The backing ASLayoutable object.
- *
  * @param size The size of this layout.
- *
  * @param sublayouts Sublayouts belong to the new layout.
  */
 + (instancetype)flattenedLayoutWithLayoutableObject:(id<ASLayoutable>)layoutableObject
@@ -137,16 +127,16 @@ extern BOOL CGPointIsNull(CGPoint point);
                                          sublayouts:(nullable NSArray<ASLayout *> *)sublayouts;
 
 /**
- * @abstract Evaluates a given predicate block against each object in the receiving layout tree
- * and returns a new, 1-level deep layout containing the objects for which the predicate block returns true.
- *
- * @param predicateBlock The block is applied to a layout to be evaluated. 
- * The block takes 1 argument: evaluatedLayout - the layout to be evaluated.
- * The block returns YES if evaluatedLayout evaluates  to true, otherwise NO.
- *
- * @return A new, 1-level deep layout containing the layouts for which the predicate block returns true.
+ * Convenience initializer that creates a layout based on the values of the given layout, with a new position
+ * @param layout    The layout to use to create the new layout
+ * @param position  The position of the new layout
  */
-- (ASLayout *)flattenedLayoutUsingPredicateBlock:(BOOL (^)(ASLayout *evaluatedLayout))predicateBlock;
++ (instancetype)layoutWithLayout:(ASLayout *)layout position:(CGPoint)position;
+
+/**
+ * Traverses the existing layout tree and generates a new tree that represents only ASDisplayNode layouts
+ */
+- (ASLayout *)filteredNodeLayoutTree;
 
 @end
 

--- a/AsyncDisplayKit/Layout/ASLayout.h
+++ b/AsyncDisplayKit/Layout/ASLayout.h
@@ -69,6 +69,12 @@ extern BOOL CGPointIsNull(CGPoint point);
 @property (nonatomic, readonly, getter=isFlattened) BOOL flattened;
 
 /**
+ * @abstract Returns a valid frame for the current layout computed with the size and position.
+ * @discussion Clamps the layout's origin or position to 0 if any of the calculated values are infinite.
+ */
+@property (nonatomic, readonly) CGRect frame;
+
+/**
  * Initializer.
  *
  * @param layoutableObject The backing ASLayoutable object.
@@ -141,12 +147,6 @@ extern BOOL CGPointIsNull(CGPoint point);
  * @return A new, 1-level deep layout containing the layouts for which the predicate block returns true.
  */
 - (ASLayout *)flattenedLayoutUsingPredicateBlock:(BOOL (^)(ASLayout *evaluatedLayout))predicateBlock;
-
-/**
- * @abstract Returns a valid frame for the current layout computed with the size and position.
- * @discussion Clamps the layout's origin or position to 0 if any of the calculated values are infinite.
- */
-- (CGRect)frame;
 
 @end
 

--- a/AsyncDisplayKit/Layout/ASLayout.h
+++ b/AsyncDisplayKit/Layout/ASLayout.h
@@ -32,6 +32,11 @@ extern BOOL CGPointIsNull(CGPoint point);
 @property (nonatomic, weak, readonly) id<ASLayoutable> layoutableObject;
 
 /**
+ * The type of ASLayoutable that created this layout
+ */
+@property (nonatomic, readonly) ASLayoutableType type;
+
+/**
  * Size of the current layout
  */
 @property (nonatomic, readonly) CGSize size;

--- a/AsyncDisplayKit/Layout/ASLayout.mm
+++ b/AsyncDisplayKit/Layout/ASLayout.mm
@@ -12,7 +12,6 @@
 
 #import "ASAssert.h"
 #import "ASDimension.h"
-#import "ASDisplayNode.h"
 #import "ASInternalHelpers.h"
 #import "ASLayoutSpecUtilities.h"
 
@@ -36,7 +35,7 @@ extern BOOL CGPointIsNull(CGPoint point)
 
 @implementation ASLayout
 
-@dynamic frame;
+@dynamic frame, type;
 
 - (instancetype)initWithLayoutableObject:(id<ASLayoutable>)layoutableObject
                     constrainedSizeRange:(ASSizeRange)sizeRange
@@ -159,7 +158,7 @@ extern BOOL CGPointIsNull(CGPoint point)
     Context context = queue.front();
     queue.pop();
 
-    if (self != context.layout && [context.layout.layoutableObject isKindOfClass:[ASDisplayNode class]]) {
+    if (self != context.layout && context.layout.type == ASLayoutableTypeDisplayNode) {
       ASLayout *layout = [ASLayout layoutWithLayout:context.layout position:context.absolutePosition];
       layout.flattened = YES;
       [flattenedSublayouts addObject:layout];
@@ -176,6 +175,13 @@ extern BOOL CGPointIsNull(CGPoint point)
                          constrainedSizeRange:_constrainedSizeRange
                                          size:_size
                                    sublayouts:flattenedSublayouts];
+}
+
+#pragma mark - Accessors
+
+- (ASLayoutableType)type
+{
+  return _layoutableObject.layoutableType;
 }
 
 - (CGRect)frame

--- a/AsyncDisplayKit/Layout/ASLayout.mm
+++ b/AsyncDisplayKit/Layout/ASLayout.mm
@@ -113,36 +113,32 @@ extern BOOL CGPointIsNull(CGPoint point)
   
   struct Context {
     ASLayout *layout;
-    CGPoint absolutePosition;
-    BOOL visited;
+    CGPoint relativePosition;
     BOOL flattened;
   };
   
   // Queue used to keep track of sublayouts while traversing this layout in a BFS fashion.
   std::queue<Context> queue;
-  queue.push({self, CGPointMake(0, 0), NO, NO});
+  queue.push({self, CGPointMake(0, 0), NO});
   
   while (!queue.empty()) {
     Context &context = queue.front();
-    if (context.visited) {
-      queue.pop();
-    } else {
-      context.visited = YES;
-      
-      if (predicateBlock(context.layout)) {
-        [flattenedSublayouts addObject:[ASLayout layoutWithLayoutableObject:context.layout.layoutableObject
-                                                       constrainedSizeRange:context.layout.constrainedSizeRange
-                                                                       size:context.layout.size
-                                                                   position:context.absolutePosition
-                                                                 sublayouts:nil
-                                                                  flattened:context.flattened]];
-      }
-      
-      for (ASLayout *sublayout in context.layout.sublayouts) {
-        // Mark layout trees that have already been flattened for future identification of immediate sublayouts
-        BOOL flattened = context.flattened ? : context.layout.flattened;
-        queue.push({sublayout, context.absolutePosition + sublayout.position, NO, flattened});
-      }
+    ASLayout *layout = context.layout;
+    queue.pop();
+
+    if (predicateBlock(layout)) {
+      [flattenedSublayouts addObject:[ASLayout layoutWithLayoutableObject:layout.layoutableObject
+                                                     constrainedSizeRange:layout.constrainedSizeRange
+                                                                     size:layout.size
+                                                                 position:context.relativePosition
+                                                               sublayouts:nil
+                                                                flattened:context.flattened]];
+    }
+    
+    for (ASLayout *sublayout in layout.sublayouts) {
+      // Mark layout trees that have already been flattened for future identification of immediate sublayouts
+      BOOL flattened = context.flattened ? : layout.flattened;
+      queue.push({sublayout, context.relativePosition + sublayout.position, flattened});
     }
   }
 

--- a/AsyncDisplayKit/Layout/ASLayout.mm
+++ b/AsyncDisplayKit/Layout/ASLayout.mm
@@ -122,22 +122,21 @@ extern BOOL CGPointIsNull(CGPoint point)
   queue.push({self, CGPointMake(0, 0), NO});
   
   while (!queue.empty()) {
-    Context &context = queue.front();
-    ASLayout *layout = context.layout;
+    Context context = queue.front();
     queue.pop();
 
-    if (predicateBlock(layout)) {
-      [flattenedSublayouts addObject:[ASLayout layoutWithLayoutableObject:layout.layoutableObject
-                                                     constrainedSizeRange:layout.constrainedSizeRange
-                                                                     size:layout.size
+    if (predicateBlock(context.layout)) {
+      [flattenedSublayouts addObject:[ASLayout layoutWithLayoutableObject:context.layout.layoutableObject
+                                                     constrainedSizeRange:context.layout.constrainedSizeRange
+                                                                     size:context.layout.size
                                                                  position:context.relativePosition
                                                                sublayouts:nil
                                                                 flattened:context.flattened]];
     }
     
-    for (ASLayout *sublayout in layout.sublayouts) {
+    for (ASLayout *sublayout in context.layout.sublayouts) {
       // Mark layout trees that have already been flattened for future identification of immediate sublayouts
-      BOOL flattened = context.flattened ? : layout.flattened;
+      BOOL flattened = context.flattened ? : context.layout.flattened;
       queue.push({sublayout, context.relativePosition + sublayout.position, flattened});
     }
   }

--- a/AsyncDisplayKit/Layout/ASLayout.mm
+++ b/AsyncDisplayKit/Layout/ASLayout.mm
@@ -24,6 +24,8 @@ extern BOOL CGPointIsNull(CGPoint point)
 
 @implementation ASLayout
 
+@dynamic frame;
+
 + (instancetype)layoutWithLayoutableObject:(id<ASLayoutable>)layoutableObject
                       constrainedSizeRange:(ASSizeRange)sizeRange
                                       size:(CGSize)size

--- a/AsyncDisplayKit/Layout/ASLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASLayoutSpec.mm
@@ -34,7 +34,8 @@
 @implementation ASLayoutSpec
 
 // these dynamic properties all defined in ASLayoutOptionsPrivate.m
-@dynamic spacingAfter, spacingBefore, flexGrow, flexShrink, flexBasis, alignSelf, ascender, descender, sizeRange, layoutPosition;
+@dynamic spacingAfter, spacingBefore, flexGrow, flexShrink, flexBasis,
+         alignSelf, ascender, descender, sizeRange, layoutPosition, layoutableType;
 @synthesize isFinalLayoutable = _isFinalLayoutable;
 
 - (instancetype)init
@@ -46,6 +47,11 @@
   _environmentState = ASEnvironmentStateMakeDefault();
   _children = [NSArray array];
   return self;
+}
+
+- (ASLayoutableType)layoutableType
+{
+  return ASLayoutableTypeLayoutSpec;
 }
 
 #pragma mark - Layout

--- a/AsyncDisplayKit/Layout/ASLayoutable.h
+++ b/AsyncDisplayKit/Layout/ASLayoutable.h
@@ -21,6 +21,11 @@
 @class ASLayout;
 @class ASLayoutSpec;
 
+typedef NS_ENUM(NSUInteger, ASLayoutableType) {
+  ASLayoutableTypeLayoutSpec,
+  ASLayoutableTypeDisplayNode
+};
+
 NS_ASSUME_NONNULL_BEGIN
 
 /** 
@@ -41,6 +46,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @protocol ASLayoutable <ASEnvironment, ASStackLayoutable, ASStaticLayoutable, ASLayoutablePrivate, ASLayoutableExtensibility>
 
+@property (nonatomic, readonly) ASLayoutableType layoutableType;
+
 /**
  * @abstract Calculate a layout based on given size range.
  *
@@ -49,7 +56,6 @@ NS_ASSUME_NONNULL_BEGIN
  * @return An ASLayout instance defining the layout of the receiver and its children.
  */
 - (ASLayout *)measureWithSizeRange:(ASSizeRange)constrainedSize;
-
 
 #pragma mark - Layout options from the Layoutable Protocols
 

--- a/AsyncDisplayKit/Private/ASLayoutTransition.mm
+++ b/AsyncDisplayKit/Private/ASLayoutTransition.mm
@@ -67,7 +67,7 @@
   }
   if (_previousLayout) {
     NSIndexSet *insertions, *deletions;
-    [_previousLayout.immediateSublayouts asdk_diffWithArray:_pendingLayout.immediateSublayouts
+    [_previousLayout.sublayouts asdk_diffWithArray:_pendingLayout.sublayouts
                                                  insertions:&insertions
                                                   deletions:&deletions
                                                compareBlock:^BOOL(ASLayout *lhs, ASLayout *rhs) {
@@ -80,7 +80,7 @@
                                                       &_removedSubnodes,
                                                       &_removedSubnodePositions);
   } else {
-    NSIndexSet *indexes = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, [_pendingLayout.immediateSublayouts count])];
+    NSIndexSet *indexes = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, [_pendingLayout.sublayouts count])];
     findNodesInLayoutAtIndexes(_pendingLayout, indexes, &_insertedSubnodes, &_insertedSubnodePositions);
     _removedSubnodes = nil;
   }
@@ -160,7 +160,7 @@ static inline void findNodesInLayoutAtIndexesWithFilteredNodes(ASLayout *layout,
   std::vector<NSUInteger> positions = std::vector<NSUInteger>();
   NSUInteger idx = [indexes firstIndex];
   while (idx != NSNotFound) {
-    ASDisplayNode *node = (ASDisplayNode *)layout.immediateSublayouts[idx].layoutableObject;
+    ASDisplayNode *node = (ASDisplayNode *)layout.sublayouts[idx].layoutableObject;
     ASDisplayNodeCAssert(node, @"A flattened layout must consist exclusively of node sublayouts");
     // Ignore the odd case in which a non-node sublayout is accessed and the type cast fails
     if (node != nil) {

--- a/AsyncDisplayKit/_ASTransitionContext.m
+++ b/AsyncDisplayKit/_ASTransitionContext.m
@@ -71,7 +71,7 @@ NSString * const ASTransitionContextToLayoutKey = @"org.asyncdisplaykit.ASTransi
 - (NSArray<ASDisplayNode *> *)subnodesForKey:(NSString *)key
 {
   NSMutableArray<ASDisplayNode *> *subnodes = [NSMutableArray array];
-  for (ASLayout *sublayout in [self layoutForKey:key].immediateSublayouts) {
+  for (ASLayout *sublayout in [self layoutForKey:key].sublayouts) {
     [subnodes addObject:(ASDisplayNode *)sublayout.layoutableObject];
   }
   return subnodes;

--- a/AsyncDisplayKitTests/ASLayoutSpecSnapshotTestsHelper.m
+++ b/AsyncDisplayKitTests/ASLayoutSpecSnapshotTestsHelper.m
@@ -65,9 +65,7 @@
                            constrainedSizeRange:sizeRange
                                            size:layout.size
                                      sublayouts:@[layout]];
-  _layoutUnderTest = [layout flattenedLayoutUsingPredicateBlock:^BOOL(ASLayout *evaluatedLayout) {
-    return [self.subnodes containsObject:(ASDisplayNode *)evaluatedLayout.layoutableObject];
-  }];
+  _layoutUnderTest = [layout filteredNodeLayoutTree];
   self.frame = CGRectMake(0, 0, _layoutUnderTest.size.width, _layoutUnderTest.size.height);
   [self measure:_layoutUnderTest.size];
 }


### PR DESCRIPTION
My aim here is to simplify the flattening process such that it is an accessible piece of code that new readers can understand. Here's an itemized overview of my process:

1. I cleaned up the flatten BFS — this was original in #1730, but I got carried away cleaning up the entire class. There are now less iterations and it now uses the `flattened` ivar as a visitation marker so that a layout doesn't contain sublayouts that aren't direct subnodes defined in the node's layout spec.
2. Removed the predicate block. It's very flexible having a block-based API, but we currently don't use it effectively to warrant the design. The API has been renamed to `filteredNodeLayoutTree`, to simplify the API footprint and better communicate the resulting structure.
3. `immediateSublayouts` is gone. This was an ill-designed property when it was unclear of the design direction of implicit hierarchy management. Now that the `flattened` bool is used more intelligently, a flattened layout will only contain subnodes referenced in its layout spec.
4. `frame` is now a dynamic property. This will make it cleaner to use in Swift and allow dot-syntax in obj-c.