### PR TITLE
[ASLayoutable] Add Convenience Methods to Enable Chaining

### DIFF
--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -546,6 +546,10 @@
 		CC3B208E1C3F7D0A00798563 /* ASWeakSetTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CC3B208D1C3F7D0A00798563 /* ASWeakSetTests.m */; };
 		CC3B20901C3F892D00798563 /* ASBridgedPropertiesTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = CC3B208F1C3F892D00798563 /* ASBridgedPropertiesTests.mm */; };
 		CC4981B31D1A02BE004E13CC /* ASTableViewThrashTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CC4981B21D1A02BE004E13CC /* ASTableViewThrashTests.m */; };
+		CC4981B61D1C6109004E13CC /* ASRelativeLayoutDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = CC4981B51D1C5CEF004E13CC /* ASRelativeLayoutDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CC4981B71D1C6109004E13CC /* ASRelativeLayoutDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = CC4981B51D1C5CEF004E13CC /* ASRelativeLayoutDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CC4981B81D1C611B004E13CC /* ASCenterLayoutDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = CC4981B41D1C5CD4004E13CC /* ASCenterLayoutDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CC4981B91D1C611E004E13CC /* ASCenterLayoutDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = CC4981B41D1C5CD4004E13CC /* ASCenterLayoutDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CC7FD9DE1BB5E962005CCB2B /* ASPhotosFrameworkImageRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = CC7FD9DC1BB5E962005CCB2B /* ASPhotosFrameworkImageRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CC7FD9DF1BB5E962005CCB2B /* ASPhotosFrameworkImageRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = CC7FD9DD1BB5E962005CCB2B /* ASPhotosFrameworkImageRequest.m */; };
 		CC7FD9E11BB5F750005CCB2B /* ASPhotosFrameworkImageRequestTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CC7FD9E01BB5F750005CCB2B /* ASPhotosFrameworkImageRequestTests.m */; };
@@ -937,6 +941,8 @@
 		CC3B208D1C3F7D0A00798563 /* ASWeakSetTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASWeakSetTests.m; sourceTree = "<group>"; };
 		CC3B208F1C3F892D00798563 /* ASBridgedPropertiesTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASBridgedPropertiesTests.mm; sourceTree = "<group>"; };
 		CC4981B21D1A02BE004E13CC /* ASTableViewThrashTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASTableViewThrashTests.m; sourceTree = "<group>"; };
+		CC4981B41D1C5CD4004E13CC /* ASCenterLayoutDefines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ASCenterLayoutDefines.h; path = AsyncDisplayKit/Layout/ASCenterLayoutDefines.h; sourceTree = "<group>"; };
+		CC4981B51D1C5CEF004E13CC /* ASRelativeLayoutDefines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ASRelativeLayoutDefines.h; path = AsyncDisplayKit/Layout/ASRelativeLayoutDefines.h; sourceTree = "<group>"; };
 		CC7FD9DC1BB5E962005CCB2B /* ASPhotosFrameworkImageRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASPhotosFrameworkImageRequest.h; sourceTree = "<group>"; };
 		CC7FD9DD1BB5E962005CCB2B /* ASPhotosFrameworkImageRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASPhotosFrameworkImageRequest.m; sourceTree = "<group>"; };
 		CC7FD9E01BB5F750005CCB2B /* ASPhotosFrameworkImageRequestTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASPhotosFrameworkImageRequestTests.m; sourceTree = "<group>"; };
@@ -1449,6 +1455,7 @@
 				9C5586681BD549CB00B50E3A /* ASAsciiArtBoxCreator.m */,
 				ACF6ED011B17843500DA7C62 /* ASBackgroundLayoutSpec.h */,
 				ACF6ED021B17843500DA7C62 /* ASBackgroundLayoutSpec.mm */,
+				CC4981B41D1C5CD4004E13CC /* ASCenterLayoutDefines.h */,
 				ACF6ED031B17843500DA7C62 /* ASCenterLayoutSpec.h */,
 				ACF6ED041B17843500DA7C62 /* ASCenterLayoutSpec.mm */,
 				ACF6ED071B17843500DA7C62 /* ASDimension.h */,
@@ -1469,6 +1476,7 @@
 				ACF6ED131B17843500DA7C62 /* ASOverlayLayoutSpec.mm */,
 				ACF6ED141B17843500DA7C62 /* ASRatioLayoutSpec.h */,
 				ACF6ED151B17843500DA7C62 /* ASRatioLayoutSpec.mm */,
+				CC4981B51D1C5CEF004E13CC /* ASRelativeLayoutDefines.h */,
 				7A06A7391C35F08800FE8DAA /* ASRelativeLayoutSpec.h */,
 				7A06A7381C35F08800FE8DAA /* ASRelativeLayoutSpec.mm */,
 				AC47D9431B3BB41900AAEE9D /* ASRelativeSize.h */,
