### PR TITLE
[ASRangeController] Minimize number of registrations to node display notifications

### DIFF
--- a/AsyncDisplayKit/Details/ASRangeController.mm
+++ b/AsyncDisplayKit/Details/ASRangeController.mm
@@ -27,7 +27,7 @@
   NSSet<NSIndexPath *> *_allPreviousIndexPaths;
   ASLayoutRangeMode _currentRangeMode;
   BOOL _didUpdateCurrentRange;
-  BOOL _didRegisterForNotifications;
+  BOOL _didRegisterForNodeDisplayNotifications;
   CFAbsoluteTime _pendingDisplayNodesTimestamp;
 }
 
@@ -56,7 +56,7 @@ static UIApplicationState __ApplicationState = UIApplicationStateActive;
 
 - (void)dealloc
 {
-  if (_didRegisterForNotifications) {
+  if (_didRegisterForNodeDisplayNotifications) {
     [[NSNotificationCenter defaultCenter] removeObserver:self name:ASRenderingEngineDidDisplayScheduledNodesNotification object:nil];
   }
 }
@@ -242,10 +242,6 @@ static UIApplicationState __ApplicationState = UIApplicationStateActive;
     [allIndexPaths addObjectsFromArray:ASIndexPathsForTwoDimensionalArray(allNodes)];
   }
   
-  // TODO Don't register for notifications if this range update doesn't cause any node to enter rendering pipeline.
-  // This can be done once there is an API to observe to (or be notified upon) interface state changes or pipeline enterings
-  [self registerForNotificationsForInterfaceStateIfNeeded:selfInterfaceState];
-  
 #if ASRangeControllerLoggingEnabled
   ASDisplayNodeAssertTrue([visibleIndexPaths isSubsetOfSet:displayIndexPaths]);
   NSMutableArray<NSIndexPath *> *modifiedIndexPaths = (ASRangeControllerLoggingEnabled ? [NSMutableArray array] : nil);
@@ -309,14 +305,19 @@ static UIApplicationState __ApplicationState = UIApplicationStateActive;
 #if ASRangeControllerLoggingEnabled
           [modifiedIndexPaths addObject:indexPath];
 #endif
+          
+          BOOL nodeShouldScheduleDisplay = [node shouldScheduleDisplayWithNewInterfaceState:interfaceState];
           [node recursivelySetInterfaceState:interfaceState];
+          
+          if (nodeShouldScheduleDisplay) {
+            [self registerForNodeDisplayNotificationsForInterfaceStateIfNeeded:selfInterfaceState];
+            if (_didRegisterForNodeDisplayNotifications) {
+              _pendingDisplayNodesTimestamp = CFAbsoluteTimeGetCurrent();
+            }
+          }
         }
       }
     }
-  }
-  
-  if (_didRegisterForNotifications) {
-    _pendingDisplayNodesTimestamp = CFAbsoluteTimeGetCurrent();
   }
   
   _rangeIsValid = YES;
@@ -338,9 +339,9 @@ static UIApplicationState __ApplicationState = UIApplicationStateActive;
 
 #pragma mark - Notification observers
 
-- (void)registerForNotificationsForInterfaceStateIfNeeded:(ASInterfaceState)interfaceState
+- (void)registerForNodeDisplayNotificationsForInterfaceStateIfNeeded:(ASInterfaceState)interfaceState
 {
-  if (!_didRegisterForNotifications) {
+  if (!_didRegisterForNodeDisplayNotifications) {
     ASLayoutRangeMode nextRangeMode = [ASRangeController rangeModeForInterfaceState:interfaceState
                                                                    currentRangeMode:_currentRangeMode];
     if (_currentRangeMode != nextRangeMode) {
@@ -348,7 +349,7 @@ static UIApplicationState __ApplicationState = UIApplicationStateActive;
                                                selector:@selector(scheduledNodesDidDisplay:)
                                                    name:ASRenderingEngineDidDisplayScheduledNodesNotification
                                                  object:nil];
-      _didRegisterForNotifications = YES;
+      _didRegisterForNodeDisplayNotifications = YES;
     }
   }
 }
@@ -359,7 +360,7 @@ static UIApplicationState __ApplicationState = UIApplicationStateActive;
   if (_pendingDisplayNodesTimestamp < notificationTimestamp) {
     // The rendering engine has processed all the nodes this range controller scheduled. Let's schedule a range update
     [[NSNotificationCenter defaultCenter] removeObserver:self name:ASRenderingEngineDidDisplayScheduledNodesNotification object:nil];
-    _didRegisterForNotifications = NO;
+    _didRegisterForNodeDisplayNotifications = NO;
     
     [self scheduleRangeUpdate];
   }

--- a/AsyncDisplayKit/Private/ASDisplayNode+FrameworkPrivate.h
+++ b/AsyncDisplayKit/Private/ASDisplayNode+FrameworkPrivate.h
@@ -135,6 +135,11 @@ inline BOOL ASHierarchyStateIncludesRangeManaged(ASHierarchyState hierarchyState
  */
 @property (nonatomic, assign) BOOL shouldBypassEnsureDisplay;
 
+/**
+ * @abstract Checks whether a node should be scheduled for display, considering its current and new interface states.
+ */
+- (BOOL)shouldScheduleDisplayWithNewInterfaceState:(ASInterfaceState)newInterfaceState;
+
 @end
 
 @interface UIView (ASDisplayNodeInternal)


### PR DESCRIPTION
Previously, `ASRangeController` registers to notification center every time a range update is performed, regardless of the number of nodes that need to schedule for a recursive display in response to the update. 

Instead, if this number is taken into account and range controller doesn't observe further notifications if it is zero, we can minimize the number of range updates executed and may fix #1460 (verification needed though).

