### PR TITLE
[Layout Transition API] Add support for custom layout transition coordinator

### DIFF
--- a/AsyncDisplayKit/ASContextTransitioning.h
+++ b/AsyncDisplayKit/ASContextTransitioning.h
@@ -35,6 +35,11 @@ extern NSString * const ASTransitionContextToLayoutKey;
 - (ASSizeRange)constrainedSizeForKey:(NSString *)key;
 
 /**
+ * @abstract The node that acts as the supernode for the nodes involved in the transition
+ */
+- (ASDisplayNode *)containerNode;
+
+/**
  * @abstract Retrieve the subnodes from either the "from" or "to" layout
  */
 - (NSArray<ASDisplayNode *> *)subnodesForKey:(NSString *)key;
@@ -68,5 +73,32 @@ extern NSString * const ASTransitionContextToLayoutKey;
 - (void)completeTransition:(BOOL)didComplete;
 
 @end
+
+
+#pragma mark - ASLayoutTransitionCoordinator
+
+@protocol ASLayoutTransitionCoordinator <NSObject>
+
+- (void)animateLayoutTransition:(id<ASContextTransitioning>)context;
+
+@optional
+- (void)didCompleteLayoutTransition:(id<ASContextTransitioning>)context;
+
+@end
+
+@interface ASDefaultLayoutTransitionCoordinator : NSObject<ASLayoutTransitionCoordinator>
+
+@end
+
+@interface ASFadeInOutLayoutTransitionCoordinator : NSObject<ASLayoutTransitionCoordinator>
+
+/**
+ * @abstract The amount of time it takes to complete the animation
+ */
+@property (nonatomic, assign) NSTimeInterval animationDuration;
+
+@end
+
+
 
 NS_ASSUME_NONNULL_END

--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -20,6 +20,7 @@
 #define ASDisplayNodeLoggingEnabled 0
 
 @class ASDisplayNode;
+@protocol ASLayoutTransitionCoordinator;
 
 /**
  * UIView creation block. Used to create the backing view of a new display node.
@@ -597,6 +598,10 @@ NS_ASSUME_NONNULL_BEGIN
  * @return The converted rectangle.
  */
 - (CGRect)convertRect:(CGRect)rect fromNode:(nullable ASDisplayNode *)node;
+
+// TODO: Move this into ASDisplayNode (LayoutTransitioning)
+
+@property (strong, nonatomic) id<ASLayoutTransitionCoordinator> layoutTransitionCoordinator;
 
 @end
 

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -866,14 +866,23 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
 
 #pragma mark - Layout Transition API / ASDisplayNode (Beta)
 
+- (id<ASLayoutTransitionCoordinator>)layoutTransitionCoordinator
+{
+  // If no layout transition coordinator was given use a default one
+  if (!_layoutTransitionCoordinator) {
+    _layoutTransitionCoordinator = [ASDefaultLayoutTransitionCoordinator new];
+  }
+  
+  return _layoutTransitionCoordinator;
+}
+
 /*
  * Hook for subclasse to perform an animation based on the given ASContextTransitioning. By default this just layouts
  * applies all subnodes without animation and calls completes the transition on the context.
  */
 - (void)animateLayoutTransition:(id<ASContextTransitioning>)context
 {
-  [self __layoutSublayouts];
-  [context completeTransition:YES];
+  [self.layoutTransitionCoordinator animateLayoutTransition:context];
 }
 
 /*
@@ -882,7 +891,12 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
  */
 - (void)didCompleteLayoutTransition:(id<ASContextTransitioning>)context
 {
-  [_pendingLayoutTransition applySubnodeRemovals];
+  if (_layoutTransitionCoordinator != nil && [_layoutTransitionCoordinator respondsToSelector:@selector(didCompleteLayoutTransition:)])
+  {
+    [_layoutTransitionCoordinator didCompleteLayoutTransition:context];
+  } else {
+    [_pendingLayoutTransition applySubnodeRemovals];
+  }
 }
 
 #pragma mark - _ASTransitionContextCompletionDelegate

