### PR TITLE
[ASVideoNode] Expose AVPlayerLayer on ASVideoNode

### DIFF
--- a/AsyncDisplayKit/ASVideoNode.h
+++ b/AsyncDisplayKit/ASVideoNode.h
@@ -12,7 +12,7 @@
 #import <AsyncDisplayKit/ASButtonNode.h>
 #import <AsyncDisplayKit/ASNetworkImageNode.h>
 
-@class AVAsset, AVPlayer, AVPlayerItem, AVVideoComposition, AVAudioMix;
+@class AVAsset, AVPlayer, AVPlayerLayer, AVPlayerItem, AVVideoComposition, AVAudioMix;
 @protocol ASVideoNodeDelegate;
 
 typedef enum {
@@ -51,6 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nullable, nonatomic, strong, readwrite) AVAudioMix *audioMix;
 
 @property (nullable, nonatomic, strong, readonly) AVPlayer *player;
+@property (nullable, nonatomic, strong, readonly) AVPlayerLayer *playerLayer;
 @property (nullable, nonatomic, strong, readonly) AVPlayerItem *currentItem;
 
 

--- a/AsyncDisplayKit/ASVideoNode.mm
+++ b/AsyncDisplayKit/ASVideoNode.mm
@@ -551,6 +551,12 @@ static NSString * const kRate = @"rate";
   return _player;
 }
 
+- (AVPlayerLayer *)playerLayer
+{
+  ASDN::MutexLocker l(__instanceLock__);
+  return (AVPlayerLayer *)_playerNode.layer;
+}
+
 - (id<ASVideoNodeDelegate>)delegate{
   return _delegate;
 }


### PR DESCRIPTION
The `playerLayer` is needed for picture in picture support on the iPad (`AVPictureInPictureController`).

Example:
```swift
guard AVPictureInPictureController.isPictureInPictureSupported() else { return }
guard let playerLayer = videoNode.playerLayer else { return }
pipController = AVPictureInPictureController(playerLayer: playerLayer)
```