### PR TITLE
[ASImageNode] Move dealloc method from ASImageNode+AnimatedImage category to ASImageNode

### DIFF
--- a/AsyncDisplayKit/ASImageNode+AnimatedImage.mm
+++ b/AsyncDisplayKit/ASImageNode+AnimatedImage.mm
@@ -233,7 +233,11 @@ NSString *const ASAnimatedImageDefaultRunLoopMode = NSRunLoopCommonModes;
   return frameIndex;
 }
 
-- (void)dealloc
+@end
+
+@implementation ASImageNode(AnimatedImageInvalidation)
+
+- (void)invalidateAnimatedImage
 {
   ASDN::MutexLocker l(_displayLinkLock);
 #if ASAnimatedImageDebug

--- a/AsyncDisplayKit/ASImageNode.mm
+++ b/AsyncDisplayKit/ASImageNode.mm
@@ -110,6 +110,12 @@ struct ASImageNodeDrawParameters {
   return nil;
 }
 
+- (void)dealloc
+{
+  // Invalidate all components around animated images
+  [self invalidateAnimatedImage];
+}
+
 #pragma mark - Layout and Sizing
 
 - (CGSize)calculateSizeThatFits:(CGSize)constrainedSize

--- a/AsyncDisplayKit/Private/ASImageNode+AnimatedImagePrivate.h
+++ b/AsyncDisplayKit/Private/ASImageNode+AnimatedImagePrivate.h
@@ -31,3 +31,10 @@ extern NSString *const ASAnimatedImageDefaultRunLoopMode;
 @property (atomic, assign) CFTimeInterval lastDisplayLinkFire;
 
 @end
+
+
+@interface ASImageNode (AnimatedImageInvalidation)
+
+- (void)invalidateAnimatedImage;
+
+@end


### PR DESCRIPTION
Having a dealloc method in a category can be very problematic as the superclass dealloc method will not be called in case it exists.