### PR TITLE
Prevent API misuse at compile time

### DIFF
--- a/AsyncDisplayKit/ASCellNode.h
+++ b/AsyncDisplayKit/ASCellNode.h
@@ -124,6 +124,16 @@ typedef NS_ENUM(NSUInteger, ASCellNodeVisibilityEvent) {
 
 @end
 
+@interface ASCellNode (Unavailable)
+
+- (instancetype)initWithLayerBlock:(ASDisplayNodeLayerBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock __unavailable;
+
+- (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock __unavailable;
+
+- (void)setLayerBacked:(BOOL)layerBacked AS_UNAVAILABLE("ASCellNode does not support layer-backing");
+
+@end
+
 
 /**
  * Simple label-style cell node.  Read its source for an example of custom <ASCellNode>s.

--- a/AsyncDisplayKit/ASCellNode.mm
+++ b/AsyncDisplayKit/ASCellNode.mm
@@ -104,24 +104,6 @@
   _viewControllerNode.frame = self.bounds;
 }
 
-- (instancetype)initWithLayerBlock:(ASDisplayNodeLayerBlock)viewBlock didLoadBlock:(ASDisplayNodeDidLoadBlock)didLoadBlock
-{
-  ASDisplayNodeAssertNotSupported();
-  return nil;
-}
-
-- (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock didLoadBlock:(ASDisplayNodeDidLoadBlock)didLoadBlock
-{
-  ASDisplayNodeAssertNotSupported();
-  return nil;
-}
-
-- (void)setLayerBacked:(BOOL)layerBacked
-{
-  // ASRangeController expects ASCellNodes to be view-backed.  (Layer-backing is supported on ASCellNode subnodes.)
-  ASDisplayNodeAssert(!layerBacked, @"ASCellNode does not support layer-backing.");
-}
-
 - (void)__setNeedsLayout
 {
   CGSize oldSize = self.calculatedSize;

--- a/AsyncDisplayKit/ASEditableTextNode.h
+++ b/AsyncDisplayKit/ASEditableTextNode.h
@@ -127,6 +127,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+@interface ASEditableTextNode (Unavailable)
+
+- (instancetype)initWithLayerBlock:(ASDisplayNodeLayerBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock __unavailable;
+
+- (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock __unavailable;
+
+@end
+
 #pragma mark -
 /**
  * The methods declared by the ASEditableTextNodeDelegate protocol allow the adopting delegate to 

--- a/AsyncDisplayKit/ASEditableTextNode.mm
+++ b/AsyncDisplayKit/ASEditableTextNode.mm
@@ -167,18 +167,6 @@
   return self;
 }
 
-- (instancetype)initWithLayerBlock:(ASDisplayNodeLayerBlock)viewBlock didLoadBlock:(ASDisplayNodeDidLoadBlock)didLoadBlock
-{
-  ASDisplayNodeAssertNotSupported();
-  return nil;
-}
-
-- (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock didLoadBlock:(ASDisplayNodeDidLoadBlock)didLoadBlock
-{
-  ASDisplayNodeAssertNotSupported();
-  return nil;
-}
-
 - (void)dealloc
 {
   _textKitComponents.textView.delegate = nil;

--- a/AsyncDisplayKit/ASImageNode.h
+++ b/AsyncDisplayKit/ASImageNode.h
@@ -154,6 +154,13 @@ typedef UIImage * _Nullable (^asimagenode_modification_block_t)(UIImage *image);
 
 @end
 
+@interface ASImageNode (Unavailable)
+
+- (instancetype)initWithLayerBlock:(ASDisplayNodeLayerBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock __unavailable;
+
+- (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock __unavailable;
+
+@end
 
 ASDISPLAYNODE_EXTERN_C_BEGIN
 

--- a/AsyncDisplayKit/ASImageNode.mm
+++ b/AsyncDisplayKit/ASImageNode.mm
@@ -171,18 +171,6 @@ struct ASImageNodeDrawParameters {
   return self;
 }
 
-- (instancetype)initWithLayerBlock:(ASDisplayNodeLayerBlock)viewBlock didLoadBlock:(ASDisplayNodeDidLoadBlock)didLoadBlock
-{
-  ASDisplayNodeAssertNotSupported();
-  return nil;
-}
-
-- (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock didLoadBlock:(ASDisplayNodeDidLoadBlock)didLoadBlock
-{
-  ASDisplayNodeAssertNotSupported();
-  return nil;
-}
-
 - (void)dealloc
 {
   // Invalidate all components around animated images

--- a/AsyncDisplayKit/ASTextNode.h
+++ b/AsyncDisplayKit/ASTextNode.h
@@ -272,6 +272,14 @@ typedef NS_ENUM(NSUInteger, ASTextNodeHighlightStyle) {
 
 @end
 
+@interface ASTextNode (Unavailable)
+
+- (instancetype)initWithLayerBlock:(ASDisplayNodeLayerBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock __unavailable;
+
+- (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock __unavailable;
+
+@end
+
 /**
  * @abstract Text node deprecated properties
  */

--- a/AsyncDisplayKit/ASTextNode.mm
+++ b/AsyncDisplayKit/ASTextNode.mm
@@ -122,18 +122,6 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
   return self;
 }
 
-- (instancetype)initWithLayerBlock:(ASDisplayNodeLayerBlock)viewBlock didLoadBlock:(ASDisplayNodeDidLoadBlock)didLoadBlock
-{
-  ASDisplayNodeAssertNotSupported();
-  return nil;
-}
-
-- (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock didLoadBlock:(ASDisplayNodeDidLoadBlock)didLoadBlock
-{
-  ASDisplayNodeAssertNotSupported();
-  return nil;
-}
-
 - (void)dealloc
 {
   if (_shadowColor != NULL) {

--- a/AsyncDisplayKit/ASVideoNode.h
+++ b/AsyncDisplayKit/ASVideoNode.h
@@ -147,6 +147,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)videoNode:(ASVideoNode *)videoNode didPlayToSecond:(NSTimeInterval)second __deprecated;
 
 @end
+
+@interface ASVideoNode (Unavailable)
+
+- (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock __unavailable;
+
+@end
+
 NS_ASSUME_NONNULL_END
 #endif
 

--- a/AsyncDisplayKit/ASVideoNode.mm
+++ b/AsyncDisplayKit/ASVideoNode.mm
@@ -105,12 +105,6 @@ static NSString * const kStatus = @"status";
   return self;
 }
 
-- (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock didLoadBlock:(ASDisplayNodeDidLoadBlock)didLoadBlock
-{
-  ASDisplayNodeAssertNotSupported();
-  return nil;
-}
-
 - (ASDisplayNode *)constructPlayerNode
 {
   ASVideoNode * __weak weakSelf = self;

--- a/AsyncDisplayKit/ASViewController.h
+++ b/AsyncDisplayKit/ASViewController.h
@@ -74,4 +74,12 @@ typedef ASTraitCollection * _Nonnull (^ASDisplayTraitsForTraitWindowSizeBlock)(C
 
 @end
 
+@interface ASViewController (Unavailable)
+
+- (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil AS_UNAVAILABLE("ASViewController requires using -initWithNode:");
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder AS_UNAVAILABLE("ASViewController requires using -initWithNode:");
+
+@end
+
 NS_ASSUME_NONNULL_END

--- a/AsyncDisplayKit/Details/ASAbstractLayoutController.h
+++ b/AsyncDisplayKit/Details/ASAbstractLayoutController.h
@@ -17,4 +17,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+@interface ASAbstractLayoutController (Unavailable)
+
+- (NSSet *)indexPathsForScrolling:(ASScrollDirection)scrollDirection rangeMode:(ASLayoutRangeMode)rangeMode rangeType:(ASLayoutRangeType)rangeType __unavailable;
+
+@end
+
 NS_ASSUME_NONNULL_END

--- a/AsyncDisplayKit/Layout/ASLayout.h
+++ b/AsyncDisplayKit/Layout/ASLayout.h
@@ -154,4 +154,10 @@ extern BOOL CGPointIsNull(CGPoint point);
 
 @end
 
+@interface ASLayout (Unavailable)
+
+- (instancetype)init __unavailable;
+
+@end
+
 NS_ASSUME_NONNULL_END

--- a/Base/ASBaseDefines.h
+++ b/Base/ASBaseDefines.h
@@ -143,3 +143,11 @@
 #define ASDISPLAYNODE_REQUIRES_SUPER
 #endif
 #endif
+
+#ifndef AS_UNAVAILABLE
+#if __has_attribute(unavailable)
+#define AS_UNAVAILABLE(message) __attribute__((unavailable(message)))
+#else
+#define AS_UNAVAILABLE(message)
+#endif
+#endif


### PR DESCRIPTION
Using Objective-C attributes, in this case `unavailable`, we can hide unsupported APIs at compile time instead of detecting and warn about it at runtime with a set of asserts.

I think this is not only more safe but also more friendly to newcomers which are able to correctly identify the API that they should be using with each node.