### PR TITLE
[ASVideoPlayerNode] Expose the UIActivityIndicatorViewStyle to clients

### DIFF
--- a/AsyncDisplayKit/ASVideoPlayerNode.h
+++ b/AsyncDisplayKit/ASVideoPlayerNode.h
@@ -119,6 +119,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Spinner delegate methods
 - (UIColor *)videoPlayerNodeSpinnerTint:(ASVideoPlayerNode *)videoPlayer;
+- (UIActivityIndicatorViewStyle)videoPlayerNodeSpinnerStyle:(ASVideoPlayerNode *)videoPlayer;
 
 #pragma mark - Playback button delegate methods
 - (UIColor *)videoPlayerNodePlaybackButtonTint:(ASVideoPlayerNode *)videoPlayer;

--- a/AsyncDisplayKit/ASVideoPlayerNode.mm
+++ b/AsyncDisplayKit/ASVideoPlayerNode.mm
@@ -24,6 +24,7 @@ static void *ASVideoPlayerNodeContext = &ASVideoPlayerNodeContext;
     unsigned int delegateNeededDefaultControls:1;
     unsigned int delegateCustomControls:1;
     unsigned int delegateSpinnerTintColor:1;
+    unsigned int delegateSpinnerStyle:1;
     unsigned int delegatePlaybackButtonTint:1;
     unsigned int delegateScrubberMaximumTrackTintColor:1;
     unsigned int delegateScrubberMinimumTrackTintColor:1;
@@ -592,6 +593,10 @@ static void *ASVideoPlayerNodeContext = &ASVideoPlayerNodeContext;
         spinnnerView.color = _defaultControlsColor;
       }
       
+      if (_delegateFlags.delegateSpinnerStyle) {
+        spinnnerView.activityIndicatorViewStyle = [_delegate videoPlayerNodeSpinnerStyle:strongSelf];
+      }
+      
       return spinnnerView;
     }];
     _spinnerNode.preferredFrameSize = CGSizeMake(44.0, 44.0);
@@ -773,6 +778,7 @@ static void *ASVideoPlayerNodeContext = &ASVideoPlayerNodeContext;
     _delegateFlags.delegateNeededDefaultControls = [_delegate respondsToSelector:@selector(videoPlayerNodeNeededDefaultControls:)];
     _delegateFlags.delegateCustomControls = [_delegate respondsToSelector:@selector(videoPlayerNodeCustomControls:)];
     _delegateFlags.delegateSpinnerTintColor = [_delegate respondsToSelector:@selector(videoPlayerNodeSpinnerTint:)];
+    _delegateFlags.delegateSpinnerStyle = [_delegate respondsToSelector:@selector(videoPlayerNodeSpinnerStyle:)];
     _delegateFlags.delegateScrubberMaximumTrackTintColor = [_delegate respondsToSelector:@selector(videoPlayerNodeScrubberMaximumTrackTint:)];
     _delegateFlags.delegateScrubberMinimumTrackTintColor = [_delegate respondsToSelector:@selector(videoPlayerNodeScrubberMinimumTrackTint:)];
     _delegateFlags.delegateScrubberThumbTintColor = [_delegate respondsToSelector:@selector(videoPlayerNodeScrubberThumbTint:)];


### PR DESCRIPTION
The default spinner size looked a bit lost in my project, especially on iPad. The default is quite small and the 'large' version isn't exactly big either.

We're already exposing the tint colour, so it seemed only right to allow the user to set the spinner style also.

I've tested this on my own project and it appears to work fine.