### PR TITLE
[ASDisplayNode] Resolve Deadlock Caused By removeFromSupernode

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -1518,6 +1518,7 @@ static NSInteger incrementIfFound(NSInteger i) {
 // NOTE: You must not called this method while holding the receiver's property lock. This may cause deadlocks.
 - (void)removeFromSupernode
 {
+  ASDisplayNodeAssertThreadAffinity(self);
   _propertyLock.lock();
     __weak ASDisplayNode *supernode = _supernode;
     __weak UIView *view = _view;

--- a/AsyncDisplayKit/Private/ASLayoutTransition.mm
+++ b/AsyncDisplayKit/Private/ASLayoutTransition.mm
@@ -48,9 +48,12 @@
 {
   ASDN::MutexLocker l(_propertyLock);
   [self calculateSubnodeOperationsIfNeeded];
-  for (NSUInteger i = 0; i < [_insertedSubnodes count]; i++) {
+  
+  NSUInteger i = 0;
+  for (ASDisplayNode *node in _insertedSubnodes) {
     NSUInteger p = _insertedSubnodePositions[i];
-    [_node insertSubnode:_insertedSubnodes[i] atIndex:p];
+    [_node insertSubnode:node atIndex:p];
+    i += 1;
   }
 }
 
@@ -58,8 +61,8 @@
 {
   ASDN::MutexLocker l(_propertyLock);
   [self calculateSubnodeOperationsIfNeeded];
-  for (NSUInteger i = 0; i < [_removedSubnodes count]; i++) {
-    [_removedSubnodes[i] removeFromSupernode];
+  for (ASDisplayNode *subnode in _removedSubnodes) {
+    [subnode removeFromSupernode];
   }
 }
 

--- a/AsyncDisplayKitTests/ASDisplayNodeTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeTests.m
@@ -1638,6 +1638,57 @@ static inline BOOL _CGPointEqualToPointWithEpsilon(CGPoint point1, CGPoint point
   [c release];
 }
 
+- (void)testRemoveFromViewBackedLoadedSupernode
+{
+  DeclareNodeNamed(a);
+  DeclareNodeNamed(b);
+  [b addSubnode:a];
+  [a view];
+  [b view];
+  XCTAssertNodesLoaded(a, b);
+  XCTAssertEqual(a.supernode, b);
+  XCTAssertEqual(a.view.superview, b.view);
+  
+  [a removeFromSupernode];
+  XCTAssertNil(a.supernode);
+  XCTAssertNil(a.view.superview);
+}
+
+- (void)testRemoveFromLayerBackedLoadedSupernode
+{
+  DeclareNodeNamed(a);
+  a.layerBacked = YES;
+  DeclareNodeNamed(b);
+  b.layerBacked = YES;
+  [b addSubnode:a];
+  [a layer];
+  [b layer];
+  XCTAssertNodesLoaded(a, b);
+  XCTAssertEqual(a.supernode, b);
+  XCTAssertEqual(a.layer.superlayer, b.layer);
+  
+  [a removeFromSupernode];
+  XCTAssertNil(a.supernode);
+  XCTAssertNil(a.layer.superlayer);
+}
+
+- (void)testRemoveLayerBackedFromViewBackedLoadedSupernode
+{
+  DeclareNodeNamed(a);
+  a.layerBacked = YES;
+  DeclareNodeNamed(b);
+  [b addSubnode:a];
+  [a layer];
+  [b view];
+  XCTAssertNodesLoaded(a, b);
+  XCTAssertEqual(a.supernode, b);
+  XCTAssertEqual(a.layer.superlayer, b.layer);
+  
+  [a removeFromSupernode];
+  XCTAssertNil(a.supernode);
+  XCTAssertNil(a.layer.superlayer);
+}
+
 - (void)testSubnodeAddedBeforeLoadingExternalView
 {
   UIView *view = [[UIDisplayNodeTestView alloc] init];


### PR DESCRIPTION
The prior implementation of removeFromSupernode would acquire _propertyLock and then attempt to lock the supernode (e.g. by calling `layerBacked` on it). If another thread is traversing down the node hierarchy at the same time, and holding a supernode's lock while trying to acquire the subnode's lock, we get a deadlock.

This patch never acquires supernode's lock while holding self's lock.

- Remove lock overlapping in `removeFromSupernode`
- Optimize `applySubnodeInsertions/Removals` for good measure
- Add some removeFromSupernode tests