### PR TITLE
[ASNetworkImageNode] Fix crash when local file URL doesn't exist

### DIFF
--- a/AsyncDisplayKit/ASNetworkImageNode.mm
+++ b/AsyncDisplayKit/ASNetworkImageNode.mm
@@ -480,10 +480,12 @@ static const CGSize kMinReleaseImageOnBackgroundSize = {20.0, 20.0};
             id<ASAnimatedImageProtocol> animatedImage = nil;
             if (_downloaderFlags.downloaderImplementsAnimatedImage) {
               NSData *data = [NSData dataWithContentsOfURL:_URL];
-              animatedImage = [_downloader animatedImageWithData:data];
+              if (data != nil) {
+                animatedImage = [_downloader animatedImageWithData:data];
 
-              if ([animatedImage respondsToSelector:@selector(isDataSupported:)] && [animatedImage isDataSupported:data] == NO) {
-                animatedImage = nil;
+                if ([animatedImage respondsToSelector:@selector(isDataSupported:)] && [animatedImage isDataSupported:data] == NO) {
+                  animatedImage = nil;
+                }
               }
             }
 


### PR DESCRIPTION
Hi guys,

This is a very simple PR concerning the issue I just opened #1848. A test project can be found here: https://github.com/flovouin/ASDK-NetworkImageCrash
Basically what happens is that when `shouldCacheImage = NO` and the `URL` fed to an `ASNetworkImageNode` points to a file that doesn't exist, `nil` data is passed to the `_downloader`, which causes a crash.

My fix is simply to check that the data is indeed not `nil` before trying to load an animated image. However I get the feeling that something more could be done here. If the image exists but is not animated, it gets loaded two times: once as the `nonAnimatedImage`, and once as the `animatedImage`. Isn't there a way to load the image only once and check whether it's animated?

Tell me what you think :-)
Cheers,