### PR TITLE
[ASCollectionDataController] Exposing -supplementaryNodeOfKind

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.h
+++ b/AsyncDisplayKit/ASCollectionView.h
@@ -278,11 +278,19 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @param indexPath The index path of the requested node.
  *
- * @returns a node for display at this indexpath.
+ * @returns a node for display at this indexpath or nil
  */
-- (ASCellNode *)nodeForItemAtIndexPath:(NSIndexPath *)indexPath;
+- (nullable ASCellNode *)nodeForItemAtIndexPath:(NSIndexPath *)indexPath;
 
-- (ASCellNode *)supplementaryNodeOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath;
+
+/**
+ * Similar to -collectionView:viewForSupplementaryElementOfKind:atIndexPath:.
+ *
+ * @param indexPath The index path of the requested supplementary node.
+ *
+ * @returns a supplementary node for display at this indexpath or nil
+ */
+- (nullable ASCellNode *)supplementaryNodeOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath;
 
 /**
  * Similar to -indexPathForCell:.

--- a/AsyncDisplayKit/ASCollectionView.h
+++ b/AsyncDisplayKit/ASCollectionView.h
@@ -282,6 +282,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (ASCellNode *)nodeForItemAtIndexPath:(NSIndexPath *)indexPath;
 
+- (ASCellNode *)supplementaryNodeOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath;
+
 /**
  * Similar to -indexPathForCell:.
  *

--- a/AsyncDisplayKit/ASCollectionView.h
+++ b/AsyncDisplayKit/ASCollectionView.h
@@ -284,13 +284,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 
 /**
- * Similar to -collectionView:viewForSupplementaryElementOfKind:atIndexPath:.
+ * Similar to -supplementaryViewForElementKind:atIndexPath:
  *
+ * @param elementKind The kind of supplementary node to locate.
  * @param indexPath The index path of the requested supplementary node.
  *
- * @returns a supplementary node for display at this indexpath or nil
+ * @returns The specified supplementary node or nil
  */
-- (nullable ASCellNode *)supplementaryNodeOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath;
+- (nullable ASCellNode *)supplementaryNodeForElementKind:(NSString *)elementKind atIndexPath:(NSIndexPath *)indexPath;
 
 /**
  * Similar to -indexPathForCell:.

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -444,6 +444,11 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   return [_dataController nodeAtIndexPath:indexPath];
 }
 
+- (ASCellNode *)supplementaryNodeOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath
+{
+  return [_dataController supplementaryNodeOfKind:kind atIndexPath:indexPath];
+}
+
 - (NSIndexPath *)indexPathForNode:(ASCellNode *)cellNode
 {
   return [_dataController indexPathForNode:cellNode];

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -444,9 +444,9 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   return [_dataController nodeAtIndexPath:indexPath];
 }
 
-- (ASCellNode *)supplementaryNodeOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath
+- (ASCellNode *)supplementaryNodeForElementKind:(NSString *)elementKind atIndexPath:(NSIndexPath *)indexPath
 {
-  return [_dataController supplementaryNodeOfKind:kind atIndexPath:indexPath];
+  return [_dataController supplementaryNodeOfKind:elementKind atIndexPath:indexPath];
 }
 
 - (NSIndexPath *)indexPathForNode:(ASCellNode *)cellNode
@@ -577,6 +577,7 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   NSString *identifier = [self __reuseIdentifierForKind:kind];
   UICollectionReusableView *view = [self dequeueReusableSupplementaryViewOfKind:kind withReuseIdentifier:identifier forIndexPath:indexPath];
   ASCellNode *node = [_dataController supplementaryNodeOfKind:kind atIndexPath:indexPath];
+  ASDisplayNodeAssert(node != nil, @"Supplementary node should exist.  Kind = %@, indexPath = %@, collectionDataSource = %@", kind, indexPath, self);
   [_rangeController configureContentView:view forCellNode:node];
   return view;
 }

--- a/AsyncDisplayKit/Details/ASCollectionDataController.mm
+++ b/AsyncDisplayKit/Details/ASCollectionDataController.mm
@@ -305,8 +305,7 @@
       return nodesOfKindInSection[itemIndex];
     }
   }
-  ASDisplayNodeAssert(NO, @"Supplementary node should exist.  Kind = %@, indexPath = %@, collectionDataSource = %@", kind, indexPath, self.collectionDataSource);
-  return [[ASCellNode alloc] init];
+  return nil;
 }
 
 #pragma mark - Private Helpers


### PR DESCRIPTION
- Exposing `-supplementaryNodeOfKind:atIndexPath:` on `ASCollectionView`
- Modifies `ASCollectionDataController` to return `nil` if a supplementary node doesn't exist (as opposed to asserting / returning an empty `ASCellNode`) much like a standard node.
- Adds proper nullability on `ASCollectionView` `-nodeForItemAtIndexPath`