@@ -1545,6 +1553,7 @@
 				058D0A76195D05F900B7D73C /* _ASScopeTimer.h in Headers */,
 				68EE0DBD1C1B4ED300BA1B99 /* ASMainSerialQueue.h in Headers */,
 				257754B31BEE44CD00737CA5 /* ASTextKitTailTruncater.h in Headers */,
+				CC4981B81D1C611B004E13CC /* ASCenterLayoutDefines.h in Headers */,
 				205F0E191B37339C007741D0 /* ASAbstractLayoutController.h in Headers */,
 				058D0A82195D060300B7D73C /* ASAssert.h in Headers */,
 				0516FA3C1A15563400B4EBED /* ASAvailability.h in Headers */,
@@ -1666,6 +1675,7 @@
 				257754AD1BEE44CD00737CA5 /* ASTextKitRenderer+Positioning.h in Headers */,
 				DEC146B61C37A16A004A0EE7 /* ASCollectionInternal.h in Headers */,
 				205F0E211B376416007741D0 /* CGRect+ASConvenience.h in Headers */,
+				CC4981B61D1C6109004E13CC /* ASRelativeLayoutDefines.h in Headers */,
 				058D0A66195D05DC00B7D73C /* NSMutableAttributedString+TextKitAdditions.h in Headers */,
 				205F0E0F1B371875007741D0 /* UICollectionViewLayout+ASConvenience.h in Headers */,
 				058D0A6F195D05EC00B7D73C /* UIView+ASConvenience.h in Headers */,
@@ -1703,6 +1713,7 @@
 				254C6B7D1BF94DF4003EC431 /* ASTextKitShadower.h in Headers */,
 				B35062581B010F070018CF92 /* ASAvailability.h in Headers */,
 				DE84918D1C8FFF2B003D89E9 /* ASRunLoopQueue.h in Headers */,
+				CC4981B91D1C611E004E13CC /* ASCenterLayoutDefines.h in Headers */,
 				254C6B731BF94DF4003EC431 /* ASTextKitCoreTextAdditions.h in Headers */,
 				A2763D7A1CBDD57D00A9ADBD /* ASPINRemoteImageDownloader.h in Headers */,
 				254C6B7A1BF94DF4003EC431 /* ASTextKitRenderer.h in Headers */,
@@ -1824,6 +1835,7 @@
 				B35062391B010EFD0018CF92 /* ASThread.h in Headers */,
 				2C107F5B1BA9F54500F13DE5 /* AsyncDisplayKit.h in Headers */,
 				509E68651B3AEDC5009B9150 /* CGRect+ASConvenience.h in Headers */,
+				CC4981B71D1C6109004E13CC /* ASRelativeLayoutDefines.h in Headers */,
 				B350623A1B010EFD0018CF92 /* NSMutableAttributedString+TextKitAdditions.h in Headers */,
 				044284FF1BAA3BD600D16268 /* UICollectionViewLayout+ASConvenience.h in Headers */,
 				B35062431B010EFD0018CF92 /* UIView+ASConvenience.h in Headers */,

--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -598,6 +598,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+@interface ASDisplayNode (Convenience)
+
+/**
+ * Set preferredFrameSize and return self.
+ */
+- (instancetype)withPreferredFrameSize:(CGSize)preferredFrameSize;
+
+@end
+
 /**
  * Convenience methods for debugging.
  */

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -35,6 +35,14 @@
 #import "ASLayoutValidation.h"
 #import "ASCellNode.h"
 
+// ASLayoutableConvenience imports
+#import "ASCenterLayoutSpec.h"
+#import "ASStaticLayoutSpec.h"
+#import "ASRatioLayoutSpec.h"
+#import "ASOverlayLayoutSpec.h"
+#import "ASBackgroundLayoutSpec.h"
+#import "ASInsetLayoutSpec.h"
+
 NSInteger const ASDefaultDrawingPriority = ASDefaultTransactionPriority;
 NSString * const ASRenderingEngineDidDisplayScheduledNodesNotification = @"ASRenderingEngineDidDisplayScheduledNodes";
 NSString * const ASRenderingEngineDidDisplayNodesScheduledBeforeTimestamp = @"ASRenderingEngineDidDisplayNodesScheduledBeforeTimestamp";
@@ -63,7 +71,7 @@ NSString * const ASRenderingEngineDidDisplayNodesScheduledBeforeTimestamp = @"AS
 
 @implementation ASDisplayNode
 
-// these dynamic properties all defined in ASLayoutOptionsPrivate.m
+// these dynamic properties all defined in ASLayoutablePrivate.h
 @dynamic spacingAfter, spacingBefore, flexGrow, flexShrink, flexBasis,
          alignSelf, ascender, descender, sizeRange, layoutPosition, layoutableType;
 
