### PR TITLE
[ASVideoNode] Ensure that observer methods don't observe all other ASVideoNode objects

### DIFF
--- a/AsyncDisplayKit/ASVideoNode.mm
+++ b/AsyncDisplayKit/ASVideoNode.mm
@@ -164,6 +164,10 @@ static NSString * const kStatus = @"status";
 
 - (void)addPlayerItemObservers:(AVPlayerItem *)playerItem
 {
+  if (playerItem == nil) {
+    return;
+  }
+  
   [playerItem addObserver:self forKeyPath:kStatus options:NSKeyValueObservingOptionInitial | NSKeyValueObservingOptionNew context:ASVideoNodeContext];
   [playerItem addObserver:self forKeyPath:kPlaybackLikelyToKeepUpKey options:NSKeyValueObservingOptionNew context:ASVideoNodeContext];
   [playerItem addObserver:self forKeyPath:kplaybackBufferEmpty options:NSKeyValueObservingOptionNew context:ASVideoNodeContext];
@@ -641,7 +645,9 @@ static NSString * const kStatus = @"status";
 
   _currentPlayerItem = currentItem;
 
-  [self addPlayerItemObservers:currentItem];
+  if (currentItem != nil) {
+    [self addPlayerItemObservers:currentItem];
+  }
 }
 
 - (ASDisplayNode *)playerNode


### PR DESCRIPTION
During testing with my own app I noticed that my observer was getting called far too often for the methods in ASVideoNodeDelegate such as `videoDidPlayToEnd:`. Some investigation identified that this was due to the object being set to observe all other ASVideoNode objects when the internal `setCurrentItem:` method was called.

This was quite simple to avoid by guarding the addPlayerItemObservers: when the player item is nil.

I tried to add a unit tests but it's difficult to mock NSNotificationCenter without injecting one into the class at construction. This would change too much of the internals, so decided against it.

I've verified the operation of this with my own app (containing multiple ASVideoNode objects) and it appears to work fine. You can probably check the behaviour with he Videos example app if you set it up.