### PR TITLE
[ASCollectionNode/ASTableNode] Remeasure cells on trait collection change

### DIFF
--- a/AsyncDisplayKit/Details/ASEnvironment.h
+++ b/AsyncDisplayKit/Details/ASEnvironment.h
@@ -141,8 +141,8 @@ ASDISPLAYNODE_EXTERN_C_END
   ASDN::MutexLocker l(lock);\
   ASEnvironmentTraitCollection oldTraits = self.environmentState.environmentTraitCollection;\
   [super setEnvironmentState:environmentState];\
-\
-   /* Extra Trait Collection Handling */\
+  \
+  /* Extra Trait Collection Handling */\
   /* If the node is not loaded  yet don't do anything as otherwise the access of the view will trigger a load*/\
   if (!self.isNodeLoaded) { return; } \
   ASEnvironmentTraitCollection currentTraits = environmentState.environmentTraitCollection;\
@@ -150,10 +150,11 @@ ASDISPLAYNODE_EXTERN_C_END
     /* Must dispatch to main for self.view && [self.view.dataController completedNodes]*/ \
     ASPerformBlockOnMainThread(^{\
       NSArray<NSArray <ASCellNode *> *> *completedNodes = [self.view.dataController completedNodes];\
+      CGSize constrainedSize = environmentState.environmentTraitCollection.containerSize;\
       for (NSArray *sectionArray in completedNodes) {\
         for (ASCellNode *cellNode in sectionArray) {\
           ASEnvironmentStatePropagateDown(cellNode, currentTraits);\
-          [cellNode setNeedsLayout];\
+          [cellNode measure:constrainedSize];\
         }\
       }\
     });\


### PR DESCRIPTION
It isn’t enough to call `setNeedsLayout` on a cell since the container size will change on a trait collection change. We must call `measure` with the new container size as the constrainted size.

This is all happening on main, which I don’t like, but since we are reacting to a trait collection change does it make sense for it to happen anywhere else?