### PR TITLE
[ASLayoutSpec] Use childrenMap directly to prevent creating an NSArray within ASDK Part 2

### DIFF
--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -214,6 +214,7 @@
 		69E1006F1CA89CB600D88C1B /* ASEnvironmentInternal.mm in Sources */ = {isa = PBXBuildFile; fileRef = 69E1006A1CA89CB600D88C1B /* ASEnvironmentInternal.mm */; };
 		69E100701CA89CB600D88C1B /* ASEnvironmentInternal.mm in Sources */ = {isa = PBXBuildFile; fileRef = 69E1006A1CA89CB600D88C1B /* ASEnvironmentInternal.mm */; };
 		69F10C871C84C35D0026140C /* ASRangeControllerUpdateRangeProtocol+Beta.h in Headers */ = {isa = PBXBuildFile; fileRef = 69F10C851C84C35D0026140C /* ASRangeControllerUpdateRangeProtocol+Beta.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		69F6058D1D3DA27E00C8CA38 /* ASLayoutSpec+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 69F6058C1D3DA27E00C8CA38 /* ASLayoutSpec+Private.h */; };
 		7630FFA81C9E267E007A7C0E /* ASVideoNode.h in Headers */ = {isa = PBXBuildFile; fileRef = AEEC47DF1C20C2DD00EC1693 /* ASVideoNode.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		764D83D51C8EA515009B4FB8 /* AsyncDisplayKit+Debug.h in Headers */ = {isa = PBXBuildFile; fileRef = 764D83D21C8EA515009B4FB8 /* AsyncDisplayKit+Debug.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		764D83D61C8EA515009B4FB8 /* AsyncDisplayKit+Debug.m in Sources */ = {isa = PBXBuildFile; fileRef = 764D83D31C8EA515009B4FB8 /* AsyncDisplayKit+Debug.m */; };
@@ -965,6 +966,7 @@
 		69E100691CA89CB600D88C1B /* ASEnvironmentInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASEnvironmentInternal.h; sourceTree = "<group>"; };
 		69E1006A1CA89CB600D88C1B /* ASEnvironmentInternal.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASEnvironmentInternal.mm; sourceTree = "<group>"; };
 		69F10C851C84C35D0026140C /* ASRangeControllerUpdateRangeProtocol+Beta.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ASRangeControllerUpdateRangeProtocol+Beta.h"; sourceTree = "<group>"; };
+		69F6058C1D3DA27E00C8CA38 /* ASLayoutSpec+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ASLayoutSpec+Private.h"; sourceTree = "<group>"; };
 		6BDC61F51978FEA400E50D21 /* AsyncDisplayKit.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; path = AsyncDisplayKit.h; sourceTree = "<group>"; };
 		764D83D21C8EA515009B4FB8 /* AsyncDisplayKit+Debug.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "AsyncDisplayKit+Debug.h"; sourceTree = "<group>"; };
 		764D83D31C8EA515009B4FB8 /* AsyncDisplayKit+Debug.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "AsyncDisplayKit+Debug.m"; sourceTree = "<group>"; };
@@ -1470,6 +1472,8 @@
 				044285051BAA63FE00D16268 /* ASBatchFetching.h */,
 				044285061BAA63FE00D16268 /* ASBatchFetching.m */,
 				251B8EF61BBB3D690087C538 /* ASDataController+Subclasses.h */,
+				8B0768B11CE752EC002E1453 /* ASDefaultPlaybackButton.h */,
+				8B0768B21CE752EC002E1453 /* ASDefaultPlaybackButton.m */,
 				AEB7B0181C5962EA00662EF4 /* ASDefaultPlayButton.h */,
 				AEB7B0191C5962EA00662EF4 /* ASDefaultPlayButton.m */,
 				058D0A08195D050800B7D73C /* ASDisplayNode+AsyncDisplay.mm */,
@@ -1478,16 +1482,17 @@
 				DE6EA3211C14000600183B10 /* ASDisplayNode+FrameworkPrivate.h */,
 				058D0A0B195D050800B7D73C /* ASDisplayNode+UIViewBridge.mm */,
 				058D0A0C195D050800B7D73C /* ASDisplayNodeInternal.h */,
-				E52405B41C8FEF16004DC8E7 /* ASLayoutTransition.h */,
-				E52405B21C8FEF03004DC8E7 /* ASLayoutTransition.mm */,
 				69E100691CA89CB600D88C1B /* ASEnvironmentInternal.h */,
 				69E1006A1CA89CB600D88C1B /* ASEnvironmentInternal.mm */,
+				68B8A4DB1CBD911D007E4543 /* ASImageNode+AnimatedImagePrivate.h */,
 				058D0A0D195D050800B7D73C /* ASImageNode+CGExtras.h */,
 				058D0A0E195D050800B7D73C /* ASImageNode+CGExtras.m */,
-				68B8A4DB1CBD911D007E4543 /* ASImageNode+AnimatedImagePrivate.h */,
 				ACF6ED431B17847A00DA7C62 /* ASInternalHelpers.h */,
 				ACF6ED441B17847A00DA7C62 /* ASInternalHelpers.m */,
+				69F6058C1D3DA27E00C8CA38 /* ASLayoutSpec+Private.h */,
 				ACF6ED451B17847A00DA7C62 /* ASLayoutSpecUtilities.h */,
+				E52405B41C8FEF16004DC8E7 /* ASLayoutTransition.h */,
+				E52405B21C8FEF03004DC8E7 /* ASLayoutTransition.mm */,
 				0442850B1BAA64EC00D16268 /* ASMultidimensionalArrayUtils.h */,
 				0442850C1BAA64EC00D16268 /* ASMultidimensionalArrayUtils.mm */,
 				CC3B20811C3F76D600798563 /* ASPendingStateController.h */,
@@ -1505,8 +1510,6 @@
 				CC3B20881C3F7A5400798563 /* ASWeakSet.m */,
 				DBC452D91C5BF64600B16017 /* NSArray+Diffing.h */,
 				DBC452DA1C5BF64600B16017 /* NSArray+Diffing.m */,
-				8B0768B11CE752EC002E1453 /* ASDefaultPlaybackButton.h */,
-				8B0768B21CE752EC002E1453 /* ASDefaultPlaybackButton.m */,
 			);
 			path = Private;
 			sourceTree = "<group>";
@@ -1740,6 +1743,7 @@
 				B350625B1B010F070018CF92 /* ASEqualityHelpers.h in Headers */,
 				680346941CE4052A0009FEB4 /* ASNavigationController.h in Headers */,
 				B350621B1B010EFD0018CF92 /* ASFlowLayoutController.h in Headers */,
+				69F6058D1D3DA27E00C8CA38 /* ASLayoutSpec+Private.h in Headers */,
 				B350621D1B010EFD0018CF92 /* ASHighlightOverlayLayer.h in Headers */,
 				C78F7E2B1BF7809800CDEAFC /* ASTableNode.h in Headers */,
 				AC7A2C181BDE11DF0093FE1A /* ASTableViewInternal.h in Headers */,

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -2981,6 +2981,15 @@ static const char *ASDisplayNodeDrawingPriorityKey = "ASDrawingPriority";
   }
 }
 
