### PR TITLE
[ASDisplayNode] Remove layoutSpecBlock

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode+Subclasses.h
+++ b/AsyncDisplayKit/ASDisplayNode+Subclasses.h
@@ -146,9 +146,6 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @note This method should not be called directly outside of ASDisplayNode; use -measure: or -calculatedLayout instead.
  *
- * @warning Subclasses that implement -layoutSpecThatFits: must not also use .layoutSpecBlock. Doing so will trigger
- * an exception. A future version of the framework may support using both, calling them serially, with the
- * .layoutSpecBlock superseding any values set by the method override.
  */
 - (ASLayoutSpec *)layoutSpecThatFits:(ASSizeRange)constrainedSize;
 

--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -48,11 +48,6 @@ typedef void (^ASDisplayNodeDidLoadBlock)(ASDisplayNode * _Nonnull node);
 typedef void (^ASDisplayNodeContextModifier)(_Nonnull CGContextRef context);
 
 /**
- * ASDisplayNode layout spec block. This block can be used instead of implementing layoutSpecThatFits: in subclass
- */
-typedef ASLayoutSpec * _Nonnull(^ASLayoutSpecBlock)(ASDisplayNode * _Nonnull node, ASSizeRange constrainedSize);
-
-/**
  Interface state is available on ASDisplayNode and ASViewController, and
  allows checking whether a node is in an interface situation where it is prudent to trigger certain
  actions: measurement, data fetching, display, and visibility (the latter for animations or other onscreen-only effects).
@@ -261,21 +256,6 @@ NS_ASSUME_NONNULL_BEGIN
  * @see [ASDisplayNode(Subclassing) calculateLayoutThatFits:]
  */
 - (ASLayout *)measureWithSizeRange:(ASSizeRange)constrainedSize;
-
-
-/**
- * @abstract Provides a way to declare a block to provide an ASLayoutSpec without having to subclass ASDisplayNode and
- * implement layoutSpecThatFits:
- *
- * @return A block that takes a constrainedSize ASSizeRange argument, and must return an ASLayoutSpec that includes all
- * of the subnodes to position in the layout. This input-output relationship is identical to the subclass override
- * method -layoutSpecThatFits:
- *
- * @warning Subclasses that implement -layoutSpecThatFits: must not also use .layoutSpecBlock. Doing so will trigger
- * an exception. A future version of the framework may support using both, calling them serially, with the
- * .layoutSpecBlock superseding any values set by the method override.
- */
-@property (nonatomic, readwrite, copy, nullable) ASLayoutSpecBlock layoutSpecBlock;
 
 /** 
  * @abstract Return the calculated size.

--- a/AsyncDisplayKitTests/ASDisplayNodeImplicitHierarchyTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeImplicitHierarchyTests.m
@@ -19,7 +19,11 @@
 #import "ASStaticLayoutSpec.h"
 #import "ASStackLayoutSpec.h"
 
+typedef ASLayoutSpec * _Nonnull(^ASSpecTestDisplayNodeSpecBlock)(ASDisplayNode * _Nonnull node, ASSizeRange constrainedSize);
+
 @interface ASSpecTestDisplayNode : ASDisplayNode
+
+@property (nonatomic, readwrite, copy, nullable) ASSpecTestDisplayNodeSpecBlock layoutSpecBlock;
 
 /**
  Simple state identifier to allow control of current spec inside of the layoutSpecBlock
@@ -37,6 +41,11 @@
     _layoutState = @1;
   }
   return self;
+}
+
+- (ASLayoutSpec *)layoutSpecThatFits:(ASSizeRange)constrainedSize
+{
+  return self.layoutSpecBlock(self, constrainedSize);
 }
 
 @end


### PR DESCRIPTION
The implementation of `layoutSpecBlock` has currently a couple of issues e.g. if a `layoutSpecBlock` is provided, `layoutSpecThatFits:` will not be called on that node. Furthermore it is make it even harder to resolve the overall issue that currently it's not possible to have multiple `layoutSpecThatFits:` implementation in a class hierarchy.

As it was just recently introduced and does not have that much of a public usage, I would propose to remove it for 2.0.

@appleguy @Adlai-Holler Let me know what you are thinking ...