### PR TITLE
[ASPINRemoteImageDownloader ] Fix inverted ASPINRemoteImageDownloader progress

### DIFF
--- a/AsyncDisplayKit/Details/ASPINRemoteImageDownloader.m
+++ b/AsyncDisplayKit/Details/ASPINRemoteImageDownloader.m
@@ -178,10 +178,10 @@
     
     /// If we're targeting the main queue and we're on the main thread, call immediately.
     if (ASDisplayNodeThreadIsMain() && callbackQueue == dispatch_get_main_queue()) {
-      downloadProgress(totalBytes / (CGFloat)completedBytes);
+      downloadProgress(completedBytes / (CGFloat)totalBytes);
     } else {
       dispatch_async(callbackQueue, ^{
-        downloadProgress(totalBytes / (CGFloat)completedBytes);
+        downloadProgress(completedBytes / (CGFloat)totalBytes);
       });
     }
   } completion:^(PINRemoteImageManagerResult * _Nonnull result) {


### PR DESCRIPTION
These values appear to be inverted, which was causing progress greater than 1.0 to be returned in the progress block.