### PR TITLE
[Examples] AsyncDisplayKitOverview collection nodes size fix

### DIFF
--- a/examples/AsyncDisplayKitOverview/Sample/Node Containers/OverviewASCollectionNode.m
+++ b/examples/AsyncDisplayKitOverview/Sample/Node Containers/OverviewASCollectionNode.m
@@ -66,9 +66,9 @@
     };
 }
 
-- (CGSize)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout sizeForItemAtIndexPath:(NSIndexPath *)indexPath
+- (ASSizeRange)collectionView:(ASCollectionView *)collectionView constrainedSizeForNodeAtIndexPath:(NSIndexPath *)indexPath
 {
-    return CGSizeMake(100, 100);
+    return ASSizeRangeMakeExactSize(CGSizeMake(100, 100));
 }
 
 @end


### PR DESCRIPTION
With "sizeForItemAtIndexPath" it shows empty screen instead of collection items.