### PR TITLE
Use children directly instead of fast enumeration of ASEnvironment object

### DIFF
--- a/AsyncDisplayKit/Private/ASEnvironmentInternal.mm
+++ b/AsyncDisplayKit/Private/ASEnvironmentInternal.mm
@@ -44,7 +44,7 @@ void ASEnvironmentPerformBlockOnObjectAndChildren(id<ASEnvironment> object, void
     
     block(object);
     
-    for (id<ASEnvironment> child in object) {
+    for (id<ASEnvironment> child in [object children]) {
       queue.push(child);
     }
   }


### PR DESCRIPTION
Using fast enumeration on an ASEnvironment child can crash. This should be a temporary fix until we have time to dive deeper into that.