### PR TITLE
[AsyncDisplayKit.org] Fix next buttons, add previous buttons

### DIFF
--- a/_docs/asviewcontroller.md
+++ b/_docs/asviewcontroller.md
@@ -2,7 +2,8 @@
 title: ASViewController
 layout: docs
 permalink: /docs/asviewcontroller.html
-next: aspagernode.html
+prevPage: 
+nextPage: aspagernode.html
 ---
 
 ASViewController is a direct subclass of UIViewController.  For the most part, it can be used in place of any UIViewController relatively easily.  

--- a/_docs/automatic-layout-basics.md
+++ b/_docs/automatic-layout-basics.md
@@ -2,7 +2,8 @@
 title: Layout Basics
 layout: docs
 permalink: /docs/automatic-layout-basics.html
-next: automatic-layout-containers.html
+prevPage: scroll-node.html
+nextPage: automatic-layout-containers.html
 ---
 
 ##Box Model Layout

--- a/_docs/automatic-layout-containers.md
+++ b/_docs/automatic-layout-containers.md
@@ -2,7 +2,8 @@
 title: Layout Containers
 layout: docs
 permalink: /docs/automatic-layout-containers.html
-next: automatic-layout-examples.html
+prevPage: automatic-layout-basics.html
+nextPage: automatic-layout-examples.html 
 ---
 
 AsyncDisplayKit includes a library of components that can be composed to declaratively specify a layout. The following LayoutSpecs allow you to have multiple children:

--- a/_docs/automatic-layout-debugging.md
+++ b/_docs/automatic-layout-debugging.md
@@ -2,7 +2,8 @@
 title: Layout Debugging
 layout: docs
 permalink: /docs/automatic-layout-debugging.html
-next: layout-options.html
+prevPage: automatic-layout-examples.html
+nextPage: layout-options.html
 ---
 
 ##Debugging with ASCII Art

--- a/_docs/automatic-layout-examples.md
+++ b/_docs/automatic-layout-examples.md
@@ -2,7 +2,8 @@
 title: Layout Examples
 layout: docs
 permalink: /docs/automatic-layout-examples.html
-next: automatic-layout-debugging.html
+prevPage: automatic-layout-containers.html
+nextPage: automatic-layout-debugging.html
 ---
 
 Three examples in increasing order of complexity. 

--- a/_docs/batch-fetching-api.md
+++ b/_docs/batch-fetching-api.md
@@ -2,7 +2,8 @@
 title: Batch Fetching API
 layout: docs
 permalink: /docs/batch-fetching-api.html
-next: image-modification-block.html
+prevPage: hit-test-slop.html
+nextPage: image-modification-block.html
 ---
 
 AsyncDisplayKit's Batch Fetching API makes it easy for developers to add fetching of new data in chunks. In case the user scrolled to a specific range of a table or collection view the automatic batch fetching mechanism of ASDK kicks in.

--- a/_docs/button-node.md
+++ b/_docs/button-node.md
@@ -2,7 +2,8 @@
 title: ASButtonNode
 layout: docs
 permalink: /docs/button-node.html
-next: text-node.html
+prevPage: control-node.html
+nextPage: text-node.html
 ---
 
 `ASButtonNode` (a subclass of `ASControlNode`) supports simple buttons, with multiple states for a text label and an image with a few different layout options. Enables layerBacking for subnodes to significantly lighten main thread impact relative to UIButton (though async preparation is the bigger win).

--- a/_docs/cell-node.md
+++ b/_docs/cell-node.md
@@ -2,7 +2,8 @@
 title: ASCellNode
 layout: docs
 permalink: /docs/cell-node.html
-next: text-cell-node.html
+prevPage: display-node.html
+nextPage: text-cell-node.html
 ---
 
 ASCellNode, as you may have guessed, is the cell class of ASDK.  Unlike the various cells in UIKit, ASCellNode can be used with ASTableNodes, ASCollectionNodes and ASPagerNodes, making it incredibly flexible.

--- a/_docs/containers-ascollectionnode.md
+++ b/_docs/containers-ascollectionnode.md
@@ -2,7 +2,8 @@
 title: ASCollectionNode
 layout: docs
 permalink: /docs/containers-ascollectionnode.html
-next: containers-aspagernode.html
+prevPage: containers-astablenode.html
+nextPage: containers-aspagernode.html
 ---
 
 ASCollectionNode is equivalent to UIKit's UICollectionView and can be used in place of any UICollectionView. 

