### PR TITLE
[ASCollectionViewLayoutInspecting] Refactor usage of ASCollectionViewLayoutInspecting

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -253,9 +253,6 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   
   _layoutFacilitator = layoutFacilitator;
   
-  // Trigger creating the layout inspector
-  [self layoutInspector];
-  
   _proxyDelegate = [[ASCollectionViewProxy alloc] initWithTarget:nil interceptor:self];
   super.delegate = (id<UICollectionViewDelegate>)_proxyDelegate;
   
@@ -371,7 +368,7 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   super.dataSource = (id<UICollectionViewDataSource>)_proxyDataSource;
   
   if (_layoutInspectorFlags.layoutInspectorDidChangeCollectionViewDataSource) {
-    [_layoutInspector didChangeCollectionViewDataSource:asyncDataSource];
+    [self.layoutInspector didChangeCollectionViewDataSource:asyncDataSource];
   }
 }
 
@@ -406,7 +403,7 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   super.delegate = (id<UICollectionViewDelegate>)_proxyDelegate;
   
   if (_layoutInspectorFlags.layoutInspectorDidChangeCollectionViewDelegate) {
-    [_layoutInspector didChangeCollectionViewDelegate:asyncDelegate];
+    [self.layoutInspector didChangeCollectionViewDelegate:asyncDelegate];
   }
 }
 
@@ -977,7 +974,7 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
 
 - (ASSizeRange)dataController:(ASDataController *)dataController constrainedSizeForNodeAtIndexPath:(NSIndexPath *)indexPath
 {
-  return [_layoutInspector collectionView:self constrainedSizeForNodeAtIndexPath:indexPath];
+  return [self.layoutInspector collectionView:self constrainedSizeForNodeAtIndexPath:indexPath];
 }
 
 - (NSUInteger)dataController:(ASDataController *)dataController rowsInSection:(NSUInteger)section
@@ -1017,17 +1014,17 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
 
 - (ASSizeRange)dataController:(ASCollectionDataController *)dataController constrainedSizeForSupplementaryNodeOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath
 {
-  return [_layoutInspector collectionView:self constrainedSizeForSupplementaryNodeOfKind:kind atIndexPath:indexPath];
+  return [self.layoutInspector collectionView:self constrainedSizeForSupplementaryNodeOfKind:kind atIndexPath:indexPath];
 }
 
 - (NSUInteger)dataController:(ASCollectionDataController *)dataController supplementaryNodesOfKind:(NSString *)kind inSection:(NSUInteger)section
 {
-  return [_layoutInspector collectionView:self supplementaryNodesOfKind:kind inSection:section];
+  return [self.layoutInspector collectionView:self supplementaryNodesOfKind:kind inSection:section];
 }
 
 - (NSUInteger)dataController:(ASCollectionDataController *)dataController numberOfSectionsForSupplementaryNodeOfKind:(NSString *)kind;
 {
-  return [_layoutInspector collectionView:self numberOfSectionsForSupplementaryNodeOfKind:kind];
+  return [self.layoutInspector collectionView:self numberOfSectionsForSupplementaryNodeOfKind:kind];
 }
 
 #pragma mark - ASRangeControllerDataSource

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -254,7 +254,7 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
     // Custom layouts will need to roll their own ASCollectionViewLayoutInspecting implementation and set a layout
     // delegate. In the meantime ASDK provides a null layout inspector that does not provide any implementation
     // and throws an exception for methods that should be implemented in the <ASCollectionViewLayoutInspecting>
-    _defaultLayoutInspector = [[ASCollectionViewNullLayoutInspector alloc] init];
+    _defaultLayoutInspector = [[ASCollectionViewDefaultCustomLayoutInspector alloc] initWithCollectionView:self];
   }
   _layoutInspector = _defaultLayoutInspector;
   

--- a/AsyncDisplayKit/Details/ASCollectionViewFlowLayoutInspector.h
+++ b/AsyncDisplayKit/Details/ASCollectionViewFlowLayoutInspector.h
@@ -26,6 +26,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (ASSizeRange)collectionView:(ASCollectionView *)collectionView constrainedSizeForNodeAtIndexPath:(NSIndexPath *)indexPath;
 
+@optional
+
 /**
  * Asks the inspector to provide a constrained size range for the given supplementary node.
  */
@@ -40,8 +42,6 @@ NS_ASSUME_NONNULL_BEGIN
  * Asks the inspector for the number of supplementary views for the given kind in the specified section.
  */
 - (NSUInteger)collectionView:(ASCollectionView *)collectionView supplementaryNodesOfKind:(NSString *)kind inSection:(NSUInteger)section;
