### PR TITLE
[Performance] Various Easy Performance Wins

### DIFF
--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -281,8 +281,8 @@
 		AC026B6B1BD57D6F00BBC17E /* ASChangeSetDataController.m in Sources */ = {isa = PBXBuildFile; fileRef = AC026B681BD57D6F00BBC17E /* ASChangeSetDataController.m */; };
 		AC026B6C1BD57D6F00BBC17E /* ASChangeSetDataController.m in Sources */ = {isa = PBXBuildFile; fileRef = AC026B681BD57D6F00BBC17E /* ASChangeSetDataController.m */; };
 		AC026B701BD57DBF00BBC17E /* _ASHierarchyChangeSet.h in Headers */ = {isa = PBXBuildFile; fileRef = AC026B6D1BD57DBF00BBC17E /* _ASHierarchyChangeSet.h */; };
-		AC026B711BD57DBF00BBC17E /* _ASHierarchyChangeSet.m in Sources */ = {isa = PBXBuildFile; fileRef = AC026B6E1BD57DBF00BBC17E /* _ASHierarchyChangeSet.m */; };
-		AC026B721BD57DBF00BBC17E /* _ASHierarchyChangeSet.m in Sources */ = {isa = PBXBuildFile; fileRef = AC026B6E1BD57DBF00BBC17E /* _ASHierarchyChangeSet.m */; };
+		AC026B711BD57DBF00BBC17E /* _ASHierarchyChangeSet.mm in Sources */ = {isa = PBXBuildFile; fileRef = AC026B6E1BD57DBF00BBC17E /* _ASHierarchyChangeSet.mm */; };
+		AC026B721BD57DBF00BBC17E /* _ASHierarchyChangeSet.mm in Sources */ = {isa = PBXBuildFile; fileRef = AC026B6E1BD57DBF00BBC17E /* _ASHierarchyChangeSet.mm */; };
 		AC3C4A521A1139C100143C57 /* ASCollectionView.mm in Sources */ = {isa = PBXBuildFile; fileRef = AC3C4A501A1139C100143C57 /* ASCollectionView.mm */; };
 		AC47D9421B3B891B00AAEE9D /* ASCellNode.mm in Sources */ = {isa = PBXBuildFile; fileRef = AC6456071B0A335000CF11B8 /* ASCellNode.mm */; };
 		AC47D9461B3BB41900AAEE9D /* ASRelativeSize.mm in Sources */ = {isa = PBXBuildFile; fileRef = AC47D9441B3BB41900AAEE9D /* ASRelativeSize.mm */; };
@@ -1020,7 +1020,7 @@
 		AC026B671BD57D6F00BBC17E /* ASChangeSetDataController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASChangeSetDataController.h; sourceTree = "<group>"; };
 		AC026B681BD57D6F00BBC17E /* ASChangeSetDataController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASChangeSetDataController.m; sourceTree = "<group>"; };
 		AC026B6D1BD57DBF00BBC17E /* _ASHierarchyChangeSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _ASHierarchyChangeSet.h; sourceTree = "<group>"; };
-		AC026B6E1BD57DBF00BBC17E /* _ASHierarchyChangeSet.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = _ASHierarchyChangeSet.m; sourceTree = "<group>"; };
+		AC026B6E1BD57DBF00BBC17E /* _ASHierarchyChangeSet.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _ASHierarchyChangeSet.mm; sourceTree = "<group>"; };
 		AC21EC0F1B3D0BF600C8B19A /* ASStackLayoutDefines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASStackLayoutDefines.h; path = AsyncDisplayKit/Layout/ASStackLayoutDefines.h; sourceTree = "<group>"; };
 		AC3C4A4F1A1139C100143C57 /* ASCollectionView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = ASCollectionView.h; sourceTree = "<group>"; };
 		AC3C4A501A1139C100143C57 /* ASCollectionView.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; lineEnding = 0; path = ASCollectionView.mm; sourceTree = "<group>"; };
@@ -1473,7 +1473,7 @@
 				058D0A03195D050800B7D73C /* _ASCoreAnimationExtras.h */,
 				058D0A04195D050800B7D73C /* _ASCoreAnimationExtras.mm */,
 				AC026B6D1BD57DBF00BBC17E /* _ASHierarchyChangeSet.h */,
