### PR TITLE
[ASEditableTextNode] Round up editable text node to the next point

### DIFF
--- a/AsyncDisplayKit/ASEditableTextNode.mm
+++ b/AsyncDisplayKit/ASEditableTextNode.mm
@@ -192,8 +192,7 @@
 {
   ASTextKitComponents *displayedComponents = [self isDisplayingPlaceholder] ? _placeholderTextKitComponents : _textKitComponents;
   CGSize textSize = [displayedComponents sizeForConstrainedWidth:constrainedSize.width];
-  textSize = ceilSizeValue(textSize);
-  return CGSizeMake(fminf(textSize.width, constrainedSize.width), fminf(textSize.height, constrainedSize.height));
+  return CGSizeMake(fminf(ceilf(textSize.width), constrainedSize.width), fminf(ceilf(textSize.height), constrainedSize.height));
 }
 
 - (void)layout


### PR DESCRIPTION
Rounding up to the next device pixel was calculating a height smaller
than UITextView's contentSize. This was causing the baseline to move as
the user was typing.