### PR TITLE
[ASTextNode] use accessor for `pointSizeScaleFactors`

### DIFF
--- a/AsyncDisplayKit/ASTextNode.mm
+++ b/AsyncDisplayKit/ASTextNode.mm
@@ -240,7 +240,7 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
     .lineBreakMode = _truncationMode,
     .maximumNumberOfLines = _maximumNumberOfLines,
     .exclusionPaths = _exclusionPaths,
-    .pointSizeScaleFactors = _pointSizeScaleFactors,
+    .pointSizeScaleFactors = self.pointSizeScaleFactors,
     .layoutManagerCreationBlock = self.layoutManagerCreationBlock,
     .textStorageCreationBlock = self.textStorageCreationBlock,
   };

--- a/AsyncDisplayKit/ASTextNode.mm
+++ b/AsyncDisplayKit/ASTextNode.mm
@@ -240,6 +240,7 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
     .lineBreakMode = _truncationMode,
     .maximumNumberOfLines = _maximumNumberOfLines,
     .exclusionPaths = _exclusionPaths,
+    // use the property getter so a subclass can provide these scale factors on demand if desired
     .pointSizeScaleFactors = self.pointSizeScaleFactors,
     .layoutManagerCreationBlock = self.layoutManagerCreationBlock,
     .textStorageCreationBlock = self.textStorageCreationBlock,


### PR DESCRIPTION
I have a subclass of `ASTextNode` that uses `pointSizeScaleFactors`. Currently I have to recompute the scale factors any time the font size changes. If `_rendererAttributes` used the property accesor for the scale factors I would only have to create them when asked. I hope this little change can make it in :)