### PR TITLE
Dont clear view.layer.contents when layer is not kind of `_ASDisplayLayer`

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -2093,7 +2093,9 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
 - (void)clearContents
 {
   // No-op if these haven't been created yet, as that guarantees they don't have contents that needs to be released.
-  _layer.contents = nil;
+  if ([_layer isKindOfClass:[_ASDisplayLayer class]]) {
+    _layer.contents = nil;
+  }
   _placeholderLayer.contents = nil;
   _placeholderImage = nil;
 }


### PR DESCRIPTION
Because only `_ASDisplayLayer` can auto re-create the contents.

https://github.com/facebook/AsyncDisplayKit/issues/853