### PR TITLE
[ASVideoPlayerNode] Expose placeholder image for the underlying ASVideoNode

### DIFF
--- a/AsyncDisplayKit/ASVideoNode.mm
+++ b/AsyncDisplayKit/ASVideoNode.mm
@@ -164,6 +164,10 @@ static NSString * const kStatus = @"status";
 
 - (void)addPlayerItemObservers:(AVPlayerItem *)playerItem
 {
+  if (playerItem == nil) {
+    return;
+  }
+  
   [playerItem addObserver:self forKeyPath:kStatus options:NSKeyValueObservingOptionInitial | NSKeyValueObservingOptionNew context:ASVideoNodeContext];
   [playerItem addObserver:self forKeyPath:kPlaybackLikelyToKeepUpKey options:NSKeyValueObservingOptionNew context:ASVideoNodeContext];
   [playerItem addObserver:self forKeyPath:kplaybackBufferEmpty options:NSKeyValueObservingOptionNew context:ASVideoNodeContext];
@@ -641,7 +645,9 @@ static NSString * const kStatus = @"status";
 
   _currentPlayerItem = currentItem;
 
-  [self addPlayerItemObservers:currentItem];
+  if (currentItem != nil) {
+    [self addPlayerItemObservers:currentItem];
+  }
 }
 
 - (ASDisplayNode *)playerNode

--- a/AsyncDisplayKit/ASVideoPlayerNode.h
+++ b/AsyncDisplayKit/ASVideoPlayerNode.h
@@ -49,6 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign, readwrite) BOOL muted;
 @property (nonatomic, assign, readonly) ASVideoNodePlayerState playerState;
 @property (nonatomic, assign, readwrite) BOOL shouldAggressivelyRecoverFromStall;
+@property (nullable, atomic, strong, readwrite) NSURL *placeholderImageURL;
 
 //! Defaults to 100
 @property (nonatomic, assign) int32_t periodicTimeObserverTimescale;

--- a/AsyncDisplayKit/ASVideoPlayerNode.mm
+++ b/AsyncDisplayKit/ASVideoPlayerNode.mm
@@ -76,6 +76,9 @@ static void *ASVideoPlayerNodeContext = &ASVideoPlayerNodeContext;
 @end
 
 @implementation ASVideoPlayerNode
+
+@dynamic placeholderImageURL;
+
 - (instancetype)init
 {
   if (!(self = [super init])) {
@@ -769,6 +772,16 @@ static void *ASVideoPlayerNodeContext = &ASVideoPlayerNodeContext;
 - (BOOL)shouldAggressivelyRecoverFromStall
 {
   return _videoNode.shouldAggressivelyRecoverFromStall;
+}
+
+- (void) setPlaceholderImageURL:(NSURL *)placeholderImageURL
+{
+  _videoNode.URL = placeholderImageURL;
+}
+
+- (NSURL*) placeholderImageURL
+{
+  return _videoNode.URL;
 }
 
 - (void)setShouldAggressivelyRecoverFromStall:(BOOL)shouldAggressivelyRecoverFromStall


### PR DESCRIPTION
At the moment there's no way to access the underlying ASVideoNode and make use of the recent functionality for placeholder images. I've added a property to expose this.