### PR TITLE
[ASDisplayNode] WIP Measure node before layout if bounds changed

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -1204,21 +1204,18 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
 - (void)measureNodeWithBoundsIfNecessary:(CGRect)bounds
 {
   BOOL supportsRangedManagedInterfaceState = NO;
-  BOOL hasDirtyLayout = NO;
-  BOOL hasSupernode = NO;
   {
     ASDN::MutexLocker l(__instanceLock__);
     supportsRangedManagedInterfaceState = [self supportsRangeManagedInterfaceState];
-    hasDirtyLayout = [self _hasDirtyLayout];
-    hasSupernode = (self.supernode != nil);
   }
   
   // Normally measure will be called before layout occurs. If this doesn't happen, nothing is going to call it at all.
   // We simply call measureWithSizeRange: using a size range equal to whatever bounds were provided to that element
-  if (!hasSupernode && !supportsRangedManagedInterfaceState && hasDirtyLayout) {
+  if (!supportsRangedManagedInterfaceState) {
     if (CGRectEqualToRect(bounds, CGRectZero)) {
       LOG(@"Warning: No size given for node before node was trying to layout itself: %@. Please provide a frame for the node.", self);
     } else {
+      // This is a no op if the bounds size is the same as the already calculated layout size
       [self measureWithSizeRange:ASSizeRangeMake(bounds.size, bounds.size)];
     }
   }


### PR DESCRIPTION
The goal of this PR is to automatically trigger a call to "measureWithSizeRange:" in case the bounds of a node did change and is different as the previous. This is necessary to kick creating an`ASLayout`. It's a no op if the current `ASLayout` has the same size as the new #bounds though.