### PR TITLE
[ASVideoNode] Ensure that both ASVideoNode and ASNetworkImageNode delegate methods are called

### DIFF
--- a/AsyncDisplayKit/ASVideoNode.mm
+++ b/AsyncDisplayKit/ASVideoNode.mm
@@ -453,7 +453,9 @@ static NSString * const kStatus = @"status";
 
 - (void)setDelegate:(id<ASVideoNodeDelegate>)delegate
 {
+  [super setDelegate:delegate];
   _delegate = delegate;
+  
   if (_delegate == nil) {
     memset(&_delegateFlags, 0, sizeof(_delegateFlags));
   } else {

--- a/AsyncDisplayKitTests/ASVideoNodeTests.m
+++ b/AsyncDisplayKitTests/ASVideoNodeTests.m
@@ -15,7 +15,7 @@
 #import <AVFoundation/AVFoundation.h>
 #import <AsyncDisplayKit/AsyncDisplayKit.h>
 
-@interface ASVideoNodeTests : XCTestCase
+@interface ASVideoNodeTests : XCTestCase <ASVideoNodeDelegate>
 {
   ASVideoNode *_videoNode;
   AVURLAsset *_firstAsset;
@@ -25,10 +25,18 @@
 }
 @end
 
+@interface ASNetworkImageNode () {
+  @public __weak id<ASNetworkImageNodeDelegate> _delegate;
+}
+@end
+
+
 @interface ASVideoNode () {
   ASDisplayNode *_playerNode;
   AVPlayer *_player;
 }
+
+
 @property (atomic, readwrite) ASInterfaceState interfaceState;
 @property (atomic, readonly) ASDisplayNode *spinner;
 @property (atomic, readwrite) ASDisplayNode *playerNode;
@@ -403,6 +411,20 @@
   XCTAssertNil(_videoNode.player);
   XCTAssertNil(_videoNode.currentItem);
   XCTAssertNil(_videoNode.image);
+}
+
+- (void)testDelegateProperlySetForClassHierarchy
+{
+  _videoNode.delegate = self;
+  
+  XCTAssertTrue([_videoNode.delegate conformsToProtocol:@protocol(ASVideoNodeDelegate)]);
+  XCTAssertTrue([_videoNode.delegate conformsToProtocol:@protocol(ASNetworkImageNodeDelegate)]);
+  XCTAssertTrue([((ASNetworkImageNode*)_videoNode).delegate conformsToProtocol:@protocol(ASNetworkImageNodeDelegate)]);
+  XCTAssertTrue([((ASNetworkImageNode*)_videoNode)->_delegate conformsToProtocol:@protocol(ASNetworkImageNodeDelegate)]);
+  
+  XCTAssertEqual(_videoNode.delegate, self);
+  XCTAssertEqual(((ASNetworkImageNode*)_videoNode).delegate, self);
+  XCTAssertEqual(((ASNetworkImageNode*)_videoNode)->_delegate, self);
 }
 
 @end


### PR DESCRIPTION
Before this change the user of ASVideoNode could set the .delegate property but the ASNetworkImageNode delegate methods were not called. This meant that the client of ASVideoNode was not able to observe image progress or errors.

I've tested this both with the test harness and in my own project.