### PR TITLE
[ASDisplayNode] Always layout nodes on a background thread

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -791,7 +791,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   };
 
   // TODO ihm: Can we always push the measure to the background thread and remove the parameter from the API?
-  if (shouldMeasureAsync) {
+  if (ASDisplayNodeThreadIsMain()) {
     ASPerformBlockOnBackgroundThread(transitionBlock);
   } else {
     transitionBlock();

--- a/AsyncDisplayKit/Details/ASDataController.mm
+++ b/AsyncDisplayKit/Details/ASDataController.mm
@@ -184,7 +184,6 @@ NSString * const ASDataControllerRowNodeKind = @"_ASDataControllerRowNodeKind";
 
   NSUInteger nodeCount = contexts.count;
   NSMutableArray<ASCellNode *> *allocatedNodes = [NSMutableArray<ASCellNode *> arrayWithCapacity:nodeCount];
-  dispatch_group_t layoutGroup = dispatch_group_create();
 
   for (NSUInteger j = 0; j < nodeCount; j += kASDataControllerSizingCountPerProcessor) {
     NSInteger batchCount = MIN(kASDataControllerSizingCountPerProcessor, nodeCount - j);


### PR DESCRIPTION
Some crazy idea and follow up to #1839. We will push the layout of nodes to always be on a background thread as based on the work in #1839 we will trampoline the layout automatically to the main thread if at least one node is loaded.

Furthermore there needs to be some more improvements to it:
- Moving away from dispatching to global dispatch queues in layout transition and ASDataController
- Remove the semaphore in ASDataController
- Adding tests

@Adlai-Holler @nguyenhuy @appleguy @levi What do you guys think about that? We have to carefully think about that and check for any gotchas that could happen, if we really want to go forward with that.