@@ -2829,6 +2837,21 @@ ASEnvironmentLayoutExtensibilityForwarding
   }
 }
 #endif
+
+#pragma mark - ASLayoutableConvenience
+
+ASLayoutableConvenienceImpl
+
+@end
+
+@implementation ASDisplayNode (Convenience)
+
+- (instancetype)withPreferredFrameSize:(CGSize)preferredFrameSize
+{
+  self.preferredFrameSize = preferredFrameSize;
+  return self;
+}
+
 @end
 
 @implementation ASDisplayNode (Debugging)

--- a/AsyncDisplayKit/Layout/ASCenterLayoutDefines.h
+++ b/AsyncDisplayKit/Layout/ASCenterLayoutDefines.h
@@ -1,0 +1,33 @@
+//
+//  ASCenterLayoutSpec.h
+//  AsyncDisplayKit
+//
+//  Copyright (c) 2014-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under the BSD-style license found in the
+//  LICENSE file in the root directory of this source tree. An additional grant
+//  of patent rights can be found in the PATENTS file in the same directory.
+//
+
+/** How the child is centered within the spec. */
+typedef NS_OPTIONS(NSUInteger, ASCenterLayoutSpecCenteringOptions) {
+  /** The child is positioned in {0,0} relatively to the layout bounds */
+  ASCenterLayoutSpecCenteringNone = 0,
+  /** The child is centered along the X axis */
+  ASCenterLayoutSpecCenteringX = 1 << 0,
+  /** The child is centered along the Y axis */
+  ASCenterLayoutSpecCenteringY = 1 << 1,
+  /** Convenience option to center both along the X and Y axis */
+  ASCenterLayoutSpecCenteringXY = ASCenterLayoutSpecCenteringX | ASCenterLayoutSpecCenteringY
+};
+
+/** How much space the spec will take up. */
+typedef NS_OPTIONS(NSUInteger, ASCenterLayoutSpecSizingOptions) {
+  /** The spec will take up the maximum size possible */
+  ASCenterLayoutSpecSizingOptionDefault = ASRelativeLayoutSpecSizingOptionDefault,
+  /** The spec will take up the minimum size possible along the X axis */
+  ASCenterLayoutSpecSizingOptionMinimumX = ASRelativeLayoutSpecSizingOptionMinimumWidth,
+  /** The spec will take up the minimum size possible along the Y axis */
+  ASCenterLayoutSpecSizingOptionMinimumY = ASRelativeLayoutSpecSizingOptionMinimumHeight,
+  /** Convenience option to take up the minimum size along both the X and Y axis */
+  ASCenterLayoutSpecSizingOptionMinimumXY = ASRelativeLayoutSpecSizingOptionMinimumSize
+};

--- a/AsyncDisplayKit/Layout/ASCenterLayoutDefines.h
+++ b/AsyncDisplayKit/Layout/ASCenterLayoutDefines.h
@@ -1,5 +1,5 @@
 //
-//  ASCenterLayoutSpec.h
+//  ASCenterLayoutDefines.h
 //  AsyncDisplayKit
 //
 //  Copyright (c) 2014-present, Facebook, Inc.  All rights reserved.

--- a/AsyncDisplayKit/Layout/ASCenterLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASCenterLayoutSpec.h
@@ -9,30 +9,8 @@
 //
 
 #import <AsyncDisplayKit/ASRelativeLayoutSpec.h>
+#import <AsyncDisplayKit/ASCenterLayoutDefines.h>
 
-/** How the child is centered within the spec. */
-typedef NS_OPTIONS(NSUInteger, ASCenterLayoutSpecCenteringOptions) {
-  /** The child is positioned in {0,0} relatively to the layout bounds */
-  ASCenterLayoutSpecCenteringNone = 0,
-  /** The child is centered along the X axis */
-  ASCenterLayoutSpecCenteringX = 1 << 0,
-  /** The child is centered along the Y axis */
-  ASCenterLayoutSpecCenteringY = 1 << 1,
-  /** Convenience option to center both along the X and Y axis */
-  ASCenterLayoutSpecCenteringXY = ASCenterLayoutSpecCenteringX | ASCenterLayoutSpecCenteringY
-};
-
-/** How much space the spec will take up. */
-typedef NS_OPTIONS(NSUInteger, ASCenterLayoutSpecSizingOptions) {
-  /** The spec will take up the maximum size possible */
-  ASCenterLayoutSpecSizingOptionDefault = ASRelativeLayoutSpecSizingOptionDefault,
-  /** The spec will take up the minimum size possible along the X axis */
-  ASCenterLayoutSpecSizingOptionMinimumX = ASRelativeLayoutSpecSizingOptionMinimumWidth,
-  /** The spec will take up the minimum size possible along the Y axis */
-  ASCenterLayoutSpecSizingOptionMinimumY = ASRelativeLayoutSpecSizingOptionMinimumHeight,
-  /** Convenience option to take up the minimum size along both the X and Y axis */
-  ASCenterLayoutSpecSizingOptionMinimumXY = ASRelativeLayoutSpecSizingOptionMinimumSize
-};
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/AsyncDisplayKit/Layout/ASLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASLayoutSpec.mm
@@ -23,6 +23,14 @@
 #import <map>
 #import <vector>
 
