### PR TITLE
[ASVideoNode] Improve playerStatus behaviour and image generation

### DIFF
--- a/AsyncDisplayKit/ASVideoNode.mm
+++ b/AsyncDisplayKit/ASVideoNode.mm
@@ -267,6 +267,7 @@ static NSString * const kStatus = @"status";
 
     AVAssetImageGenerator *previewImageGenerator = [AVAssetImageGenerator assetImageGeneratorWithAsset:asset];
     previewImageGenerator.appliesPreferredTrackTransform = YES;
+    previewImageGenerator.videoComposition = _videoComposition;
 
     [previewImageGenerator generateCGImagesAsynchronouslyForTimes:@[[NSValue valueWithCMTime:imageTime]]
                                                 completionHandler:^(CMTime requestedTime, CGImageRef image, CMTime actualTime, AVAssetImageGeneratorResult result, NSError *error) {


### PR DESCRIPTION
Hi guys,

I looked into how the `playerStatus` is handled in the `ASVideoNode`, and how the `asset` / `playerItem` are loaded. It seems that some unnecessary reloading is happening. For example, `fetchData` loads the `playerItem` if the state is not `ASVideoNodePlayerStateInitialLoading`, but what about if the `playerItem` is already loaded (paused for example)?

This brought me to make the following changes:
- `fetchData` only triggers loading when the state is `ASVideoNodePlayerStateUnknown`. If you think about it, all other states actually indicate that the item is currently loading or has been loaded, so no need to do that again.
- `ASVideoNodePlayerStateInitialLoading` is no longer used. I think it is a bit ambiguous. For example, if someone calls `pause` during the initial loading, the state is changed to `ASVideoNodePlayerStateLoading`. This does not affect the "initial loading" delegate methods, which stay valid. `ASVideoNodePlayerStateInitialLoading` could probably be marked deprecated.
- When clearing data, the state is put back to `ASVideoNodePlayerStateUnknown`. This makes more sense than keeping the old, no longer valid, state. "NotLoaded" or something like that would probably be a better name, but I didn't want to break the API.
- When calling `pause`, the state is only changed to `ASVideoNodePlayerStatePaused` if the player was currently playing. Otherwise we might lose the info that the item is currently loading.
- When receiving a `playbackLikelyToKeepUp` notification, make sure that the value is `true` when setting the `ASVideoNodePlayerStatePlaybackLikelyToKeepUpButNotPlaying` state. Actually I'm not sure of the usefulness of this state, maybe it could be removed altogether and use `ASVideoNodePlayerStateReadyToPlay` instead?
- _EDIT:_ When calling `play`, only change the state if it's not `Unknown`, as it doesn't make sense if the asset hasn't been loaded yet. Thanks maxsz on Slack for reporting this!

In my app, making these changes brought two improvements:
- The `ASVideoNode` no longer flickers when `fetchData` is called several times and the asset was already loaded.
- The video stays loaded and resumes playback at the correct time when the view reappears on the screen (for example when another view controller is popped from the navigation stack).

Please tell me what you think of these changes. I might have missed edge cases in the state handling, so feedback would be nice :-)

Also, there's another commit in this branch that simply make the `AVAssetImageGenerator` use the `videoComposition` if it exists, to make sure that the correct preview is generated. I had forgotten that when implementing the `videoComposition` and `audioMix` properties.

Cheers,