### PR TITLE
[ASRangeController] Fix Major Range Mode Updating Issues

### DIFF
--- a/AsyncDisplayKit/ASCollectionNode.h
+++ b/AsyncDisplayKit/ASCollectionNode.h
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
  * ASCollectionNode is a node based class that wraps an ASCollectionView. It can be used
  * as a subnode of another node, and provide room for many (great) features and improvements later on.
  */
-@interface ASCollectionNode : ASDisplayNode
+@interface ASCollectionNode : ASDisplayNode <ASRangeControllerUpdateRangeProtocol>
 
 - (instancetype)initWithCollectionViewLayout:(UICollectionViewLayout *)layout;
 - (instancetype)initWithFrame:(CGRect)frame collectionViewLayout:(UICollectionViewLayout *)layout;
@@ -108,10 +108,6 @@ NS_ASSUME_NONNULL_BEGIN
  * while all the cells load.
  */
 - (void)reloadDataImmediately;
-
-@end
-
-@interface ASCollectionNode (ASRangeControllerUpdateRangeProtocol) <ASRangeControllerUpdateRangeProtocol>
 
 @end
 

--- a/AsyncDisplayKit/ASDisplayNode+Beta.h
+++ b/AsyncDisplayKit/ASDisplayNode+Beta.h
@@ -9,6 +9,7 @@
 //
 
 #import "ASContextTransitioning.h"
+#import "ASLayoutRangeType.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -115,6 +116,15 @@ ASDISPLAYNODE_EXTERN_C_END
  * progressImage block.
  */
 - (void)hierarchyDisplayDidFinish;
+
+/**
+ * Only ASLayoutRangeModeVisibleOnly or ASLayoutRangeModeLowMemory are recommended.  Default is ASLayoutRangeModeVisibleOnly,
+ * because this is the only way to ensure an application will not have blank / flashing views as the user navigates back after
+ * a memory warning.  Apps that wish to use the more effective / aggressive ASLayoutRangeModeLowMemory may need to take steps
+ * to mitigate this behavior, including: restoring a larger range mode to the next controller before the user navigates there,
+ * enabling .neverShowPlaceholders on ASCellNodes so that the navigation operation is blocked on redisplay completing, etc.
+ */
++ (void)setRangeModeForMemoryWarnings:(ASLayoutRangeMode)rangeMode;
 
 @end
 

--- a/AsyncDisplayKit/ASTableNode.h
+++ b/AsyncDisplayKit/ASTableNode.h
@@ -22,7 +22,7 @@
  * ASTableNode is a node based class that wraps an ASTableView. It can be used
  * as a subnode of another node, and provide room for many (great) features and improvements later on.
  */
-@interface ASTableNode : ASDisplayNode
+@interface ASTableNode : ASDisplayNode <ASRangeControllerUpdateRangeProtocol>
 
 - (instancetype)init; // UITableViewStylePlain
 - (instancetype)initWithStyle:(UITableViewStyle)style;
@@ -32,9 +32,5 @@
 // These properties can be set without triggering the view to be created, so it's fine to set them in -init.
 @property (weak, nonatomic) id <ASTableDelegate>   delegate;
 @property (weak, nonatomic) id <ASTableDataSource> dataSource;
-
-@end
-
-@interface ASTableNode (ASRangeControllerUpdateRangeProtocol) <ASRangeControllerUpdateRangeProtocol>
 
 @end