+#pragma mark - NSFastEnumeration
+
+- (NSUInteger)countByEnumeratingWithState:(NSFastEnumerationState *)state
+                                  objects:(id __unsafe_unretained [])stackbuf
+                                    count:(NSUInteger)stackbufLength
+{
+  return [self.children countByEnumeratingWithState:state objects:stackbuf count:stackbufLength];
+}
+
 ASEnvironmentLayoutOptionsForwarding
 ASEnvironmentLayoutExtensibilityForwarding
 

--- a/AsyncDisplayKit/ASViewController.mm
+++ b/AsyncDisplayKit/ASViewController.mm
@@ -289,8 +289,7 @@ ASVisibilityDepthImplementation;
     self.node.environmentState = environmentState;
     [self.node setNeedsLayout];
     
-    NSArray<id<ASEnvironment>> *children = [self.node children];
-    for (id<ASEnvironment> child in children) {
+    for (id<ASEnvironment> child in self.node) {
       ASEnvironmentStatePropagateDown(child, environmentState.environmentTraitCollection);
     }
   }

--- a/AsyncDisplayKit/Details/ASEnvironment.h
+++ b/AsyncDisplayKit/Details/ASEnvironment.h
@@ -99,7 +99,7 @@ ASDISPLAYNODE_EXTERN_C_END
  * defined in an ASEnvironmentState up and down the ASEnvironment tree. To be able to define how merges of
  * States should happen, specific merge functions can be provided
  */
-@protocol ASEnvironment <NSObject>
+@protocol ASEnvironment <NSObject, NSFastEnumeration>
 
 /// The environment collection of an object which class conforms to the ASEnvironment protocol
 - (ASEnvironmentState)environmentState;
@@ -126,6 +126,7 @@ ASDISPLAYNODE_EXTERN_C_END
 
 /// sets a trait collection on this environment state.
 - (void)setEnvironmentTraitCollection:(ASEnvironmentTraitCollection)environmentTraitCollection;
+
 @end
 
 // ASCollection/TableNodes don't actually have ASCellNodes as subnodes. Because of this we can't rely on display trait

