### PR TITLE
[ASTextNode] Refactor locking to account for recent feature additions and on-demand initialization.

### DIFF
--- a/AsyncDisplayKit/ASTextNode.mm
+++ b/AsyncDisplayKit/ASTextNode.mm
@@ -236,6 +236,8 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
 
 - (ASTextKitAttributes)_rendererAttributes
 {
+  std::lock_guard<std::recursive_mutex> l(_textLock);
+  
   return {
     .attributedString = _attributedText,
     .truncationAttributedString = _composedTruncationText,


### PR DESCRIPTION
- Move lock from ASDN::Mutex to std::mutex in ASTextKitContext
- Small cleanup in ASTextNode
- For now we use a big recursive lock. This needs to be revisited as we revisit the whole ASDK locking strategy.

Related: #1739, #1703