### PR TITLE
[ASTextKitComponents] Remove Unused Scale Conversion Functions

### DIFF
--- a/AsyncDisplayKit/TextKit/ASTextKitComponents.h
+++ b/AsyncDisplayKit/TextKit/ASTextKitComponents.h
@@ -10,23 +10,8 @@
 
 #import <UIKit/UIKit.h>
 #import <AsyncDisplayKit/ASBaseDefines.h>
-#import <tgmath.h>
 
 NS_ASSUME_NONNULL_BEGIN
-
-ASDISPLAYNODE_INLINE CGFloat ceilPixelValueForScale(CGFloat f, CGFloat scale)
-{
-  // Round up to device pixel (.5 on retina)
-  return ceil(f * scale) / scale;
-}
-
-ASDISPLAYNODE_INLINE CGSize ceilSizeValue(CGSize s)
-{
-  CGFloat screenScale = [UIScreen mainScreen].scale;
-  s.width = ceilPixelValueForScale(s.width, screenScale);
-  s.height = ceilPixelValueForScale(s.height, screenScale);
-  return s;
-}
 
 @interface ASTextKitComponents : NSObject
 


### PR DESCRIPTION
I don't know why these were here but they're not currently used.

Technically, since this header file is public, this is an API change. But it's incredibly minor and any user that's upset can easily implement their own.

`[UIScreen mainScreen]` should only be called on main. Plus it's expensive! I advocate for landing this immediately despite the teensy API change. @maicki @appleguy @levi @Yue-Wang-Google