+// ASLayoutableConvenience imports
+#import "ASCenterLayoutSpec.h"
+#import "ASStaticLayoutSpec.h"
+#import "ASRatioLayoutSpec.h"
+#import "ASOverlayLayoutSpec.h"
+#import "ASBackgroundLayoutSpec.h"
+#import "ASInsetLayoutSpec.h"
+
 typedef std::map<unsigned long, id<ASLayoutable>, std::less<unsigned long>> ASChildMap;
 
 @interface ASLayoutSpec() {
@@ -225,6 +233,10 @@ ASEnvironmentLayoutExtensibilityForwarding
   ASDN::MutexLocker l(_propertyLock);
   return [ASTraitCollection traitCollectionWithASEnvironmentTraitCollection:self.environmentTraitCollection];
 }
+
+#pragma mark ASLayoutableConvenience
+
+ASLayoutableConvenienceImpl
 
 @end
 

--- a/AsyncDisplayKit/Layout/ASLayoutable.h
+++ b/AsyncDisplayKit/Layout/ASLayoutable.h
@@ -17,9 +17,18 @@
 #import <AsyncDisplayKit/ASLayoutablePrivate.h>
 #import <AsyncDisplayKit/ASEnvironment.h>
 #import <AsyncDisplayKit/ASLayoutableExtensibility.h>
+#import <AsyncDisplayKit/ASRelativeLayoutDefines.h>
+#import <AsyncDisplayKit/ASCenterLayoutDefines.h>
+
 
 @class ASLayout;
