### PR TITLE
[ASCollectionView] Greatly Improve Cell Node Resize Handling

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -24,7 +24,6 @@
 #import "UICollectionViewLayout+ASConvenience.h"
 #import "ASRangeControllerUpdateRangeProtocol+Beta.h"
 #import "_ASDisplayLayer.h"
-#import "ASAvailability.h"
 
 static const NSUInteger kASCollectionViewAnimationNone = UITableViewRowAnimationNone;
 static const ASSizeRange kInvalidSizeRange = {CGSizeZero, CGSizeZero};

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -1139,14 +1139,15 @@ static const NSTimeInterval kASCollectionViewAnimationDuration = 0.3;
   
   BOOL isFirstInvalidation = !_didInvalidateCollectionViewLayoutDueToCellNodeResize;
   if (isFirstInvalidation) {
-    UICollectionViewLayoutInvalidationContext *inval = [[[[self.collectionViewLayout class] invalidationContextClass] alloc] init];
+    UICollectionViewLayout *layout = self.collectionViewLayout;
+    UICollectionViewLayoutInvalidationContext *inval = [[[[layout class] invalidationContextClass] alloc] init];
 
     // NOTE: We don't invalidate specific items here because the layout
     // will not move other items to account for the change. This is almost
     // never good, so we intentionally don't do it. Plus this allows us to
     // only invalidate once even if multiple cell nodes resize.
 
-    [self.collectionViewLayout invalidateLayoutWithContext:inval];
+    [layout invalidateLayoutWithContext:inval];
     
     _didInvalidateCollectionViewLayoutDueToCellNodeResize = YES;
     _shouldAnimateNextLayout = YES;

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -1191,7 +1191,7 @@ static const NSTimeInterval kASCollectionViewAnimationDuration = 0.3;
     [_layoutFacilitator collectionViewWillEditCellsAtIndexPaths:indexPaths batched:NO];
     UICollectionViewLayoutInvalidationContext *inval = [[[[self.collectionViewLayout class] invalidationContextClass] alloc] init];
     
-    // NOTE: If we invalidate specific items, then flow layout
+    // NOTE: We don't invalidate specific items here because the layout
     // will not move other items to account for the change. This is almost
     // never good, so we intentionally don't do it.
     

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -1187,20 +1187,15 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   
   if (indexPaths.count > 0) {
     [_layoutFacilitator collectionViewWillEditCellsAtIndexPaths:indexPaths batched:NO];
-    UICollectionViewLayoutInvalidationContext *inval = [[UICollectionViewLayoutInvalidationContext alloc] init];
+    UICollectionViewLayoutInvalidationContext *inval = [[[[self.collectionViewLayout class] invalidationContextClass] alloc] init];
     if (AS_AT_LEAST_IOS8) {
       [inval invalidateItemsAtIndexPaths:indexPaths];
     }
     
-    if (_queuedNodeSizeInvalidationContext.shouldAnimate) {
-      [UIView animateWithDuration:0.5 animations:^{
+    [UIView performWithoutAnimation:^{
         [self.collectionViewLayout invalidateLayoutWithContext:inval];
         [self layoutIfNeeded];
-      }];
-      
-    } else {
-      [self.collectionViewLayout invalidateLayoutWithContext:inval];
-    }
+    }];
   }
   
   _queuedNodeSizeInvalidationContext = nil;

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -772,6 +772,8 @@ static const NSTimeInterval kASCollectionViewAnimationDuration = 0.3;
       [self performBatchAnimated:YES updates:^{
         [_dataController relayoutAllNodes];
       } completion:nil];
+      // We need to ensure the size requery is done before we update our layout.
+      [self waitUntilAllUpdatesAreCommitted];
     }
   }
   

--- a/AsyncDisplayKit/Details/ASDataController.mm
+++ b/AsyncDisplayKit/Details/ASDataController.mm
@@ -32,8 +32,6 @@ const static NSUInteger kASDataControllerSizingCountPerProcessor = 5;
 
 NSString * const ASDataControllerRowNodeKind = @"_ASDataControllerRowNodeKind";
 
-static void *kASSizingQueueContext = &kASSizingQueueContext;
-
 @interface ASDataController () {
   NSMutableArray *_externalCompletedNodes;    // Main thread only.  External data access can immediately query this if available.
   NSMutableDictionary *_completedNodes;       // Main thread only.  External data access can immediately query this if _externalCompletedNodes is unavailable.


### PR DESCRIPTION
When an ASCellNode performs a layout that results in a size change, it informs its collection view which must update the layout to account for the new size. This was achieved by submitting an empty update block to the collection view. We do the same thing for table view, with `beginUpdates/endUpdates`.

However, unlike a table view, a collection view generates expensive animations when given an empty update. Instead, we can simply invalidate the layout and it will be updated using the normal Core Animation layout system.

Since this is so much cheaper, we can invalidate the layout synchronously and ensure that another frame is not drawn between the node relayout and the collection view relayout.

- Use `invalidateLayoutWithContext:` rather than `performBatchUpdates:^{}` to handle cell node size changes.
- Invalidate the layout synchronously rather than coalescing in the main queue. This is possible now because invalidating the layout multiple times in the same run loop is not expensive. This **critically** guarantees that another frame will not be composited in between the node relayout and the corresponding collection view layout.
- Ignore batch updates that don't contain changes.
  - These can cause a performance hit.
  - ASDK has a separate way to resize cell nodes.
  - Using an empty batch update to resize cells is an undocumented feature of UIKit.
- Remove an unused variable from ASDataController

Plz review @maicki @appleguy