### PR TITLE
[Performance] Prevent GCD thread explosion due to object deallocation workloads (serial deallocation queue).

### DIFF
--- a/AsyncDisplayKit/ASMultiplexImageNode.mm
+++ b/AsyncDisplayKit/ASMultiplexImageNode.mm
@@ -531,7 +531,7 @@ typedef void(^ASMultiplexImageLoadCompletionBlock)(UIImage *image, id imageIdent
   BOOL shouldReleaseImageOnBackgroundThread = imageSize.width > kMinReleaseImageOnBackgroundSize.width ||
   imageSize.height > kMinReleaseImageOnBackgroundSize.height;
   if (shouldReleaseImageOnBackgroundThread) {
-    ASPerformBlockOnBackgroundThread(^{
+    ASPerformBlockOnDeallocationQueue(^{
       image = nil;
     });
   }

--- a/AsyncDisplayKit/ASNetworkImageNode.mm
+++ b/AsyncDisplayKit/ASNetworkImageNode.mm
@@ -378,7 +378,7 @@ static const CGSize kMinReleaseImageOnBackgroundSize = {20.0, 20.0};
   BOOL shouldReleaseImageOnBackgroundThread = imageSize.width > kMinReleaseImageOnBackgroundSize.width ||
                                               imageSize.height > kMinReleaseImageOnBackgroundSize.height;
   if (shouldReleaseImageOnBackgroundThread) {
-    ASPerformBlockOnBackgroundThread(^{
+    ASPerformBlockOnDeallocationQueue(^{
       image = nil;
     });
   }

--- a/AsyncDisplayKit/ASTextNode.mm
+++ b/AsyncDisplayKit/ASTextNode.mm
@@ -260,7 +260,7 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
     // actually dealloc.
     __block ASTextKitRenderer *renderer = _renderer;
     
-    ASPerformBlockOnBackgroundThread(^{
+    ASPerformBlockOnDeallocationQueue(^{
       renderer = nil;
     });
     _renderer = nil;

--- a/AsyncDisplayKit/Private/ASInternalHelpers.h
+++ b/AsyncDisplayKit/Private/ASInternalHelpers.h
@@ -17,8 +17,15 @@ ASDISPLAYNODE_EXTERN_C_BEGIN
 
 BOOL ASSubclassOverridesSelector(Class superclass, Class subclass, SEL selector);
 BOOL ASSubclassOverridesClassSelector(Class superclass, Class subclass, SEL selector);
+
+/// Dispatches the given block to the main queue if not already running on the main thread
 void ASPerformBlockOnMainThread(void (^block)());
-void ASPerformBlockOnBackgroundThread(void (^block)()); // DISPATCH_QUEUE_PRIORITY_DEFAULT 
+
+/// Dispatches the given block to a background queue with priority of DISPATCH_QUEUE_PRIORITY_DEFAULT if not already run on a background queue
+void ASPerformBlockOnBackgroundThread(void (^block)()); // DISPATCH_QUEUE_PRIORITY_DEFAULT
+
+/// Dispatches a block on to a serial queue that's main purpose is for deallocation of objects on a background thread
+void ASPerformBlockOnDeallocationQueue(void (^block)());
 
 CGFloat ASScreenScale();
 

--- a/AsyncDisplayKit/Private/ASInternalHelpers.mm
+++ b/AsyncDisplayKit/Private/ASInternalHelpers.mm
@@ -52,6 +52,17 @@ void ASPerformBlockOnBackgroundThread(void (^block)())
   }
 }
 
+void ASPerformBlockOnDeallocationQueue(void (^block)())
+{
+  static dispatch_queue_t queue;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    queue = dispatch_queue_create("org.AsyncDisplayKit.deallocationQueue", DISPATCH_QUEUE_SERIAL);
+  });
+  
+  dispatch_async(queue, block);
+}
+
 CGFloat ASScreenScale()
 {
   static CGFloat __scale = 0.0;


### PR DESCRIPTION
Currently it’s very suboptimal how many threads ASDK is spawning at some point. You can see that especially by running the ASCollectionView and reload the collection view a couple of times or ASTableViewStressTest example by just running it and push a couple of view controller. It spawns over 100 threads pretty fast.

I looked into that a bit into this and it seems like the main drivers are the dispatches to the background queue in ASTextNode, ASNetworkImageNode, ASMultiplexImageNode where we destroy the text renderer, images etc. 

Instead of using a global background queue this PR is adding a dedicated serial queue that we use to destroy the objects mentioned above. This reduces the threads we spawn tremendously.