-@class ASLayoutSpec;
+@class ASRatioLayoutSpec;
+@class ASBackgroundLayoutSpec;
+@class ASOverlayLayoutSpec;
+@class ASInsetLayoutSpec;
+@class ASStaticLayoutSpec;
+@class ASCenterLayoutSpec;
+@class ASRelativeLayoutSpec;
 
 typedef NS_ENUM(NSUInteger, ASLayoutableType) {
   ASLayoutableTypeLayoutSpec,
@@ -115,6 +124,69 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** The position of this object within its parent spec. */
 @property (nonatomic, assign) CGPoint layoutPosition;
+
+#pragma mark - Convenience
+
+// TODO: Finalize documentation
+/**
+ * Set flexBasis on the receiver and return the receiver.
+ */
+- (instancetype)withFlexBasis:(ASRelativeDimension)flexBasis;
+
+/**
+ * Set flexGrow on the receiver and return the receiver.
+ */
+- (instancetype)withFlexGrow:(BOOL)flexGrow;
+
+/**
+ * Set flexShrink on the receiver and return the receiver.
+ */
+- (instancetype)withFlexShrink:(BOOL)flexShrink;
+
+/**
+ * Set flexShrink on the receiver and return the receiver.
+ */
+- (instancetype)withAlignSelf:(ASStackLayoutAlignSelf)alignSelf;
+
+/**
+ * Set spacingBefore and spacingAfter on the receiver, then return the receiver.
+ */
+- (instancetype)withSpacingBefore:(CGFloat)spacingBefore after:(CGFloat)spacingAfter;
+
+/**
+ * Embed the receiver in a center layout spec with the given options.
+ */
+- (ASCenterLayoutSpec *)centeredWithOptions:(ASCenterLayoutSpecCenteringOptions)centeringOptions sizingOptions:(ASCenterLayoutSpecSizingOptions)sizingOptions;
+
+/**
+ * Embed the receiver in a relative layout spec with the given options.
+ */
+- (ASRelativeLayoutSpec *)positionedRelativeWithHorizontalPosition:(ASRelativeLayoutSpecPosition)horizontalPosition verticalPosition:(ASRelativeLayoutSpecPosition)verticalPosition sizingOption:(ASRelativeLayoutSpecSizingOption)sizingOption;
+
+/**
+ * Embed the receiver in a static layout spec with the given size range and layout position
+ */
+- (ASStaticLayoutSpec *)withStaticSizeRange:(ASRelativeSizeRange)sizeRange position:(CGPoint)layoutPosition;
+
+/**
+ * Embed the receiver in a ratio layout spec with the given ratio.
+ */
+- (ASRatioLayoutSpec *)withAspectRatio:(CGFloat)ratio;
+
+/**
+ * Embed the receiver in an overlay layout spec with the given overlay.
+ */
+- (ASOverlayLayoutSpec *)withOverlay:(nullable id<ASLayoutable>)overlay;
+
+/**
+ * Embed the receiver in a background layout spec with the given background.
+ */
+- (ASBackgroundLayoutSpec *)withBackground:(nullable id<ASLayoutable>)background;
+
+/**
+ * Embed the receiver in an inset layout spec with the given insets.
+ */
+- (ASInsetLayoutSpec *)withInset:(UIEdgeInsets)insets;
 
 @end
 

--- a/AsyncDisplayKit/Layout/ASLayoutablePrivate.h
+++ b/AsyncDisplayKit/Layout/ASLayoutablePrivate.h
@@ -61,6 +61,65 @@ extern void ASLayoutableClearCurrentContext();
 
 @end
 
+#pragma mark - ASLayoutableConvenience
+
+#define ASLayoutableConvenienceImpl \
+- (instancetype)withFlexBasis:(ASRelativeDimension)flexBasis\
+{\
+  self.flexBasis = flexBasis;\
+  return self;\
+}\
+- (instancetype)withFlexGrow:(BOOL)flexGrow\
+{\
+  self.flexGrow = flexGrow;\
+  return self;\
+}\
+- (instancetype)withFlexShrink:(BOOL)flexShrink\
+{\
+  self.flexShrink = flexShrink;\
+  return self;\
+}\
+- (instancetype)withAlignSelf:(ASStackLayoutAlignSelf)alignSelf\
+{\
+  self.alignSelf = alignSelf;\
+  return self;\
+}\
+- (instancetype)withSpacingBefore:(CGFloat)spacingBefore after:(CGFloat)spacingAfter\
+{\
+  self.spacingBefore = spacingBefore;\
+  self.spacingAfter = spacingAfter;\
+  return self;\
+}\
+- (ASStaticLayoutSpec *)withStaticSizeRange:(ASRelativeSizeRange)sizeRange position:(CGPoint)layoutPosition\
+{\
+  self.sizeRange = sizeRange;\
+  self.layoutPosition = layoutPosition;\
+  return [ASStaticLayoutSpec staticLayoutSpecWithChildren:@[ self ]];\
+}\
+- (ASCenterLayoutSpec *)centeredWithOptions:(ASCenterLayoutSpecCenteringOptions)centeringOptions sizingOptions:(ASCenterLayoutSpecSizingOptions)sizingOptions\
+{\
+  return [ASCenterLayoutSpec centerLayoutSpecWithCenteringOptions:centeringOptions sizingOptions:sizingOptions child:self];\
+}\
+- (ASRelativeLayoutSpec *)positionedRelativeWithHorizontalPosition:(ASRelativeLayoutSpecPosition)horizontalPosition verticalPosition:(ASRelativeLayoutSpecPosition)verticalPosition sizingOption:(ASRelativeLayoutSpecSizingOption)sizingOption\
+{\
+  return [ASRelativeLayoutSpec relativePositionLayoutSpecWithHorizontalPosition:horizontalPosition verticalPosition:verticalPosition sizingOption:sizingOption child:self];\
+}\
+- (ASRatioLayoutSpec *)withAspectRatio:(CGFloat)ratio\
+{\
+  return [ASRatioLayoutSpec ratioLayoutSpecWithRatio:ratio child:self];\
+}\
+- (ASOverlayLayoutSpec *)withOverlay:(nullable id<ASLayoutable>)overlay\
+{\
+  return [ASOverlayLayoutSpec overlayLayoutSpecWithChild:self overlay:overlay];\
+}\
+- (ASBackgroundLayoutSpec *)withBackground:(nullable id<ASLayoutable>)background\
+{\
+  return [ASBackgroundLayoutSpec backgroundLayoutSpecWithChild:self background:background];\
+}\
+- (ASInsetLayoutSpec *)withInset:(UIEdgeInsets)insets\
+{\
+  return [ASInsetLayoutSpec insetLayoutSpecWithInsets:insets child:self];\
+}
 
 #pragma mark - ASLayoutOptionsForwarding
 

--- a/AsyncDisplayKit/Layout/ASRelativeLayoutDefines.h
+++ b/AsyncDisplayKit/Layout/ASRelativeLayoutDefines.h
@@ -1,8 +1,6 @@
 //
-//  ASRelativeLayoutSpec.h
+//  ASRelativeLayoutDefines.h
 //  AsyncDisplayKit
-//
-//  Created by Samuel Stow on 12/31/15.
 //
 //  Copyright (c) 2014-present, Facebook, Inc.  All rights reserved.
 //  This source code is licensed under the BSD-style license found in the

--- a/AsyncDisplayKit/Layout/ASRelativeLayoutDefines.h
+++ b/AsyncDisplayKit/Layout/ASRelativeLayoutDefines.h
@@ -1,0 +1,34 @@
+//
+//  ASRelativeLayoutSpec.h
+//  AsyncDisplayKit
+//
+//  Created by Samuel Stow on 12/31/15.
+//
+//  Copyright (c) 2014-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under the BSD-style license found in the
+//  LICENSE file in the root directory of this source tree. An additional grant
+//  of patent rights can be found in the PATENTS file in the same directory.
+//
+
+
+/** How the child is positioned within the spec. */
+typedef NS_OPTIONS(NSUInteger, ASRelativeLayoutSpecPosition) {
+  /** The child is positioned at point 0 relatively to the layout axis (ie left / top most) */
+  ASRelativeLayoutSpecPositionStart = 0,
+  /** The child is centered along the specified axis */
+  ASRelativeLayoutSpecPositionCenter = 1 << 0,
+  /** The child is positioned at the maximum point of the layout axis (ie right / bottom most) */
+  ASRelativeLayoutSpecPositionEnd = 1 << 1,
+};
+
+/** How much space the spec will take up. */
+typedef NS_OPTIONS(NSUInteger, ASRelativeLayoutSpecSizingOption) {
+  /** The spec will take up the maximum size possible */
+  ASRelativeLayoutSpecSizingOptionDefault,
+  /** The spec will take up the minimum size possible along the X axis */
+  ASRelativeLayoutSpecSizingOptionMinimumWidth = 1 << 0,
+  /** The spec will take up the minimum size possible along the Y axis */
+  ASRelativeLayoutSpecSizingOptionMinimumHeight = 1 << 1,
+  /** Convenience option to take up the minimum size along both the X and Y axis */
+  ASRelativeLayoutSpecSizingOptionMinimumSize = ASRelativeLayoutSpecSizingOptionMinimumWidth | ASRelativeLayoutSpecSizingOptionMinimumHeight,
+};

--- a/AsyncDisplayKit/Layout/ASRelativeLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASRelativeLayoutSpec.h
@@ -11,28 +11,7 @@
 //
 
 #import <AsyncDisplayKit/ASLayoutSpec.h>
-
-/** How the child is positioned within the spec. */
-typedef NS_OPTIONS(NSUInteger, ASRelativeLayoutSpecPosition) {
-    /** The child is positioned at point 0 relatively to the layout axis (ie left / top most) */
-    ASRelativeLayoutSpecPositionStart = 0,
-    /** The child is centered along the specified axis */
-    ASRelativeLayoutSpecPositionCenter = 1 << 0,
-    /** The child is positioned at the maximum point of the layout axis (ie right / bottom most) */
-    ASRelativeLayoutSpecPositionEnd = 1 << 1,
-};
-
-/** How much space the spec will take up. */
-typedef NS_OPTIONS(NSUInteger, ASRelativeLayoutSpecSizingOption) {
-    /** The spec will take up the maximum size possible */
-    ASRelativeLayoutSpecSizingOptionDefault,
-    /** The spec will take up the minimum size possible along the X axis */
-    ASRelativeLayoutSpecSizingOptionMinimumWidth = 1 << 0,
-    /** The spec will take up the minimum size possible along the Y axis */
-    ASRelativeLayoutSpecSizingOptionMinimumHeight = 1 << 1,
-    /** Convenience option to take up the minimum size along both the X and Y axis */
-    ASRelativeLayoutSpecSizingOptionMinimumSize = ASRelativeLayoutSpecSizingOptionMinimumWidth | ASRelativeLayoutSpecSizingOptionMinimumHeight,
-};
+#import <AsyncDisplayKit/ASRelativeLayoutDefines.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/examples/ASDKgram/Sample/PhotoCellNode.m
+++ b/examples/ASDKgram/Sample/PhotoCellNode.m
@@ -112,56 +112,57 @@
 
 - (ASLayoutSpec *)layoutSpecThatFits:(ASSizeRange)constrainedSize
 {
-  // username / photo location header vertical stack
-  _photoLocationLabel.flexShrink    = YES;
   _userNameLabel.flexShrink         = YES;
   
-  ASStackLayoutSpec *headerSubStack = [ASStackLayoutSpec verticalStackLayoutSpec];
-  headerSubStack.flexShrink         = YES;
-  if (_photoLocationLabel.attributedString) {
-    [headerSubStack setChildren:@[_userNameLabel, _photoLocationLabel]];
-  } else {
-    [headerSubStack setChildren:@[_userNameLabel]];
-  }
-  
-  // header stack
-  
-  _userAvatarImageView.preferredFrameSize        = CGSizeMake(USER_IMAGE_HEIGHT, USER_IMAGE_HEIGHT);     // constrain avatar image frame size
-  _photoTimeIntervalSincePostLabel.spacingBefore = HORIZONTAL_BUFFER;                                    // to remove double spaces around spacer
-  
-  ASLayoutSpec *spacer           = [[ASLayoutSpec alloc] init];    // FIXME: long locations overflow post time - set max size?
-  spacer.flexGrow                = YES;
-  
-  UIEdgeInsets avatarInsets      = UIEdgeInsetsMake(HORIZONTAL_BUFFER, 0, HORIZONTAL_BUFFER, HORIZONTAL_BUFFER);
-  ASInsetLayoutSpec *avatarInset = [ASInsetLayoutSpec insetLayoutSpecWithInsets:avatarInsets child:_userAvatarImageView];
-
-  ASStackLayoutSpec *headerStack = [ASStackLayoutSpec horizontalStackLayoutSpec];
-  headerStack.alignItems         = ASStackLayoutAlignItemsCenter;                     // center items vertically in horizontal stack
-  headerStack.justifyContent     = ASStackLayoutJustifyContentStart;                  // justify content to the left side of the header stack
-  [headerStack setChildren:@[avatarInset, headerSubStack, spacer, _photoTimeIntervalSincePostLabel]];
-  
-  // header inset stack
-  UIEdgeInsets insets                = UIEdgeInsetsMake(0, HORIZONTAL_BUFFER, 0, HORIZONTAL_BUFFER);
-  ASInsetLayoutSpec *headerWithInset = [ASInsetLayoutSpec insetLayoutSpecWithInsets:insets child:headerStack];
-  
-  // footer stack
-  ASStackLayoutSpec *footerStack     = [ASStackLayoutSpec verticalStackLayoutSpec];
-  footerStack.spacing                = VERTICAL_BUFFER;
-  [footerStack setChildren:@[_photoLikesLabel, _photoDescriptionLabel, _photoCommentsView]];
-  
-  // footer inset stack
-  UIEdgeInsets footerInsets          = UIEdgeInsetsMake(VERTICAL_BUFFER, HORIZONTAL_BUFFER, VERTICAL_BUFFER, HORIZONTAL_BUFFER);
-  ASInsetLayoutSpec *footerWithInset = [ASInsetLayoutSpec insetLayoutSpecWithInsets:footerInsets child:footerStack];
-  
-  // vertical stack
-  CGFloat cellWidth                  = constrainedSize.max.width;
-  _photoImageView.preferredFrameSize = CGSizeMake(cellWidth, cellWidth);              // constrain photo frame size
-  
-  ASStackLayoutSpec *verticalStack   = [ASStackLayoutSpec verticalStackLayoutSpec];
-  verticalStack.alignItems           = ASStackLayoutAlignItemsStretch;                // stretch headerStack to fill horizontal space
-  [verticalStack setChildren:@[headerWithInset, _photoImageView, footerWithInset]];
-
-  return verticalStack;
+  return
+  // Main vertical stack
+  [ASStackLayoutSpec
+   stackLayoutSpecWithDirection:ASStackLayoutDirectionVertical
+   spacing:0
+   justifyContent:ASStackLayoutJustifyContentStart
+   alignItems:ASStackLayoutAlignItemsStretch
+   children:
+   @[
+     // Horizontal stack header
+     [[ASStackLayoutSpec
+       stackLayoutSpecWithDirection:ASStackLayoutDirectionHorizontal
+       spacing:0
+       justifyContent:ASStackLayoutJustifyContentStart
+       alignItems:ASStackLayoutAlignItemsCenter
+       children:
+       @[
+         // Avatar
+         [[_userAvatarImageView
+           withPreferredFrameSize:CGSizeMake(USER_IMAGE_HEIGHT, USER_IMAGE_HEIGHT)]
+          withInset:UIEdgeInsetsMake(HORIZONTAL_BUFFER, 0, HORIZONTAL_BUFFER, HORIZONTAL_BUFFER)],
+         // Username & Location vertical stack
+         [[ASStackLayoutSpec
+           stackLayoutSpecWithDirection:ASStackLayoutDirectionVertical
+           spacing:0
+           justifyContent:ASStackLayoutJustifyContentStart
+           alignItems:ASStackLayoutAlignItemsStart
+           children:(_photoLocationLabel.attributedString ? @[_userNameLabel, [_photoLocationLabel withFlexShrink:YES]] : @[_userNameLabel])]
+          withFlexShrink:YES],
+         // Spacer
+         [[[ASLayoutSpec alloc] init] withFlexGrow:YES],
+         // Timestamp text
+         [_photoTimeIntervalSincePostLabel withSpacingBefore:HORIZONTAL_BUFFER after:0]]]
+      withInset:UIEdgeInsetsMake(0, HORIZONTAL_BUFFER, 0, HORIZONTAL_BUFFER)],
+     // Photo
+     [_photoImageView withPreferredFrameSize:CGSizeMake(constrainedSize.max.width, constrainedSize.max.width)],
+     // Vertical bottom – likes, description, comments.
+     [[ASStackLayoutSpec
+       stackLayoutSpecWithDirection:ASStackLayoutDirectionVertical
+       spacing:VERTICAL_BUFFER
+       justifyContent:ASStackLayoutJustifyContentStart
+       alignItems:ASStackLayoutAlignItemsStart
+       children:
+       @[
+         _photoLikesLabel,
+         _photoDescriptionLabel,
+         _photoCommentsView]]
+      withInset:UIEdgeInsetsMake(VERTICAL_BUFFER, HORIZONTAL_BUFFER, VERTICAL_BUFFER, HORIZONTAL_BUFFER)]
+     ]];
 }
 
 #pragma mark - Instance Methods

--- a/examples/Kittens/Sample/BlurbNode.m
+++ b/examples/Kittens/Sample/BlurbNode.m
@@ -82,13 +82,10 @@ static NSString *kLinkAttributeName = @"PlaceKittenNodeLinkAttributeName";
 #if UseAutomaticLayout
 - (ASLayoutSpec *)layoutSpecThatFits:(ASSizeRange)constrainedSize
 {
-  ASCenterLayoutSpec *centerSpec = [[ASCenterLayoutSpec alloc] init];
-  centerSpec.centeringOptions = ASCenterLayoutSpecCenteringX;
-  centerSpec.sizingOptions = ASCenterLayoutSpecSizingOptionMinimumY;
-  centerSpec.child = _textNode;
-  
-  UIEdgeInsets padding =UIEdgeInsetsMake(kTextPadding, kTextPadding, kTextPadding, kTextPadding);
-  return [ASInsetLayoutSpec insetLayoutSpecWithInsets:padding child:centerSpec];
+  return [[_textNode
+           centeredWithOptions:ASCenterLayoutSpecCenteringX
+           sizingOptions:ASCenterLayoutSpecSizingOptionMinimumY]
+          withInset:UIEdgeInsetsMake(kTextPadding, kTextPadding, kTextPadding, kTextPadding)];
 }
 #else
 - (CGSize)calculateSizeThatFits:(CGSize)constrainedSize

--- a/examples/Kittens/Sample/KittenNode.mm
+++ b/examples/Kittens/Sample/KittenNode.mm
@@ -144,17 +144,12 @@ static const CGFloat kInnerPadding = 10.0f;
 {
   _imageNode.preferredFrameSize = _isImageEnlarged ? CGSizeMake(2.0 * kImageSize, 2.0 * kImageSize) : CGSizeMake(kImageSize, kImageSize);
   _textNode.flexShrink = YES;
-  
-  ASStackLayoutSpec *stackSpec = [[ASStackLayoutSpec alloc] init];
-  stackSpec.direction = ASStackLayoutDirectionHorizontal;
-  stackSpec.spacing = kInnerPadding;
-  [stackSpec setChildren:!_swappedTextAndImage ? @[_imageNode, _textNode] : @[_textNode, _imageNode]];
-  
-  ASInsetLayoutSpec *insetSpec = [[ASInsetLayoutSpec alloc] init];
-  insetSpec.insets = UIEdgeInsetsMake(kOuterPadding, kOuterPadding, kOuterPadding, kOuterPadding);
-  insetSpec.child = stackSpec;
-  
-  return insetSpec;
+  return [[ASStackLayoutSpec stackLayoutSpecWithDirection:ASStackLayoutDirectionHorizontal
+                                                  spacing:kInnerPadding
+                                           justifyContent:ASStackLayoutJustifyContentStart
+                                               alignItems:ASStackLayoutAlignItemsStart
+                                                 children:!_swappedTextAndImage ? @[_imageNode, _textNode] : @[_textNode, _imageNode]]
+          withInset:UIEdgeInsetsMake(kOuterPadding, kOuterPadding, kOuterPadding, kOuterPadding)];
 }
 
 // With box model, you don't need to override this method, unless you want to add custom logic.


### PR DESCRIPTION
This is mostly a PoC/proposal to see what people think about this. The goal is, for the most part, to be able to specify a complex layout spec in one gigantic declarative-style call and avoid intermediate variables and order-inversion while building it. I think it's an improvement but still sort of daunting.

I don't expect to merge this necessarily. It didn't take long to create so I'm not married to it. But it proves that something like this is possible and I think beneficial.

- Add methods like `-(instancetype)withFlexGrow:(BOOL)flexGrow` to ASLayoutable to set properties while chaining
- Add methods like `-(ASInsetLayoutSpec *)withInset:(UIEdgeInsets)insets` to ASLayoutable to embed layoutables while chaining
- Implementations for these methods are stored in a ASLayoutableConvenienceImpl macro, which is added to ASDisplayNode.mm and ASLayoutSpec.m
- All indentation is Xcode-correct. There are questions about where newlines should go but I think ASDKgram::PhotoCellNode has a pretty nice style.
- Update a couple sample app layout spec methods as demo.

@appleguy @maicki @levi @hannahmbanana Thoughts?