### PR TITLE
[ASCollectionView] Greatly Improve Cell Node Resizing

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -24,7 +24,6 @@
 #import "UICollectionViewLayout+ASConvenience.h"
 #import "ASRangeControllerUpdateRangeProtocol+Beta.h"
 #import "_ASDisplayLayer.h"
-#import "ASAvailability.h"
 
 static const NSUInteger kASCollectionViewAnimationNone = UITableViewRowAnimationNone;
 static const ASSizeRange kInvalidSizeRange = {CGSizeZero, CGSizeZero};

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -1139,14 +1139,15 @@ static const NSTimeInterval kASCollectionViewAnimationDuration = 0.3;
   
   BOOL isFirstInvalidation = !_didInvalidateCollectionViewLayoutDueToCellNodeResize;
   if (isFirstInvalidation) {
-    UICollectionViewLayoutInvalidationContext *inval = [[[[self.collectionViewLayout class] invalidationContextClass] alloc] init];
+    UICollectionViewLayout *layout = self.collectionViewLayout;
+    UICollectionViewLayoutInvalidationContext *inval = [[[[layout class] invalidationContextClass] alloc] init];
 
     // NOTE: We don't invalidate specific items here because the layout
     // will not move other items to account for the change. This is almost
     // never good, so we intentionally don't do it. Plus this allows us to
     // only invalidate once even if multiple cell nodes resize.
 
-    [self.collectionViewLayout invalidateLayoutWithContext:inval];
+    [layout invalidateLayoutWithContext:inval];
     
     _didInvalidateCollectionViewLayoutDueToCellNodeResize = YES;
     _shouldAnimateNextLayout = YES;

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -35,9 +35,6 @@ static const NSUInteger kASCollectionViewAnimationNone = UITableViewRowAnimation
 static const ASSizeRange kInvalidSizeRange = {CGSizeZero, CGSizeZero};
 static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
 
-/// The duration used when animating to new layout attributes
-static const NSTimeInterval kASCollectionViewAnimationDuration = 0.3;
-
 #pragma mark -
 #pragma mark ASCellNode<->UICollectionViewCell bridging.
 

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -1191,7 +1191,7 @@ static const NSTimeInterval kASCollectionViewAnimationDuration = 0.3;
     [_layoutFacilitator collectionViewWillEditCellsAtIndexPaths:indexPaths batched:NO];
     UICollectionViewLayoutInvalidationContext *inval = [[[[self.collectionViewLayout class] invalidationContextClass] alloc] init];
     
-    // NOTE: If we invalidate specific items, then flow layout
+    // NOTE: We don't invalidate specific items here because the layout
     // will not move other items to account for the change. This is almost
     // never good, so we intentionally don't do it.
     

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -1187,20 +1187,15 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   
   if (indexPaths.count > 0) {
     [_layoutFacilitator collectionViewWillEditCellsAtIndexPaths:indexPaths batched:NO];
-    UICollectionViewLayoutInvalidationContext *inval = [[UICollectionViewLayoutInvalidationContext alloc] init];
+    UICollectionViewLayoutInvalidationContext *inval = [[[[self.collectionViewLayout class] invalidationContextClass] alloc] init];
     if (AS_AT_LEAST_IOS8) {
       [inval invalidateItemsAtIndexPaths:indexPaths];
     }
     
-    if (_queuedNodeSizeInvalidationContext.shouldAnimate) {
-      [UIView animateWithDuration:0.5 animations:^{
+    [UIView performWithoutAnimation:^{
         [self.collectionViewLayout invalidateLayoutWithContext:inval];
         [self layoutIfNeeded];
-      }];
-      
-    } else {
-      [self.collectionViewLayout invalidateLayoutWithContext:inval];
-    }
+    }];
   }
   
   _queuedNodeSizeInvalidationContext = nil;

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -772,6 +772,8 @@ static const NSTimeInterval kASCollectionViewAnimationDuration = 0.3;
       [self performBatchAnimated:YES updates:^{
         [_dataController relayoutAllNodes];
       } completion:nil];
+      // We need to ensure the size requery is done before we update our layout.
+      [self waitUntilAllUpdatesAreCommitted];
     }
   }
   

--- a/AsyncDisplayKit/Details/ASDataController.mm
+++ b/AsyncDisplayKit/Details/ASDataController.mm
@@ -32,8 +32,6 @@ const static NSUInteger kASDataControllerSizingCountPerProcessor = 5;
 
 NSString * const ASDataControllerRowNodeKind = @"_ASDataControllerRowNodeKind";
 
-static void *kASSizingQueueContext = &kASSizingQueueContext;
-
 @interface ASDataController () {
   NSMutableArray *_externalCompletedNodes;    // Main thread only.  External data access can immediately query this if available.
   NSMutableDictionary *_completedNodes;       // Main thread only.  External data access can immediately query this if _externalCompletedNodes is unavailable.


### PR DESCRIPTION
This is a modification of #1827 that achieves the same effect in a different way. Let's call 1827 option A and this option B. In this option, to achieve the animated relayout, we submit an empty update just before [super layoutSubviews] rather than wrapping the layout in an animation block.

Reasons to go with option B:
- Doesn't cause the collection view to take any snapshots.
- Update animations follow the layout's normal update style (e.g. moved items slide rather than crossfade). Option A causes all items to crossfade.

Reasons to go with A:
- Option A is completely API-safe. This is Apple's "golden path."
- The resized cell node gets a fancy double-sided crossfade animation as it moves to its new size, rather than simply "jumping" to its new size.
- Option B's submitting an empty update inside -layoutSubviews seems a little risky. May not be much worse than we currently submit empty updates async on main.

Great things about both options:
- Right now if you update size without animation, since the update happens asynchronously you will probably see a frame that shows the cell node at its new size, but the collection view layout not updated.

Videos: 
[Updates Videos.zip](https://github.com/facebook/AsyncDisplayKit/files/350557/Updates.Videos.zip)

I advocate for option B. The crossfading and snapshots of option A are ugly.

