### PR TITLE
[ASDataController] Cancel Work if We Lose Data Source, Cleanup

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -87,7 +87,7 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
 #pragma mark -
 #pragma mark ASCollectionView.
 
-@interface ASCollectionView () <ASRangeControllerDataSource, ASRangeControllerDelegate, ASDataControllerSource, ASCellNodeInteractionDelegate, ASDelegateProxyInterceptor, ASBatchFetchingScrollView, ASDataControllerEnvironmentDelegate> {
+@interface ASCollectionView () <ASRangeControllerDataSource, ASRangeControllerDelegate, ASCollectionDataControllerSource, ASCellNodeInteractionDelegate, ASDelegateProxyInterceptor, ASBatchFetchingScrollView, ASDataControllerEnvironmentDelegate> {
   ASCollectionViewProxy *_proxyDataSource;
   ASCollectionViewProxy *_proxyDelegate;
   
@@ -232,9 +232,8 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   _rangeController.delegate = self;
   _rangeController.layoutController = _layoutController;
   
-  _dataController = [[ASCollectionDataController alloc] init];
+  _dataController = [[ASCollectionDataController alloc] initWithDataSource:self];
   _dataController.delegate = _rangeController;
-  _dataController.dataSource = self;
   _dataController.environmentDelegate = self;
   
   _batchContext = [[ASBatchContext alloc] init];

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -189,8 +189,7 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
   _rangeController.dataSource = self;
   _rangeController.delegate = self;
   
-  _dataController = [[dataControllerClass alloc] init];
-  _dataController.dataSource = self;
+  _dataController = [[dataControllerClass alloc] initWithDataSource:self];
   _dataController.delegate = _rangeController;
   _dataController.environmentDelegate = self;
   

--- a/AsyncDisplayKit/Details/ASCollectionDataController.h
+++ b/AsyncDisplayKit/Details/ASCollectionDataController.h
@@ -40,6 +40,8 @@
 
 @interface ASCollectionDataController : ASChangeSetDataController
 
+- (instancetype)initWithDataSource:(id<ASCollectionDataControllerSource>)dataSource NS_DESIGNATED_INITIALIZER;
+
 - (ASCellNode *)supplementaryNodeOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath;
 
 @end

--- a/AsyncDisplayKit/Details/ASDataController.h
+++ b/AsyncDisplayKit/Details/ASDataController.h
@@ -109,10 +109,12 @@ FOUNDATION_EXPORT NSString * const ASDataControllerRowNodeKind;
 @protocol ASFlowLayoutControllerDataSource;
 @interface ASDataController : ASDealloc2MainObject <ASFlowLayoutControllerDataSource>
 
+- (instancetype)initWithDataSource:(id<ASDataControllerSource>)dataSource NS_DESIGNATED_INITIALIZER;
+
 /**
  Data source for fetching data info.
  */
-@property (nonatomic, weak) id<ASDataControllerSource> dataSource;
+@property (nonatomic, weak, readonly) id<ASDataControllerSource> dataSource;
 
 /**
  Delegate to notify when data is updated.

--- a/AsyncDisplayKit/Details/ASIndexedNodeContext.h
+++ b/AsyncDisplayKit/Details/ASIndexedNodeContext.h
@@ -29,4 +29,6 @@
  */
 - (ASCellNode *)allocateNode;
 
++ (NSArray<NSIndexPath *> *)indexPathsFromContexts:(NSArray<ASIndexedNodeContext *> *)contexts;
+
 @end

--- a/AsyncDisplayKit/Details/ASIndexedNodeContext.mm
+++ b/AsyncDisplayKit/Details/ASIndexedNodeContext.mm
@@ -48,4 +48,13 @@
   return node;
 }
 
++ (NSArray<NSIndexPath *> *)indexPathsFromContexts:(NSArray<ASIndexedNodeContext *> *)contexts
+{
+  NSMutableArray *result = [NSMutableArray arrayWithCapacity:contexts.count];
+  for (ASIndexedNodeContext *ctx in contexts) {
+    [result addObject:ctx.indexPath];
+  }
+  return result;
+}
+
 @end

--- a/AsyncDisplayKit/Details/ASRangeController.mm
+++ b/AsyncDisplayKit/Details/ASRangeController.mm
@@ -415,50 +415,44 @@ static UIApplicationState __ApplicationState = UIApplicationStateActive;
 
 - (void)dataControllerBeginUpdates:(ASDataController *)dataController
 {
-  ASPerformBlockOnMainThread(^{
-    [_delegate didBeginUpdatesInRangeController:self];
-  });
+  ASDisplayNodeAssertMainThread();
+  [_delegate didBeginUpdatesInRangeController:self];
 }
 
 - (void)dataController:(ASDataController *)dataController endUpdatesAnimated:(BOOL)animated completion:(void (^)(BOOL))completion
 {
-  ASPerformBlockOnMainThread(^{
-    [_delegate rangeController:self didEndUpdatesAnimated:animated completion:completion];
-  });
+  ASDisplayNodeAssertMainThread();
+  [_delegate rangeController:self didEndUpdatesAnimated:animated completion:completion];
 }
 
 - (void)dataController:(ASDataController *)dataController didInsertNodes:(NSArray *)nodes atIndexPaths:(NSArray *)indexPaths withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions
 {
   ASDisplayNodeAssert(nodes.count == indexPaths.count, @"Invalid index path");
-  ASPerformBlockOnMainThread(^{
-    _rangeIsValid = NO;
-    [_delegate rangeController:self didInsertNodes:nodes atIndexPaths:indexPaths withAnimationOptions:animationOptions];
-  });
+  ASDisplayNodeAssertMainThread();
+  _rangeIsValid = NO;
+  [_delegate rangeController:self didInsertNodes:nodes atIndexPaths:indexPaths withAnimationOptions:animationOptions];
 }
 
 - (void)dataController:(ASDataController *)dataController didDeleteNodes:(NSArray *)nodes atIndexPaths:(NSArray *)indexPaths withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions
 {
-  ASPerformBlockOnMainThread(^{
-    _rangeIsValid = NO;
-    [_delegate rangeController:self didDeleteNodes:nodes atIndexPaths:indexPaths withAnimationOptions:animationOptions];
-  });
+  ASDisplayNodeAssertMainThread();
+  _rangeIsValid = NO;
+  [_delegate rangeController:self didDeleteNodes:nodes atIndexPaths:indexPaths withAnimationOptions:animationOptions];
 }
 
 - (void)dataController:(ASDataController *)dataController didInsertSections:(NSArray *)sections atIndexSet:(NSIndexSet *)indexSet withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions
 {
   ASDisplayNodeAssert(sections.count == indexSet.count, @"Invalid sections");
-  ASPerformBlockOnMainThread(^{
-    _rangeIsValid = NO;
-    [_delegate rangeController:self didInsertSectionsAtIndexSet:indexSet withAnimationOptions:animationOptions];
-  });
+  ASDisplayNodeAssertMainThread();
+  _rangeIsValid = NO;
+  [_delegate rangeController:self didInsertSectionsAtIndexSet:indexSet withAnimationOptions:animationOptions];
 }
 
 - (void)dataController:(ASDataController *)dataController didDeleteSectionsAtIndexSet:(NSIndexSet *)indexSet withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions
 {
-  ASPerformBlockOnMainThread(^{
-    _rangeIsValid = NO;
-    [_delegate rangeController:self didDeleteSectionsAtIndexSet:indexSet withAnimationOptions:animationOptions];
-  });
+  ASDisplayNodeAssertMainThread();
+  _rangeIsValid = NO;
+  [_delegate rangeController:self didDeleteSectionsAtIndexSet:indexSet withAnimationOptions:animationOptions];
 }
 
 #pragma mark - Memory Management

--- a/AsyncDisplayKit/Private/ASDataController+Subclasses.h
+++ b/AsyncDisplayKit/Private/ASDataController+Subclasses.h
@@ -53,16 +53,11 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCellNode *> *nodes, NS
 
 /**
  * Measure and layout the given nodes in optimized batches, constraining each to a given size in `constrainedSizeForNodeOfKind:atIndexPath:`.
- */
-- (void)batchLayoutNodesFromContexts:(NSArray<ASIndexedNodeContext *> *)contexts ofKind:(NSString *)kind completion:(ASDataControllerCompletionBlock)completionBlock;
-
-/**
- * Perform measurement and layout of loaded nodes on the main thread, skipping unloaded nodes.
  *
- * @discussion Once nodes have loaded their views, we can't layout in the background so this is a chance
- * to do so immediately on the main thread.
+ * This method runs synchronously.
+ * @param batchCompletion A handler to be run after each batch is completed. It is executed synchronously on the calling thread.
  */
-- (void)layoutLoadedNodes:(NSArray<ASCellNode *> *)nodes fromContexts:(NSArray<ASIndexedNodeContext *> *)contexts ofKind:(NSString *)kind;
+- (void)batchLayoutNodesFromContexts:(NSArray<ASIndexedNodeContext *> *)contexts batchCompletion:(ASDataControllerCompletionBlock)batchCompletionHandler;
 
 /**
  * Provides the size range for a specific node during the layout process.


### PR DESCRIPTION
- Set it up to cancel work if the data source goes away.
- Rename and clean up some methods
- Make `dataSource` readonly, so that once it's gone we can be sure it's time to stop doing anything
- Add a mechanism to see how much work we avoided with this change. I don't have a device handy right now but the results on the simulator aren't great. I'll test it with a device and report back. 

@appleguy I'd like to cancel laying out nodes on reload data, but I'm hesitating because I want your opinion about the risk involved with completion handlers. So if I call insertRowsAtIndexPaths: with 20 items, and in the completion handler I assume those 20 items are there, but I pre-empted it with reloadData, we should probably still call the completion handler but those items may not have been inserted. I think we should go for it in a separate PR, and if it ever becomes an issue deal with it at that time.