--- a/AsyncDisplayKit/ASViewController.h
+++ b/AsyncDisplayKit/ASViewController.h
@@ -64,7 +64,12 @@ typedef ASTraitCollection * _Nonnull (^ASDisplayTraitsForTraitWindowSizeBlock)(C
 
 @interface ASViewController (ASRangeControllerUpdateRangeProtocol)
 
-/// Automatically adjust range mode based on view events if the containing node confirms to the ASRangeControllerUpdateRangeProtocol
+/**
+ * Automatically adjust range mode based on view events. If you set this to YES, the view controller or its node
+ * must conform to the ASRangeControllerUpdateRangeProtocol. 
+ *
+ * Default value is NO.
+ */
 @property (nonatomic, assign) BOOL automaticallyAdjustRangeModeBasedOnViewEvents;
 
 @end

--- a/AsyncDisplayKit/ASViewController.mm
+++ b/AsyncDisplayKit/ASViewController.mm
@@ -27,6 +27,9 @@
   BOOL _automaticallyAdjustRangeModeBasedOnViewEvents;
   BOOL _parentManagesVisibilityDepth;
   NSInteger _visibilityDepth;
+  BOOL _selfConformsToRangeModeProtocol;
+  BOOL _nodeConformsToRangeModeProtocol;
+  BOOL _didCheckRangeModeProtocolConformance;
 }
 
 - (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
@@ -172,17 +175,29 @@ ASVisibilityDepthImplementation;
 - (void)setAutomaticallyAdjustRangeModeBasedOnViewEvents:(BOOL)automaticallyAdjustRangeModeBasedOnViewEvents
 {
   _automaticallyAdjustRangeModeBasedOnViewEvents = automaticallyAdjustRangeModeBasedOnViewEvents;
+  if (automaticallyAdjustRangeModeBasedOnViewEvents && !_didCheckRangeModeProtocolConformance) {
+    _selfConformsToRangeModeProtocol = [self conformsToProtocol:@protocol(ASRangeControllerUpdateRangeProtocol)];
+    _nodeConformsToRangeModeProtocol = [_node conformsToProtocol:@protocol(ASRangeControllerUpdateRangeProtocol)];
+    _didCheckRangeModeProtocolConformance = YES;
+    if (!_selfConformsToRangeModeProtocol && !_nodeConformsToRangeModeProtocol) {
+      NSLog(@"Warning: automaticallyAdjustRangeModeBasedOnViewEvents set to YES in %@, but range mode updating is not possible because neither view controller nor node %@ conform to ASRangeControllerUpdateRangeProtocol.", self, _node);
+    }
+  }
 }
 
 - (void)updateCurrentRangeModeWithModeIfPossible:(ASLayoutRangeMode)rangeMode
 {
   if (!_automaticallyAdjustRangeModeBasedOnViewEvents) { return; }
-  if (![_node conformsToProtocol:@protocol(ASRangeControllerUpdateRangeProtocol)]) {
-    return;
+  
+  if (_selfConformsToRangeModeProtocol) {
+    id<ASRangeControllerUpdateRangeProtocol> rangeUpdater = (id<ASRangeControllerUpdateRangeProtocol>)self;
+    [rangeUpdater updateCurrentRangeWithMode:rangeMode];
   }
-
-  id<ASRangeControllerUpdateRangeProtocol> updateRangeNode = (id<ASRangeControllerUpdateRangeProtocol>)_node;
-  [updateRangeNode updateCurrentRangeWithMode:rangeMode];
+  
+  if (_nodeConformsToRangeModeProtocol) {
+    id<ASRangeControllerUpdateRangeProtocol> rangeUpdater = (id<ASRangeControllerUpdateRangeProtocol>)_node;
+    [rangeUpdater updateCurrentRangeWithMode:rangeMode];
+  }
 }
 
 #pragma mark - Layout Helpers

--- a/AsyncDisplayKit/ASViewController.mm
+++ b/AsyncDisplayKit/ASViewController.mm
@@ -175,7 +175,13 @@ ASVisibilityDepthImplementation;
 - (void)setAutomaticallyAdjustRangeModeBasedOnViewEvents:(BOOL)automaticallyAdjustRangeModeBasedOnViewEvents
 {
   _automaticallyAdjustRangeModeBasedOnViewEvents = automaticallyAdjustRangeModeBasedOnViewEvents;
-  if (automaticallyAdjustRangeModeBasedOnViewEvents && !_didCheckRangeModeProtocolConformance) {
+}
+
+- (void)updateCurrentRangeModeWithModeIfPossible:(ASLayoutRangeMode)rangeMode
+{
+  if (!_automaticallyAdjustRangeModeBasedOnViewEvents) { return; }
+  
+  if (!_didCheckRangeModeProtocolConformance) {
     _selfConformsToRangeModeProtocol = [self conformsToProtocol:@protocol(ASRangeControllerUpdateRangeProtocol)];
     _nodeConformsToRangeModeProtocol = [_node conformsToProtocol:@protocol(ASRangeControllerUpdateRangeProtocol)];
     _didCheckRangeModeProtocolConformance = YES;
@@ -183,11 +189,6 @@ ASVisibilityDepthImplementation;
       NSLog(@"Warning: automaticallyAdjustRangeModeBasedOnViewEvents set to YES in %@, but range mode updating is not possible because neither view controller nor node %@ conform to ASRangeControllerUpdateRangeProtocol.", self, _node);
     }
   }
-}
-
-- (void)updateCurrentRangeModeWithModeIfPossible:(ASLayoutRangeMode)rangeMode
-{
-  if (!_automaticallyAdjustRangeModeBasedOnViewEvents) { return; }
   
   if (_selfConformsToRangeModeProtocol) {
     id<ASRangeControllerUpdateRangeProtocol> rangeUpdater = (id<ASRangeControllerUpdateRangeProtocol>)self;

--- a/AsyncDisplayKit/Details/ASRangeController.mm
+++ b/AsyncDisplayKit/Details/ASRangeController.mm
@@ -599,3 +599,12 @@ static ASLayoutRangeMode __rangeModeForMemoryWarnings = ASLayoutRangeModeVisible
 }
 
 @end
+
+@implementation ASDisplayNode (RangeModeConfiguring)
+
++ (void)setRangeModeForMemoryWarnings:(ASLayoutRangeMode)rangeMode
+{
+  [ASRangeController setRangeModeForMemoryWarnings:rangeMode];
+}
+
+@end

--- a/AsyncDisplayKit/Details/ASRangeControllerUpdateRangeProtocol+Beta.h
+++ b/AsyncDisplayKit/Details/ASRangeControllerUpdateRangeProtocol+Beta.h
@@ -18,21 +18,4 @@
  */
 - (void)updateCurrentRangeWithMode:(ASLayoutRangeMode)rangeMode;
 
-/**
- * Only ASLayoutRangeModeVisibleOnly or ASLayoutRangeModeLowMemory are recommended.  Default is ASLayoutRangeModeVisibleOnly,
- * because this is the only way to ensure an application will not have blank / flashing views as the user navigates back after
- * a memory warning.  Apps that wish to use the more effective / aggressive ASLayoutRangeModeLowMemory may need to take steps
- * to mitigate this behavior, including: restoring a larger range mode to the next controller before the user navigates there,
- * enabling .neverShowPlaceholders on ASCellNodes so that the navigation operation is blocked on redisplay completing, etc.
- */
-+ (void)setRangeModeForMemoryWarnings:(ASLayoutRangeMode)rangeMode;
-
 @end
-
-
-
-
-
-
-
-

--- a/AsyncDisplayKitTests/ASCollectionViewTests.m
+++ b/AsyncDisplayKitTests/ASCollectionViewTests.m
@@ -13,6 +13,7 @@
 #import "ASCollectionDataController.h"
 #import "ASCollectionViewFlowLayoutInspector.h"
 #import "ASCellNode.h"
+#import "ASCollectionNode.h"
 
 @interface ASTextCellNodeWithSetSelectedCounter : ASTextCellNode
 
@@ -238,6 +239,16 @@
   
   XCTAssertTrue(ASRangeTuningParametersEqualToRangeTuningParameters(renderParams, [collectionView tuningParametersForRangeType:ASLayoutRangeTypeDisplay]));
   XCTAssertTrue(ASRangeTuningParametersEqualToRangeTuningParameters(preloadParams, [collectionView tuningParametersForRangeType:ASLayoutRangeTypeFetchData]));
+}
+
+/**
+ * This may seem silly, but we had issues where the runtime sometimes wouldn't correctly report
+ * conformances declared on categories.
+ */
+- (void)testThatCollectionNodeConformsToExpectedProtocols
+{
+  ASCollectionNode *node = [[ASCollectionNode alloc] initWithFrame:CGRectZero collectionViewLayout:[[UICollectionViewFlowLayout alloc] init]];
+  XCTAssert([node conformsToProtocol:@protocol(ASRangeControllerUpdateRangeProtocol)]);
 }
 
 @end

--- a/AsyncDisplayKitTests/ASTableViewTests.m
+++ b/AsyncDisplayKitTests/ASTableViewTests.m
@@ -15,6 +15,7 @@
 #import "ASDisplayNode+Subclasses.h"
 #import "ASChangeSetDataController.h"
 #import "ASCellNode.h"
+#import "ASTableNode.h"
 
 #define NumberOfSections 10
 #define NumberOfRowsPerSection 20
@@ -516,6 +517,16 @@
       XCTFail(@"Expectation failed: %@", error);
     }
   }];