--- a/AsyncDisplayKit/Layout/ASLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASLayoutSpec.mm
@@ -23,6 +23,7 @@
   ASEnvironmentState _environmentState;
   ASDN::RecursiveMutex __instanceLock__;
   ASChildrenMap _childrenMap;
+  unsigned long _mutations;
 }
 @end
 
@@ -41,6 +42,7 @@
   }
   _isMutable = YES;
   _environmentState = ASEnvironmentStateMakeDefault();
+  _mutations = 0;
   return self;
 }
 
@@ -106,6 +108,7 @@
 
 - (void)setParent:(id<ASLayoutable>)parent
 {
+  // FIXME: Locking should be evaluated here.  _parent is not widely used yet, though.
   _parent = parent;
   
   if ([parent supportsUpwardPropagation]) {
@@ -122,16 +125,7 @@
 
 - (void)setChild:(id<ASLayoutable>)child
 {
-  ASDisplayNodeAssert(self.isMutable, @"Cannot set properties when layout spec is not mutable");
-  if (child) {
-    id<ASLayoutable> finalLayoutable = [self layoutableToAddFromLayoutable:child];
-    if (finalLayoutable) {
-      _childrenMap[0] = finalLayoutable;
-      [self propagateUpLayoutable:finalLayoutable];
-    }
-  } else {
-    _childrenMap.erase(0);
-  }
+  [self setChild:child forIndex:0];
 }
 
 - (void)setChild:(id<ASLayoutable>)child forIndex:(NSUInteger)index
@@ -139,11 +133,16 @@
   ASDisplayNodeAssert(self.isMutable, @"Cannot set properties when layout spec is not mutable");
   if (child) {
     id<ASLayoutable> finalLayoutable = [self layoutableToAddFromLayoutable:child];
-    _childrenMap[index] = finalLayoutable;
+    if (finalLayoutable) {
+      _childrenMap[index] = finalLayoutable;
+      [self propagateUpLayoutable:finalLayoutable];
+    }
   } else {
     _childrenMap.erase(index);
   }
-  // TODO: Should we propagate up the layoutable at it could happen that multiple children will propagated up their
+  _mutations++;
+  
+  // TODO: Should we propagate up the layoutable as it could happen that multiple children will propagated up their
   //       layout options and one child will overwrite values from another child
   // [self propagateUpLayoutable:finalLayoutable];
 }
@@ -157,6 +156,8 @@
   for (id<ASLayoutable> child in children) {
     _childrenMap[i] = [self layoutableToAddFromLayoutable:child];
     i += 1;
+    
+    _mutations++;
   }
 }
 
