### PR TITLE
[ASDelegateProxy] Add `conformsToProtocol:`

### DIFF
--- a/AsyncDisplayKit/Details/ASDelegateProxy.m
+++ b/AsyncDisplayKit/Details/ASDelegateProxy.m
@@ -118,6 +118,15 @@
   return self;
 }
 
+- (BOOL)conformsToProtocol:(Protocol *)aProtocol
+{
+  if (_target) {
+    return [_target conformsToProtocol:aProtocol];
+  } else {
+    return [super conformsToProtocol:aProtocol];
+  }
+}
+
 - (BOOL)respondsToSelector:(SEL)aSelector
 {
   if ([self interceptsSelector:aSelector]) {


### PR DESCRIPTION
Currently we don't forward `conformsToProtocol:` to the `target` in `ASDelegateProxy`. Unfortunately there can be some problems with that. I ran into this as I tried to implement a custom UICollectionViewLayout that checks if it's delegate conforms to a protocol. Currently this will will crash so we should forward that `conformsToProtocol:` call to the target.