### PR TITLE
Don't propagate trait collections to cells if the node is not loaded yet

### DIFF
--- a/AsyncDisplayKit/Details/ASEnvironment.h
+++ b/AsyncDisplayKit/Details/ASEnvironment.h
@@ -157,6 +157,10 @@ ASDISPLAYNODE_EXTERN_C_END
   ASDN::MutexLocker l(lock);\
   ASEnvironmentTraitCollection oldTraits = self.environmentState.environmentTraitCollection;\
   [super setEnvironmentState:environmentState];\
+\
+   /* Extra Trait Collection Handling */\
+  /* If the node is not loaded  yet don't do anything as otherwise the access of the view will trigger a load*/\
+  if (!self.isNodeLoaded) { return; } \
   ASEnvironmentTraitCollection currentTraits = environmentState.environmentTraitCollection;\
   if (ASEnvironmentTraitCollectionIsEqualToASEnvironmentTraitCollection(currentTraits, oldTraits) == NO) {\
     /* Must dispatch to main for self.view && [self.view.dataController completedNodes]*/ \


### PR DESCRIPTION
This fixes an issue where the propagation of trait collections trigger are creation of the node if the node view was not loaded yet.

cc @rcancro Does this make sense or am I overlooking something?