-				AC026B6E1BD57DBF00BBC17E /* _ASHierarchyChangeSet.m */,
+				AC026B6E1BD57DBF00BBC17E /* _ASHierarchyChangeSet.mm */,
 				058D0A05195D050800B7D73C /* _ASPendingState.h */,
 				058D0A06195D050800B7D73C /* _ASPendingState.mm */,
 				058D0A07195D050800B7D73C /* _ASScopeTimer.h */,
@@ -2054,7 +2054,7 @@
 				257754B41BEE44CD00737CA5 /* ASTextKitTailTruncater.mm in Sources */,
 				68B8A4E31CBDB958007E4543 /* ASWeakProxy.m in Sources */,
 				69E1006F1CA89CB600D88C1B /* ASEnvironmentInternal.mm in Sources */,
-				AC026B711BD57DBF00BBC17E /* _ASHierarchyChangeSet.m in Sources */,
+				AC026B711BD57DBF00BBC17E /* _ASHierarchyChangeSet.mm in Sources */,
 				257754BF1BEE458E00737CA5 /* ASTextKitCoreTextAdditions.m in Sources */,
 				058D0A18195D050800B7D73C /* _ASDisplayLayer.mm in Sources */,
 				68355B3C1CB57A5A001D4E68 /* ASImageContainerProtocolCategories.m in Sources */,
@@ -2220,7 +2220,7 @@
 				9B92C8851BC2EB6E00EE46B2 /* ASCollectionDataController.mm in Sources */,
 				B350623D1B010EFD0018CF92 /* _ASAsyncTransaction.mm in Sources */,
 				B35062401B010EFD0018CF92 /* _ASAsyncTransactionContainer.m in Sources */,
-				AC026B721BD57DBF00BBC17E /* _ASHierarchyChangeSet.m in Sources */,
+				AC026B721BD57DBF00BBC17E /* _ASHierarchyChangeSet.mm in Sources */,
 				B35062421B010EFD0018CF92 /* _ASAsyncTransactionGroup.m in Sources */,
 				B350624A1B010EFD0018CF92 /* _ASCoreAnimationExtras.mm in Sources */,
 				68EE0DC01C1B4ED300BA1B99 /* ASMainSerialQueue.mm in Sources */,

