### PR TITLE
Fixed ASPINRemoteImageDownloader cancelImageDownloadForIdentifier: crash

### DIFF
--- a/AsyncDisplayKit/Details/ASPINRemoteImageDownloader.m
+++ b/AsyncDisplayKit/Details/ASPINRemoteImageDownloader.m
@@ -214,6 +214,10 @@
 
 - (void)cancelImageDownloadForIdentifier:(id)downloadIdentifier
 {
+  if (!downloadIdentifier) {
+    return;
+  }
+  
   ASDisplayNodeAssert([downloadIdentifier isKindOfClass:[NSUUID class]], @"downloadIdentifier must be NSUUID");
   [[self sharedPINRemoteImageManager] cancelTaskWithUUID:downloadIdentifier];
 }


### PR DESCRIPTION
The ASImageDownloaderProtocol specifies that cancelImageDownloadForIdentifier: has no effect if `downloadIdentifier` is nil.

While ASBasicImageDownloader checks for nil, ASPINRemoteImageDownloader does not.

I tested this and passing in nil does indeed result in a crash.