+}
+
+/**
+ * This may seem silly, but we had issues where the runtime sometimes wouldn't correctly report
+ * conformances declared on categories.
+ */
+- (void)testThatTableNodeConformsToExpectedProtocols
+{
+  ASTableNode *node = [[ASTableNode alloc] initWithStyle:UITableViewStylePlain];
+  XCTAssert([node conformsToProtocol:@protocol(ASRangeControllerUpdateRangeProtocol)]);
 }
 
 @end


### PR DESCRIPTION
This morning Michael and I found that our range mode updating is basically not working at all for a couple reasons.

- ASCollectionNode and ASTableNode declare their conformance in a category, which apparently doesn't work and causes the runtime to return NO for conformsToProtocol:
- Pinterest (and I'm sure other apps) have ASViewControllers with non-table, non-collection nodes. Sometimes these are plain old ASDisplayNodes. None of them conform to the update protocol.
- ASTableNode and ASCollectionNode did not implement +setRangeModeForMemoryWarnings: so they actually didn't conform to the updating protocol. This also means none of our users is calling that method or it would have crashed.
- Worst of all, we had no idea that none of this was working.

So

- Move the conformances in ASTableNode/ASCollectionNode to the main @interface instead of the category. This makes them return YES from `conformsToProtocol`.
- Allow ASViewController to conform to the range updating protocol as well as its node.
- Add a one-time-per-VC log if we try to adjust the range mode but can't because neither the VC nor the node conforms to the protocol.
- **BREAKING** Remove +setRangeModeForMemoryWarnings from the protocol and replace with a global method `+[ASDisplayNode setRangeModeForMemoryWarnings:]`.
  - I think we can land this even with the breaking change.
  - Obviously nobody was calling it or they would have gotten crashes.
  - It's not clear what calling it on, say, ASTableNode would have done. It would probably have called through to ASRangeController, which would have affected ASCollectionNode as well.
  - It would be a pain to override for every conforming node/VC.

@appleguy @maicki @levi This is pretty urgent. I think we should cherry-pick this to 6.7 if it's approved.