--- a/AsyncDisplayKit/ASControlNode.mm
+++ b/AsyncDisplayKit/ASControlNode.mm
@@ -330,7 +330,7 @@ void _ASEnumerateControlEventsIncludedInMaskWithBlock(ASControlNodeEvent mask, v
   NSMutableSet *targets = [[NSMutableSet alloc] init];
 
   // Look at each event...
-  for (NSMapTable *eventDispatchTable in [_controlEventDispatchTable allValues])
+  for (NSMapTable *eventDispatchTable in [_controlEventDispatchTable objectEnumerator])
   {
     // and each event's targets...
     for (id target in eventDispatchTable)

--- a/AsyncDisplayKit/ASDisplayNodeExtras.mm
+++ b/AsyncDisplayKit/ASDisplayNodeExtras.mm
@@ -80,8 +80,9 @@ extern void ASDisplayNodePerformBlockOnEveryNodeBFS(ASDisplayNode *node, void(^b
     block(node);
 
     // Add all subnodes to process in next step
-    for (int i = 0; i < node.subnodes.count; i++)
-      queue.push(node.subnodes[i]);
+    for (ASDisplayNode *subnode in node.subnodes) {
+      queue.push(subnode);
+    }
   }
 }
 

--- a/AsyncDisplayKit/ASVideoPlayerNode.mm
+++ b/AsyncDisplayKit/ASVideoPlayerNode.mm
@@ -303,9 +303,9 @@ static void *ASVideoPlayerNodeContext = &ASVideoPlayerNodeContext;
 - (void)removeControls
 {
   NSArray *controls = [_cachedControls allValues];
-  [controls enumerateObjectsUsingBlock:^(ASDisplayNode   *_Nonnull node, NSUInteger idx, BOOL * _Nonnull stop) {
+  for (ASDisplayNode *node in controls) {
     [node removeFromSupernode];
-  }];
+  }
 
   [self cleanCachedControls];
 }

--- a/AsyncDisplayKit/ASVideoPlayerNode.mm
+++ b/AsyncDisplayKit/ASVideoPlayerNode.mm
@@ -302,8 +302,7 @@ static void *ASVideoPlayerNodeContext = &ASVideoPlayerNodeContext;
 
 - (void)removeControls
 {
-  NSArray *controls = [_cachedControls allValues];
-  for (ASDisplayNode *node in controls) {
+  for (ASDisplayNode *node in [_cachedControls objectEnumerator]) {
     [node removeFromSupernode];
   }
 

--- a/AsyncDisplayKit/Details/ASCollectionDataController.mm
+++ b/AsyncDisplayKit/Details/ASCollectionDataController.mm
@@ -88,8 +88,7 @@
 
 - (void)willInsertSections:(NSIndexSet *)sections
 {
-  for (NSString *kind in _pendingContexts) {
-    NSMutableArray<ASIndexedNodeContext *> *contexts = _pendingContexts[kind];
+  [_pendingContexts enumerateKeysAndObjectsUsingBlock:^(NSString * _Nonnull kind, NSMutableArray<ASIndexedNodeContext *> * _Nonnull contexts, BOOL * _Nonnull stop) {
     NSMutableArray *sectionArray = [NSMutableArray arrayWithCapacity:sections.count];
     for (NSUInteger i = 0; i < sections.count; i++) {
       [sectionArray addObject:[NSMutableArray array]];
@@ -99,7 +98,7 @@
     [self batchLayoutNodesFromContexts:contexts ofKind:kind completion:^(NSArray<ASCellNode *> *nodes, NSArray<NSIndexPath *> *indexPaths) {
       [self insertNodes:nodes ofKind:kind atIndexPaths:indexPaths completion:nil];
     }];
-  }
+  }];
   [_pendingContexts removeAllObjects];
 }
 
@@ -145,13 +144,12 @@
 
 - (void)willInsertRowsAtIndexPaths:(NSArray<NSIndexPath *> *)indexPaths
 {
-  for (NSString *kind in _pendingContexts) {
-    NSMutableArray<ASIndexedNodeContext *> *contexts = _pendingContexts[kind];
-
+  [_pendingContexts enumerateKeysAndObjectsUsingBlock:^(NSString * _Nonnull kind, NSMutableArray<ASIndexedNodeContext *> * _Nonnull contexts, BOOL * _Nonnull stop) {
     [self batchLayoutNodesFromContexts:contexts ofKind:kind completion:^(NSArray<ASCellNode *> *nodes, NSArray<NSIndexPath *> *indexPaths) {
       [self insertNodes:nodes ofKind:kind atIndexPaths:indexPaths completion:nil];
     }];
-  }
+  }];
+
   [_pendingContexts removeAllObjects];
 }
 

--- a/AsyncDisplayKit/Details/ASDataController.mm
+++ b/AsyncDisplayKit/Details/ASDataController.mm
@@ -302,8 +302,9 @@ NSString * const ASDataControllerRowNodeKind = @"_ASDataControllerRowNodeKind";
   _editingNodes[kind] = editingNodes;
 
   [_mainSerialQueue performBlockOnMainThread:^{
-    NSArray *nodes = ASFindElementsInMultidimensionalArrayAtIndexPaths(_completedNodes[kind], indexPaths);
-    ASDeleteElementsInMultidimensionalArrayAtIndexPaths(_completedNodes[kind], indexPaths);
+    NSMutableArray *allNodes = _completedNodes[kind];
+    NSArray *nodes = ASFindElementsInMultidimensionalArrayAtIndexPaths(allNodes, indexPaths);
+    ASDeleteElementsInMultidimensionalArrayAtIndexPaths(allNodes, indexPaths);
     if (completionBlock) {
       completionBlock(nodes, indexPaths);
     }
@@ -512,17 +513,19 @@ NSString * const ASDataControllerRowNodeKind = @"_ASDataControllerRowNodeKind";
   ASEnvironmentTraitCollection environmentTraitCollection = environment.environmentTraitCollection;
   
   NSMutableArray<ASIndexedNodeContext *> *contexts = [NSMutableArray array];
-  [indexSet enumerateIndexesUsingBlock:^(NSUInteger sectionIndex, BOOL *stop) {
-    NSUInteger rowNum = [_dataSource dataController:self rowsInSection:sectionIndex];
-    for (NSUInteger i = 0; i < rowNum; i++) {
-      NSIndexPath *indexPath = [NSIndexPath indexPathForItem:i inSection:sectionIndex];
-      ASCellNodeBlock nodeBlock = [_dataSource dataController:self nodeBlockAtIndexPath:indexPath];
-      
-      ASSizeRange constrainedSize = [self constrainedSizeForNodeOfKind:ASDataControllerRowNodeKind atIndexPath:indexPath];
-      [contexts addObject:[[ASIndexedNodeContext alloc] initWithNodeBlock:nodeBlock
-                                                                indexPath:indexPath
-                                                          constrainedSize:constrainedSize
-                                               environmentTraitCollection:environmentTraitCollection]];
+  [indexSet enumerateRangesUsingBlock:^(NSRange range, BOOL * _Nonnull stop) {
+    for (NSUInteger sectionIndex = range.location; sectionIndex < NSMaxRange(range); sectionIndex++) {
+      NSUInteger itemCount = [_dataSource dataController:self rowsInSection:sectionIndex];
+      for (NSUInteger i = 0; i < itemCount; i++) {
+        NSIndexPath *indexPath = [NSIndexPath indexPathForItem:i inSection:sectionIndex];
+        ASCellNodeBlock nodeBlock = [_dataSource dataController:self nodeBlockAtIndexPath:indexPath];
+        
+        ASSizeRange constrainedSize = [self constrainedSizeForNodeOfKind:ASDataControllerRowNodeKind atIndexPath:indexPath];
+        [contexts addObject:[[ASIndexedNodeContext alloc] initWithNodeBlock:nodeBlock
+                                                                  indexPath:indexPath
+                                                            constrainedSize:constrainedSize
+                                                 environmentTraitCollection:environmentTraitCollection]];
+      }
     }
   }];
   return contexts;
@@ -564,10 +567,12 @@ NSString * const ASDataControllerRowNodeKind = @"_ASDataControllerRowNodeKind";
     // Running these commands may result in blocking on an _editingTransactionQueue operation that started even before -beginUpdates.
     // Each subsequent command in the queue will also wait on the full asynchronous completion of the prior command's edit transaction.
     LOG(@"endUpdatesWithCompletion - %zd blocks to run", _pendingEditCommandBlocks.count);
-    [_pendingEditCommandBlocks enumerateObjectsUsingBlock:^(dispatch_block_t block, NSUInteger idx, BOOL *stop) {
-      LOG(@"endUpdatesWithCompletion - running block #%zd", idx);
+    NSUInteger i = 0;
+    for (dispatch_block_t block in _pendingEditCommandBlocks) {
+      LOG(@"endUpdatesWithCompletion - running block #%zd", i);
       block();
-    }];
+      i += 1;
+    }
     [_pendingEditCommandBlocks removeAllObjects];
     
     [_editingTransactionQueue addOperationWithBlock:^{
@@ -861,8 +866,8 @@ NSString * const ASDataControllerRowNodeKind = @"_ASDataControllerRowNodeKind";
     
     [_editingTransactionQueue addOperationWithBlock:^{
       LOG(@"Edit Transaction - moveRow: %@ > %@", indexPath, newIndexPath);
-      NSArray *nodes = ASFindElementsInMultidimensionalArrayAtIndexPaths(_editingNodes[ASDataControllerRowNodeKind], @[indexPath]);
       NSArray *indexPaths = @[indexPath];
+      NSArray *nodes = ASFindElementsInMultidimensionalArrayAtIndexPaths(_editingNodes[ASDataControllerRowNodeKind], indexPaths);
       [self _deleteNodesAtIndexPaths:indexPaths withAnimationOptions:animationOptions];
 
       // Don't re-calculate size for moving
@@ -876,12 +881,13 @@ NSString * const ASDataControllerRowNodeKind = @"_ASDataControllerRowNodeKind";
 
 - (NSArray *)indexPathsForEditingNodesOfKind:(NSString *)kind
 {
-  return _editingNodes[kind] != nil ? ASIndexPathsForTwoDimensionalArray(_editingNodes[kind]) : nil;
+  NSArray *nodes = _editingNodes[kind];
+  return nodes != nil ? ASIndexPathsForTwoDimensionalArray(nodes) : nil;
 }
 
 - (NSMutableArray *)editingNodesOfKind:(NSString *)kind
 {
-  return _editingNodes[kind] != nil ? _editingNodes[kind] : [NSMutableArray array];
+  return _editingNodes[kind] ? : [NSMutableArray array];
 }
 
 - (NSMutableArray *)completedNodesOfKind:(NSString *)kind
@@ -958,7 +964,7 @@ NSString * const ASDataControllerRowNodeKind = @"_ASDataControllerRowNodeKind";
 - (void)dealloc
 {
   ASDisplayNodeAssertMainThread();
-  [_completedNodes enumerateKeysAndObjectsUsingBlock:^(NSString *kind, NSMutableArray *sections, BOOL *stop) {
+  for (NSMutableArray *sections in [_completedNodes objectEnumerator]) {
     for (NSArray *section in sections) {
       for (ASCellNode *node in section) {
         if (node.isNodeLoaded) {
@@ -970,7 +976,7 @@ NSString * const ASDataControllerRowNodeKind = @"_ASDataControllerRowNodeKind";
         }
       }
     }
-  }];
+  }
 }
 
 @end

--- a/AsyncDisplayKit/Details/ASFlowLayoutController.mm
+++ b/AsyncDisplayKit/Details/ASFlowLayoutController.mm
@@ -113,11 +113,11 @@
   range.start = currentIndexPath;
   range.end = currentIndexPath;
   
-  [indexPaths enumerateObjectsUsingBlock:^(NSIndexPath *indexPath, NSUInteger idx, BOOL *stop) {
+  for (NSIndexPath *indexPath in indexPaths) {
     currentIndexPath = [indexPath ASIndexPathValue];
     range.start = ASIndexPathMinimum(range.start, currentIndexPath);
     range.end = ASIndexPathMaximum(range.end, currentIndexPath);
-  }];
+  }
   return range;
 }
 

--- a/AsyncDisplayKit/Details/NSIndexSet+ASHelpers.m
+++ b/AsyncDisplayKit/Details/NSIndexSet+ASHelpers.m
@@ -15,10 +15,12 @@
 - (NSIndexSet *)as_indexesByMapping:(NSUInteger (^)(NSUInteger))block
 {
   NSMutableIndexSet *result = [NSMutableIndexSet indexSet];
-  [self enumerateIndexesUsingBlock:^(NSUInteger idx, __unused BOOL * _Nonnull stop) {
-    NSUInteger newIndex = block(idx);
-    if (newIndex != NSNotFound) {
-      [result addIndex:newIndex];
+  [self enumerateRangesUsingBlock:^(NSRange range, BOOL * _Nonnull stop) {
+    for (NSUInteger i = range.location; i < NSMaxRange(range); i++) {
+      NSUInteger newIndex = block(i);
+      if (newIndex != NSNotFound) {
+        [result addIndex:newIndex];
+      }
     }
   }];
   return result;
@@ -49,11 +51,13 @@
 - (NSUInteger)as_indexChangeByInsertingItemsBelowIndex:(NSUInteger)index
 {
   __block NSUInteger newIndex = index;
-  [self enumerateIndexesUsingBlock:^(NSUInteger idx, BOOL * _Nonnull stop) {
-    if (idx <= newIndex) {
-      newIndex += 1;
-    } else {
-      *stop = YES;
+  [self enumerateRangesUsingBlock:^(NSRange range, BOOL * _Nonnull stop) {
+    for (NSUInteger i = range.location; i < NSMaxRange(range); i++) {
+      if (i <= newIndex) {
+        newIndex += 1;
+      } else {
+        *stop = YES;
+      }
     }
   }];
   return newIndex - index;
@@ -64,9 +68,9 @@
   NSMutableString *result = [NSMutableString stringWithString:@"{ "];
   [self enumerateRangesUsingBlock:^(NSRange range, BOOL * _Nonnull stop) {
     if (range.length == 1) {
-      [result appendFormat:@"%lu ", (unsigned long)range.location];
+      [result appendFormat:@"%zu ", range.location];
     } else {
-      [result appendFormat:@"%lu-%lu ", (unsigned long)range.location, (unsigned long)NSMaxRange(range)];
+      [result appendFormat:@"%zu-%zu ", range.location, NSMaxRange(range) - 1];
     }
   }];
   [result appendString:@"}"];

--- a/AsyncDisplayKit/Layout/ASLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASLayoutSpec.mm
@@ -148,9 +148,11 @@ typedef std::map<unsigned long, id<ASLayoutable>, std::less<unsigned long>> ASCh
   ASDisplayNodeAssert(self.isMutable, @"Cannot set properties when layout spec is not mutable");
   
   _children.clear();
-  [children enumerateObjectsUsingBlock:^(id<ASLayoutable>  _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
-    _children[idx] = [self layoutableToAddFromLayoutable:obj];
-  }];
+  NSUInteger i = 0;
+  for (id<ASLayoutable> child in children) {
+    _children[i] = [self layoutableToAddFromLayoutable:child];
+    i += 1;
+  }
 }
 
 - (id<ASLayoutable>)childForIndex:(NSUInteger)index

--- a/AsyncDisplayKit/Private/ASLayoutTransition.mm
+++ b/AsyncDisplayKit/Private/ASLayoutTransition.mm
@@ -38,8 +38,8 @@ static inline BOOL ASLayoutCanTransitionAsynchronous(ASLayout *layout) {
     }
     
     // Add all sublayouts to process in next step
-    for (int i = 0; i < layout.sublayouts.count; i++) {
-      queue.push(layout.sublayouts[0]);
+    for (ASLayout *sublayout in layout.sublayouts) {
+      queue.push(sublayout);
     }
   }
   

--- a/AsyncDisplayKit/Private/ASMultidimensionalArrayUtils.mm
+++ b/AsyncDisplayKit/Private/ASMultidimensionalArrayUtils.mm
@@ -171,8 +171,10 @@ NSArray *ASFindElementsInMultidimensionalArrayAtIndexPaths(NSMutableArray *mutab
 NSArray *ASIndexPathsForMultidimensionalArrayAtIndexSet(NSArray *multidimensionalArray, NSIndexSet *indexSet)
 {
   NSMutableArray *res = [NSMutableArray array];
-  [indexSet enumerateIndexesUsingBlock:^(NSUInteger idx, BOOL *stop) {
-    ASRecursivelyFindIndexPathsForMultidimensionalArray(multidimensionalArray[idx], [NSIndexPath indexPathWithIndex:idx], res);
+  [indexSet enumerateRangesUsingBlock:^(NSRange range, BOOL * _Nonnull stop) {
+    for (NSUInteger i = range.location; i < NSMaxRange(range); i++) {
+      ASRecursivelyFindIndexPathsForMultidimensionalArray(multidimensionalArray[i], [NSIndexPath indexPathWithIndex:i], res);
+    }
   }];
 
   return res;


### PR DESCRIPTION
I got on a bit of a rabbit trail here. A couple common tactics:

- Replace `enumerateIndexes` with `enumerateRanges`, using a for-loop to go through the indexes in each range. This reduces block invocations.
- Replace `.allKeys/.allValues` with plain dictionary enumeration and `objectEnumerator` when possible to avoid making copies. 
- Replace `enumerateObjectsUsingBlock` with fast enumeration when possible.
- Prefer `-[NSIndexPath indexPathForItem:inSection:]` because in 64-bit architectures there's some special mechanism to use singletons for these.
- Don't call the same thing 3 times in a row. Especially if that thing allocates memory!