--- a/_docs/containers-aspagernode.md
+++ b/_docs/containers-aspagernode.md
@@ -2,7 +2,8 @@
 title: ASPagerNode
 layout: docs
 permalink: /docs/containers-aspagernode.html
-next: display-node.html
+prevPage: containers-ascollectionnode.html
+nextPage: display-node.html
 ---
 
 `ASPagerNode` is a subclass of `ASCollectionNode` with a specific UICollectionViewLayout used under the hood. 

--- a/_docs/containers-astablenode.md
+++ b/_docs/containers-astablenode.md
@@ -2,7 +2,8 @@
 title: ASTableNode
 layout: docs
 permalink: /docs/containers-astablenode.html
-next: containers-ascollectionnode.html
+prevPage: containers-asviewcontroller.html
+nextPage: containers-ascollectionnode.html
 ---
 
 ASTableNode is equivalent to UIKit's UITableView and can be used in place of any UITableView. 

--- a/_docs/containers-asviewcontroller.md
+++ b/_docs/containers-asviewcontroller.md
@@ -2,7 +2,8 @@
 title: ASViewController
 layout: docs
 permalink: /docs/containers-asviewcontroller.html
-next: containers-astablenode.html
+prevPage: containers-overview.html
+nextPage: containers-astablenode.html
 ---
 
 `ASViewController` is a subclass of `UIViewController` that adds several useful features for hosting `ASDisplayNode` hierarchies. 

--- a/_docs/containers-overview.md
+++ b/_docs/containers-overview.md
@@ -2,7 +2,8 @@
 title: Containers Overview
 layout: docs
 permalink: /docs/containers-overview.html
-next: containers-asviewcontroller.html
+prevPage: layout-engine.html
+nextPage: containers-asviewcontroller.html
 ---
 
 ### Use Nodes in Node Containers

--- a/_docs/control-node.md
+++ b/_docs/control-node.md
@@ -2,7 +2,8 @@
 title: ASControlNode
 layout: docs
 permalink: /docs/control-node.html
-next: button-node.html
+prevPage: text-cell-node.html
+nextPage: button-node.html
 ---
 
 ASControlNode is the ASDK equivalent to UIControl.  You don't create instances of ASControlNode directly.  Instead, you can use it as a subclassing point when creating controls of your own.  In fact, <a href = "/docs/text-node.html">ASTextNode</a>, <a href = "/docs/image-node.html">ASImageNode</a>, <href = "#">ASVideoNode</a> and <a href = "/docs/video-node.html">ASMapNode</a> are all subclasses of ASControlNode.

--- a/_docs/debug-tool-hit-test-visualization.md
+++ b/_docs/debug-tool-hit-test-visualization.md
@@ -2,7 +2,8 @@
 title: Hit Test Visualization
 layout: docs
 permalink: /docs/debug-tool-hit-test-visualization.html
-next: debug-tool-pixel-scaling.html
+prevPage: placeholder-fade-duration.html
+nextPage: debug-tool-pixel-scaling.html
 ---
 
 ##Visualize ASControlNode Tappable Areas##

--- a/_docs/debug-tool-pixel-scaling.md
+++ b/_docs/debug-tool-pixel-scaling.md
@@ -2,7 +2,8 @@
 title: Image Scaling
 layout: docs
 permalink: /docs/debug-tool-pixel-scaling.html
-next: debug-tool-ASRangeController.html
+prevPage: debug-tool-hit-test-visualization.html
+nextPage: implicit-hierarchy-mgmt.html
 ---
 
 ##Visualize ASImageNode.image’s pixel scaling##

--- a/_docs/display-node.md
+++ b/_docs/display-node.md
@@ -2,7 +2,8 @@
 title: ASDisplayNode
 layout: docs
 permalink: /docs/display-node.html
-next: cell-node.html
+prevPage: containers-aspagernode.html
+nextPage: cell-node.html
 ---
 
 ### Node Basics

--- a/_docs/drawing-priority.md
+++ b/_docs/drawing-priority.md
@@ -2,7 +2,8 @@
 title: Drawing Priority
 layout: docs
 permalink: /docs/drawing-priority.html
-next: hit-test-slop.html
+prevPage: subtree-rasterization.html
+nextPage: hit-test-slop.html
 ---
 
 <div class = "warning">😑 This page is coming soon...</div>

--- a/_docs/editable-text-node.md
+++ b/_docs/editable-text-node.md
@@ -2,7 +2,8 @@
 title: ASEditableTextNode
 layout: docs
 permalink: /docs/editable-text-node.html
