### PR TITLE
[ASVideoPlayerNode] Ensure activity indicator view is transparent

### DIFF
--- a/AsyncDisplayKit/ASVideoPlayerNode.mm
+++ b/AsyncDisplayKit/ASVideoPlayerNode.mm
@@ -502,6 +502,7 @@ static void *ASVideoPlayerNodeContext = &ASVideoPlayerNodeContext;
       return spinnnerView;
     }];
     _spinnerNode.preferredFrameSize = CGSizeMake(44.0, 44.0);
+    _spinnerNode.backgroundColor = [UIColor clearColor];
 
     [self addSubnode:_spinnerNode];
     [self setNeedsLayout];


### PR DESCRIPTION
At the moment the activity indicator for ASVideoPlayerNode, shown when the video is loading, is displayed inside a black box. This seems to be due to the background of the containing node not being transparent.

This simple change makes the node transparent, leaving the activity indicator shown in white just like the other playback controls.