### PR TITLE
[ASDataController] Remove asyncDataFetching Option, Cleanup

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.h
+++ b/AsyncDisplayKit/ASCollectionView.h
@@ -407,8 +407,9 @@ NS_ASSUME_NONNULL_BEGIN
  * due to the data access in async mode.
  *
  * @param collectionView The sender.
+ * @deprecated The data source is always accessed on the main thread, and this method will not be called.
  */
-- (void)collectionViewLockDataSource:(ASCollectionView *)collectionView;
+- (void)collectionViewLockDataSource:(ASCollectionView *)collectionView ASDISPLAYNODE_DEPRECATED;
 
 /**
  * Indicator to unlock the data source for data fetching in async mode.
@@ -416,8 +417,9 @@ NS_ASSUME_NONNULL_BEGIN
  * due to the data access in async mode.
  *
  * @param collectionView The sender.
+ * @deprecated The data source is always accessed on the main thread, and this method will not be called.
  */
-- (void)collectionViewUnlockDataSource:(ASCollectionView *)collectionView;
+- (void)collectionViewUnlockDataSource:(ASCollectionView *)collectionView ASDISPLAYNODE_DEPRECATED;
 
 @end
 

--- a/AsyncDisplayKit/ASTableView.h
+++ b/AsyncDisplayKit/ASTableView.h
@@ -44,18 +44,8 @@ NS_ASSUME_NONNULL_BEGIN
  * The frame of the table view changes as table cells are added and deleted.
  *
  * @param style A constant that specifies the style of the table view. See UITableViewStyle for descriptions of valid constants.
- *
- * @param asyncDataFetchingEnabled This option is reserved for future use, and currently a no-op.
- *
- * @discussion If asyncDataFetching is enabled, the `ASTableView` will fetch data through `tableView:numberOfRowsInSection:` and
- * `tableView:nodeForRowAtIndexPath:` in async mode from background thread. Otherwise, the methods will be invoked synchronically
- * from calling thread.
- * Enabling asyncDataFetching could avoid blocking main thread for `ASCellNode` allocation, which is frequently reported issue for
- * large scale data. On another hand, the application code need take the responsibility to avoid data inconsistence. Specifically,
- * we will lock the data source through `tableViewLockDataSource`, and unlock it by `tableViewUnlockDataSource` after the data fetching.
- * The application should not update the data source while the data source is locked, to keep data consistence.
  */
-- (instancetype)initWithFrame:(CGRect)frame style:(UITableViewStyle)style asyncDataFetching:(BOOL)asyncDataFetchingEnabled;
+- (instancetype)initWithFrame:(CGRect)frame style:(UITableViewStyle)style;
 
 /**
  * Tuning parameters for a range type in full mode.
@@ -363,8 +353,9 @@ NS_ASSUME_NONNULL_BEGIN
  * due to the data access in async mode.
  *
  * @param tableView The sender.
+ * @deprecated The data source is always accessed on the main thread, and this method will not be called.
  */
-- (void)tableViewLockDataSource:(ASTableView *)tableView;
+- (void)tableViewLockDataSource:(ASTableView *)tableView ASDISPLAYNODE_DEPRECATED;
 
 /**
  * Indicator to unlock the data source for data fetching in asyn mode.
@@ -372,8 +363,9 @@ NS_ASSUME_NONNULL_BEGIN
  * due to the data access in async mode.
  *
  * @param tableView The sender.
+ * @deprecated The data source is always accessed on the main thread, and this method will not be called.
  */
-- (void)tableViewUnlockDataSource:(ASTableView *)tableView;
+- (void)tableViewUnlockDataSource:(ASTableView *)tableView ASDISPLAYNODE_DEPRECATED;
 
 @end
 
@@ -456,6 +448,12 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @protocol ASTableViewDelegate <ASTableDelegate>
+@end
+
+@interface ASTableView (Deprecated)
+
+- (instancetype)initWithFrame:(CGRect)frame style:(UITableViewStyle)style asyncDataFetching:(BOOL)asyncDataFetchingEnabled ASDISPLAYNODE_DEPRECATED;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -100,8 +100,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
 
   ASRangeController *_rangeController;
 
-  BOOL _asyncDataFetchingEnabled;
-
   ASBatchContext *_batchContext;
 
   NSIndexPath *_pendingVisibleIndexPath;
@@ -133,12 +131,9 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     unsigned int asyncDataSourceNumberOfSectionsInTableView:1;
     unsigned int asyncDataSourceTableViewNodeBlockForRowAtIndexPath:1;
     unsigned int asyncDataSourceTableViewNodeForRowAtIndexPath:1;