-next: image-node.html
+prevPage: text-node.html
+nextPage: image-node.html
 ---
 
 `ASEditableTextNode` provides a flexible, efficient, and animation-friendly editable text component. 

--- a/_docs/getting-started.md
+++ b/_docs/getting-started.md
@@ -2,7 +2,7 @@
 title: Getting Started
 layout: docs
 permalink: /docs/getting-started.html
-next: philosophy.html
+nextPage: philosophy.html
 ---
 
 AsyncDisplayKit's basic unit is the `node`.  ASDisplayNode is an abstraction

--- a/_docs/hit-test-slop.md
+++ b/_docs/hit-test-slop.md
@@ -2,7 +2,8 @@
 title: Hit Test Slop
 layout: docs
 permalink: /docs/hit-test-slop.html
-next: batch-fetching-api.html
+prevPage: drawing-priority.html
+nextPage: batch-fetching-api.html
 ---
 
 `ASDisplayNode` has a `hitTestSlop` property of type `UIEdgeInsets` that when set to a non-zero inset, increase the bounds for hit testing to make it easier to tap or perform gestures on this node. 

--- a/_docs/image-modification-block.md
+++ b/_docs/image-modification-block.md
@@ -2,7 +2,8 @@
 title: Image Modification Blocks
 layout: docs
 permalink: /docs/image-modification-block.html
-next: placeholder-fade-duration.html
+prevPage: batch-fetching-api.html
+nextPage: placeholder-fade-duration.html
 ---
 
 <div class = "warning">😑 This page is coming soon...</div>

--- a/_docs/image-node.md
+++ b/_docs/image-node.md
@@ -2,7 +2,8 @@
 title: ASImageNode
 layout: docs
 permalink: /docs/image-node.html
-next: network-image-node.html
+prevPage: editable-text-node.html
+nextPage: network-image-node.html
 ---
 
 <div>😑 This page is coming soon...</div>

--- a/_docs/implicit-hierarchy-mgmt.md
+++ b/_docs/implicit-hierarchy-mgmt.md
@@ -2,7 +2,8 @@
 title: Implicit Hierarchy Management
 layout: docs
 permalink: /docs/implicit-hierarchy-mgmt.html
-next: debug-hit-test.html
+prevPage: debug-tool-pixel-scaling.html
+nextPage: debug-hit-test.html
 ---
 
 This feature was initially a result of building the AsyncDisplayKit Layout Transition API. However, even apps using AsyncDisplayKit that don't require animations can still benefit from the reduction in code size that this feature enables.

--- a/_docs/installation.md
+++ b/_docs/installation.md
@@ -2,7 +2,8 @@
 title: Installation
 layout: docs
 permalink: /docs/installation.html
-next: intelligent-preloading.html
+prevPage: philosophy.html
+nextPage: intelligent-preloading.html
 ---
 
 ### CocoaPods

--- a/_docs/intelligent-preloading.md
+++ b/_docs/intelligent-preloading.md
@@ -2,7 +2,8 @@
 title: Intelligent Preloading 
 layout: docs
 permalink: /docs/intelligent-preloading.html
-next: subclassing.html
+prevPage: installation.html
+nextPage: subclassing.html
 ---
 
 While a node's ability to be rendered and measured asynchronously makes it quite powerful, another crucially important layer to ASDK is the idea of intelligent preloading.

--- a/_docs/layer-backing.md
+++ b/_docs/layer-backing.md
@@ -2,7 +2,8 @@
 title: Layer Backing
 layout: docs
 permalink: /docs/layer-backing.html
-next: synchronous-concurrency.html
+prevPage: layout-options.html
+nextPage: synchronous-concurrency.html
 ---
 
 Layer-backing. In some cases, you can substantially improve your app's performance by using layers instead of views. Manually converting view-based code to layers is laborious due to the difference in APIs. Worse, if at some point you need to enable touch handling or other view-specific functionality, you have to manually convert everything back (and risk regressions!).

--- a/_docs/layout-engine.md
+++ b/_docs/layout-engine.md
@@ -2,7 +2,8 @@
 title: Layout Engine 
 layout: docs
 permalink: /docs/layout-engine.html
-next: containers-overview.html
+prevPage: subclassing.html
+nextPage: containers-overview.html
 ---
 
 AsyncDisplayKit's layout engine is based on the CSS Box Model.  While it is the feature of the framework that bears the weakest resemblance to the UIKit equivalent (AutoLayout), it is also among the most useful features once you've gotten used to it.  With enough practice, you may just come to prefer creating declarative layouts to the constraint based approach. ;]

