### PR TITLE
[ASTextNode] Fix wrong truncation after constrained size changes

### DIFF
--- a/AsyncDisplayKit/ASTextNode.mm
+++ b/AsyncDisplayKit/ASTextNode.mm
@@ -326,8 +326,10 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
   
   if (layout != nil) {
     ASDN::MutexLocker l(_propertyLock);
-    _constrainedSize = layout.size;
-    _renderer.constrainedSize = layout.size;
+    if (CGSizeEqualToSize(_constrainedSize, layout.size) == NO) {
+      _constrainedSize = layout.size;
+      _renderer.constrainedSize = layout.size;
+    }
   }
 }
 
@@ -397,6 +399,7 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
   // Tell the display node superclasses that the cached layout is incorrect now
   [self invalidateCalculatedLayout];
 
+  // Force display to create renderer with new size and redisplay with new string
   [self setNeedsDisplay];
   
   

--- a/AsyncDisplayKit/TextKit/ASTextKitRenderer.mm
+++ b/AsyncDisplayKit/TextKit/ASTextKitRenderer.mm
@@ -123,14 +123,14 @@ static NSCharacterSet *_defaultAvoidTruncationCharacterSet()
   if (!CGSizeEqualToSize(constrainedSize, _constrainedSize)) {
     _sizeIsCalculated = NO;
     _constrainedSize = constrainedSize;
-    // If the context isn't created yet, it will be initialized with the appropriate size when next accessed.
-    if (_context || _fontSizeAdjuster) {
-      // If we're updating an existing context, make sure to use the same inset logic used during initialization.
-      // This codepath allows us to reuse the
-      CGSize shadowConstrainedSize = [[self shadower] insetSizeWithConstrainedSize:constrainedSize];
-      if (_context) _context.constrainedSize = shadowConstrainedSize;
-      if (_fontSizeAdjuster) _fontSizeAdjuster.constrainedSize = shadowConstrainedSize;
-    }
+    
+    // Throw away the all subcomponents to create them with the new constrained size new as well as let the
+    // truncater do it's job again for the new constrained size. This is necessary as after a truncation did happen
+    // the context would use the truncated string and not the original string to truncate based on the new
+    // constrained size
+    _context = nil;
+    _truncater = nil;
+    _fontSizeAdjuster = nil;
   }
 }
 

--- a/AsyncDisplayKitTests/ASTextNodeTests.m
+++ b/AsyncDisplayKitTests/ASTextNodeTests.m
@@ -125,7 +125,7 @@ static BOOL CGSizeEqualToSizeWithIn(CGSize size1, CGSize size2, CGFloat delta)
   for (NSInteger i = 10; i < 500; i += 50) {
     CGSize constrainedSize = CGSizeMake(i, i);
     CGSize calculatedSize = [_textNode measure:constrainedSize];
-    CGSize recalculatedSize = [_textNode measure:calculatedSize];
+    CGSize recalculatedSize = [_textNode measure:constrainedSize];
     
     XCTAssertTrue(CGSizeEqualToSizeWithIn(calculatedSize, recalculatedSize, 4.0), @"Recalculated size %@ should be same as original size %@", NSStringFromCGSize(recalculatedSize), NSStringFromCGSize(calculatedSize));
   }
@@ -136,7 +136,7 @@ static BOOL CGSizeEqualToSizeWithIn(CGSize size1, CGSize size2, CGFloat delta)
   for (CGFloat i = 10; i < 500; i *= 1.3) {
     CGSize constrainedSize = CGSizeMake(i, i);
     CGSize calculatedSize = [_textNode measure:constrainedSize];
-    CGSize recalculatedSize = [_textNode measure:calculatedSize];
+    CGSize recalculatedSize = [_textNode measure:constrainedSize];
 
     XCTAssertTrue(CGSizeEqualToSizeWithIn(calculatedSize, recalculatedSize, 11.0), @"Recalculated size %@ should be same as original size %@", NSStringFromCGSize(recalculatedSize), NSStringFromCGSize(calculatedSize));
   }


### PR DESCRIPTION
Throw away the all subcomponents to create them with the new constrained size new as well as let the truncater do it's job again for the new constrained size. This is necessary as after a truncation did happen the context would use the truncated string and not the original string to truncate based on the new constrained size

This should fix #1841 and finally #1865