### PR TITLE
[ASDisplayNode] Fix setNeedsLayout triggered from subnode will not trigger relayout

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -1055,13 +1055,15 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
 - (void)__setNeedsLayout
 {
   ASDisplayNodeAssertThreadAffinity(self);
+  
   _propertyLock.lock();
   
-  if ([self _hasDirtyLayout]) {
+  if (_layout == nil) {
+    // Can't proceed without a layout as no constrained size would be available
     _propertyLock.unlock();
     return;
   }
-  
+    
   [self invalidateCalculatedLayout];
   
   if (_supernode) {
@@ -1091,6 +1093,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
     CGFloat yDelta = (newSize.height - oldSize.height) * anchorPoint.y;
     self.position = CGPointMake(oldPosition.x + xDelta, oldPosition.y + yDelta);
   }
+  
   _propertyLock.unlock();
 }
 


### PR DESCRIPTION
Current if `[ASDisplayNode invalidateCalculatedLayout]` and `[ASDisplayNode setNeedsLayout]` called in a subclass (see` [ASButtonNode setTitle:]`) the call actually does not trigger any relayout. It does not even bubble up the tree as it returns early in `[ASDisplayNode __setNeedsDisplay]`

After talking with @nguyenhuy about the initial intention why we are returning early there we found a better way for it.

This should resolve: #1865

@nguyenhuy @levi @appleguy Can I get a look over please