### PR TITLE
[ASPagerNode] Invalidate the pager’s layout when its trait collection changes

### DIFF
--- a/AsyncDisplayKit/ASPagerNode.m
+++ b/AsyncDisplayKit/ASPagerNode.m
@@ -157,4 +157,12 @@
   [self setDataSource:nil];
 }
 
+- (void)asyncTraitCollectionDidChange
+{
+  [super asyncTraitCollectionDidChange];
+  if (self.isNodeLoaded) {
+    [self.view.collectionViewLayout invalidateLayout];
+  }
+}
+
 @end


### PR DESCRIPTION
Is this something that I should have to be doing explicitly? If ASCollectioView (i.e., UICollectionView) does this automatically, shouldn’t the pager as well?