### PR TITLE
[ASButtonNode] Correctly compare and update its title

### DIFF
--- a/AsyncDisplayKit/ASButtonNode.mm
+++ b/AsyncDisplayKit/ASButtonNode.mm
@@ -184,7 +184,7 @@
     newTitle = _normalAttributedTitle;
   }
 
-  if ((_titleNode != nil || newTitle.length > 0) && newTitle != self.titleNode.attributedString) {
+  if ((_titleNode != nil || newTitle.length > 0) && [self.titleNode.attributedString isEqualToAttributedString:newTitle] == NO) {
     _titleNode.attributedString = newTitle;
     self.accessibilityLabel = _titleNode.accessibilityLabel;
     [self setNeedsLayout];


### PR DESCRIPTION
I found this interesting line while debugging #1865. We're basically trying to avoid unnecessary updates by comparing the old and existing titles. However, we should be comparing the contents of these strings instead of their memory addresses, no?