--- a/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
+++ b/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
@@ -196,6 +196,7 @@ FOUNDATION_EXPORT NSString * const ASRenderingEngineDidDisplayNodesScheduledBefo
 - (void)__setNeedsDisplay;
 
 - (void)__layout;
+- (void)__layoutSublayouts;
 - (void)__setSupernode:(ASDisplayNode *)supernode;
 
 // Private API for helper functions / unit tests.  Use ASDisplayNodeDisableHierarchyNotifications() to control this.

--- a/AsyncDisplayKit/Private/ASLayoutTransition.h
+++ b/AsyncDisplayKit/Private/ASLayoutTransition.h
@@ -16,6 +16,8 @@
 @class ASDisplayNode;
 @class ASLayout;
 
+#pragma mark - ASLayoutTransition
+
 @interface ASLayoutTransition : NSObject <_ASTransitionContextLayoutDelegate>
 
 /**

--- a/AsyncDisplayKit/Private/ASLayoutTransition.mm
+++ b/AsyncDisplayKit/Private/ASLayoutTransition.mm
@@ -132,6 +132,11 @@ static inline BOOL ASLayoutCanTransitionAsynchronous(ASLayout *layout) {
 
 #pragma mark - _ASTransitionContextDelegate
 
+- (ASDisplayNode *)containerNode
+{
+    return self.node;
+}
+
 - (NSArray<ASDisplayNode *> *)currentSubnodesWithTransitionContext:(_ASTransitionContext *)context
 {
   ASDN::MutexLocker l(__instanceLock__);
@@ -223,6 +228,105 @@ static inline void findNodesInLayoutAtIndexesWithFilteredNodes(ASLayout *layout,
   }
   *storedNodes = nodes;
   *storedPositions = positions;
+}
+
+@end
+
+@implementation ASDefaultLayoutTransitionCoordinator
+
+- (void)animateLayoutTransition:(id<ASContextTransitioning>)context
+{
+  ASDisplayNode *node = [context containerNode];
+  NSAssert(node.isNodeLoaded == YES, @"Invalid node state");
+    
+  [node __layoutSublayouts];
+  [context completeTransition:YES];
+}
+
+@end
+
+@implementation ASFadeInOutLayoutTransitionCoordinator : NSObject
+
+- (instancetype)init
+{
+  self = [super init];
+  if (self) {
+    _animationDuration = 0.2;
+  }
+  return self;
+}
+
+- (void)animateLayoutTransition:(id<ASContextTransitioning>)context
+{
+  ASDisplayNode *node = [context containerNode];
+  NSAssert(node.isNodeLoaded == YES, @"Invalid node state");
+  NSAssert([context isAnimated] == YES, @"Can't animate a non-animatable context");
+  
+  NSArray<ASDisplayNode *> *removedSubnodes = [context removedSubnodes];
+  NSMutableArray<UIView *> *removedViews = [NSMutableArray array];
+  NSMutableArray<ASDisplayNode *> *insertedSubnodes = [[context insertedSubnodes] mutableCopy];
+  NSMutableArray<ASDisplayNode *> *movedSubnodes = [NSMutableArray array];
+  
+  for (ASDisplayNode *subnode in [context subnodesForKey:ASTransitionContextToLayoutKey]) {
+    if ([insertedSubnodes containsObject:subnode] == NO) {
+      // This is an existing subnode, check if it is resized, moved or both
+      CGRect fromFrame = [context initialFrameForNode:subnode];
+      CGRect toFrame = [context finalFrameForNode:subnode];
+      if (CGSizeEqualToSize(fromFrame.size, toFrame.size) == NO) {
+        // To crossfade resized subnodes, show a snapshot of it on top.
+        // The node itself can then be treated as a newly-inserted one.
+        UIView *snapshotView = [subnode.view snapshotViewAfterScreenUpdates:YES];
+        snapshotView.frame = [context initialFrameForNode:subnode];
+        snapshotView.alpha = 1;
+        
+        [node.view insertSubview:snapshotView aboveSubview:subnode.view];
+        [removedViews addObject:snapshotView];
+        
+        [insertedSubnodes addObject:subnode];
+      }
+      if (CGPointEqualToPoint(fromFrame.origin, toFrame.origin) == NO) {
+        [movedSubnodes addObject:subnode];
+      }
+    }
+  }
+  
+  for (ASDisplayNode *insertedSubnode in insertedSubnodes) {
+    insertedSubnode.frame = [context finalFrameForNode:insertedSubnode];
+    insertedSubnode.alpha = 0;
+  }
+  
+  [UIView animateWithDuration:self.animationDuration animations:^{
+    // Fade removed subnodes and views out
+    for (ASDisplayNode *removedSubnode in removedSubnodes) {
+      removedSubnode.alpha = 0;
+    }
+    for (UIView *removedView in removedViews) {
+      removedView.alpha = 0;
+    }
+    
+    // Fade inserted subnodes in
+    for (ASDisplayNode *insertedSubnode in insertedSubnodes) {
+      insertedSubnode.alpha = 1;
+    }
+    
+    // Update frame of self and moved subnodes
+    CGSize fromSize = [context layoutForKey:ASTransitionContextFromLayoutKey].size;
+    CGSize toSize = [context layoutForKey:ASTransitionContextToLayoutKey].size;
+    BOOL isResized = (CGSizeEqualToSize(fromSize, toSize) == NO);
+    if (isResized == YES) {
+      CGPoint position = node.frame.origin;
+      node.frame = CGRectMake(position.x, position.y, toSize.width, toSize.height);
+    }
+    for (ASDisplayNode *movedSubnode in movedSubnodes) {
+      movedSubnode.frame = [context finalFrameForNode:movedSubnode];
+    }
+  } completion:^(BOOL finished) {
+    for (UIView *removedView in removedViews) {
+      [removedView removeFromSuperview];
+    }
+    // Subnode removals are automatically performed
+    [context completeTransition:finished];
+  }];
 }
 
 @end

--- a/AsyncDisplayKit/_ASTransitionContext.h
+++ b/AsyncDisplayKit/_ASTransitionContext.h
@@ -19,6 +19,8 @@
 
 @protocol _ASTransitionContextLayoutDelegate <NSObject>
 
+- (ASDisplayNode *)containerNode;
+
 - (NSArray<ASDisplayNode *> *)currentSubnodesWithTransitionContext:(_ASTransitionContext *)context;
 
 - (NSArray<ASDisplayNode *> *)insertedSubnodesWithTransitionContext:(_ASTransitionContext *)context;

--- a/AsyncDisplayKit/_ASTransitionContext.m
+++ b/AsyncDisplayKit/_ASTransitionContext.m
@@ -20,6 +20,7 @@ NSString * const ASTransitionContextToLayoutKey = @"org.asyncdisplaykit.ASTransi
 
 @interface _ASTransitionContext ()
 
+@property (weak, nonatomic) ASDisplayNode *containerNode;
 @property (weak, nonatomic) id<_ASTransitionContextLayoutDelegate> layoutDelegate;
 @property (weak, nonatomic) id<_ASTransitionContextCompletionDelegate> completionDelegate;
 
@@ -70,6 +71,11 @@ NSString * const ASTransitionContextToLayoutKey = @"org.asyncdisplaykit.ASTransi
     }
   }
   return CGRectZero;
+}
+
+- (ASDisplayNode *)containerNode
+{
+    return [self.layoutDelegate containerNode];
 }
 
 - (NSArray<ASDisplayNode *> *)subnodesForKey:(NSString *)key


### PR DESCRIPTION
- Add new protocol `ASLayoutTransitionCoordinator`
- Add property to `ASDisplayNode` called `layoutTransitionCoordinator`
- Add a default fade in / out transition coordinator for layout transitions: `ASFadeInOutLayoutTransitionCoordinator`

I'm not happy yet with the names of the transition coordinator we provide by default yet: `ASDefaultLayoutTransitionCoordinator` and `ASFadeInOutLayoutTransitionCoordinator` and open for any API improvement suggestions

cc @levi @Adlai-Holler @appleguy 