### PR TITLE
[Wrapping Views] Fix wrapped UIKit components are disappearing

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -445,9 +445,13 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   }
   
   // Update flags related to special handling of UIImageView layers. More details on the flags
-  BOOL isUIIMageViewViewClass = [view isKindOfClass:[UIImageView class]];
-  _flags.canClearContentsOfLayer = !isUIIMageViewViewClass;
-  _flags.canCallNeedsDisplayOfLayer = (_flags.synchronous && !isUIIMageViewViewClass);
+  if (_flags.synchronous) {
+    if ([view isKindOfClass:[UIImageView class]]) {
+      _flags.canClearContentsOfLayer = NO;
+    } else {
+      _flags.canCallNeedsDisplayOfLayer = YES;
+    }
+  }
 
   return view;
 }

--- a/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
+++ b/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
@@ -75,6 +75,20 @@ FOUNDATION_EXPORT NSString * const ASRenderingEngineDidDisplayNodesScheduledBefo
     unsigned displaySuspended:1;
     unsigned shouldAnimateSizeChanges:1;
     unsigned hasCustomDrawingPriority:1;
+    
+    // Wrapped view handling
+    
+    // The layer contents should not be cleared in case the node is wrapping a UIImageView.UIImageView is specifically
+    // optimized for performance and does not use the usual way to provide the contents of the CALayer via the
+    // CALayerDelegate method that backs the UIImageView.
+    unsigned canClearContentsOfLayer:1;
+    
+    // Prevent calling setNeedsDisplay on a layer that backs a UIImageView. Usually calling setNeedsDisplay on a CALayer
+    // triggers a recreation of the contents of layer unfortunately calling it on a CALayer that backs a UIImageView
+    // it goes trough the normal flow to assign the contents to a layer via the CALayerDelegate methods. Unfortunately
+    // UIImageView does not do recreate the layer contents the usual way, it actually does not implement some of the
+    // methods at all instead it throws away the contents of the layer and nothing will show up.
+    unsigned canCallNeedsDisplayOfLayer:1;
 
     // whether custom drawing is enabled
     unsigned implementsInstanceDrawRect:1;


### PR DESCRIPTION
Should fix: #853

I looked into the internals of `UIImageView` a bit. I would recommend to not fixing this in a universal way. `UIImageView` is specifically optimized for performance and does not use the usual way to provide the contents of the `CALayer` that backs the `UIImageView`.

Furthermore we cannot trigger a recreation of the contents of the `UIImageView` layer as if it get’s cleared and we call `setNeedsDisplay` on it it goes trough the normal flow to assign the contents to a layer via the `CALayerDelegate` methods. Unfortunately `UIImageView` does not do it, it actually does not implement some of the methods at all, so nothing will show up. It’s getting better, by calling `setNeedsDisplay` on an `UIImageView` layer it actually clears the contents and nothing is visible anymore. So we have to be careful to not calling that too.

Unfortunately I didn’t find a way yet to trigger a recreation of the `UIImageView` layers content except calling the private `_updateState` method.

That said it’s different for layers of other UIKit components like `UILabel` for example. Clearing the contents of a `UILabel` layer and calling `setNeedsDisplay` on the layer usually recreates the contents of  it and it will show up again.

This PR prevents to clear the contents of a layer for all wrapped UIKit components and instead only NOT clear the content if the node wraps a `UIImageView`, otherwise we should clear the contents of the layer to reclaim memory as usual.