### PR TITLE
[Batch Fetching] Check for batch fetching in scrollViewDidScroll

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -659,6 +659,9 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
                                       inScrollView:scrollView
                                      withCellFrame:collectionCell.frame];
   }
+
+  [self _checkForBatchFetching];
+
   if (_asyncDelegateFlags.asyncDelegateScrollViewDidScroll) {
     [_asyncDelegate scrollViewDidScroll:scrollView];
   }

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -681,6 +681,9 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
                                  inScrollView:scrollView
                                 withCellFrame:tableCell.frame];
   }
+
+  [self _checkForBatchFetching];
+
   if (_asyncDelegateFlags.asyncDelegateScrollViewDidScroll) {
     [_asyncDelegate scrollViewDidScroll:scrollView];
   }


### PR DESCRIPTION
Following #1681 I'm opening this very simple pull request. The idea is that batch fetching isn't triggered when the `contentOffset` of the `ASCollectionView` / `ASTableView` is changed programmatically. This is the case for example when setting the `contentOffset` directly, or when calling `scrollRectToVisible` on the underlying `UIScrollView`.
The following repository shows a simplified version of my use case: https://github.com/flovouin/ASDK-BatchFetchingTests
`scrollEnabled` is set to `false` on the `ASCollectionView`, and its scrolling behaviour is controlled by another `UIScrollView` (this is loosely inspired by WWDC 2012 - Session 223). Obviously this is useless in the above example, but very handy in my real-life application. One could think of other use cases, like scrolling (programmatically) to a specific item in the collection.

The most generic solution I found is simply to check if a batch fetch should be performed when the `contentOffset` is changed, in `scrollViewDidScroll`. Although this method might be called quite often, `_checkForBatchFetching` should introduce very little computations as it returns directly during dragging. This also works for the `scrollRectToVisible`, as obviously the `contentOffset` is changed.

Additional thoughts:
- Although this solves my very simple problem, it does not address nickvelloff's original issue #1681. Unfortunately I've never worked on zooming / scaling a collection view and I'm not sure what would be the best way to solve this problem. Also, I saw there's a somewhat related PR #1697.
- A (very small) limitation is that the check is performed at the current `contentOffset`, contrary to the check in `scrollViewWillEndDragging`, that takes into account the target offset of the animation. When simply setting the `contentOffset`, this is the best we can do, but for an animated `scrollRectToVisible`, it would technically be possible to know the target offset (passed to this method), and directly check if a batch fetch is needed at this location. Instead, the proposed solution will trigger a check at every step of the animation (each time the `contentOffset` is updated).

Please tell me if this is an acceptable change and if I can improve it in any way. :-)
Cheers,
Flo

Edit: Now that I think about it, maybe the same change could be applied to zooming by simply checking for batch fetch in `scrollViewDidZoom`? I don't have a toy example to check though.