### PR TITLE
Remove check of [UIDevice systemVersion] if running on iOS 7

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -9,6 +9,7 @@
 //
 
 #import "ASAssert.h"
+#import "ASAvailability.h"
 #import "ASBatchFetching.h"
 #import "ASDelegateProxy.h"
 #import "ASCellNode+Internal.h"
@@ -592,7 +593,7 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   cell.node = node;
   [_rangeController configureContentView:cell.contentView forCellNode:node];
   
-  if (ASRunningOnOS7()) {
+  if (!AS_AT_LEAST_IOS8) {
     // Even though UICV was introduced in iOS 6, and UITableView has always had the equivalent method,
     // -willDisplayCell: was not introduced until iOS 8 for UICV.  didEndDisplayingCell, however, is available.
     [self collectionView:collectionView willDisplayCell:cell forItemAtIndexPath:indexPath];

--- a/AsyncDisplayKit/Private/ASInternalHelpers.h
+++ b/AsyncDisplayKit/Private/ASInternalHelpers.h
@@ -8,9 +8,9 @@
 //  of patent rights can be found in the PATENTS file in the same directory.
 //
 
-#include <CoreGraphics/CGBase.h>
-#import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
+#import <CoreGraphics/CGBase.h>
+
 #import "ASBaseDefines.h"
 
 ASDISPLAYNODE_EXTERN_C_BEGIN
@@ -34,8 +34,6 @@ CGFloat ASFloorPixelValue(CGFloat f);
 CGFloat ASCeilPixelValue(CGFloat f);
 
 CGFloat ASRoundPixelValue(CGFloat f);
-
-BOOL ASRunningOnOS7();
 
 ASDISPLAYNODE_EXTERN_C_END
 

--- a/AsyncDisplayKit/Private/ASInternalHelpers.mm
+++ b/AsyncDisplayKit/Private/ASInternalHelpers.mm
@@ -89,16 +89,6 @@ CGFloat ASRoundPixelValue(CGFloat f)
   return roundf(f * ASScreenScale()) / ASScreenScale();
 }
 
-BOOL ASRunningOnOS7()
-{
-  static BOOL isOS7 = NO;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    isOS7 = ([[UIDevice currentDevice].systemVersion floatValue] < 8.0);
-  });
-  return isOS7;
-}
-
 @implementation NSIndexPath (ASInverseComparison)
 
 - (NSComparisonResult)asdk_inverseCompare:(NSIndexPath *)otherIndexPath


### PR DESCRIPTION
We should not check if we are running under a specific iOS version via [UIDevice systemVersion]. This PR switches to check the foundation version.