-    unsigned int asyncDataSourceTableViewLockDataSource:1;
-    unsigned int asyncDataSourceTableViewUnlockDataSource:1;
   } _asyncDataSourceFlags;
 }
 
-@property (atomic, assign) BOOL asyncDataSourceLocked;
 @property (nonatomic, strong, readwrite) ASDataController *dataController;
 
 // Used only when ASTableView is created directly rather than through ASTableNode.
@@ -177,15 +172,12 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
   _rangeController.dataSource = self;
   _rangeController.delegate = self;
   
-  _dataController = [[dataControllerClass alloc] initWithAsyncDataFetching:NO];
+  _dataController = [[dataControllerClass alloc] init];
   _dataController.dataSource = self;
   _dataController.delegate = _rangeController;
   _dataController.environmentDelegate = self;
   
   _layoutController.dataSource = _dataController;
-
-  _asyncDataFetchingEnabled = NO;
-  _asyncDataSourceLocked = NO;
 
   _leadingScreensForBatching = 2.0;
   _batchContext = [[ASBatchContext alloc] init];
@@ -290,8 +282,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     _asyncDataSourceFlags.asyncDataSourceNumberOfSectionsInTableView = [_asyncDataSource respondsToSelector:@selector(numberOfSectionsInTableView:)];
     _asyncDataSourceFlags.asyncDataSourceTableViewNodeForRowAtIndexPath = [_asyncDataSource respondsToSelector:@selector(tableView:nodeForRowAtIndexPath:)];
     _asyncDataSourceFlags.asyncDataSourceTableViewNodeBlockForRowAtIndexPath = [_asyncDataSource respondsToSelector:@selector(tableView:nodeBlockForRowAtIndexPath:)];
-    _asyncDataSourceFlags.asyncDataSourceTableViewLockDataSource = [_asyncDataSource respondsToSelector:@selector(tableViewLockDataSource:)];
-    _asyncDataSourceFlags.asyncDataSourceTableViewUnlockDataSource = [_asyncDataSource respondsToSelector:@selector(tableViewUnlockDataSource:)];
     
     // Data source must implement tableView:nodeBlockForRowAtIndexPath: or tableView:nodeForRowAtIndexPath:
     ASDisplayNodeAssertTrue(_asyncDataSourceFlags.asyncDataSourceTableViewNodeBlockForRowAtIndexPath || _asyncDataSourceFlags.asyncDataSourceTableViewNodeForRowAtIndexPath);
@@ -1081,28 +1071,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
 {
   return ASSizeRangeMake(CGSizeMake(_nodesConstrainedWidth, 0),
                          CGSizeMake(_nodesConstrainedWidth, FLT_MAX));
-}
-
-- (void)dataControllerLockDataSource
-{
-  ASDisplayNodeAssert(!self.asyncDataSourceLocked, @"The data source has already been locked");
-
-  self.asyncDataSourceLocked = YES;
-
-  if (_asyncDataSourceFlags.asyncDataSourceTableViewLockDataSource) {
-    [_asyncDataSource tableViewLockDataSource:self];
-  }
-}
-
-- (void)dataControllerUnlockDataSource
-{
-  ASDisplayNodeAssert(self.asyncDataSourceLocked, @"The data source has already been unlocked");
-
-  self.asyncDataSourceLocked = NO;
-
-  if (_asyncDataSourceFlags.asyncDataSourceTableViewUnlockDataSource) {
-    [_asyncDataSource tableViewUnlockDataSource:self];
-  }
 }
 
 - (NSUInteger)dataController:(ASDataController *)dataController rowsInSection:(NSUInteger)section

--- a/AsyncDisplayKit/Details/ASChangeSetDataController.m
+++ b/AsyncDisplayKit/Details/ASChangeSetDataController.m
@@ -26,17 +26,6 @@
 
 @implementation ASChangeSetDataController
 
-- (instancetype)initWithAsyncDataFetching:(BOOL)asyncDataFetchingEnabled
-{
-  if (!(self = [super initWithAsyncDataFetching:asyncDataFetchingEnabled])) {
-    return nil;
-  }
-  
-  _changeSetBatchUpdateCounter = 0;
-  
-  return self;
-}
-
 #pragma mark - Batching (External API)
 
 - (void)beginUpdates
