### PR TITLE
[ASVideoNode] don't temporarily clear the preview image in setAsset:

### DIFF
--- a/AsyncDisplayKit/ASVideoNode.mm
+++ b/AsyncDisplayKit/ASVideoNode.mm
@@ -389,17 +389,20 @@ static NSString * const kStatus = @"status";
   }
 }
 
+- (void)__clearFetchedData
+{
+  ASDN::MutexLocker l(__instanceLock__);
+  
+  self.player = nil;
+  self.currentItem = nil;
+}
+
 - (void)clearFetchedData
 {
   [super clearFetchedData];
-  
-  {
-    ASDN::MutexLocker l(__instanceLock__);
-
-    self.player = nil;
-    self.currentItem = nil;
-  }
+  [self __clearFetchedData];
 }
+
 
 - (void)visibleStateDidChange:(BOOL)isVisible
 {
@@ -445,7 +448,7 @@ static NSString * const kStatus = @"status";
     return;
   }
 
-  [self clearFetchedData];
+  [self __clearFetchedData]; // clear the player but not the underlying ASNetworkImageNode to avoid flicker
 
   _asset = asset;
 

--- a/AsyncDisplayKitTests/ASVideoNodeTests.m
+++ b/AsyncDisplayKitTests/ASVideoNodeTests.m
@@ -375,16 +375,19 @@
   XCTAssertEqual(UIViewContentModeScaleAspectFill, _videoNode.contentMode);
 }
 
-- (void)testChangingAssetsChangesPlaceholderImage
+- (void)testChangingAssetsDoesNotChangePlaceholderImage
 {
   UIImage *firstImage = [[UIImage alloc] init];
 
+  // test setting asset then placeholder
   _videoNode.asset = _firstAsset;
   [_videoNode setVideoPlaceholderImage:firstImage];
   XCTAssertEqual(firstImage, _videoNode.image);
 
+  // now setting placeholder followed by asset
+  [_videoNode setVideoPlaceholderImage:firstImage];
   _videoNode.asset = _secondAsset;
-  XCTAssertNotEqual(firstImage, _videoNode.image);
+  XCTAssertEqual(firstImage, _videoNode.image);
 }
 
 - (void)testClearingFetchedContentShouldClearAssetData


### PR DESCRIPTION
In my project I delay setting the `ASVideoNode`'s `asset` until I need to, setting only the preview image initially. Since `ASVideoNode` starts preloading as soon as you set the asset my guess is this isn't an uncommon use case.

This works fine, unfortunately there is a flicker because we currently clear the image (ultimately in `[super clearFetchedData];`) in `setAsset:`. This PR is a fix for this issue.

@maicki @appleguy I wasn't sure about the method name `__clearFetchedData` (technically __ is reserved.) Happy to change if you have something better in mind.