### PR TITLE
[ASMapNode] create the MKPinAnnotationView on the main thread

### DIFF
--- a/AsyncDisplayKit/ASMapNode.mm
+++ b/AsyncDisplayKit/ASMapNode.mm
@@ -207,7 +207,10 @@
                     [image drawAtPoint:CGPointZero];
                     
                     // Get a standard annotation view pin. Future implementations should use a custom annotation image property.
-                    MKAnnotationView *pin = [[MKPinAnnotationView alloc] initWithAnnotation:nil reuseIdentifier:@""];
+                    __block MKAnnotationView *pin;
+                    dispatch_sync(dispatch_get_main_queue(), ^{
+                      pin = [[MKPinAnnotationView alloc] initWithAnnotation:nil reuseIdentifier:@""];
+                    });
                     UIImage *pinImage = pin.image;
                     CGSize pinSize = pin.bounds.size;
                     


### PR DESCRIPTION
I noticed that pretty often my app's animations would be disabled. I tracked it down to where the `MKPinAnnotationView` is created, and moving that to the main thread fixes the issue.