### PR TITLE
[Carthage] Add cartfile, update example

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,0 +1,1 @@
+github "pinterest/PINRemoteImage" "3.0.0-beta.2"

--- a/examples/CarthageBuildTest/Sample.xcodeproj/project.pbxproj
+++ b/examples/CarthageBuildTest/Sample.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		871BB3591C7C98B1005CF62A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 871BB3581C7C98B1005CF62A /* Assets.xcassets */; };
 		871BB35C1C7C98B1005CF62A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 871BB35A1C7C98B1005CF62A /* LaunchScreen.storyboard */; };
 		871BB3651C7C99B0005CF62A /* AsyncDisplayKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 871BB3641C7C99B0005CF62A /* AsyncDisplayKit.framework */; };
+		DEAE185D1D1A504A0083FAD0 /* PINCache.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DEAE185B1D1A504A0083FAD0 /* PINCache.framework */; };
+		DEAE185E1D1A504A0083FAD0 /* PINRemoteImage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DEAE185C1D1A504A0083FAD0 /* PINRemoteImage.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -28,6 +30,8 @@
 		871BB35B1C7C98B1005CF62A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		871BB35D1C7C98B1005CF62A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		871BB3641C7C99B0005CF62A /* AsyncDisplayKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AsyncDisplayKit.framework; path = Carthage/Build/iOS/AsyncDisplayKit.framework; sourceTree = SOURCE_ROOT; };
+		DEAE185B1D1A504A0083FAD0 /* PINCache.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PINCache.framework; path = ../Carthage/Build/iOS/PINCache.framework; sourceTree = "<group>"; };
+		DEAE185C1D1A504A0083FAD0 /* PINRemoteImage.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PINRemoteImage.framework; path = ../Carthage/Build/iOS/PINRemoteImage.framework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -36,6 +40,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				871BB3651C7C99B0005CF62A /* AsyncDisplayKit.framework in Frameworks */,
+				DEAE185D1D1A504A0083FAD0 /* PINCache.framework in Frameworks */,
+				DEAE185E1D1A504A0083FAD0 /* PINRemoteImage.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -87,6 +93,8 @@
 			isa = PBXGroup;
 			children = (
 				871BB3641C7C99B0005CF62A /* AsyncDisplayKit.framework */,
+				DEAE185B1D1A504A0083FAD0 /* PINCache.framework */,
+				DEAE185C1D1A504A0083FAD0 /* PINRemoteImage.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -126,7 +134,7 @@
 					};
 				};
 			};
-			buildConfigurationList = 871BB3441C7C98B1005CF62A /* Build configuration list for PBXProject "CarthageExample" */;
+			buildConfigurationList = 871BB3441C7C98B1005CF62A /* Build configuration list for PBXProject "Sample" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
@@ -325,7 +333,7 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		871BB3441C7C98B1005CF62A /* Build configuration list for PBXProject "CarthageExample" */ = {
+		871BB3441C7C98B1005CF62A /* Build configuration list for PBXProject "Sample" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				871BB35E1C7C98B1005CF62A /* Debug */,


### PR DESCRIPTION
Resolve Issue 2 of #1780 with ASDK Cartfile addition.

Installation Notes (WIP)

Create project with a cartfile that just lists ASDK, as seen in the following. NOTE: this will only work with master until we have a release with a cartfile.
git "file:///Users/htroisi/Code/AsyncDisplayKit" "master" (testing on my machine)
github "facebook/AsyncDisplayKit" "master" (haven't tested this yet, will test this once cartfile is merged)

Run carthage update. This will fetch dependencies into a Carthage/Checkouts folder, then build each one.
> carthage update --platform iOS (don't need iOS, but I only tested with that so far)

Look for terminal output confirming AsyncDisplayKit, PINRemoteImage (3.0.0-beta.2) and PINCache are ALL installed (despite only ASDK being listed in your project's Cartfile).

The ASDK framework Cartfile (in this commit) should do the dependencies correctly. PINRemoteImage binary fetched seems to correctly add PINCache as a dependency. ASDK seems to correctly add PINRemoteImage as a dependency (with this cartfile proposed for merge).

On your application targets’ “General” settings tab, in the “Linked Frameworks and Libraries” section, drag and drop each framework you want to use from the Carthage/Build folder on disk.

On your application targets’ “Build Phases” settings tab, click the “+” icon and choose “New Run Script Phase”. Create a Run Script in which you specify your shell (ex: bin/sh), add the following contents to the script area below the shell:

/usr/local/bin/carthage copy-frameworks
and add the paths to the frameworks you want to use under “Input Files”, e.g.:

$(SRCROOT)/Carthage/Build/iOS/Box.framework
$(SRCROOT)/Carthage/Build/iOS/Result.framework
$(SRCROOT)/Carthage/Build/iOS/ReactiveCocoa.framework