@@ -175,8 +176,8 @@
 
 - (NSArray *)children
 {
-  // If used inside ASDK, the childrenMap property should be preferred over the children array to prevent unecessary
-  // boxing
+  // If used inside ASDK, the childrenMap property should be preferred over the children array to prevent
+  // unecessary boxing
   std::vector<ASLayout *> children;
   for (auto const &entry : _childrenMap) {
     children.push_back(entry.second);
@@ -195,14 +196,16 @@
   unsigned long countOfItemsAlreadyEnumerated = state->state;
   
   if (countOfItemsAlreadyEnumerated == 0) {
-    state->mutationsPtr = &state->extra[0];
+    state->mutationsPtr = &_mutations;
   }
 
   if (countOfItemsAlreadyEnumerated < _childrenMap.size()) {
     state->itemsPtr = stackbuf;
         
     while((countOfItemsAlreadyEnumerated < _childrenMap.size()) && (count < stackbufLength)) {
-      stackbuf[count] = _childrenMap[countOfItemsAlreadyEnumerated];
+      // Hold on for the object while enumerating
+      __autoreleasing id child = _childrenMap[countOfItemsAlreadyEnumerated];
+      stackbuf[count] = child;
       countOfItemsAlreadyEnumerated++;
       count++;
     }

--- a/AsyncDisplayKit/Layout/ASStaticLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASStaticLayoutSpec.mm
@@ -10,6 +10,7 @@
 
 #import "ASStaticLayoutSpec.h"
 
+#import "ASLayoutSpec+Private.h"
 #import "ASLayoutSpecUtilities.h"
 #import "ASLayout.h"
 
@@ -38,10 +39,8 @@
 {
   CGSize maxConstrainedSize = CGSizeMake(constrainedSize.max.width, constrainedSize.max.height);
   
-  NSArray *children = self.children;
-  NSMutableArray *sublayouts = [NSMutableArray arrayWithCapacity:children.count];
-
-  for (id<ASLayoutable> child in children) {
+  NSMutableArray *sublayouts = [NSMutableArray arrayWithCapacity:self.childrenMap.size()];
+  for (id<ASLayoutable> child in self) {
     CGPoint layoutPosition = child.layoutPosition;
     CGSize autoMaxSize = CGSizeMake(maxConstrainedSize.width  - layoutPosition.x,
                                     maxConstrainedSize.height - layoutPosition.y);

--- a/AsyncDisplayKit/Private/ASEnvironmentInternal.mm
+++ b/AsyncDisplayKit/Private/ASEnvironmentInternal.mm
@@ -44,7 +44,7 @@ void ASEnvironmentPerformBlockOnObjectAndChildren(id<ASEnvironment> object, void
     
     block(object);
     
-    for (id<ASEnvironment> child in [object children]) {
+    for (id<ASEnvironment> child in object) {
       queue.push(child);
     }
   }

--- a/AsyncDisplayKit/Private/ASLayoutSpec+Private.h
+++ b/AsyncDisplayKit/Private/ASLayoutSpec+Private.h
@@ -1,0 +1,25 @@
+//
+//  ASLayoutSpec+Private.h
+//  AsyncDisplayKit
+//
+//  Copyright (c) 2014-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under the BSD-style license found in the
+//  LICENSE file in the root directory of this source tree. An additional grant
+//  of patent rights can be found in the PATENTS file in the same directory.
+//
+
+#import "ASLayoutSpec.h"
+
+#import <objc/runtime.h>
+#import <map>
+
+typedef std::map<unsigned long, id<ASLayoutable>, std::less<unsigned long>> ASChildrenMap;
+
+@interface ASLayoutSpec (Private)
+
+/*
+ * Inside ASDK the childrenMap property should be preferred over the children array to prevent unecessary boxing
+ */
+@property (nonatomic, assign, readonly) ASChildrenMap childrenMap;
+
+@end

--- a/AsyncDisplayKitTests/ASDisplayNodeTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeTests.m
@@ -1723,6 +1723,24 @@ static inline BOOL _CGPointEqualToPointWithEpsilon(CGPoint point1, CGPoint point
   XCTAssertEqual(1, view.subviews.count, @"View should have 1 subview");
 }
 
+- (void)testFastEnumeration
+{
+  ASDisplayNode *parent = [[ASDisplayNode alloc] init];
+  
+  NSMutableArray *children = [NSMutableArray array];
+  for (int i = 0; i < 100; i++) {
+    ASDisplayNode *child = [[[ASDisplayNode alloc] init] autorelease];
+    [children addObject:child];
+    [parent addSubnode:child];
+  }
+  
+  NSInteger i = 0;
+  for (ASDisplayNode *child in parent) {
+    XCTAssertEqualObjects(child, children[i]);
+    i++;
+  }
+}
+
 - (void)checkBackgroundColorOpaqueRelationshipWithViewLoaded:(BOOL)loaded layerBacked:(BOOL)isLayerBacked
 {
   ASDisplayNode *node = [[ASDisplayNode alloc] init];

--- a/AsyncDisplayKitTests/ASLayoutSpecSnapshotTestsHelper.m
+++ b/AsyncDisplayKitTests/ASLayoutSpecSnapshotTestsHelper.m
@@ -42,6 +42,23 @@
   ASSnapshotVerifyNode(node, identifier);
 }
 
+- (void)testFastEnumeration
+{
+  ASLayoutSpec *layoutSpec = [[ASLayoutSpec alloc] init];
+
+  NSMutableArray *children = [NSMutableArray array];
+  for (int i = 0; i < 100; i++) {
+    [children addObject:[[ASDisplayNode alloc] init]];
+  }
+  layoutSpec.children = children;
+  
+  NSInteger i = 0;
+  for (ASDisplayNode *child in layoutSpec) {
+    XCTAssertEqualObjects(child, children[i]);
+    i++;
+  }
+}
+
 @end
 
 @implementation ASTestNode


### PR DESCRIPTION
I reverted the revert of the previous PR and added one important fix for fast enumeration in ASLayoutSpec:

NSFastEnumeration is potentially quite dangerous in the wrong hands. In particular, it does not provide a safe mechanism for you to return temporary objects directly, and it does not provide any guarantee that you will be called when the enumeration has completed; therefore if we generate temporaries and store them in an instance variable, we will not necessarily be able to clean them up! This means fast enumeration methods should never be called within an autorelease pool or the autorelease pool be drained within the fast enumeration loop.

The reason is we store references to objects in the stackBuf struct by casting the child pointer to __autoreleasing id. If we pop the autorelease pool between calls to -countByEnumeratingWithState:objects:count:, it will die in a messy explosion of pointer dereferences and EXC_BAD_ACCESS.

Furthermore I added tests for ASDisplayNode and ASLayoutSpec enumeration.