-
-@optional
 
 /**
  * Allow the inspector to respond to delegate changes.

--- a/AsyncDisplayKit/Details/ASCollectionViewFlowLayoutInspector.h
+++ b/AsyncDisplayKit/Details/ASCollectionViewFlowLayoutInspector.h
@@ -60,10 +60,14 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 /**
- * Simple "Null Object" inspector for non-flow layouts that does throws exceptions if methods are called
- * from <ASCollectionViewLayoutInspecting>
+ * A layout inspector for non-flow layouts that returns a constrained size to let the cells layout itself as
+ * far as possible based on the scrollable direction of the collection view. It throws exceptions for delegate
+ * methods that are related to supplementary node's management.
  */
-@interface ASCollectionViewNullLayoutInspector : NSObject <ASCollectionViewLayoutInspecting>
+@interface ASCollectionViewDefaultCustomLayoutInspector : NSObject <ASCollectionViewLayoutInspecting>
+
+- (instancetype)init NS_UNAVAILABLE;
+- (instancetype)initWithCollectionView:(ASCollectionView *)collectionView NS_DESIGNATED_INITIALIZER;
 
 @end
 
@@ -74,7 +78,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, weak, readonly) UICollectionViewFlowLayout *layout;
 
-- (instancetype)initWithCollectionView:(ASCollectionView *)collectionView flowLayout:(UICollectionViewFlowLayout *)flowLayout;
+- (instancetype)init NS_UNAVAILABLE;
+- (instancetype)initWithCollectionView:(ASCollectionView *)collectionView flowLayout:(UICollectionViewFlowLayout *)flowLayout NS_DESIGNATED_INITIALIZER;
 
 @end
 

--- a/AsyncDisplayKit/Details/ASCollectionViewFlowLayoutInspector.h
+++ b/AsyncDisplayKit/Details/ASCollectionViewFlowLayoutInspector.h
@@ -14,12 +14,15 @@
 #import <AsyncDisplayKit/ASDimension.h>
 
 @class ASCollectionView;
+@protocol ASCollectionDataSource;
 @protocol ASCollectionDelegate;
+
+NS_ASSUME_NONNULL_BEGIN
 
 @protocol ASCollectionViewLayoutInspecting <NSObject>
 
 /**
- * Provides the size range needed to measure the collection view's item.
+ * Asks the inspector to provide a constarained size range for the given collection view node.
  */
 - (ASSizeRange)collectionView:(ASCollectionView *)collectionView constrainedSizeForNodeAtIndexPath:(NSIndexPath *)indexPath;
 
@@ -47,12 +50,32 @@
  */
 - (void)didChangeCollectionViewDelegate:(id<ASCollectionDelegate>)delegate;
 
+/**
+ * Allow the inspector to respond to dataSource changes.
+ *
+ * @discussion A great time to update perform selector caches!
+ */
+- (void)didChangeCollectionViewDataSource:(id<ASCollectionDataSource>)dataSource;
+
 @end
 
+/**
+ * Simple "Null Object" inspector for non-flow layouts that does throws exceptions if methods are called
+ * from <ASCollectionViewLayoutInspecting>
+ */
+@interface ASCollectionViewNullLayoutInspector : NSObject <ASCollectionViewLayoutInspecting>
+
+@end
+
+/**
+ * A layout inspector implementation specific for the sizing behavior of UICollectionViewFlowLayouts
+ */
 @interface ASCollectionViewFlowLayoutInspector : NSObject <ASCollectionViewLayoutInspecting>
 
-@property (nonatomic, weak) UICollectionViewFlowLayout *layout;
+@property (nonatomic, weak, readonly) UICollectionViewFlowLayout *layout;
 
 - (instancetype)initWithCollectionView:(ASCollectionView *)collectionView flowLayout:(UICollectionViewFlowLayout *)flowLayout;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/AsyncDisplayKit/Details/ASCollectionViewFlowLayoutInspector.h
+++ b/AsyncDisplayKit/Details/ASCollectionViewFlowLayoutInspector.h
@@ -64,7 +64,7 @@ NS_ASSUME_NONNULL_BEGIN
  * far as possible based on the scrollable direction of the collection view. It throws exceptions for delegate
  * methods that are related to supplementary node's management.
  */
-@interface ASCollectionViewDefaultCustomLayoutInspector : NSObject <ASCollectionViewLayoutInspecting>
+@interface ASCollectionViewLayoutInspector : NSObject <ASCollectionViewLayoutInspecting>
 
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithCollectionView:(ASCollectionView *)collectionView NS_DESIGNATED_INITIALIZER;

--- a/AsyncDisplayKit/Details/ASCollectionViewFlowLayoutInspector.m
+++ b/AsyncDisplayKit/Details/ASCollectionViewFlowLayoutInspector.m
@@ -19,7 +19,7 @@
 
 // Returns a constrained size to let the cells layout itself as far as possible based on the scrollable direction
 // of the collection view
