### PR TITLE
[ASTextNode / ASImageNode] Use structs for drawing parameter

### DIFF
--- a/AsyncDisplayKit/ASImageNode.mm
+++ b/AsyncDisplayKit/ASImageNode.mm
@@ -174,7 +174,7 @@ struct ASImageNodeDrawParameters {
   ASDN::MutexLocker l(_imageLock);
   
   _drawParameter = {
-    .bounds = self.threadSafeBounds,
+    .bounds = self.bounds,
     .opaque = self.opaque,
     .contentsScale = _contentsScaleForDisplay,
     .backgroundColor = self.backgroundColor,

--- a/AsyncDisplayKit/ASImageNode.mm
+++ b/AsyncDisplayKit/ASImageNode.mm
@@ -26,46 +26,18 @@
 #import "ASInternalHelpers.h"
 #import "ASEqualityHelpers.h"
 
-@interface _ASImageNodeDrawParameters : NSObject
-
-@property (nonatomic, retain) UIImage *image;
-@property (nonatomic, assign) BOOL opaque;
-@property (nonatomic, assign) CGRect bounds;
-@property (nonatomic, assign) CGFloat contentsScale;
-@property (nonatomic, strong) UIColor *backgroundColor;
-@property (nonatomic, assign) UIViewContentMode contentMode;
-
-@end
-
-// TODO: eliminate explicit parameters with a set of keys copied from the node
-@implementation _ASImageNodeDrawParameters
-
-- (instancetype)initWithImage:(UIImage *)image
-                       bounds:(CGRect)bounds
-                       opaque:(BOOL)opaque
-                contentsScale:(CGFloat)contentsScale
-              backgroundColor:(UIColor *)backgroundColor
-                  contentMode:(UIViewContentMode)contentMode
-{
-  if (!(self = [self init]))
-    return nil;
-
-  _image = image;
-  _opaque = opaque;
-  _bounds = bounds;
-  _contentsScale = contentsScale;
-  _backgroundColor = backgroundColor;
-  _contentMode = contentMode;
-
-  return self;
-}
-
-- (NSString *)description
-{
-  return [NSString stringWithFormat:@"<%@ : %p opaque:%@ bounds:%@ contentsScale:%.2f backgroundColor:%@ contentMode:%@>", [self class], self, @(self.opaque), NSStringFromCGRect(self.bounds), self.contentsScale, self.backgroundColor, ASDisplayNodeNSStringFromUIContentMode(self.contentMode)];
-}
-
-@end
+struct ASImageNodeDrawParameters {
+  BOOL opaque;
+  CGRect bounds;
+  CGFloat contentsScale;
+  UIColor *backgroundColor;
+  UIViewContentMode contentMode;
+  BOOL cropEnabled;
+  BOOL forceUpscaling;
+  CGRect cropRect;
+  CGRect cropDisplayBounds;
+  asimagenode_modification_block_t imageModificationBlock;
+};
 
 @implementation ASImageNode
 {
@@ -75,17 +47,21 @@
   void (^_displayCompletionBlock)(BOOL canceled);
   ASDN::RecursiveMutex _imageLock;
   
+  // Drawing
+  ASImageNodeDrawParameters _drawParameter;
+  ASTextNode *_debugLabelNode;
+  
   // Cropping.
   BOOL _cropEnabled; // Defaults to YES.
   BOOL _forceUpscaling; //Defaults to NO.
   CGRect _cropRect; // Defaults to CGRectMake(0.5, 0.5, 0, 0)
-  CGRect _cropDisplayBounds;
-  
-  ASTextNode *_debugLabelNode;
+  CGRect _cropDisplayBounds; // Defaults to CGRectNull
 }
 
 @synthesize image = _image;
 @synthesize imageModificationBlock = _imageModificationBlock;
+
+#pragma mark - NSObject
 
 - (instancetype)init
 {
@@ -124,6 +100,8 @@
   return nil;
 }
 
+#pragma mark - Layout and Sizing
+
 - (CGSize)calculateSizeThatFits:(CGSize)constrainedSize
 {
   ASDN::MutexLocker l(_imageLock);
@@ -135,6 +113,8 @@
   else
     return CGSizeZero;
 }
+
+#pragma mark - Setter / Getter
 
 - (void)setImage:(UIImage *)image
 {
@@ -177,54 +157,72 @@
   self.placeholderEnabled = placeholderColor != nil;
 }
 
+#pragma mark - Drawing
+
 - (NSObject *)drawParametersForAsyncLayer:(_ASDisplayLayer *)layer
 {
-  return [[_ASImageNodeDrawParameters alloc] initWithImage:self.image
-                                                    bounds:self.bounds
-                                                    opaque:self.opaque
-                                             contentsScale:self.contentsScaleForDisplay
-                                           backgroundColor:self.backgroundColor
-                                               contentMode:self.contentMode];
+  ASDN::MutexLocker l(_imageLock);
+  
+  _drawParameter = {
+    .bounds = self.bounds,
+    .opaque = self.opaque,
+    .contentsScale = _contentsScaleForDisplay,
+    .backgroundColor = self.backgroundColor,
+    .contentMode = self.contentMode,
+    .cropEnabled = _cropEnabled,
+    .forceUpscaling = _forceUpscaling,
+    .cropRect = _cropRect,
+    .cropDisplayBounds = _cropDisplayBounds,
+    .imageModificationBlock = _imageModificationBlock
+  };
+  
+  return nil;
 }
 
 - (NSDictionary *)debugLabelAttributes
 {
-  return @{ NSFontAttributeName: [UIFont systemFontOfSize:15.0],
-            NSForegroundColorAttributeName: [UIColor redColor] };
+  return @{
+    NSFontAttributeName: [UIFont systemFontOfSize:15.0],
+    NSForegroundColorAttributeName: [UIColor redColor]
+  };
 }
 
-- (UIImage *)displayWithParameters:(_ASImageNodeDrawParameters *)parameters isCancelled:(asdisplaynode_iscancelled_block_t)isCancelled
+- (UIImage *)displayWithParameters:(id<NSObject> *)parameter isCancelled:(asdisplaynode_iscancelled_block_t)isCancelled
 {
-  UIImage *image = parameters.image;
-  if (!image) {
+  UIImage *image = self.image;
+  if (image == nil) {
     return nil;
   }
   
+  CGRect drawParameterBounds    = CGRectZero;
   BOOL forceUpscaling           = NO;
-  BOOL cropEnabled              = NO;
-  BOOL isOpaque                 = parameters.opaque;
-  UIColor *backgroundColor      = parameters.backgroundColor;
-  UIViewContentMode contentMode = parameters.contentMode;
+  BOOL cropEnabled              = YES;
+  BOOL isOpaque                 = NO;
+  UIColor *backgroundColor      = nil;
+  UIViewContentMode contentMode = UIViewContentModeScaleAspectFill;
   CGFloat contentsScale         = 0.0;
   CGRect cropDisplayBounds      = CGRectZero;
   CGRect cropRect               = CGRectZero;
   asimagenode_modification_block_t imageModificationBlock;
-  
+
+  ASDN::MutexLocker l(_imageLock);
   {
-    ASDN::MutexLocker l(_imageLock);
+    ASImageNodeDrawParameters drawParameter = _drawParameter;
     
-    // FIXME: There is a small risk of these values changing between the main thread creation of drawParameters, and the execution of this method.
-    // We should package these up into the draw parameters object.  Might be easiest to create a struct for the non-objects and make it one property.
-    cropEnabled = _cropEnabled;
-    forceUpscaling = _forceUpscaling;
-    contentsScale = _contentsScaleForDisplay;
-    cropDisplayBounds = _cropDisplayBounds;
-    cropRect = _cropRect;
-    imageModificationBlock = _imageModificationBlock;
+    drawParameterBounds       = drawParameter.bounds;
+    forceUpscaling            = drawParameter.forceUpscaling;
+    cropEnabled               = drawParameter.cropEnabled;
+    isOpaque                  = drawParameter.opaque;
+    backgroundColor           = drawParameter.backgroundColor;
+    contentMode               = drawParameter.contentMode;
+    contentsScale             = drawParameter.contentsScale;
+    cropDisplayBounds         = drawParameter.cropDisplayBounds;
+    cropRect                  = drawParameter.cropRect;
+    imageModificationBlock    = drawParameter.imageModificationBlock;
   }
   
   BOOL hasValidCropBounds = cropEnabled && !CGRectIsNull(cropDisplayBounds) && !CGRectIsEmpty(cropDisplayBounds);
-  CGRect bounds = (hasValidCropBounds ? cropDisplayBounds : parameters.bounds);
+  CGRect bounds = (hasValidCropBounds ? cropDisplayBounds : drawParameterBounds);
   
   ASDisplayNodeContextModifier preContextBlock = self.willDisplayNodeContentWithRenderingContext;
   ASDisplayNodeContextModifier postContextBlock = self.didDisplayNodeContentWithRenderingContext;
@@ -359,7 +357,6 @@
   }
 }
 
-#pragma mark -
 - (void)setNeedsDisplayWithCompletion:(void (^ _Nullable)(BOOL canceled))displayCompletionBlock
 {
   if (self.displaySuspended) {
@@ -378,6 +375,7 @@
 }
 
 #pragma mark - Cropping
+
 - (BOOL)isCropEnabled
 {
   ASDN::MutexLocker l(_imageLock);
@@ -462,6 +460,7 @@
 }
 
 #pragma mark - Debug
+
 - (void)layout
 {
   [super layout];
@@ -477,6 +476,7 @@
 @end
 
 #pragma mark - Extras
+
 extern asimagenode_modification_block_t ASImageNodeRoundBorderModificationBlock(CGFloat borderWidth, UIColor *borderColor)
 {
   return ^(UIImage *originalImage) {

--- a/AsyncDisplayKit/ASImageNode.mm
+++ b/AsyncDisplayKit/ASImageNode.mm
@@ -63,6 +63,16 @@ struct ASImageNodeDrawParameters {
 
 #pragma mark - NSObject
 
++ (void)initialize
+{
+  [super initialize];
+  
+  if (self != [ASImageNode class]) {
+    // Prevent custom drawing in subclasses
+    ASDisplayNodeAssert(!ASSubclassOverridesClassSelector([ASImageNode class], self, @selector(displayWithParameters:isCancelled:)), @"Subclass %@ must not override displayWithParameters:isCancelled: method. Custom drawing in %@ subclass is not supported.", NSStringFromClass(self), NSStringFromClass([ASImageNode class]));
+  }
+}
+
 - (instancetype)init
 {
   if (!(self = [super init]))

--- a/AsyncDisplayKit/ASImageNode.mm
+++ b/AsyncDisplayKit/ASImageNode.mm
@@ -174,7 +174,7 @@ struct ASImageNodeDrawParameters {
   ASDN::MutexLocker l(_imageLock);
   
   _drawParameter = {
-    .bounds = self.bounds,
+    .bounds = self.threadSafeBounds,
     .opaque = self.opaque,
     .contentsScale = _contentsScaleForDisplay,
     .backgroundColor = self.backgroundColor,

--- a/AsyncDisplayKit/ASTextNode.mm
+++ b/AsyncDisplayKit/ASTextNode.mm
@@ -441,7 +441,7 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
   
   _drawParameter = {
     .backgroundColor = self.backgroundColor,
-    .bounds = self.bounds
+    .bounds = self.threadSafeBounds
   };
 }
 

--- a/AsyncDisplayKit/ASTextNode.mm
+++ b/AsyncDisplayKit/ASTextNode.mm
@@ -210,7 +210,14 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
 - (void)setBounds:(CGRect)bounds
 {
   [super setBounds:bounds];
+  [self updateDrawingParameter];
   [self _invalidateRendererIfNeededForBoundsSize:bounds.size];
+}
+
+- (void)setBackgroundColor:(UIColor *)backgroundColor
+{
+  [super setBackgroundColor:backgroundColor];
+  [self updateDrawingParameter];
 }
 
 #pragma mark - Renderer Management
@@ -428,13 +435,14 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
 
 #pragma mark - Drawing
 
-- (NSObject *)drawParametersForAsyncLayer:(_ASDisplayLayer *)layer
+- (void)updateDrawingParameter
 {
+  std::lock_guard<std::recursive_mutex> l(_textLock);
+  
   _drawParameter = {
     .backgroundColor = self.backgroundColor,
     .bounds = self.bounds
   };
-  return nil;
 }
 
 - (void)drawRect:(CGRect)bounds withParameters:(id <NSObject>)p isCancelled:(asdisplaynode_iscancelled_block_t)isCancelledBlock isRasterizing:(BOOL)isRasterizing;

--- a/AsyncDisplayKit/ASTextNode.mm
+++ b/AsyncDisplayKit/ASTextNode.mm
@@ -71,6 +71,16 @@ struct ASTextNodeDrawParameter {
 
 #pragma mark - NSObject
 
++ (void)initialize
+{
+  [super initialize];
+  
+  if (self != [ASTextNode class]) {
+    // Prevent custom drawing in subclasses
+    ASDisplayNodeAssert(!ASSubclassOverridesClassSelector([ASTextNode class], self, @selector(drawRect:withParameters:isCancelled:isRasterizing:)), @"Subclass %@ must not override drawRect:withParameters:isCancelled:isRasterizing: method. Custom drawing in %@ subclass is not supported.", NSStringFromClass(self), NSStringFromClass([ASTextNode class]));
+  }
+}
+
 static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
 
 - (instancetype)init

--- a/AsyncDisplayKit/ASTextNode.mm
+++ b/AsyncDisplayKit/ASTextNode.mm
@@ -210,14 +210,7 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
 - (void)setBounds:(CGRect)bounds
 {
   [super setBounds:bounds];
-  [self updateDrawingParameter];
   [self _invalidateRendererIfNeededForBoundsSize:bounds.size];
-}
-
-- (void)setBackgroundColor:(UIColor *)backgroundColor
-{
-  [super setBackgroundColor:backgroundColor];
-  [self updateDrawingParameter];
 }
 
 #pragma mark - Renderer Management
@@ -435,15 +428,17 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
 
 #pragma mark - Drawing
 
-- (void)updateDrawingParameter
+- (NSObject *)drawParametersForAsyncLayer:(_ASDisplayLayer *)layer
 {
   std::lock_guard<std::recursive_mutex> l(_textLock);
   
   _drawParameter = {
     .backgroundColor = self.backgroundColor,
-    .bounds = self.threadSafeBounds
+    .bounds = self.bounds
   };
+  return nil;
 }
+
 
 - (void)drawRect:(CGRect)bounds withParameters:(id <NSObject>)p isCancelled:(asdisplaynode_iscancelled_block_t)isCancelledBlock isRasterizing:(BOOL)isRasterizing;
 {


### PR DESCRIPTION
The purpose of this PR is to move from an ObjC object to a struct for drawing parameters in ASTextNode and ASImageNode.

Furthermore as we improved the performance by going from the class drawing method to an instance drawing method we prevent custom drawing in ASTextNode or ASImageNode subclasses now.
If we decide to merge that PR we should close: #1728 as this is not necessary anymore.

cc @appleguy @ocrickard @garrettmoon: Curious about your thoughts about this PR.