@@ -66,6 +55,8 @@
       [super deleteSections:change.indexSet withAnimationOptions:change.animationOptions];
     }
 
+    // TODO: Shouldn't reloads be processed before deletes, since deletes affect
+    // the index space and reloads don't?
     for (_ASHierarchySectionChange *change in [_changeSet sectionChangesOfType:_ASHierarchyChangeTypeReload]) {
       [super reloadSections:change.indexSet withAnimationOptions:change.animationOptions];
     }

--- a/AsyncDisplayKit/Details/ASCollectionDataController.mm
+++ b/AsyncDisplayKit/Details/ASCollectionDataController.mm
@@ -32,9 +32,9 @@
   NSMutableDictionary<NSString *, NSMutableArray<ASIndexedNodeContext *> *> *_pendingContexts;
 }
 
-- (instancetype)initWithAsyncDataFetching:(BOOL)asyncDataFetchingEnabled
+- (instancetype)init
 {
-  self = [super initWithAsyncDataFetching:asyncDataFetchingEnabled];
+  self = [super init];
   if (self != nil) {
     _pendingContexts = [NSMutableDictionary dictionary];
   }

--- a/AsyncDisplayKit/Details/ASCollectionDataController.mm
+++ b/AsyncDisplayKit/Details/ASCollectionDataController.mm
@@ -53,15 +53,13 @@
 
 - (void)willReloadData
 {
-  NSArray *keys = _pendingContexts.allKeys;
-  for (NSString *kind in keys) {
-    NSMutableArray<ASIndexedNodeContext *> *contexts = _pendingContexts[kind];
+  [_pendingContexts enumerateKeysAndObjectsUsingBlock:^(NSString * _Nonnull kind, NSMutableArray<ASIndexedNodeContext *> * _Nonnull contexts, __unused BOOL * _Nonnull stop) {
     // Remove everything that existed before the reload, now that we're ready to insert replacements
     NSArray *indexPaths = [self indexPathsForEditingNodesOfKind:kind];
     [self deleteNodesOfKind:kind atIndexPaths:indexPaths completion:nil];
     
     NSArray *editingNodes = [self editingNodesOfKind:kind];
-    NSMutableIndexSet *indexSet = [[NSMutableIndexSet alloc] initWithIndexesInRange:NSMakeRange(0, editingNodes.count)];
+    NSIndexSet *indexSet = [[NSIndexSet alloc] initWithIndexesInRange:NSMakeRange(0, editingNodes.count)];
     [self deleteSectionsOfKind:kind atIndexSet:indexSet completion:nil];
     
     // Insert each section
@@ -75,8 +73,8 @@
     [self batchLayoutNodesFromContexts:contexts ofKind:kind completion:^(NSArray<ASCellNode *> *nodes, NSArray<NSIndexPath *> *indexPaths) {
       [self insertNodes:nodes ofKind:kind atIndexPaths:indexPaths completion:nil];
     }];
-    [_pendingContexts removeObjectForKey:kind];
-  }
+  }];
+  [_pendingContexts removeAllObjects];
 }
 
 - (void)prepareForInsertSections:(NSIndexSet *)sections

--- a/AsyncDisplayKit/Details/ASDataController.h
+++ b/AsyncDisplayKit/Details/ASDataController.h
@@ -57,17 +57,6 @@ FOUNDATION_EXPORT NSString * const ASDataControllerRowNodeKind;
  */
 - (NSUInteger)numberOfSectionsInDataController:(ASDataController *)dataController;
 
-/**
- Lock the data source for data fetching.
- */
-- (void)dataControllerLockDataSource;
-
-/**
- Unlock the data source after data fetching.
- */
-- (void)dataControllerUnlockDataSource;
-
-
 @end
 
 @protocol ASDataControllerEnvironmentDelegate
@@ -134,20 +123,6 @@ FOUNDATION_EXPORT NSString * const ASDataControllerRowNodeKind;
  *
  */
 @property (nonatomic, weak) id<ASDataControllerEnvironmentDelegate> environmentDelegate;
-
-/**
- *  Designated initializer.
- *
- * @param asyncDataFetchingEnabled Enable the data fetching in async mode.
- *
- * @discussion If enabled, we will fetch data through `dataController:nodeAtIndexPath:` and `dataController:rowsInSection:` in background thread.
- * Otherwise, the methods will be invoked synchronically in calling thread. Enabling data fetching in async mode could avoid blocking main thread
- * while allocating cell on main thread, which is frequently reported issue for handling large scale data. On another hand, the application code
- * will take the responsibility to avoid data inconsistency. Specifically, we will lock the data source through `dataControllerLockDataSource`,
- * and unlock it by `dataControllerUnlockDataSource` after the data fetching. The application should not update the data source while
- * the data source is locked.
- */
-- (instancetype)initWithAsyncDataFetching:(BOOL)asyncDataFetchingEnabled;
 
 /** @name Data Updating */
 

--- a/AsyncDisplayKit/Details/ASDataController.mm
+++ b/AsyncDisplayKit/Details/ASDataController.mm
@@ -461,7 +461,7 @@ static void *kASSizingQueueContext = &kASSizingQueueContext;
       NSUInteger editingNodesSectionCount = editingNodes.count;
       
       if (editingNodesSectionCount) {
-        NSMutableIndexSet *indexSet = [[NSMutableIndexSet alloc] initWithIndexesInRange:NSMakeRange(0, editingNodesSectionCount)];
+        NSIndexSet *indexSet = [[NSIndexSet alloc] initWithIndexesInRange:NSMakeRange(0, editingNodesSectionCount)];
         [self _deleteNodesAtIndexPaths:ASIndexPathsForTwoDimensionalArray(editingNodes) withAnimationOptions:animationOptions];
         [self _deleteSectionsAtIndexSet:indexSet withAnimationOptions:animationOptions];
       }

--- a/AsyncDisplayKit/Details/ASDataController.mm
+++ b/AsyncDisplayKit/Details/ASDataController.mm
@@ -457,7 +457,7 @@ static void *kASSizingQueueContext = &kASSizingQueueContext;
       // Allow subclasses to perform setup before going into the edit transaction
       [self prepareForReloadData];
       
-      void (^transactionBlock)() = ^{
+      [_editingTransactionQueue addOperationWithBlock:^{
         LOG(@"Edit Transaction - reloadData");
         
         // Remove everything that existed before the reload, now that we're ready to insert replacements
@@ -484,12 +484,9 @@ static void *kASSizingQueueContext = &kASSizingQueueContext;
         if (completion) {
           dispatch_async(dispatch_get_main_queue(), completion);
         }
-      };
-      
+      }];
       if (synchronously) {
-        transactionBlock();
-      } else {
-        [_editingTransactionQueue addOperationWithBlock:transactionBlock];
+        [self waitUntilAllUpdatesAreCommitted];
       }
     }];
   }];