-static ASSizeRange ASDefaultConstrainedSizeForNodeForCollectionView(ASCollectionView *collectionView) {
+static inline ASSizeRange NodeConstrainedSizeWithCollectionView(ASCollectionView *collectionView) {
   CGSize maxSize = collectionView.bounds.size;
   if (ASScrollDirectionContainsHorizontalDirection(collectionView.scrollableDirections)) {
     maxSize.width = FLT_MAX;
@@ -29,9 +29,9 @@ static ASSizeRange ASDefaultConstrainedSizeForNodeForCollectionView(ASCollection
   return ASSizeRangeMake(CGSizeZero, maxSize);
 }
 
-#pragma mark - ASCollectionViewDefaultCustomLayoutInspector
+#pragma mark - ASCollectionViewLayoutInspector
 
-@implementation ASCollectionViewDefaultCustomLayoutInspector {
+@implementation ASCollectionViewLayoutInspector {
   struct {
     unsigned int implementsConstrainedSizeForNodeAtIndexPath:1;
   } _dataSourceFlags;
@@ -65,7 +65,7 @@ static ASSizeRange ASDefaultConstrainedSizeForNodeForCollectionView(ASCollection
     return [collectionView.asyncDataSource collectionView:collectionView constrainedSizeForNodeAtIndexPath:indexPath];
   }
   
-  return ASDefaultConstrainedSizeForNodeForCollectionView(collectionView);
+  return NodeConstrainedSizeWithCollectionView(collectionView);
 }
 
 - (ASSizeRange)collectionView:(ASCollectionView *)collectionView constrainedSizeForSupplementaryNodeOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath
@@ -152,11 +152,11 @@ static ASSizeRange ASDefaultConstrainedSizeForNodeForCollectionView(ASCollection
   }
   
   CGSize itemSize = _layout.itemSize;
-  if (!CGSizeEqualToSize(itemSize, kDefaultItemSize)) {
+  if (CGSizeEqualToSize(itemSize, kDefaultItemSize) == NO) {
     return ASSizeRangeMake(itemSize, itemSize);
   }
   
-  return ASDefaultConstrainedSizeForNodeForCollectionView(collectionView);
+  return NodeConstrainedSizeWithCollectionView(collectionView);
 }
 
 - (ASSizeRange)collectionView:(ASCollectionView *)collectionView constrainedSizeForSupplementaryNodeOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath

--- a/AsyncDisplayKit/Details/ASCollectionViewFlowLayoutInspector.m
+++ b/AsyncDisplayKit/Details/ASCollectionViewFlowLayoutInspector.m
@@ -19,7 +19,7 @@
 
 // Returns a constrained size to let the cells layout itself as far as possible based on the scrollable direction
 // of the collection view
-static inline ASSizeRange NodeConstrainedSizeWithCollectionView(ASCollectionView *collectionView) {
+static inline ASSizeRange NodeConstrainedSizeForScrollDirection(ASCollectionView *collectionView) {
   CGSize maxSize = collectionView.bounds.size;
   if (ASScrollDirectionContainsHorizontalDirection(collectionView.scrollableDirections)) {
     maxSize.width = FLT_MAX;
@@ -65,7 +65,7 @@ static inline ASSizeRange NodeConstrainedSizeWithCollectionView(ASCollectionView
     return [collectionView.asyncDataSource collectionView:collectionView constrainedSizeForNodeAtIndexPath:indexPath];
   }
   
-  return NodeConstrainedSizeWithCollectionView(collectionView);
+  return NodeConstrainedSizeForScrollDirection(collectionView);
 }
 
 - (ASSizeRange)collectionView:(ASCollectionView *)collectionView constrainedSizeForSupplementaryNodeOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath
@@ -156,7 +156,7 @@ static inline ASSizeRange NodeConstrainedSizeWithCollectionView(ASCollectionView
     return ASSizeRangeMake(itemSize, itemSize);
   }
   
-  return NodeConstrainedSizeWithCollectionView(collectionView);
+  return NodeConstrainedSizeForScrollDirection(collectionView);
 }
 
 - (ASSizeRange)collectionView:(ASCollectionView *)collectionView constrainedSizeForSupplementaryNodeOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath

--- a/AsyncDisplayKitTests/ASCollectionViewTests.m
+++ b/AsyncDisplayKitTests/ASCollectionViewTests.m
@@ -129,7 +129,7 @@
   UICollectionViewLayout *layout = [[UICollectionViewLayout alloc] init];
   ASCollectionView *collectionView = [[ASCollectionView alloc] initWithFrame:CGRectZero collectionViewLayout:layout];
   XCTAssert(collectionView.layoutInspector != nil, @"should automatically set a layout delegate for flow layouts");
-  XCTAssert([collectionView.layoutInspector isKindOfClass:[ASCollectionViewDefaultCustomLayoutInspector class]], @"should have a flow layout inspector by default");
+  XCTAssert([collectionView.layoutInspector isKindOfClass:[ASCollectionViewLayoutInspector class]], @"should have a default layout inspector by default");
 }
 
 - (void)testThatRegisteringASupplementaryNodeStoresItForIntrospection

--- a/AsyncDisplayKitTests/ASCollectionViewTests.m
+++ b/AsyncDisplayKitTests/ASCollectionViewTests.m
@@ -124,7 +124,7 @@
   XCTAssert([collectionView.layoutInspector isKindOfClass:[ASCollectionViewFlowLayoutInspector class]], @"should have a flow layout inspector by default");
 }
 
-- (void)testThatISetALayoutInspectorForCustomLayouts
+- (void)testThatADefaultLayoutInspectorIsProvidedForCustomLayouts
 {
   UICollectionViewLayout *layout = [[UICollectionViewLayout alloc] init];
   ASCollectionView *collectionView = [[ASCollectionView alloc] initWithFrame:CGRectZero collectionViewLayout:layout];

--- a/AsyncDisplayKitTests/ASCollectionViewTests.m
+++ b/AsyncDisplayKitTests/ASCollectionViewTests.m
@@ -124,14 +124,12 @@
   XCTAssert([collectionView.layoutInspector isKindOfClass:[ASCollectionViewFlowLayoutInspector class]], @"should have a flow layout inspector by default");
 }
 
-- (void)testThatItDoesNotSetALayoutInspectorForCustomLayouts
+- (void)testThatISetALayoutInspectorForCustomLayouts
 {
   UICollectionViewLayout *layout = [[UICollectionViewLayout alloc] init];
   ASCollectionView *collectionView = [[ASCollectionView alloc] initWithFrame:CGRectZero collectionViewLayout:layout];
-  XCTAssert(collectionView.layoutInspector != nil, @"should automatically set a layout delegate for custom layouts");
-  XCTAssert([collectionView.layoutInspector isKindOfClass:[ASCollectionViewNullLayoutInspector class]], @"should have a null layout inspector by default if no layout inspector is given for a custom layout");
-  XCTAssertThrows([collectionView.layoutInspector collectionView:collectionView constrainedSizeForNodeAtIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]], @"should throw an exception for <ASCollectionViewLayoutInspecting> methods");
-  XCTAssertThrows([collectionView.layoutInspector collectionView:collectionView supplementaryNodesOfKind:UICollectionElementKindSectionHeader inSection:0], @"should throw an exception for <ASCollectionViewLayoutInspecting> methods");
+  XCTAssert(collectionView.layoutInspector != nil, @"should automatically set a layout delegate for flow layouts");
+  XCTAssert([collectionView.layoutInspector isKindOfClass:[ASCollectionViewDefaultCustomLayoutInspector class]], @"should have a flow layout inspector by default");
 }
 
 - (void)testThatRegisteringASupplementaryNodeStoresItForIntrospection

--- a/AsyncDisplayKitTests/ASCollectionViewTests.m
+++ b/AsyncDisplayKitTests/ASCollectionViewTests.m
@@ -128,7 +128,10 @@
 {
   UICollectionViewLayout *layout = [[UICollectionViewLayout alloc] init];
   ASCollectionView *collectionView = [[ASCollectionView alloc] initWithFrame:CGRectZero collectionViewLayout:layout];
-  XCTAssert(collectionView.layoutInspector == nil, @"should not set a layout delegate for custom layouts");
+  XCTAssert(collectionView.layoutInspector != nil, @"should automatically set a layout delegate for custom layouts");
+  XCTAssert([collectionView.layoutInspector isKindOfClass:[ASCollectionViewNullLayoutInspector class]], @"should have a null layout inspector by default if no layout inspector is given for a custom layout");
+  XCTAssertThrows([collectionView.layoutInspector collectionView:collectionView constrainedSizeForNodeAtIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]], @"should throw an exception for <ASCollectionViewLayoutInspecting> methods");
+  XCTAssertThrows([collectionView.layoutInspector collectionView:collectionView supplementaryNodesOfKind:UICollectionElementKindSectionHeader inSection:0], @"should throw an exception for <ASCollectionViewLayoutInspecting> methods");
 }
 
 - (void)testThatRegisteringASupplementaryNodeStoresItForIntrospection


### PR DESCRIPTION
- Fix not using itemSize of UICollectionViewFlowLayout
- Move automatic constrained size calculation to the ASCollectionViewFlowLayoutInspector
- Provide a null layout inspector for throwing exceptions if a custom
  UICollectionView is given but no ASCollectionViewLayoutInspecting
- Fix not checking for optional layout inspecting data source methods
  are implemented or not
- Improving tests around ASCollectionViewLayoutInspecting

cc @levi that's the pull request we talked the other day about. Let me know what you think