### PR TITLE
[Carthage] define PIN_REMOTE_IMAGE in .pch for non-CocoaPod users

### DIFF
--- a/AsyncDisplayKit/AsyncDisplayKit-Prefix.pch
+++ b/AsyncDisplayKit/AsyncDisplayKit-Prefix.pch
@@ -7,3 +7,13 @@
 #ifdef __OBJC__
   #import <Foundation/Foundation.h>
 #endif
+
+
+// CocoaPods has a preproceessor macro for PIN_REMOTE_IMAGE, if already defined, okay
+#ifndef PIN_REMOTE_IMAGE
+
+// For Carthage or manual builds, this will define PIN_REMOTE_IMAGE if the header is available in the
+// search path e.g. they've dragged in the framework (technically this will not be able to detect if
+// a user does not include the framework in the link binary with build step).
+#define PIN_REMOTE_IMAGE __has_include(<PINRemoteImage/PINRemoteImage.h>)
+#endif

--- a/AsyncDisplayKit/Details/ASPINRemoteImageDownloader.m
+++ b/AsyncDisplayKit/Details/ASPINRemoteImageDownloader.m
@@ -85,7 +85,23 @@
   static PINRemoteImageManager *sharedPINRemoteImageManager = nil;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
+  
 #if PIN_ANIMATED_AVAILABLE
+    // Check that Carthage users have linked both PINRemoteImage & PINCache by testing for one file each
+    if (!(NSClassFromString(@"PINRemoteImageManager.m"))) {
+        NSException *e = [NSException
+                          exceptionWithName:@"FrameworkSetupException"
+                          reason:@"Missing the path to the PINRemoteImage framework."
+                          userInfo:nil];
+        @throw e;
+    }
+    if (!(NSClassFromString(@"PINCache.m"))) {
+        NSException *e = [NSException
+                          exceptionWithName:@"FrameworkSetupException"
+                          reason:@"Missing the path to the PINCache framework."
+                          userInfo:nil];
+        @throw e;
+    }
     sharedPINRemoteImageManager = [[PINRemoteImageManager alloc] initWithSessionConfiguration:nil alternativeRepresentationProvider:self];
 #else
     sharedPINRemoteImageManager = [[PINRemoteImageManager alloc] initWithSessionConfiguration:nil];

--- a/AsyncDisplayKit/Details/ASPINRemoteImageDownloader.m
+++ b/AsyncDisplayKit/Details/ASPINRemoteImageDownloader.m
@@ -88,14 +88,14 @@
   
 #if PIN_ANIMATED_AVAILABLE
     // Check that Carthage users have linked both PINRemoteImage & PINCache by testing for one file each
-    if (!(NSClassFromString(@"PINRemoteImageManager.m"))) {
+    if (!(NSClassFromString(@"PINRemoteImageManager"))) {
         NSException *e = [NSException
                           exceptionWithName:@"FrameworkSetupException"
                           reason:@"Missing the path to the PINRemoteImage framework."
                           userInfo:nil];
         @throw e;
     }
-    if (!(NSClassFromString(@"PINCache.m"))) {
+    if (!(NSClassFromString(@"PINCache"))) {
         NSException *e = [NSException
                           exceptionWithName:@"FrameworkSetupException"
                           reason:@"Missing the path to the PINCache framework."


### PR DESCRIPTION
Resolves Issue 1 of #1780. 

Users who don't use CocoaPods will have PIN_REMOTE_IMAGE defined in .pch file. 