### PR TITLE
[ASVisibility] Don't change the range mode if the node was not loaded yet

### DIFF
--- a/AsyncDisplayKit/ASCollectionNode.h
+++ b/AsyncDisplayKit/ASCollectionNode.h
@@ -25,10 +25,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithCollectionViewLayout:(UICollectionViewLayout *)layout;
 - (instancetype)initWithFrame:(CGRect)frame collectionViewLayout:(UICollectionViewLayout *)layout;
 
+@property (strong, nonatomic, readonly) ASCollectionView *view;
+
 @property (weak, nonatomic) id <ASCollectionDelegate>   delegate;
 @property (weak, nonatomic) id <ASCollectionDataSource> dataSource;
-
-@property (nonatomic, readonly) ASCollectionView *view;
 
 /**
  * Tuning parameters for a range type in full mode.

--- a/AsyncDisplayKit/ASCollectionNode.mm
+++ b/AsyncDisplayKit/ASCollectionNode.mm
@@ -12,51 +12,75 @@
 
 #import "ASCollectionNode.h"
 #import "ASCollectionInternal.h"
-#import "ASCollectionViewLayoutFacilitatorProtocol.h"
 #import "ASDisplayNode+Subclasses.h"
 #import "ASEnvironmentInternal.h"
 #import "ASInternalHelpers.h"
 #import "ASRangeControllerUpdateRangeProtocol+Beta.h"
+
 #include <vector>
+
+#pragma mark - _ASCollectionPendingState
 
 @interface _ASCollectionPendingState : NSObject
 @property (weak, nonatomic) id <ASCollectionDelegate>   delegate;
 @property (weak, nonatomic) id <ASCollectionDataSource> dataSource;
+@property (assign, nonatomic) ASLayoutRangeMode rangeMode;
 @end
 
 @implementation _ASCollectionPendingState
-@end
 
-#if 0  // This is not used yet, but will provide a way to avoid creating the view to set range values.
-@implementation _ASCollectionPendingState
+- (instancetype)init
 {
-  std::vector<ASRangeTuningParameters> _tuningParameters;
+  self = [super init];
+  if (self) {
+    _rangeMode = ASLayoutRangeModeCount;
+  }
+  return self;
+}
+@end
+
+// TODO: Add support for tuning parameters in the pending state
+#if 0  // This is not used yet, but will provide a way to avoid creating the view to set range values.
+@implementation _ASCollectionPendingState {
+  std::vector<std::vector<ASRangeTuningParameters>> _tuningParameters;
 }
 
 - (instancetype)init
 {
-  if (!(self = [super init])) {
-    return nil;
+  self = [super init];
+  if (self) {
+    _tuningParameters = std::vector<std::vector<ASRangeTuningParameters>> (ASLayoutRangeModeCount, std::vector<ASRangeTuningParameters> (ASLayoutRangeTypeCount));
+    _rangeMode = ASLayoutRangeModeCount;
   }
-  _tuningParameters = std::vector<ASRangeTuningParameters>(ASLayoutRangeTypeCount);
   return self;
 }
 
 - (ASRangeTuningParameters)tuningParametersForRangeType:(ASLayoutRangeType)rangeType
 {
-  ASDisplayNodeAssert(rangeType < _tuningParameters.size(), @"Requesting a range that is OOB for the configured tuning parameters");
-  return _tuningParameters[rangeType];
+  return [self tuningParametersForRangeMode:ASLayoutRangeModeFull rangeType:rangeType];
 }
 
 - (void)setTuningParameters:(ASRangeTuningParameters)tuningParameters forRangeType:(ASLayoutRangeType)rangeType
 {
-  ASDisplayNodeAssert(rangeType < _tuningParameters.size(), @"Requesting a range that is OOB for the configured tuning parameters");
-  ASDisplayNodeAssert(rangeType != ASLayoutRangeTypeVisible, @"Must not set Visible range tuning parameters (always 0, 0)");
-  _tuningParameters[rangeType] = tuningParameters;
+  return [self setTuningParameters:tuningParameters forRangeMode:ASLayoutRangeModeFull rangeType:rangeType];
+}
+
+- (ASRangeTuningParameters)tuningParametersForRangeMode:(ASLayoutRangeMode)rangeMode rangeType:(ASLayoutRangeType)rangeType
+{
+  ASDisplayNodeAssert(rangeMode < _tuningParameters.size() && rangeType < _tuningParameters[rangeMode].size(), @"Requesting a range that is OOB for the configured tuning parameters");
+  return _tuningParameters[rangeMode][rangeType];
+}
+
+- (void)setTuningParameters:(ASRangeTuningParameters)tuningParameters forRangeMode:(ASLayoutRangeMode)rangeMode rangeType:(ASLayoutRangeType)rangeType
+{
+  ASDisplayNodeAssert(rangeMode < _tuningParameters.size() && rangeType < _tuningParameters[rangeMode].size(), @"Setting a range that is OOB for the configured tuning parameters");
+  _tuningParameters[rangeMode][rangeType] = tuningParameters;
 }
 
 @end
 #endif
+
+#pragma mark - ASCollectionNode
 
 @interface ASCollectionNode ()
 {
@@ -66,6 +90,8 @@
 @end
 
 @implementation ASCollectionNode
+
+#pragma mark Lifecycle
 
 - (instancetype)init
 {
@@ -109,6 +135,8 @@
   return nil;
 }
 
+#pragma mark ASDisplayNode
+
 - (void)didLoad
 {
   [super didLoad];
@@ -121,8 +149,38 @@
     self.pendingState      = nil;
     view.asyncDelegate     = pendingState.delegate;
     view.asyncDataSource   = pendingState.dataSource;
+    if (pendingState.rangeMode != ASLayoutRangeModeCount) {
+      [view.rangeController updateCurrentRangeWithMode:pendingState.rangeMode];
+    }
   }
 }
+
+- (ASCollectionView *)view
+{
+  return (ASCollectionView *)[super view];
+}
+
+- (void)clearContents
+{
+  [super clearContents];
+  [self.view clearContents];
+}
+
+- (void)clearFetchedData
+{
+  [super clearFetchedData];
+  [self.view clearFetchedData];
+}
+
+#if ASRangeControllerLoggingEnabled
+- (void)visibleStateDidChange:(BOOL)isVisible
+{
+  [super visibleStateDidChange:isVisible];
+  NSLog(@"%@ - visible: %d", self, isVisible);
+}
+#endif
+
+#pragma mark Setter / Getter
 
 - (_ASCollectionPendingState *)pendingState
 {
@@ -171,47 +229,7 @@
   }
 }
 
-- (ASCollectionView *)view
-{
-  return (ASCollectionView *)[super view];
-}
-
-#if ASRangeControllerLoggingEnabled
-- (void)visibleStateDidChange:(BOOL)isVisible
-{
-  [super visibleStateDidChange:isVisible];
-  NSLog(@"%@ - visible: %d", self, isVisible);
-}
-#endif
-
-- (void)clearContents
-{
-  [super clearContents];
-  [self.view clearContents];
-}
-
-- (void)clearFetchedData
-{
-  [super clearFetchedData];
-  [self.view clearFetchedData];
-}
-
-- (void)beginUpdates
-{
-  [self.view.dataController beginUpdates];
-}
-
-- (void)endUpdatesAnimated:(BOOL)animated
-{
-  [self endUpdatesAnimated:animated completion:nil];
-}
-
-- (void)endUpdatesAnimated:(BOOL)animated completion:(void (^)(BOOL))completion
-{
-  [self.view.dataController endUpdatesAnimated:animated completion:completion];
-}
-
-#pragma mark - ASCollectionView Forwards
+#pragma mark ASCollectionView Forwards
 
 - (ASRangeTuningParameters)tuningParametersForRangeType:(ASLayoutRangeType)rangeType
 {
@@ -233,11 +251,6 @@
   return [self.view.rangeController setTuningParameters:tuningParameters forRangeMode:rangeMode rangeType:rangeType];
 }
 
-- (void)updateCurrentRangeWithMode:(ASLayoutRangeMode)rangeMode;
-{
-  [self.view.rangeController updateCurrentRangeWithMode:rangeMode];
-}
-
 - (void)reloadDataWithCompletion:(void (^)())completion
 {
   [self.view reloadDataWithCompletion:completion];
@@ -252,6 +265,34 @@
 {
   [self.view reloadDataImmediately];
 }
+
+- (void)beginUpdates
+{
+  [self.view.dataController beginUpdates];
+}
+
+- (void)endUpdatesAnimated:(BOOL)animated
+{
+  [self endUpdatesAnimated:animated completion:nil];
+}
+
+- (void)endUpdatesAnimated:(BOOL)animated completion:(void (^)(BOOL))completion
+{
+  [self.view.dataController endUpdatesAnimated:animated completion:completion];
+}
+
+#pragma mark - ASRangeControllerUpdateRangeProtocol
+
+- (void)updateCurrentRangeWithMode:(ASLayoutRangeMode)rangeMode;
+{
+  if ([self pendingState]) {
+    _pendingState.rangeMode = rangeMode;
+  } else {
+    [self.view.rangeController updateCurrentRangeWithMode:rangeMode];
+  }
+}
+
+#pragma mark ASEnvironment
 
 ASEnvironmentCollectionTableSetEnvironmentState(_environmentStateLock)
 

--- a/AsyncDisplayKit/ASTableNode.h
+++ b/AsyncDisplayKit/ASTableNode.h
@@ -21,7 +21,7 @@
 - (instancetype)init; // UITableViewStylePlain
 - (instancetype)initWithStyle:(UITableViewStyle)style;
 
-@property (nonatomic, readonly) ASTableView *view;
+@property (strong, nonatomic, readonly) ASTableView *view;
 
 // These properties can be set without triggering the view to be created, so it's fine to set them in -init.
 @property (weak, nonatomic) id <ASTableDelegate>   delegate;

--- a/AsyncDisplayKit/ASTableNode.mm
+++ b/AsyncDisplayKit/ASTableNode.mm
@@ -10,20 +10,34 @@
 //  of patent rights can be found in the PATENTS file in the same directory.
 //
 
+#import "ASTableNode.h"
+#import "ASTableViewInternal.h"
 #import "ASEnvironmentInternal.h"
 #import "ASDisplayNode+Subclasses.h"
-#import "ASFlowLayoutController.h"
 #import "ASInternalHelpers.h"
 #import "ASRangeControllerUpdateRangeProtocol+Beta.h"
-#import "ASTableViewInternal.h"
+
+#pragma mark - _ASTablePendingState
 
 @interface _ASTablePendingState : NSObject
 @property (weak, nonatomic) id <ASTableDelegate>   delegate;
 @property (weak, nonatomic) id <ASTableDataSource> dataSource;
+@property (assign, nonatomic) ASLayoutRangeMode rangeMode;
 @end
 
 @implementation _ASTablePendingState
+- (instancetype)init
+{
+  self = [super init];
+  if (self) {
+    _rangeMode = ASLayoutRangeModeCount;
+  }
+  return self;
+}
+
 @end
+
+#pragma mark - ASTableView
 
 @interface ASTableNode ()
 {
@@ -38,6 +52,8 @@
 @end
 
 @implementation ASTableNode
+
+#pragma mark Lifecycle
 
 - (instancetype)_initWithTableView:(ASTableView *)tableView
 {
@@ -72,6 +88,8 @@
   return [self _initWithFrame:CGRectZero style:UITableViewStylePlain dataControllerClass:nil];
 }
 
+#pragma mark ASDisplayNode
+
 - (void)didLoad
 {
   [super didLoad];
@@ -84,22 +102,43 @@
     self.pendingState    = nil;
     view.asyncDelegate   = pendingState.delegate;
     view.asyncDataSource = pendingState.dataSource;
+    if (pendingState.rangeMode != ASLayoutRangeModeCount) {
+      [view.rangeController updateCurrentRangeWithMode:pendingState.rangeMode];
+    }
   }
 }
 
-- (void)updateCurrentRangeWithMode:(ASLayoutRangeMode)rangeMode
+- (ASTableView *)view
 {
-    if (!self.isNodeLoaded) {
-        return;
-    }
-    
-    [self.view.rangeController updateCurrentRangeWithMode:rangeMode];
+  return (ASTableView *)[super view];
 }
+
+- (void)clearContents
+{
+  [super clearContents];
+  [self.view clearContents];
+}
+
+- (void)clearFetchedData
+{
+  [super clearFetchedData];
+  [self.view clearFetchedData];
+}
+
+#if ASRangeControllerLoggingEnabled
+- (void)visibleStateDidChange:(BOOL)isVisible
+{
+  [super visibleStateDidChange:isVisible];
+  NSLog(@"%@ - visible: %d", self, isVisible);
+}
+#endif
+
+#pragma mark Setter / Getter
 
 - (_ASTablePendingState *)pendingState
 {
   if (!_pendingState && ![self isNodeLoaded]) {
-    self.pendingState = [[_ASTablePendingState alloc] init];
+    _pendingState = [[_ASTablePendingState alloc] init];
   }
   ASDisplayNodeAssert(![self isNodeLoaded] || !_pendingState, @"ASTableNode should not have a pendingState once it is loaded");
   return _pendingState;
@@ -143,30 +182,19 @@
   }
 }
 
-- (ASTableView *)view
+#pragma mark ASRangeControllerUpdateRangeProtocol
+
+- (void)updateCurrentRangeWithMode:(ASLayoutRangeMode)rangeMode
 {
-  return (ASTableView *)[super view];
+  if ([self pendingState]) {
+    _pendingState.rangeMode = rangeMode;
+  } else {
+    ASDisplayNodeAssert([self isNodeLoaded], @"ASTableNode should be loaded if pendingState doesn't exist");
+    [self.view.rangeController updateCurrentRangeWithMode:rangeMode];
+  }
 }
 
-#if ASRangeControllerLoggingEnabled
-- (void)visibleStateDidChange:(BOOL)isVisible
-{
-  [super visibleStateDidChange:isVisible];
-  NSLog(@"%@ - visible: %d", self, isVisible);
-}
-#endif
-
-- (void)clearContents
-{
-  [super clearContents];
-  [self.view clearContents];
-}
-
-- (void)clearFetchedData
-{
-  [super clearFetchedData];
-  [self.view clearFetchedData];
-}
+#pragma mark ASEnvironment
 
 ASEnvironmentCollectionTableSetEnvironmentState(_environmentStateLock)
 

--- a/AsyncDisplayKit/Details/ASAbstractLayoutController.mm
+++ b/AsyncDisplayKit/Details/ASAbstractLayoutController.mm
@@ -91,15 +91,13 @@ extern BOOL ASRangeTuningParametersEqualToRangeTuningParameters(ASRangeTuningPar
 
 - (ASRangeTuningParameters)tuningParametersForRangeMode:(ASLayoutRangeMode)rangeMode rangeType:(ASLayoutRangeType)rangeType
 {
-  ASDisplayNodeAssert(rangeMode < _tuningParameters.size() && rangeType < _tuningParameters[rangeMode].size(),
-                      @"Requesting a range that is OOB for the configured tuning parameters");
+  ASDisplayNodeAssert(rangeMode < _tuningParameters.size() && rangeType < _tuningParameters[rangeMode].size(), @"Requesting a range that is OOB for the configured tuning parameters");
   return _tuningParameters[rangeMode][rangeType];
 }
 
 - (void)setTuningParameters:(ASRangeTuningParameters)tuningParameters forRangeMode:(ASLayoutRangeMode)rangeMode rangeType:(ASLayoutRangeType)rangeType
 {
-  ASDisplayNodeAssert(rangeMode < _tuningParameters.size() && rangeType < _tuningParameters[rangeMode].size(),
-                      @"Setting a range that is OOB for the configured tuning parameters");
+  ASDisplayNodeAssert(rangeMode < _tuningParameters.size() && rangeType < _tuningParameters[rangeMode].size(), @"Setting a range that is OOB for the configured tuning parameters");
   _tuningParameters[rangeMode][rangeType] = tuningParameters;
 }
 


### PR DESCRIPTION
Changing the range mode needs to access the view within the node. If the view was not loaded at this point it will trigger a view load, but that's not necessarily wanted so prevent changing it if the node is not loaded yet.

cc @garrettmoon Garrett does this change makes sense or do you have other ideas around it?