--- a/AsyncDisplayKit/Details/ASDataController.mm
+++ b/AsyncDisplayKit/Details/ASDataController.mm
@@ -119,6 +119,8 @@ static void *kASSizingQueueContext = &kASSizingQueueContext;
 
 - (void)batchLayoutNodesFromContexts:(NSArray<ASIndexedNodeContext *> *)contexts ofKind:(NSString *)kind completion:(ASDataControllerCompletionBlock)completionBlock
 {
+  ASDisplayNodeAssert([NSOperationQueue currentQueue] == _editingTransactionQueue, @"%@ must be called on the editing transaction queue", NSStringFromSelector(_cmd));
+  
   NSUInteger blockSize = [[ASDataController class] parallelProcessorCount] * kASDataControllerSizingCountPerProcessor;
   NSUInteger count = contexts.count;
   
@@ -152,6 +154,8 @@ static void *kASSizingQueueContext = &kASSizingQueueContext;
  */
 - (void)_batchLayoutNodesFromContexts:(NSArray<ASIndexedNodeContext *> *)contexts withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions
 {
+  ASDisplayNodeAssert([NSOperationQueue currentQueue] == _editingTransactionQueue, @"%@ must be called on the editing transaction queue", NSStringFromSelector(_cmd));
+  
   [self batchLayoutNodesFromContexts:contexts ofKind:ASDataControllerRowNodeKind completion:^(NSArray<ASCellNode *> *nodes, NSArray<NSIndexPath *> *indexPaths) {
     // Insert finished nodes into data storage
     [self _insertNodes:nodes atIndexPaths:indexPaths withAnimationOptions:animationOptions];
@@ -163,6 +167,8 @@ static void *kASSizingQueueContext = &kASSizingQueueContext;
  */
 - (void)_layoutNodes:(NSArray<ASCellNode *> *)nodes fromContexts:(NSArray<ASIndexedNodeContext *> *)contexts atIndexesOfRange:(NSRange)range ofKind:(NSString *)kind
 {
+  ASDisplayNodeAssert([NSOperationQueue currentQueue] != _editingTransactionQueue, @"%@ should not be called on the editing transaction queue", NSStringFromSelector(_cmd));
+  
   if (_dataSource == nil) {
     return;
   }
@@ -182,6 +188,8 @@ static void *kASSizingQueueContext = &kASSizingQueueContext;
 
 - (void)_layoutNodesFromContexts:(NSArray<ASIndexedNodeContext *> *)contexts ofKind:(NSString *)kind completion:(ASDataControllerCompletionBlock)completionBlock
 {
+  ASDisplayNodeAssert([NSOperationQueue currentQueue] == _editingTransactionQueue, @"%@ must be called on the editing transaction queue", NSStringFromSelector(_cmd));
+  
   if (!contexts.count || _dataSource == nil) {
     return;
   }
@@ -359,7 +367,11 @@ static void *kASSizingQueueContext = &kASSizingQueueContext;
  */
 - (void)_insertNodes:(NSArray *)nodes atIndexPaths:(NSArray *)indexPaths withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions
 {
+  ASDisplayNodeAssert([NSOperationQueue currentQueue] == _editingTransactionQueue, @"%@ must be called on the editing transaction queue", NSStringFromSelector(_cmd));
+  
   [self insertNodes:nodes ofKind:ASDataControllerRowNodeKind atIndexPaths:indexPaths completion:^(NSArray *nodes, NSArray *indexPaths) {
+    ASDisplayNodeAssertMainThread();
+    
     if (_delegateDidInsertNodes)
       [_delegate dataController:self didInsertNodes:nodes atIndexPaths:indexPaths withAnimationOptions:animationOptions];
   }];
@@ -373,7 +385,11 @@ static void *kASSizingQueueContext = &kASSizingQueueContext;
  */
 - (void)_deleteNodesAtIndexPaths:(NSArray *)indexPaths withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions
 {
+  ASDisplayNodeAssert([NSOperationQueue currentQueue] == _editingTransactionQueue, @"%@ must be called on the editing transaction queue", NSStringFromSelector(_cmd));
+  
   [self deleteNodesOfKind:ASDataControllerRowNodeKind atIndexPaths:indexPaths completion:^(NSArray *nodes, NSArray *indexPaths) {
+    ASDisplayNodeAssertMainThread();
+    
     if (_delegateDidDeleteNodes)
       [_delegate dataController:self didDeleteNodes:nodes atIndexPaths:indexPaths withAnimationOptions:animationOptions];
   }];
@@ -387,7 +403,11 @@ static void *kASSizingQueueContext = &kASSizingQueueContext;
  */
 - (void)_insertSections:(NSMutableArray *)sections atIndexSet:(NSIndexSet *)indexSet withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions
 {
+  ASDisplayNodeAssert([NSOperationQueue currentQueue] == _editingTransactionQueue, @"%@ must be called on the editing transaction queue", NSStringFromSelector(_cmd));
+  
   [self insertSections:sections ofKind:ASDataControllerRowNodeKind atIndexSet:indexSet completion:^(NSArray *sections, NSIndexSet *indexSet) {
+    ASDisplayNodeAssertMainThread();
+    
     if (_delegateDidInsertSections)
       [_delegate dataController:self didInsertSections:sections atIndexSet:indexSet withAnimationOptions:animationOptions];
   }];
@@ -401,7 +421,11 @@ static void *kASSizingQueueContext = &kASSizingQueueContext;
  */
 - (void)_deleteSectionsAtIndexSet:(NSIndexSet *)indexSet withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions
 {
+  ASDisplayNodeAssert([NSOperationQueue currentQueue] == _editingTransactionQueue, @"%@ must be called on the editing transaction queue", NSStringFromSelector(_cmd));
+  
   [self deleteSectionsOfKind:ASDataControllerRowNodeKind atIndexSet:indexSet completion:^(NSIndexSet *indexSet) {
+    ASDisplayNodeAssertMainThread();
+    
     if (_delegateDidDeleteSections)
       [_delegate dataController:self didDeleteSectionsAtIndexSet:indexSet withAnimationOptions:animationOptions];
   }];

--- a/AsyncDisplayKit/Private/ASMultidimensionalArrayUtils.mm
+++ b/AsyncDisplayKit/Private/ASMultidimensionalArrayUtils.mm
@@ -25,8 +25,10 @@ static void ASRecursivelyUpdateMultidimensionalArrayAtIndexPaths(NSMutableArray 
   }
 
   if (curIndexPath.length < dimension - 1) {
-    for (int i = 0; i < mutableArray.count; i++) {
-      ASRecursivelyUpdateMultidimensionalArrayAtIndexPaths(mutableArray[i], indexPaths, curIdx, [curIndexPath indexPathByAddingIndex:i], dimension, updateBlock);
+    NSInteger i = 0;
+    for (NSMutableArray *subarray in mutableArray) {
+      ASRecursivelyUpdateMultidimensionalArrayAtIndexPaths(subarray, indexPaths, curIdx, [curIndexPath indexPathByAddingIndex:i], dimension, updateBlock);
+      i += 1;
     }
   } else {
     NSMutableIndexSet *indexSet = [[NSMutableIndexSet alloc] init];

--- a/AsyncDisplayKit/Private/ASMultidimensionalArrayUtils.mm
+++ b/AsyncDisplayKit/Private/ASMultidimensionalArrayUtils.mm
@@ -11,6 +11,10 @@
 #import "ASAssert.h"
 #import "ASMultidimensionalArrayUtils.h"
 
+// Import UIKit to get [NSIndexPath indexPathForItem:inSection:] which uses
+// static memory addresses rather than allocating new index path objects.
+#import <UIKit/UIKit.h>
+
 #pragma mark - Internal Methods
 
 static void ASRecursivelyUpdateMultidimensionalArrayAtIndexPaths(NSMutableArray *mutableArray,
@@ -74,7 +78,12 @@ static BOOL ASElementExistsAtIndexPathForMultidimensionalArray(NSArray *array, N
   NSUInteger indexesLength = indexLength - 1;
   NSUInteger indexes[indexesLength];
   [indexPath getIndexes:indexes range:NSMakeRange(1, indexesLength)];
-  NSIndexPath *indexPathByRemovingFirstIndex = [NSIndexPath indexPathWithIndexes:indexes length:indexesLength];
+  NSIndexPath *indexPathByRemovingFirstIndex;
+  if (indexesLength == 2) {
+    indexPathByRemovingFirstIndex = [NSIndexPath indexPathForItem:indexes[1] inSection:indexes[0]];
+  } else {
+    indexPathByRemovingFirstIndex = [NSIndexPath indexPathWithIndexes:indexes length:indexesLength];
+  }
 
   return ASElementExistsAtIndexPathForMultidimensionalArray(array[firstIndex], indexPathByRemovingFirstIndex);
 }
@@ -186,9 +195,8 @@ NSArray *ASIndexPathsForTwoDimensionalArray(NSArray <NSArray *>* twoDimensionalA
   NSUInteger section = 0;
   for (NSArray *subarray in twoDimensionalArray) {
     ASDisplayNodeCAssert([subarray isKindOfClass:[NSArray class]], @"This function expects NSArray<NSArray *> *");
-    NSUInteger itemCount = subarray.count;
-    for (NSUInteger item = 0; item < itemCount; item++) {
-      [result addObject:[NSIndexPath indexPathWithIndexes:(const NSUInteger []){ section, item } length:2]];
+    for (NSUInteger item = 0; item < subarray.count; item++) {
+      [result addObject:[NSIndexPath indexPathForItem:item inSection:section]];
     }
     section++;
   }

--- a/AsyncDisplayKitTests/ASTableViewTests.m
+++ b/AsyncDisplayKitTests/ASTableViewTests.m
@@ -408,8 +408,7 @@
 {
   CGSize tableViewSize = CGSizeMake(100, 500);
   ASTestTableView *tableView = [[ASTestTableView alloc] initWithFrame:CGRectMake(0, 0, tableViewSize.width, tableViewSize.height)
-                                                                style:UITableViewStylePlain
-                                                    asyncDataFetching:YES];
+                                                                style:UITableViewStylePlain];
   ASTableViewFilledDataSource *dataSource = [ASTableViewFilledDataSource new];
 
   tableView.asyncDelegate = dataSource;


### PR DESCRIPTION
I was doing a deep-dive into this code in preparation for some work, and I saw a bunch of possible improvements. So here they are.

- Remove asyncDataFetching logic, deprecating the associated methods. We no longer call the locking methods because we now follow the UIKit synchronization paradigm – submit your edits on the main queue, and we'll query you back immediately on the main queue.
- Add assertions to data controller about which queue we're on
- Make data controller use _editingTransactionQueue even when doing synchronous reload (so that those assertions pass).
- Other small tweaks/optimizations (avoiding needless allocations/method calls)

I've tested this thoroughly by hand.