### PR TITLE
[ASCollectionView] Add strong Layer Pointer Under iOS < 9 to Workaround Crashes

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -108,6 +108,15 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   ASCollectionViewInvalidationStyle _nextLayoutInvalidationStyle;
   
   /**
+   * Our layer, retained. Under iOS < 9, when collection views are removed from the hierarchy,
+   * their layers may be deallocated and become dangling pointers. This puts the collection view
+   * into a very dangerous state where pretty much any call will crash it. So we manually retain our layer.
+   *
+   * You should never access this, and it will be nil under iOS >= 9.
+   */
+  CALayer *_retainedLayer;
+  
+  /**
    * If YES, the `UICollectionView` will reload its data on next layout pass so we should not forward any updates to it.
    
    * Rationale:
@@ -247,6 +256,10 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   self.backgroundColor = [UIColor whiteColor];
   
   [self registerClass:[_ASCollectionViewCell class] forCellWithReuseIdentifier:kCellReuseIdentifier];
+  
+  if (!AS_AT_LEAST_IOS9) {
+    _retainedLayer = self.layer;
+  }
   
   return self;
 }


### PR DESCRIPTION
Under iOS < 9, when a collection view is removed from the hierarchy and being prepared for deallocation, its layer may become a dangling pointer and put the collection view into a dangerous state where pretty much any call will crash.

This shouldn't be possible, since views are supposed to retain their layers, but it happens all the same. This adds a separate strong pointer to ASCollectionView to workaround the issue.

This issue is not technically ASDK-specific, but under ASDK it is _far_ more likely to manifest because of the fact that ASDisplayNode intentionally keeps self alive for the next run loop turn in -didExitHierarchy 