### PR TITLE
[ASTextNode] Fix text node truncation

### DIFF
--- a/AsyncDisplayKit/TextKit/ASTextKitContext.h
+++ b/AsyncDisplayKit/TextKit/ASTextKitContext.h
@@ -10,6 +10,8 @@
 
 #import <UIKit/UIKit.h>
 
+typedef NSTextStorage *(^ASTextKitContextTextStorageCreationBlock)(NSAttributedString *attributedString);
+
 /**
  A threadsafe container for the TextKit components that ASTextKit uses to lay out and truncate its text.
 
@@ -30,9 +32,18 @@
                          constrainedSize:(CGSize)constrainedSize
               layoutManagerCreationBlock:(NSLayoutManager * (^)(void))layoutCreationBlock
                    layoutManagerDelegate:(id<NSLayoutManagerDelegate>)layoutManagerDelegate
-                textStorageCreationBlock:(NSTextStorage * (^)(NSAttributedString *attributedString))textStorageCreationBlock;
+                textStorageCreationBlock:(ASTextKitContextTextStorageCreationBlock)textStorageCreationBlock;
 
+/**
+ Set the constrained size for the text context.
+ */
 @property (nonatomic, assign, readwrite) CGSize constrainedSize;
+
+/**
+ Resets the text storage to the original value in case it was truncated before. This method is called within
+ a locked context.
+ */
+- (void)resetTextStorage;
 
 /**
  All operations on TextKit values MUST occur within this locked context.  Simultaneous access (even non-mutative) to

--- a/AsyncDisplayKit/TextKit/ASTextKitContext.mm
+++ b/AsyncDisplayKit/TextKit/ASTextKitContext.mm
@@ -21,7 +21,11 @@
   NSLayoutManager *_layoutManager;
   NSTextStorage *_textStorage;
   NSTextContainer *_textContainer;
+  
+  NSAttributedString *_attributedString;
 }
+
+#pragma mark - Lifecycle
 
 - (instancetype)initWithAttributedString:(NSAttributedString *)attributedString
                            lineBreakMode:(NSLineBreakMode)lineBreakMode
@@ -37,16 +41,23 @@
     // Concurrently initialising TextKit components crashes (rdar://18448377) so we use a global lock.
     static std::mutex __static_mutex;
     std::lock_guard<std::mutex> l(__static_mutex);
+    
+    _attributedString = [attributedString copy];
+    
     // Create the TextKit component stack with our default configuration.
     if (textStorageCreationBlock) {
       _textStorage = textStorageCreationBlock(attributedString);
     } else {
-      _textStorage = (attributedString ? [[NSTextStorage alloc] initWithAttributedString:attributedString] : [[NSTextStorage alloc] init]);
+      _textStorage = [[NSTextStorage alloc] init];
+      [self _resetTextStorage];
     }
+    
+    
     _layoutManager = layoutCreationBlock ? layoutCreationBlock() : [[ASLayoutManager alloc] init];
     _layoutManager.usesFontLeading = NO;
     _layoutManager.delegate = layoutManagerDelegate;
     [_textStorage addLayoutManager:_layoutManager];
+
     _textContainer = [[NSTextContainer alloc] initWithSize:constrainedSize];
     // We want the text laid out up to the very edges of the container.
     _textContainer.lineFragmentPadding = 0;
@@ -57,6 +68,21 @@
   }
   return self;
 }
+
+#pragma mark - Text Storage
+
+- (void)resetTextStorage
+{
+  std::lock_guard<std::mutex> l(_textKitMutex);
+  [self _resetTextStorage];
+}
+
+- (void)_resetTextStorage
+{
+  [_textStorage setAttributedString:_attributedString];
+}
+
+#pragma mark - Setter / Getter
 
 - (CGSize)constrainedSize
 {
@@ -69,6 +95,8 @@
   std::lock_guard<std::mutex> l(_textKitMutex);
   _textContainer.size = constrainedSize;
 }
+
+#pragma mark - Locking
 
 - (void)performBlockWithLockedTextKitComponents:(void (^)(NSLayoutManager *,
                                                           NSTextStorage *,

--- a/AsyncDisplayKit/TextKit/ASTextKitRenderer.mm
+++ b/AsyncDisplayKit/TextKit/ASTextKitRenderer.mm
@@ -129,8 +129,12 @@ static NSCharacterSet *_defaultAvoidTruncationCharacterSet()
       // If we're updating an existing context, make sure to use the same inset logic used during initialization.
       // This codepath allows us to reuse the
       CGSize shadowConstrainedSize = [[self shadower] insetSizeWithConstrainedSize:constrainedSize];
-      if (_context) _context.constrainedSize = shadowConstrainedSize;
-      if (_fontSizeAdjuster) _fontSizeAdjuster.constrainedSize = shadowConstrainedSize;
+      if (_context) {
+        _context.constrainedSize = shadowConstrainedSize;
+      }
+      if (_fontSizeAdjuster) {
+        _fontSizeAdjuster.constrainedSize = shadowConstrainedSize;
+      }
     }
   }
 }

--- a/AsyncDisplayKit/TextKit/ASTextKitTailTruncater.mm
+++ b/AsyncDisplayKit/TextKit/ASTextKitTailTruncater.mm
@@ -152,9 +152,14 @@
 
 - (void)truncate
 {
-  [_context performBlockWithLockedTextKitComponents:^(NSLayoutManager *layoutManager, NSTextStorage *textStorage, NSTextContainer *textContainer) {
-    NSUInteger originalStringLength = textStorage.length;
+  // Reset the text storage to start always with the full string
+  [_context resetTextStorage];
 
+  // Start truncation
+  [_context performBlockWithLockedTextKitComponents:^(NSLayoutManager *layoutManager, NSTextStorage *textStorage, NSTextContainer *textContainer) {
+    
+    NSUInteger originalStringLength = textStorage.length;
+    
     [layoutManager ensureLayoutForTextContainer:textContainer];
 
     NSRange visibleGlyphRange = [layoutManager glyphRangeForBoundingRect:{ .size = textContainer.size }

--- a/AsyncDisplayKitTests/ASTextNodeTests.m
+++ b/AsyncDisplayKitTests/ASTextNodeTests.m
@@ -125,7 +125,7 @@ static BOOL CGSizeEqualToSizeWithIn(CGSize size1, CGSize size2, CGFloat delta)
   for (NSInteger i = 10; i < 500; i += 50) {
     CGSize constrainedSize = CGSizeMake(i, i);
     CGSize calculatedSize = [_textNode measure:constrainedSize];
-    CGSize recalculatedSize = [_textNode measure:calculatedSize];
+    CGSize recalculatedSize = [_textNode measure:constrainedSize];
     
     XCTAssertTrue(CGSizeEqualToSizeWithIn(calculatedSize, recalculatedSize, 4.0), @"Recalculated size %@ should be same as original size %@", NSStringFromCGSize(recalculatedSize), NSStringFromCGSize(calculatedSize));
   }
@@ -136,7 +136,7 @@ static BOOL CGSizeEqualToSizeWithIn(CGSize size1, CGSize size2, CGFloat delta)
   for (CGFloat i = 10; i < 500; i *= 1.3) {
     CGSize constrainedSize = CGSizeMake(i, i);
     CGSize calculatedSize = [_textNode measure:constrainedSize];
-    CGSize recalculatedSize = [_textNode measure:calculatedSize];
+    CGSize recalculatedSize = [_textNode measure:constrainedSize];
 
     XCTAssertTrue(CGSizeEqualToSizeWithIn(calculatedSize, recalculatedSize, 11.0), @"Recalculated size %@ should be same as original size %@", NSStringFromCGSize(recalculatedSize), NSStringFromCGSize(calculatedSize));
   }


### PR DESCRIPTION
Before truncation happens no invalidation of the text storage happened. That had the effect, if the constrained size of a text node increases a new size for the text node will be calculated. While this calculation is happening a truncation on the text will happen. Unfortunately the truncation will happen on the already truncated string.

This PR resets the text storage to the original value before the truncation is happening so it always will truncate on the same string no matter what constrained size is given.

Should fix #1841