### PR TITLE
[ASDisplayNode] Allow measure always be off the main thread

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -718,7 +718,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   int32_t transitionID = [self _startNewTransition];
   
   ASDisplayNodePerformBlockOnEverySubnode(self, ^(ASDisplayNode * _Nonnull node) {
-    ASDisplayNodeAssert([node _hasTransitionInProgress] == NO, @"Can't start a transition when one of the subnodes is performing one.");
+    ASDisplayNodeAssert([node _isTransitionInProgress] == NO, @"Can't start a transition when one of the subnodes is performing one.");
     node.hierarchyState |= ASHierarchyStateLayoutPending;
     node.pendingTransitionID = transitionID;
   });
@@ -821,7 +821,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
 - (void)cancelLayoutTransitionsInProgress
 {
   ASDN::MutexLocker l(_propertyLock);
-  if ([self _hasTransitionInProgress]) {
+  if ([self _isTransitionInProgress]) {
     // Cancel transition in progress
     [self _finishOrCancelTransition];
       
@@ -844,7 +844,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   _usesImplicitHierarchyManagement = value;
 }
 
-- (BOOL)_hasTransitionInProgress
+- (BOOL)_isTransitionInProgress
 {
   ASDN::MutexLocker l(_propertyLock);
   return _transitionInProgress;
@@ -2445,7 +2445,7 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
   }
 
   // Trampoline to the main thread if necessary
-  if (ASDisplayNodeThreadIsMain() == NO && layoutTransition.canTransitionAsynchronous == NO) {
+  if (ASDisplayNodeThreadIsMain() == NO && layoutTransition.isSynchronous == NO) {
 
     // Subnode insertions and removals need to happen always on the main thread if at least one subnode is already loaded
     ASPerformBlockOnMainThread(^{

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -2449,13 +2449,13 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
 
     // Subnode insertions and removals need to happen always on the main thread if at least one subnode is already loaded
     ASPerformBlockOnMainThread(^{
-      [layoutTransition applySubnodeTransition];
+      [layoutTransition startTransition];
     });
     
     return;
   }
   
-  [layoutTransition applySubnodeTransition];
+  [layoutTransition startTransition];
 }
 
 - (void)layout

--- a/AsyncDisplayKit/Layout/ASLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASLayoutSpec.mm
@@ -54,6 +54,11 @@ typedef std::map<unsigned long, id<ASLayoutable>, std::less<unsigned long>> ASCh
   return ASLayoutableTypeLayoutSpec;
 }
 
+- (BOOL)canLayoutAsynchronous
+{
+  return YES;
+}
+
 #pragma mark - Layout
 
 - (ASLayout *)measureWithSizeRange:(ASSizeRange)constrainedSize

--- a/AsyncDisplayKit/Layout/ASLayoutable.h
+++ b/AsyncDisplayKit/Layout/ASLayoutable.h
@@ -46,7 +46,15 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @protocol ASLayoutable <ASEnvironment, ASStackLayoutable, ASStaticLayoutable, ASLayoutablePrivate, ASLayoutableExtensibility>
 
+/**
+ * @abstract Returns type of layoutable
+ */
 @property (nonatomic, readonly) ASLayoutableType layoutableType;
+
+/**
+ * @abstract Returns if the layoutable can be used to layout in an asynchronous way on a background thread.
+ */
+@property (nonatomic, readonly) BOOL canLayoutAsynchronous;
 
 /**
  * @abstract Calculate a layout based on given size range.

--- a/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
+++ b/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
@@ -118,6 +118,7 @@ FOUNDATION_EXPORT NSString * const ASRenderingEngineDidDisplayNodesScheduledBefo
   ASEnvironmentState _environmentState;
   ASLayout *_layout;
 
+
   UIEdgeInsets _hitTestSlop;
   NSMutableArray *_subnodes;
   

--- a/AsyncDisplayKit/Private/ASLayoutTransition.h
+++ b/AsyncDisplayKit/Private/ASLayoutTransition.h
@@ -18,16 +18,45 @@
 
 @interface ASLayoutTransition : NSObject <_ASTransitionContextLayoutDelegate>
 
+/**
+ * Node to apply layout transition on
+ */
 @property (nonatomic, readonly, weak) ASDisplayNode *node;
-@property (nonatomic, readonly, strong) ASLayout *pendingLayout;
+
+/**
+ * Previous layout to transition from
+ */
 @property (nonatomic, readonly, strong) ASLayout *previousLayout;
 
-- (instancetype)initWithNode:(ASDisplayNode *)node
-               pendingLayout:(ASLayout *)pendingLayout
-              previousLayout:(ASLayout *)previousLayout;
+/**
+ * Pending layout to transition to
+ */
+@property (nonatomic, readonly, strong) ASLayout *pendingLayout;
 
+/**
+ * Returns if the layout transition can happen asynchronously
+ */
+@property (nonatomic, readonly, assign) BOOL canTransitionAsynchronous;
+
+/**
+ * Returns a newly initialized layout transition
+ */
+- (instancetype)initWithNode:(ASDisplayNode *)node pendingLayout:(ASLayout *)pendingLayout previousLayout:(ASLayout *)previousLayout NS_DESIGNATED_INITIALIZER;
+- (instancetype)init NS_UNAVAILABLE;
+
+/**
+ * Insert and remove subnodes that where added or removed between the previousLayout and the pendingLayout
+ */
+- (void)applySubnodeTransition;
+
+/**
+ * Insert all new subnodes that where added between the previous layout and the pending layout
+ */
 - (void)applySubnodeInsertions;
 
+/**
+ * Remove all subnodes that are removed between the previous layout and the pending layout
+ */
 - (void)applySubnodeRemovals;
 
 @end

--- a/AsyncDisplayKit/Private/ASLayoutTransition.h
+++ b/AsyncDisplayKit/Private/ASLayoutTransition.h
@@ -36,7 +36,7 @@
 /**
  * Returns if the layout transition can happen asynchronously
  */
-@property (nonatomic, readonly, assign) BOOL canTransitionAsynchronous;
+@property (nonatomic, readonly, assign, getter=isSynchronous) BOOL synchronous;
 
 /**
  * Returns a newly initialized layout transition

--- a/AsyncDisplayKit/Private/ASLayoutTransition.h
+++ b/AsyncDisplayKit/Private/ASLayoutTransition.h
@@ -36,7 +36,7 @@
 /**
  * Returns if the layout transition can happen asynchronously
  */
-@property (nonatomic, readonly, assign, getter=isSynchronous) BOOL synchronous;
+@property (nonatomic, readonly, assign) BOOL isSynchronous;
 
 /**
  * Returns a newly initialized layout transition
@@ -47,7 +47,7 @@
 /**
  * Insert and remove subnodes that where added or removed between the previousLayout and the pendingLayout
  */
-- (void)applySubnodeTransition;
+- (void)startTransition;
 
 /**
  * Insert all new subnodes that where added between the previous layout and the pending layout

--- a/AsyncDisplayKit/Private/ASLayoutTransition.mm
+++ b/AsyncDisplayKit/Private/ASLayoutTransition.mm
@@ -27,7 +27,7 @@
  * Search the whole layout stack if at least one layout has a layoutable object that can not be layed out asynchronous.
  * This can be the case for example if a node was already loaded
  */
-static BOOL ASLayoutCanTransitionAsynchronous(ASLayout *layout) {
+static inline BOOL ASLayoutCanTransitionAsynchronous(ASLayout *layout) {
   // Queue used to keep track of sublayouts while traversing this layout in a BFS fashion.
   std::queue<ASLayout *> queue;
   queue.push(layout);
@@ -71,7 +71,7 @@ static BOOL ASLayoutCanTransitionAsynchronous(ASLayout *layout) {
   return self;
 }
 
-- (BOOL)canTransitionAsynchronous
+- (BOOL)isSynchronous
 {
   ASDN::MutexLocker l(_propertyLock);
   return ASLayoutCanTransitionAsynchronous(_pendingLayout);

--- a/AsyncDisplayKit/Private/ASLayoutTransition.mm
+++ b/AsyncDisplayKit/Private/ASLayoutTransition.mm
@@ -18,9 +18,36 @@
 #import "ASLayout.h"
 
 #import <vector>
+#import <queue>
 
 #import "NSArray+Diffing.h"
 #import "ASEqualityHelpers.h"
+
+/**
+ * Search the whole layout stack if at least one layout has a layoutable object that can not be layed out asynchronous.
+ * This can be the case for example if a node was already loaded
+ */
+static BOOL ASLayoutCanTransitionAsynchronous(ASLayout *layout) {
+  // Queue used to keep track of sublayouts while traversing this layout in a BFS fashion.
+  std::queue<ASLayout *> queue;
+  queue.push(layout);
+  
+  while (!queue.empty()) {
+    layout = queue.front();
+    queue.pop();
+    
+    if (layout.layoutableObject.canLayoutAsynchronous == NO) {
+      return NO;
+    }
+    
+    // Add all sublayouts to process in next step
+    for (int i = 0; i < layout.sublayouts.count; i++) {
+      queue.push(layout.sublayouts[0]);
+    }
+  }
+  
+  return YES;
+}
 
 @implementation ASLayoutTransition {
   ASDN::RecursiveMutex _propertyLock;
@@ -42,6 +69,18 @@
     _previousLayout = previousLayout;
   }
   return self;
+}
+
+- (BOOL)canTransitionAsynchronous
+{
+  ASDN::MutexLocker l(_propertyLock);
+  return ASLayoutCanTransitionAsynchronous(_pendingLayout);
+}
+
+- (void)applySubnodeTransition
+{
+  [self applySubnodeInsertions];
+  [self applySubnodeRemovals];
 }
 
 - (void)applySubnodeInsertions

--- a/AsyncDisplayKit/Private/ASLayoutTransition.mm
+++ b/AsyncDisplayKit/Private/ASLayoutTransition.mm
@@ -77,7 +77,7 @@ static inline BOOL ASLayoutCanTransitionAsynchronous(ASLayout *layout) {
   return ASLayoutCanTransitionAsynchronous(_pendingLayout);
 }
 
-- (void)applySubnodeTransition
+- (void)startTransition
 {
   [self applySubnodeInsertions];
   [self applySubnodeRemovals];

--- a/AsyncDisplayKitTests/ASDisplayNodeImplicitHierarchyTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeImplicitHierarchyTests.m
@@ -130,4 +130,88 @@
   XCTAssertEqual(node.subnodes[2], node2);
 }
 
+- (void)testMeasurementInBackgroundThreadWithLoadedNode
+{
+  ASDisplayNode *node1 = [[ASDisplayNode alloc] init];
+  ASDisplayNode *node2 = [[ASDisplayNode alloc] init];
+  
+  ASSpecTestDisplayNode *node = [[ASSpecTestDisplayNode alloc] init];
+  node.layoutSpecBlock = ^(ASDisplayNode *weakNode, ASSizeRange constrainedSize) {
+    ASSpecTestDisplayNode *strongNode = (ASSpecTestDisplayNode *)weakNode;
+    if ([strongNode.layoutState isEqualToNumber:@1]) {
+      return [ASStaticLayoutSpec staticLayoutSpecWithChildren:@[node1]];
+    } else {
+      return [ASStaticLayoutSpec staticLayoutSpecWithChildren:@[node2]];
+    }
+  };
+  
+  // Intentionally trigger view creation
+  [node2 view];
+  
+  XCTestExpectation *expectation = [self expectationWithDescription:@"Fix IHM layout also if one node is already loaded"];
+  
+  dispatch_async(dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+    
+    [node measureWithSizeRange:ASSizeRangeMake(CGSizeZero, CGSizeZero)];
+    XCTAssertEqual(node.subnodes[0], node1);
+    
+    node.layoutState = @2;
+    [node invalidateCalculatedLayout];
+    [node measureWithSizeRange:ASSizeRangeMake(CGSizeZero, CGSizeZero)];
+    
+    // Dispatch back to the main thread to let the insertion / deletion of subnodes happening
+    dispatch_async(dispatch_get_main_queue(), ^{
+      XCTAssertEqual(node.subnodes[0], node2);
+      [expectation fulfill];
+    });
+  });
+  
+  [self waitForExpectationsWithTimeout:5.0 handler:^(NSError *error) {
+    if (error) {
+      NSLog(@"Timeout Error: %@", error);
+    }
+  }];
+}
+
+- (void)testTransitionLayoutWithAnimationWithLoadedNodes
+{
+  ASDisplayNode *node1 = [[ASDisplayNode alloc] init];
+  ASDisplayNode *node2 = [[ASDisplayNode alloc] init];
+  
+  ASSpecTestDisplayNode *node = [[ASSpecTestDisplayNode alloc] init];
+  
+  node.layoutSpecBlock = ^(ASDisplayNode *weakNode, ASSizeRange constrainedSize) {
+    ASSpecTestDisplayNode *strongNode = (ASSpecTestDisplayNode *)weakNode;
+    if ([strongNode.layoutState isEqualToNumber:@1]) {
+      return [ASStaticLayoutSpec staticLayoutSpecWithChildren:@[node1]];
+    } else {
+      return [ASStaticLayoutSpec staticLayoutSpecWithChildren:@[node2]];
+    }
+  };
+ 
+  // Intentionally trigger view creation
+  [node2 view];
+  
+  XCTestExpectation *expectation = [self expectationWithDescription:@"Fix IHM layout transition also if one node is already loaded"];
+  
+  [node measureWithSizeRange:ASSizeRangeMake(CGSizeZero, CGSizeZero)];
+  XCTAssertEqual(node.subnodes[0], node1);
+  
+  node.layoutState = @2;
+  [node invalidateCalculatedLayout];
+  [node transitionLayoutWithAnimation:YES shouldMeasureAsync:YES measurementCompletion:^{
+    // Push this to the next runloop to let async insertion / removing of nodes finished before checking
+    dispatch_async(dispatch_get_main_queue(), ^{
+      XCTAssertEqual(node.subnodes[0], node2);
+      [expectation fulfill];
+    });
+  }];
+  
+  [self waitForExpectationsWithTimeout:5.0 handler:^(NSError *error) {
+    if (error) {
+      NSLog(@"Timeout Error: %@", error);
+    }
+  }];
+}
+
 @end


### PR DESCRIPTION
Currently measurement always needs to happen on the main thread if implicit hierarchy management is enabled as adding and removing from nodes needs to happen on the main thread. We now will trampoline to the main thread to do the insertion and deletion of nodes.

This also resolves the issue that can occur if a node is already loaded deep in the layout hierarchy in the layout that the node is transforming to. Before insertion or deletion is happening we need to crawl the layout hierarchy to check that though.

*Open things:*
* This theoretically that would enable us always measure nodes in the data controller asynchronous
* Furthermore this also would us allow to get rid of the `shouldMeasureAsync` parameter in `transitionLayoutWithAnimation:shouldMeasureAsync:measurementCompletion:` that I think should not be exposed at all - @levi any thoughts on that?
* Do we need to check somehow the transition id in `_applyLayout:layoutTransition:` to abort the insertion or deletion of nodes if the block runs on the main thread?
* Would it be worth to have it's own transition queue instead of always using one of the global background queues?

@appleguy @Adlai-Holler @levi Would be great if I could get a review and thoughts