### PR TITLE
[ASVideoNode] Only seek to beginning when auto repeating

### DIFF
--- a/AsyncDisplayKit/ASVideoNode.mm
+++ b/AsyncDisplayKit/ASVideoNode.mm
@@ -595,9 +595,9 @@ static NSString * const kStatus = @"status";
     [_delegate videoPlaybackDidFinish:self];
 #pragma clang diagnostic pop
   }
-  [_player seekToTime:kCMTimeZero];
 
   if (_shouldAutorepeat) {
+    [_player seekToTime:kCMTimeZero];
     [self play];
   } else {
     [self pause];


### PR DESCRIPTION
At the moment ASVideoNode automatically resets the playback of the video to the beginning when the end is reached. This, as far as I can tell, is not done by the standard AVVideoPlayer. 

If the user wanted to do this there is no reason why they couldn't by implementing `videoDidPlayToEnd:` and doing the seek themselves there. The seek is obviously required if the video is set to auto-repeat, so I've left the code in there, but inside the `if`.

For my own project I was trying to get the video to pause at the end of the playback and stick on the last frame. The previous code made this impossible because the `videoDidPlayToEnd:` is invoked before the seek. Any modifications I did to the seek time were overwritten.