### PR TITLE
Add assert for calling ~layoutSpecThatFits: in ASDisplayNode without _layoutSpecBlock

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -2070,7 +2070,9 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
   if (_layoutSpecBlock != NULL) {
     return _layoutSpecBlock(self, constrainedSize);
   }
-  
+
+  ASDisplayNodeAssert(NO, @"ASDisplayNode's ~layoutSpecThatFits: should not be called without a _layoutSpecBlock. You should override this method in the subclass without calling [super layoutSpecThatFits:]");
+
   return nil;
 }
 


### PR DESCRIPTION
This assert will catch cases where an `ASDisplayNode` subclass overrides and calls `[super layoutSpecThatFits:]` which is not intended and will crash during async layout due to adding a nil layout object to an `NSArray`.