### PR TITLE
[ASDisplayNode] Ensure that nil can never be returned from -measureWithSizeRange:

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -643,11 +643,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   ASDN::MutexLocker l(__instanceLock__);
   if (! [self shouldMeasureWithSizeRange:constrainedSize]) {
     ASDisplayNodeAssertNotNil(_calculatedLayout, @"-[ASDisplayNode measureWithSizeRange:] _layout should not be nil! %@", self);
-    if (_calculatedLayout != nil) {
-      return _calculatedLayout;
-    } else {
-      return [ASLayout layoutWithLayoutableObject:self constrainedSizeRange:constrainedSize size:CGSizeZero];
-    }
+    return _calculatedLayout ? : [ASLayout layoutWithLayoutableObject:self constrainedSizeRange:constrainedSize size:CGSizeZero];
   }
   
   [self cancelLayoutTransitionsInProgress];

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -642,7 +642,12 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
 {
   ASDN::MutexLocker l(__instanceLock__);
   if (! [self shouldMeasureWithSizeRange:constrainedSize]) {
-    return _calculatedLayout;
+    ASDisplayNodeAssertNotNil(_calculatedLayout, @"-[ASDisplayNode measureWithSizeRange:] _layout should not be nil! %@", self);
+    if (_calculatedLayout != nil) {
+      return _calculatedLayout;
+    } else {
+      return [ASLayout layoutWithLayoutableObject:self constrainedSizeRange:constrainedSize size:CGSizeZero];
+    }
   }
   
   [self cancelLayoutTransitionsInProgress];
@@ -659,6 +664,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
     [self _completePendingLayoutTransition];
   }
   
+  ASDisplayNodeAssertNotNil(newLayout, @"-[ASDisplayNode measureWithSizeRange:] newLayout should not be nil! %@", self);
   return newLayout;
 }
 
@@ -2071,6 +2077,8 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
     
     layoutSpec.isMutable = NO;
     ASLayout *layout = [layoutSpec measureWithSizeRange:constrainedSize];
+    ASDisplayNodeAssertNotNil(layout, @"[ASLayoutSpec measureWithSizeRange:] should never return nil! %@, %@", self, layoutSpec);
+      
     // Make sure layoutableObject of the root layout is `self`, so that the flattened layout will be structurally correct.
     BOOL isFinalLayoutable = (layout.layoutableObject != self);
     if (isFinalLayoutable) {

--- a/AsyncDisplayKit/Private/ASStackUnpositionedLayout.mm
+++ b/AsyncDisplayKit/Private/ASStackUnpositionedLayout.mm
@@ -28,7 +28,13 @@ static ASLayout *crossChildLayout(const id<ASLayoutable> child,
   // stretched children will have a cross dimension of at least crossMin
   const CGFloat childCrossMin = alignItems == ASStackLayoutAlignItemsStretch ? crossMin : 0;
   const ASSizeRange childSizeRange = directionSizeRange(style.direction, stackMin, stackMax, childCrossMin, crossMax);
-  return [child measureWithSizeRange:childSizeRange];
+  ASLayout *layout = [child measureWithSizeRange:childSizeRange];
+  ASDisplayNodeCAssertNotNil(layout, @"ASLayout returned from measureWithSizeRange: must not be nil: %@", child);
+  if (layout != nil) {
+    return layout;
+  } else {
+    return [ASLayout layoutWithLayoutableObject:child constrainedSizeRange:childSizeRange size:CGSizeZero];
+  }
 }
 
 /**

--- a/AsyncDisplayKit/Private/ASStackUnpositionedLayout.mm
+++ b/AsyncDisplayKit/Private/ASStackUnpositionedLayout.mm
@@ -30,11 +30,7 @@ static ASLayout *crossChildLayout(const id<ASLayoutable> child,
   const ASSizeRange childSizeRange = directionSizeRange(style.direction, stackMin, stackMax, childCrossMin, crossMax);
   ASLayout *layout = [child measureWithSizeRange:childSizeRange];
   ASDisplayNodeCAssertNotNil(layout, @"ASLayout returned from measureWithSizeRange: must not be nil: %@", child);
-  if (layout != nil) {
-    return layout;
-  } else {
-    return [ASLayout layoutWithLayoutableObject:child constrainedSizeRange:childSizeRange size:CGSizeZero];
-  }
+  return layout ? : [ASLayout layoutWithLayoutableObject:child constrainedSizeRange:childSizeRange size:CGSizeZero];
 }
 
 /**


### PR DESCRIPTION
This can happen in rare cases when multiple relayouts occur while a transition is being measured.