--- a/_docs/layout-options.md
+++ b/_docs/layout-options.md
@@ -2,7 +2,8 @@
 title: Layout Options
 layout: docs
 permalink: /docs/layout-options.html
-next: layer-backing.html
+prevPage: automatic-layout-debugging.html
+nextPage: layer-backing.html
 ---
 
 When using ASDK, you have three options for layout. Note that UIKit Autolayout is **not** supported by ASDK. 

--- a/_docs/layout-transition-api.md
+++ b/_docs/layout-transition-api.md
@@ -2,7 +2,7 @@
 title: Layout Transition API
 layout: docs
 permalink: /docs/layout-transition-api.html
-next: layout-transition-api.html
+prevPage: implicit-hierarchy-mgmt.html
 ---
 ###Overview
 <a href="https://github.com/facebook/AsyncDisplayKit/pulls?utf8=%E2%9C%93&q=is%3Apr+author%3Alevi+">@levi</a> designed this API to make all animations with AsyncDisplayKit easy - even transforming an entire set of views into a completely different set of views!

--- a/_docs/map-node.md
+++ b/_docs/map-node.md
@@ -2,7 +2,8 @@
 title: ASMapNode
 layout: docs
 permalink: /docs/map-node.html
-next: video-node.html
+prevPage: multiplex-image-node.html
+nextPage: video-node.html
 ---
 
 `ASMapNode` offers completely asynchronous preparation, automatic preloading, and efficient memory handling. Its standard mode is a fully asynchronous snapshot, with liveMap mode loading automatically triggered by any `ASTableView` or `ASCollectionView`; its `.liveMap` mode can be flipped on with ease (even on a background thread) to provide a cached, fully interactive map when necessary. 

--- a/_docs/multiplex-image-node.md
+++ b/_docs/multiplex-image-node.md
@@ -2,7 +2,8 @@
 title: ASMultiplexImageNode
 layout: docs
 permalink: /docs/multiplex-image-node.html
-next: map-node.html
+prevPage: network-image-node.html
+nextPage: map-node.html
 ---
 
 Let's say your API is out of your control and the images in your app can't be progressive jpegs but you can retrieve a few different sizes of the image asset you want to display. This is where you would use an ASMultiplexImageNode instead of an <a href = "/docs/network-image-node.html">ASNetworkImageNode</a>.

--- a/_docs/network-image-node.md
+++ b/_docs/network-image-node.md
@@ -2,7 +2,8 @@
 title: ASNetworkImageNode
 layout: docs
 permalink: /docs/network-image-node.html
-next: multiplex-image-node.html
+prevPage: image-node.html
+nextPage: multiplex-image-node.html
 ---
 
 ASNetworkImageNode can be used any time you need to display an image that is being hosted remotely.  All you have to do is set the .URL property with the appropriate NSURL instance and the image will be asynchonously loaded and concurrently rendered for you.

--- a/_docs/philosophy.md
+++ b/_docs/philosophy.md
@@ -2,7 +2,8 @@
 title: Philosophy
 layout: docs
 permalink: /docs/philosophy.html
-next: installation.html
+prevPage: getting-started.html
+nextPage: installation.html
 ---
 
 #Asynchronous Performance Gains

--- a/_docs/placeholder-fade-duration.md
+++ b/_docs/placeholder-fade-duration.md
@@ -2,7 +2,8 @@
 title: Placeholder Fade Duration
 layout: docs
 permalink: /docs/placeholder-fade-duration.html
-next: debug-tool-hit-test-visualization.html
+prevPage: image-modification-block.html
+nextPage: debug-tool-hit-test-visualization.html
 ---
 
 <div class = "warning">😑 This page is coming soon...</div>

--- a/_docs/scroll-node.md
+++ b/_docs/scroll-node.md
@@ -2,7 +2,8 @@
 title: ASScrollNode
 layout: docs
 permalink: /docs/scroll-node.html
-next: automatic-layout-basics.html
+prevPage: video-node.html
+nextPage: automatic-layout-basics.html
 ---
 
 <div>😑 This page is coming soon...</div>

--- a/_docs/subclassing.md
+++ b/_docs/subclassing.md
@@ -2,7 +2,8 @@
 title: Subclassing 
 layout: docs
 permalink: /docs/subclassing.html
-next: layout-engine.html
+prevPage: intelligent-preloading.html
+nextPage: layout-engine.html
 ---
 
 While subclassing nodes is similar to writing a UIView subclass, there are a few guidelines to follow to ensure that both that you're utilizing the framework to its full potential and that your nodes behave as expected.

