### PR TITLE
[ASCollectionView] Explicitly Retain CALayer Under iOS < 9 to Workaround Issue

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -120,6 +120,19 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   
   CGPoint _deceleratingVelocity;
   
+#if !AS_AT_LEAST_IOS9
+  /**
+   A strong reference to the underlying layer.
+   
+   In iOS < 9, ASCollectionView may be leaked even though its node,
+   its layer, its owning VC, everything else is deallocated. This shouldn't
+   be possible because UIView should retain its layer. However, it happens and it puts
+   the collection view into an extremely dangerous state with a dangling layer pointer
+   and crashes are inevitable.
+   */
+  CALayer *_retainedLayer;
+#endif
+  
   /**
    * If YES, the `UICollectionView` will reload its data on next layout pass so we should not forward any updates to it.
    
@@ -237,6 +250,10 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   
   _asyncDataFetchingEnabled = NO;
   _asyncDataSourceLocked = NO;
+  
+#if !AS_AT_LEAST_IOS9
+  _retainedLayer = self.layer;
+#endif
   
   _performingBatchUpdates = NO;
   _batchUpdateBlocks = [NSMutableArray array];


### PR DESCRIPTION
This works around an issue where ASCollectionView may mysteriously be leaked and outlive its layer under iOS < 9. This only occurs under some view controller containment/transition situations and makes crashes virtually inevitable.

The leak does not seem to originate in ASDK. Manual investigation, plus the fact that it depends on iOS version & view controller transition/containment scheme, plus the fact that even if ASDK simply leaked the view, the layer should survive along with it, all point to an internal UIKit/Core Animation issue that was fixed in iOS 9. @maicki @appleguy 