### PR TITLE
[Layout Transition API] Simplify applying layout transition

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -787,7 +787,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
       _pendingLayoutTransition = [[ASLayoutTransition alloc] initWithNode:self
                                                             pendingLayout:newLayout
                                                            previousLayout:previousLayout];
-      [_pendingLayoutTransition completeSubnodeInsertions];
+      [_pendingLayoutTransition applySubnodeInsertions];
 
       _transitionContext = [[_ASTransitionContext alloc] initWithAnimation:animated
                                                             layoutDelegate:_pendingLayoutTransition
@@ -887,7 +887,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
 
 - (void)didCompleteLayoutTransition:(id<ASContextTransitioning>)context
 {
-  [_pendingLayoutTransition completeSubnodeRemovals];
+  [_pendingLayoutTransition applySubnodeRemovals];
   [self _completeLayoutCalculation];
   _pendingLayoutTransition = nil;
 }

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -867,7 +867,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
  */
 - (void)animateLayoutTransition:(id<ASContextTransitioning>)context
 {
-  [self __layoutSubnodes];
+  [self __layoutSublayouts];
   [context completeTransition:YES];
 }
 
@@ -901,7 +901,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
  */
 - (void)_completePendingLayoutTransition
 {
-  ASDN::MutexLocker l(_propertyLock);
+  ASDN::MutexLocker l(__instanceLock__);
   if (_pendingLayoutTransition) {
     [self setCalculatedLayout:_pendingLayoutTransition.pendingLayout];
     [self _completeLayoutTransition:_pendingLayoutTransition];
@@ -2118,7 +2118,7 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
 
 - (void)setCalculatedLayout:(ASLayout *)layout
 {
-  ASDN::MutexLocker l(_propertyLock);
+  ASDN::MutexLocker l(__instanceLock__);
   
   ASDisplayNodeAssertTrue(layout.layoutableObject == self);
   ASDisplayNodeAssertTrue(layout.size.width >= 0.0);
@@ -2575,13 +2575,13 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
 
     // Subnode insertions and removals need to happen always on the main thread if at least one subnode is already loaded
     ASPerformBlockOnMainThread(^{
-      [layoutTransition startTransition];
+      [layoutTransition commitTransition];
     });
     
     return;
   }
   
-  [layoutTransition startTransition];
+  [layoutTransition commitTransition];
 }
 
 - (void)layout
@@ -2604,7 +2604,6 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
 
 #pragma mark - Display
 
->>>>>>> Simplify applying layout transition in preparation for bigger layout transition API work
 - (void)displayWillStart
 {
   ASDisplayNodeAssertMainThread();

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -932,17 +932,14 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   }
 
   // Trampoline to the main thread if necessary
-  if (ASDisplayNodeThreadIsMain() == NO && layoutTransition.isSynchronous == NO) {
-
+  if (ASDisplayNodeThreadIsMain() || layoutTransition.isSynchronous == NO) {
+    [layoutTransition commitTransition];
+  } else {
     // Subnode insertions and removals need to happen always on the main thread if at least one subnode is already loaded
     ASPerformBlockOnMainThread(^{
-      [layoutTransition completeTransition];
+      [layoutTransition commitTransition];
     });
-    
-    return;
   }
-  
-  [layoutTransition completeTransition];
 }
 
 #pragma mark - Asynchronous display

--- a/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
+++ b/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
@@ -123,7 +123,7 @@ FOUNDATION_EXPORT NSString * const ASRenderingEngineDidDisplayNodesScheduledBefo
   NSMutableArray *_subnodes;
   
   // Main thread only
-  _ASTransitionContext *_transitionContext;
+  _ASTransitionContext *_pendingLayoutTransitionContext;
   BOOL _usesImplicitHierarchyManagement;
 
   int32_t _pendingTransitionID;

--- a/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
+++ b/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
@@ -116,7 +116,7 @@ FOUNDATION_EXPORT NSString * const ASRenderingEngineDidDisplayNodesScheduledBefo
   CGFloat _contentsScaleForDisplay;
 
   ASEnvironmentState _environmentState;
-  ASLayout *_layout;
+  ASLayout *_calculatedLayout;
 
 
   UIEdgeInsets _hitTestSlop;

--- a/AsyncDisplayKit/Private/ASLayoutTransition.h
+++ b/AsyncDisplayKit/Private/ASLayoutTransition.h
@@ -47,7 +47,7 @@
 /**
  * Insert and remove subnodes that where added or removed between the previousLayout and the pendingLayout
  */
-- (void)startTransition;
+- (void)applyTransition;
 
 /**
  * Insert all new subnodes that where added between the previous layout and the pending layout

--- a/AsyncDisplayKit/Private/ASLayoutTransition.h
+++ b/AsyncDisplayKit/Private/ASLayoutTransition.h
@@ -47,16 +47,16 @@
 /**
  * Insert and remove subnodes that where added or removed between the previousLayout and the pendingLayout
  */
-- (void)applyTransition;
+- (void)completeTransition;
 
 /**
  * Insert all new subnodes that where added between the previous layout and the pending layout
  */
-- (void)applySubnodeInsertions;
+- (void)completeSubnodeInsertions;
 
 /**
  * Remove all subnodes that are removed between the previous layout and the pending layout
  */
-- (void)applySubnodeRemovals;
+- (void)completeSubnodeRemovals;
 
 @end

--- a/AsyncDisplayKit/Private/ASLayoutTransition.h
+++ b/AsyncDisplayKit/Private/ASLayoutTransition.h
@@ -34,7 +34,7 @@
 @property (nonatomic, readonly, strong) ASLayout *pendingLayout;
 
 /**
- * Returns if the layout transition can happen asynchronously
+ * Returns if the layout transition needs to happen synchronously
  */
 @property (nonatomic, readonly, assign) BOOL isSynchronous;
 
@@ -47,7 +47,7 @@
 /**
  * Insert and remove subnodes that where added or removed between the previousLayout and the pendingLayout
  */
-- (void)completeTransition;
+- (void)commitTransition;
 
 /**
  * Insert all new subnodes that where added between the previous layout and the pending layout

--- a/AsyncDisplayKit/Private/ASLayoutTransition.h
+++ b/AsyncDisplayKit/Private/ASLayoutTransition.h
@@ -52,11 +52,11 @@
 /**
  * Insert all new subnodes that where added between the previous layout and the pending layout
  */
-- (void)completeSubnodeInsertions;
+- (void)applySubnodeInsertions;
 
 /**
  * Remove all subnodes that are removed between the previous layout and the pending layout
  */
-- (void)completeSubnodeRemovals;
+- (void)applySubnodeRemovals;
 
 @end

--- a/AsyncDisplayKit/Private/ASLayoutTransition.mm
+++ b/AsyncDisplayKit/Private/ASLayoutTransition.mm
@@ -76,11 +76,11 @@ static inline BOOL ASLayoutCanTransitionAsynchronous(ASLayout *layout) {
 
 - (void)completeTransition
 {
-  [self completeSubnodeInsertions];
-  [self completeSubnodeRemovals];
+  [self applySubnodeInsertions];
+  [self applySubnodeRemovals];
 }
 
-- (void)completeSubnodeInsertions
+- (void)applySubnodeInsertions
 {
   ASDN::MutexLocker l(__instanceLock__);
   [self calculateSubnodeOperationsIfNeeded];
@@ -93,7 +93,7 @@ static inline BOOL ASLayoutCanTransitionAsynchronous(ASLayout *layout) {
   }
 }
 
-- (void)completeSubnodeRemovals
+- (void)applySubnodeRemovals
 {
   ASDN::MutexLocker l(__instanceLock__);
   [self calculateSubnodeOperationsIfNeeded];

--- a/AsyncDisplayKit/Private/ASLayoutTransition.mm
+++ b/AsyncDisplayKit/Private/ASLayoutTransition.mm
@@ -71,10 +71,10 @@ static inline BOOL ASLayoutCanTransitionAsynchronous(ASLayout *layout) {
 - (BOOL)isSynchronous
 {
   ASDN::MutexLocker l(__instanceLock__);
-  return ASLayoutCanTransitionAsynchronous(_pendingLayout);
+  return !ASLayoutCanTransitionAsynchronous(_pendingLayout);
 }
 
-- (void)completeTransition
+- (void)commitTransition
 {
   [self applySubnodeInsertions];
   [self applySubnodeRemovals];

--- a/AsyncDisplayKit/Private/ASLayoutTransition.mm
+++ b/AsyncDisplayKit/Private/ASLayoutTransition.mm
@@ -74,13 +74,13 @@ static inline BOOL ASLayoutCanTransitionAsynchronous(ASLayout *layout) {
   return ASLayoutCanTransitionAsynchronous(_pendingLayout);
 }
 
-- (void)applyTransition
+- (void)completeTransition
 {
-  [self applySubnodeInsertions];
-  [self applySubnodeRemovals];
+  [self completeSubnodeInsertions];
+  [self completeSubnodeRemovals];
 }
 
-- (void)applySubnodeInsertions
+- (void)completeSubnodeInsertions
 {
   ASDN::MutexLocker l(__instanceLock__);
   [self calculateSubnodeOperationsIfNeeded];
@@ -93,7 +93,7 @@ static inline BOOL ASLayoutCanTransitionAsynchronous(ASLayout *layout) {
   }
 }
 
-- (void)applySubnodeRemovals
+- (void)completeSubnodeRemovals
 {
   ASDN::MutexLocker l(__instanceLock__);
   [self calculateSubnodeOperationsIfNeeded];

--- a/AsyncDisplayKit/Private/ASLayoutTransition.mm
+++ b/AsyncDisplayKit/Private/ASLayoutTransition.mm
@@ -74,7 +74,7 @@ static inline BOOL ASLayoutCanTransitionAsynchronous(ASLayout *layout) {
   return ASLayoutCanTransitionAsynchronous(_pendingLayout);
 }
 
-- (void)startTransition
+- (void)applyTransition
 {
   [self applySubnodeInsertions];
   [self applySubnodeRemovals];


### PR DESCRIPTION
Simplify applying layout transition in preparation for bigger Layout Transition API work. Changes are:
- Always go through `_pendingLayoutTransition`
- Move from `[ASDisplayNode _applyLayout:layoutTransition:]` to `[ASDisplayNode _applyLayout:]` and `[ASDisplayNode _applyLayoutTransition:]`
- Change from `[ASLayoutTransition startTransition]` to `[ASLayoutTransition applyTransition]`

@levi @appleguy Can you review. This is the first small change in preparation for the bigger change that will come for the Layout Transition API