### PR TITLE
[Automatic Hierarchy Management] Rename IHM to automatic hierarchy management and move out of beta header

### DIFF
--- a/AsyncDisplayKit/ASButtonNode.mm
+++ b/AsyncDisplayKit/ASButtonNode.mm
@@ -55,7 +55,7 @@
 - (instancetype)init
 {
   if (self = [super init]) {
-    self.automaticHierarchy = YES;
+    self.automaticallyManagesSubnodes = YES;
     
     _contentSpacing = 8.0;
     _laysOutHorizontally = YES;

--- a/AsyncDisplayKit/ASButtonNode.mm
+++ b/AsyncDisplayKit/ASButtonNode.mm
@@ -14,7 +14,6 @@
 #import "ASDisplayNode+Subclasses.h"
 #import "ASBackgroundLayoutSpec.h"
 #import "ASInsetLayoutSpec.h"
-#import "ASDisplayNode+Beta.h"
 #import "ASStaticLayoutSpec.h"
 
 @interface ASButtonNode ()

--- a/AsyncDisplayKit/ASButtonNode.mm
+++ b/AsyncDisplayKit/ASButtonNode.mm
@@ -56,7 +56,7 @@
 - (instancetype)init
 {
   if (self = [super init]) {
-    self.usesImplicitHierarchyManagement = YES;
+    self.automaticHierarchy = YES;
     
     _contentSpacing = 8.0;
     _laysOutHorizontally = YES;

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -18,7 +18,6 @@
 #import "ASCollectionViewFlowLayoutInspector.h"
 #import "ASDisplayNodeExtras.h"
 #import "ASDisplayNode+FrameworkPrivate.h"
-#import "ASDisplayNode+Beta.h"
 #import "ASInternalHelpers.h"
 #import "UICollectionViewLayout+ASConvenience.h"
 #import "ASRangeController.h"

--- a/AsyncDisplayKit/ASDisplayNode+Beta.h
+++ b/AsyncDisplayKit/ASDisplayNode+Beta.h
@@ -20,9 +20,6 @@ ASDISPLAYNODE_EXTERN_C_END
 
 @interface ASDisplayNode (Beta)
 
-+ (BOOL)usesImplicitHierarchyManagement;
-+ (void)setUsesImplicitHierarchyManagement:(BOOL)enabled;
-
 /**
  * ASTableView and ASCollectionView now throw exceptions on invalid updates
  * like their UIKit counterparts. If YES, these classes will log messages
@@ -63,7 +60,14 @@ ASDISPLAYNODE_EXTERN_C_END
 
 /** @name Layout Transitioning */
 
-@property (nonatomic) BOOL usesImplicitHierarchyManagement;
+/**
+ * @abstract A boolean that shows whether the node automatically inserts and removes nodes based on the presence or
+ * absence of the node and its subnodes is completely determined in its layoutSpecThatFits: method.
+ *
+ * @discussion If flag is YES the node no longer require addSubnode: or removeFromSupernode method calls. The presence
+ * or absence of subnodes is completely determined in its layoutSpecThatFits: method.
+ */
+@property (nonatomic) BOOL automaticHierarchy;
 
 /**
  * @discussion A place to perform your animation. New nodes have been inserted here. You can also use this time to re-order the hierarchy.
@@ -139,6 +143,20 @@ ASDISPLAYNODE_EXTERN_C_END
  * enabling .neverShowPlaceholders on ASCellNodes so that the navigation operation is blocked on redisplay completing, etc.
  */
 + (void)setRangeModeForMemoryWarnings:(ASLayoutRangeMode)rangeMode;
+
+
+#pragma mark - Deprecated
+
+/**
+ * @abstract A boolean that shows whether the node automatically inserts and removes nodes based on the presence or
+ * absence of the node and its subnodes is completely determined in its layoutSpecThatFits: method.
+ *
+ * @discussion If flag is YES the node no longer require addSubnode: or removeFromSupernode method calls. The presence
+ * or absence of subnodes is completely determined in its layoutSpecThatFits: method.
+ *
+ * @deprecated Deprecated in version 2.0: Use automaticHierarchy
+ */
+@property (nonatomic, assign) BOOL usesImplicitHierarchyManagement __deprecated;
 
 @end
 

--- a/AsyncDisplayKit/ASDisplayNode+Beta.h
+++ b/AsyncDisplayKit/ASDisplayNode+Beta.h
@@ -61,15 +61,6 @@ ASDISPLAYNODE_EXTERN_C_END
 /** @name Layout Transitioning */
 
 /**
- * @abstract A boolean that shows whether the node automatically inserts and removes nodes based on the presence or
- * absence of the node and its subnodes is completely determined in its layoutSpecThatFits: method.
- *
- * @discussion If flag is YES the node no longer require addSubnode: or removeFromSupernode method calls. The presence
- * or absence of subnodes is completely determined in its layoutSpecThatFits: method.
- */
-@property (nonatomic) BOOL automaticHierarchy;
-
-/**
  * @discussion A place to perform your animation. New nodes have been inserted here. You can also use this time to re-order the hierarchy.
  */
 - (void)animateLayoutTransition:(id<ASContextTransitioning>)context;
@@ -143,20 +134,6 @@ ASDISPLAYNODE_EXTERN_C_END
  * enabling .neverShowPlaceholders on ASCellNodes so that the navigation operation is blocked on redisplay completing, etc.
  */
 + (void)setRangeModeForMemoryWarnings:(ASLayoutRangeMode)rangeMode;
-
-
-#pragma mark - Deprecated
-
-/**
- * @abstract A boolean that shows whether the node automatically inserts and removes nodes based on the presence or
- * absence of the node and its subnodes is completely determined in its layoutSpecThatFits: method.
- *
- * @discussion If flag is YES the node no longer require addSubnode: or removeFromSupernode method calls. The presence
- * or absence of subnodes is completely determined in its layoutSpecThatFits: method.
- *
- * @deprecated Deprecated in version 2.0: Use automaticHierarchy
- */
-@property (nonatomic, assign) BOOL usesImplicitHierarchyManagement __deprecated;
 
 @end
 

--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -758,7 +758,7 @@ NS_ASSUME_NONNULL_END
  * @discussion If flag is YES the node no longer require addSubnode: or removeFromSupernode method calls. The presence
  * or absence of subnodes is completely determined in its layoutSpecThatFits: method.
  */
-@property (nonatomic, assign) BOOL automaticHierarchy;
+@property (nonatomic, assign) BOOL automaticallyManagesSubnodes;
 
 @end
 

--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -747,8 +747,24 @@ NS_ASSUME_NONNULL_END
 @end
 
 /*
- ASDisplayNode participates in ASAsyncTransactions, so you can determine when your subnodes are done rendering.
- See: -(void)asyncdisplaykit_asyncTransactionContainerStateDidChange in ASDisplayNodeSubclass.h
+ * ASDisplayNode support for automatic hierarchy management.
+ */
+@interface ASDisplayNode (AutomaticHierarchyManagement)
+
+/**
+ * @abstract A boolean that shows whether the node automatically inserts and removes nodes based on the presence or
+ * absence of the node and its subnodes is completely determined in its layoutSpecThatFits: method.
+ *
+ * @discussion If flag is YES the node no longer require addSubnode: or removeFromSupernode method calls. The presence
+ * or absence of subnodes is completely determined in its layoutSpecThatFits: method.
+ */
+@property (nonatomic, assign) BOOL automaticHierarchy;
+
+@end
+
+/*
+ * ASDisplayNode participates in ASAsyncTransactions, so you can determine when your subnodes are done rendering.
+ * See: -(void)asyncdisplaykit_asyncTransactionContainerStateDidChange in ASDisplayNodeSubclass.h
  */
 @interface ASDisplayNode (ASDisplayNodeAsyncTransactionContainer) <ASDisplayNodeAsyncTransactionContainer>
 @end
@@ -763,7 +779,9 @@ NS_ASSUME_NONNULL_END
 - (void)addSubnode:(nonnull ASDisplayNode *)node;
 @end
 
-/** CALayer(AsyncDisplayKit) defines convenience method for adding sub-ASDisplayNode to a CALayer. */
+/*
+ * CALayer(AsyncDisplayKit) defines convenience method for adding sub-ASDisplayNode to a CALayer.
+ */
 @interface CALayer (AsyncDisplayKit)
 /**
  * Convenience method, equivalent to [layer addSublayer:node.layer].
@@ -775,6 +793,17 @@ NS_ASSUME_NONNULL_END
 
 
 @interface ASDisplayNode (Deprecated)
+
+/**
+ * @abstract A boolean that shows whether the node automatically inserts and removes nodes based on the presence or
+ * absence of the node and its subnodes is completely determined in its layoutSpecThatFits: method.
+ *
+ * @discussion If flag is YES the node no longer require addSubnode: or removeFromSupernode method calls. The presence
+ * or absence of subnodes is completely determined in its layoutSpecThatFits: method.
+ *
+ * @deprecated Deprecated in version 2.0: Use automaticHierarchy
+ */
+@property (nonatomic, assign) BOOL usesImplicitHierarchyManagement ASDISPLAYNODE_DEPRECATED;
 
 - (void)reclaimMemory ASDISPLAYNODE_DEPRECATED;
 - (void)recursivelyReclaimMemory ASDISPLAYNODE_DEPRECATED;

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -689,16 +689,16 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
 
 #pragma mark - Automatic Hierarchy
 
-- (BOOL)automaticHierarchy
+- (BOOL)automaticallyManagesSubnodes
 {
   ASDN::MutexLocker l(__instanceLock__);
-  return _automaticHierarchy;
+  return _automaticallyManagesSubnodes;
 }
 
-- (void)setAutomaticHierarchy:(BOOL)automaticHierachy
+- (void)setAutomaticallyManagesSubnodes:(BOOL)automaticallyManagesSubnodes
 {
   ASDN::MutexLocker l(__instanceLock__);
-  _automaticHierarchy = automaticHierachy;
+  _automaticallyManagesSubnodes = automaticallyManagesSubnodes;
 }
 
 #pragma mark - Layout Transition
@@ -753,11 +753,11 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
       ASLayoutableSetCurrentContext(ASLayoutableContextMake(transitionID, NO));
 
       ASDN::MutexLocker l(__instanceLock__);
-      BOOL automaticHierarchyWasDisabled = (self.automaticHierarchy == NO);
-      self.automaticHierarchy = YES; // Temporary flag for 1.9.x
+      BOOL automaticallyManagesSubnodesDisabled = (self.automaticallyManagesSubnodes == NO);
+      self.automaticallyManagesSubnodes = YES; // Temporary flag for 1.9.x
       newLayout = [self calculateLayoutThatFits:constrainedSize];
-      if (automaticHierarchyWasDisabled) {
-        self.automaticHierarchy = NO; // Temporary flag for 1.9.x
+      if (automaticallyManagesSubnodesDisabled) {
+        self.automaticallyManagesSubnodes = NO; // Temporary flag for 1.9.x
       }
       
       ASLayoutableClearCurrentContext();
@@ -911,7 +911,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
 - (void)_completeLayoutTransition:(ASLayoutTransition *)layoutTransition
 {
   // Layout transition is not supported for nodes that are not have automatic hierarchy management enabled
-  if (layoutTransition == nil || self.automaticHierarchy == NO) {
+  if (layoutTransition == nil || self.automaticallyManagesSubnodes == NO) {
     return;
   }
 
@@ -2592,7 +2592,7 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
   ASDisplayNodeAssertTrue(layout.size.width >= 0.0);
   ASDisplayNodeAssertTrue(layout.size.height >= 0.0);
   
-  if (layoutTransition == nil || self.automaticHierarchy == NO) {
+  if (layoutTransition == nil || self.automaticallyManagesSubnodes == NO) {
     return;
   }
 
@@ -3167,12 +3167,12 @@ static const char *ASDisplayNodeAssociatedNodeKey = "ASAssociatedNode";
 
 - (BOOL)usesImplicitHierarchyManagement
 {
-  return self.automaticHierarchy;
+  return self.automaticallyManagesSubnodes;
 }
 
 - (void)setUsesImplicitHierarchyManagement:(BOOL)enabled
 {
-  self.automaticHierarchy = enabled;
+  self.automaticallyManagesSubnodes = enabled;
 }
 
 

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -17,7 +17,6 @@
 #import "ASChangeSetDataController.h"
 #import "ASDelegateProxy.h"
 #import "ASDisplayNodeExtras.h"
-#import "ASDisplayNode+Beta.h"
 #import "ASDisplayNode+FrameworkPrivate.h"
 #import "ASInternalHelpers.h"
 #import "ASLayout.h"

--- a/AsyncDisplayKit/Private/ASDisplayNode+UIViewBridge.mm
+++ b/AsyncDisplayKit/Private/ASDisplayNode+UIViewBridge.mm
@@ -344,7 +344,7 @@ if (shouldApply) { _layer.layerProperty = (layerValueExpr); } else { ASDisplayNo
     // The node is loaded but we're not on main.
     // We will call [self __setNeedsLayout] when we apply
     // the pending state. We need to call it on main if the node is loaded
-    // to support implicit hierarchy management.
+    // to support automatic hierarchy management.
     [ASDisplayNodeGetPendingState(self) setNeedsLayout];
   } else {
     // The node is not loaded and we're not on main.

--- a/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
+++ b/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
@@ -124,7 +124,7 @@ FOUNDATION_EXPORT NSString * const ASRenderingEngineDidDisplayNodesScheduledBefo
   
   // Main thread only
   _ASTransitionContext *_pendingLayoutTransitionContext;
-  BOOL _usesImplicitHierarchyManagement;
+  BOOL _automaticHierarchy;
 
   int32_t _pendingTransitionID;
   ASLayoutTransition *_pendingLayoutTransition;

--- a/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
+++ b/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
@@ -124,7 +124,7 @@ FOUNDATION_EXPORT NSString * const ASRenderingEngineDidDisplayNodesScheduledBefo
   
   // Main thread only
   _ASTransitionContext *_pendingLayoutTransitionContext;
-  BOOL _automaticHierarchy;
+  BOOL _automaticallyManagesSubnodes;
 
   int32_t _pendingTransitionID;
   ASLayoutTransition *_pendingLayoutTransition;

--- a/AsyncDisplayKit/Private/_ASHierarchyChangeSet.mm
+++ b/AsyncDisplayKit/Private/_ASHierarchyChangeSet.mm
@@ -15,6 +15,7 @@
 #import "NSIndexSet+ASHelpers.h"
 #import "ASAssert.h"
 #import "ASDisplayNode+Beta.h"
+
 #import <unordered_map>
 
 #define ASFailUpdateValidation(...)\

--- a/AsyncDisplayKitTests/ASDisplayNodeImplicitHierarchyTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeImplicitHierarchyTests.m
@@ -50,10 +50,10 @@
 - (void)testFeatureFlag
 {
   ASDisplayNode *node = [[ASDisplayNode alloc] init];
-  XCTAssertFalse(node.automaticHierarchy);
+  XCTAssertFalse(node.automaticallyManagesSubnodes);
   
-  node.automaticHierarchy = YES;
-  XCTAssertTrue(node.automaticHierarchy);
+  node.automaticallyManagesSubnodes = YES;
+  XCTAssertTrue(node.automaticallyManagesSubnodes);
 }
 
 - (void)testInitialNodeInsertionWithOrdering
@@ -65,7 +65,7 @@
   ASDisplayNode *node5 = [[ASDisplayNode alloc] init];
 
   ASSpecTestDisplayNode *node = [[ASSpecTestDisplayNode alloc] init];
-  node.automaticHierarchy = YES;
+  node.automaticallyManagesSubnodes = YES;
   node.layoutSpecBlock = ^(ASDisplayNode *weakNode, ASSizeRange constrainedSize) {
     ASStaticLayoutSpec *staticLayout = [ASStaticLayoutSpec staticLayoutSpecWithChildren:@[node4]];
     
@@ -92,7 +92,7 @@
   ASDisplayNode *node3 = [[ASDisplayNode alloc] init];
   
   ASSpecTestDisplayNode *node = [[ASSpecTestDisplayNode alloc] init];
-  node.automaticHierarchy = YES;
+  node.automaticallyManagesSubnodes = YES;
   node.layoutSpecBlock = ^(ASDisplayNode *weakNode, ASSizeRange constrainedSize){
     ASSpecTestDisplayNode *strongNode = (ASSpecTestDisplayNode *)weakNode;
     if ([strongNode.layoutState isEqualToNumber:@1]) {
@@ -123,7 +123,7 @@
   ASDisplayNode *node2 = [[ASDisplayNode alloc] init];
   
   ASSpecTestDisplayNode *node = [[ASSpecTestDisplayNode alloc] init];
-  node.automaticHierarchy = YES;
+  node.automaticallyManagesSubnodes = YES;
   node.layoutSpecBlock = ^(ASDisplayNode *weakNode, ASSizeRange constrainedSize) {
     ASSpecTestDisplayNode *strongNode = (ASSpecTestDisplayNode *)weakNode;
     if ([strongNode.layoutState isEqualToNumber:@1]) {
@@ -167,7 +167,7 @@
   ASDisplayNode *node2 = [[ASDisplayNode alloc] init];
   
   ASSpecTestDisplayNode *node = [[ASSpecTestDisplayNode alloc] init];
-  node.automaticHierarchy = YES;
+  node.automaticallyManagesSubnodes = YES;
   
   node.layoutSpecBlock = ^(ASDisplayNode *weakNode, ASSizeRange constrainedSize) {
     ASSpecTestDisplayNode *strongNode = (ASSpecTestDisplayNode *)weakNode;

--- a/AsyncDisplayKitTests/ASDisplayNodeImplicitHierarchyTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeImplicitHierarchyTests.m
@@ -47,28 +47,13 @@
 
 @implementation ASDisplayNodeImplicitHierarchyTests
 
-- (void)setUp {
-  [super setUp];
-  [ASDisplayNode setUsesImplicitHierarchyManagement:YES];
-}
-
-- (void)tearDown {
-  [ASDisplayNode setUsesImplicitHierarchyManagement:NO];
-  [super tearDown];
-}
-
 - (void)testFeatureFlag
 {
-  XCTAssert([ASDisplayNode usesImplicitHierarchyManagement]);
   ASDisplayNode *node = [[ASDisplayNode alloc] init];
-  XCTAssert(node.usesImplicitHierarchyManagement);
-
-  [ASDisplayNode setUsesImplicitHierarchyManagement:NO];
-  XCTAssertFalse([ASDisplayNode usesImplicitHierarchyManagement]);
-  XCTAssertFalse(node.usesImplicitHierarchyManagement);
-
-  node.usesImplicitHierarchyManagement = YES;
-  XCTAssert(node.usesImplicitHierarchyManagement);
+  XCTAssertFalse(node.automaticHierarchy);
+  
+  node.automaticHierarchy = YES;
+  XCTAssertTrue(node.automaticHierarchy);
 }
 
 - (void)testInitialNodeInsertionWithOrdering
@@ -80,6 +65,7 @@
   ASDisplayNode *node5 = [[ASDisplayNode alloc] init];
 
   ASSpecTestDisplayNode *node = [[ASSpecTestDisplayNode alloc] init];
+  node.automaticHierarchy = YES;
   node.layoutSpecBlock = ^(ASDisplayNode *weakNode, ASSizeRange constrainedSize) {
     ASStaticLayoutSpec *staticLayout = [ASStaticLayoutSpec staticLayoutSpecWithChildren:@[node4]];
     
@@ -106,6 +92,7 @@
   ASDisplayNode *node3 = [[ASDisplayNode alloc] init];
   
   ASSpecTestDisplayNode *node = [[ASSpecTestDisplayNode alloc] init];
+  node.automaticHierarchy = YES;
   node.layoutSpecBlock = ^(ASDisplayNode *weakNode, ASSizeRange constrainedSize){
     ASSpecTestDisplayNode *strongNode = (ASSpecTestDisplayNode *)weakNode;
     if ([strongNode.layoutState isEqualToNumber:@1]) {
@@ -136,6 +123,7 @@
   ASDisplayNode *node2 = [[ASDisplayNode alloc] init];
   
   ASSpecTestDisplayNode *node = [[ASSpecTestDisplayNode alloc] init];
+  node.automaticHierarchy = YES;
   node.layoutSpecBlock = ^(ASDisplayNode *weakNode, ASSizeRange constrainedSize) {
     ASSpecTestDisplayNode *strongNode = (ASSpecTestDisplayNode *)weakNode;
     if ([strongNode.layoutState isEqualToNumber:@1]) {
@@ -179,6 +167,7 @@
   ASDisplayNode *node2 = [[ASDisplayNode alloc] init];
   
   ASSpecTestDisplayNode *node = [[ASSpecTestDisplayNode alloc] init];
+  node.automaticHierarchy = YES;
   
   node.layoutSpecBlock = ^(ASDisplayNode *weakNode, ASSizeRange constrainedSize) {
     ASSpecTestDisplayNode *strongNode = (ASSpecTestDisplayNode *)weakNode;


### PR DESCRIPTION
Renames `Implicit Hierarchy Management` to `Automatic Hierarchy Management`:
- Deprecate `usesImplicitHierarchyManagement`
- New property: `automaticHierarchy`
- Move out of `ASDisplayNode` beta header
- Cleanup headers around `ASDisplayNode` beta header