--- a/_docs/subtree-rasterization.md
+++ b/_docs/subtree-rasterization.md
@@ -2,7 +2,8 @@
 title: Subtree Rasterization
 layout: docs
 permalink: /docs/subtree-rasterization.html
-next: drawing-priority.html
+prevPage: synchronous-concurrency.html
+nextPage: drawing-priority.html
 ---
 
 Precompositing. Flattening an entire view hierarchy into a single layer also improves performance, but comes with a hit to maintainability and hierarchy-based reasoning. Nodes can do this for you too!

--- a/_docs/synchronous-concurrency.md
+++ b/_docs/synchronous-concurrency.md
@@ -2,7 +2,8 @@
 title: Synchronous Concurrency
 layout: docs
 permalink: /docs/synchronous-concurrency.html
-next: subtree-rasterization.html
+prevPage: layer-backing.html
+nextPage: subtree-rasterization.html
 ---
 
 Both `ASViewController` and `ASCellNode` have a property called `neverShowPlaceholders`.  

--- a/_docs/text-cell-node.md
+++ b/_docs/text-cell-node.md
@@ -2,7 +2,8 @@
 title: ASTextCellNode
 layout: docs
 permalink: /docs/text-cell-node.html
-next: control-node.html
+prevPage: cell-node.html
+nextPage: control-node.html
 ---
 
 ASTextCellNode is a simple ASCellNode subclass you can use when all you need is a cell with styled text. 

--- a/_docs/text-node.md
+++ b/_docs/text-node.md
@@ -2,7 +2,8 @@
 title: ASTextNode
 layout: docs
 permalink: /docs/text-node.html
-next: editable-text-node.html
+prevPage: button-node.html
+nextPage: editable-text-node.html
 ---
 
 <div>😑 This page is coming soon...</div>

--- a/_docs/video-node.md
+++ b/_docs/video-node.md
@@ -2,7 +2,8 @@
 title: ASVideoNode
 layout: docs
 permalink: /docs/video-node.html
-next: scroll-node.html
+prevPage: map-node.html
+nextPage: scroll-node.html
 ---
 
 `ASVideoNode` is a newer class that exposes a relatively full-featured API, and is designed for both efficient and convenient implementation of embedded videos in scrolling views.

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -17,16 +17,16 @@ sectionid: docs
 
     {{ content }}
 
-<!--    <div class="docs-prevnext">-->
-<!--      {% if page.prev %}-->
-<!--        <a href="/docs/{{ page.prev }}">&larr; Prev</a>-->
-<!--      {% endif %}-->
-<!--      {% if page.next %}-->
-<!--        <a class="right" href="/docs/{{ page.next }}">Next &rarr;</a>-->
-<!--      {% endif %}-->
-<!--    </div>-->
-<!---->
-<!--    <a id="_"></a>-->
+    <div class="docs-prevnext">
+      {% if page.prevPage %}
+        <a href="/docs/{{ page.prevPage }}">&larr; Prev</a>
+      {% endif %}
+      {% if page.nextPage %}
+        <a class="right" href="/docs/{{ page.nextPage }}">Next &rarr;</a>
+      {% endif %}
+    </div>
+
+    <a id="_"></a>
 </article>
 
 </div></section>

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -17,16 +17,16 @@ sectionid: docs
 
     {{ content }}
 
-    <div class="docs-prevnext">
-      {% if page.prev %}
-        <a href="/docs/{{ page.prev }}">&larr; Prev</a>
-      {% endif %}
-      {% if page.next %}
-        <a class="right" href="/docs/{{ page.next }}">Next &rarr;</a>
-      {% endif %}
-    </div>
-
-    <a id="_"></a>
+<!--    <div class="docs-prevnext">-->
+<!--      {% if page.prev %}-->
+<!--        <a href="/docs/{{ page.prev }}">&larr; Prev</a>-->
+<!--      {% endif %}-->
+<!--      {% if page.next %}-->
+<!--        <a class="right" href="/docs/{{ page.next }}">Next &rarr;</a>-->
+<!--      {% endif %}-->
+<!--    </div>-->
+<!---->
+<!--    <a id="_"></a>-->
 </article>
 
 </div></section>


### PR DESCRIPTION
I wasted an hour trying to figure out how to fix the problem, but I wasn't able to. For now, I'm just going to comment out the next button functionality.

The issue is that it's somehow picking up the content at the first <a></a> link included in the markdown content docs.