### PR TITLE
[ASTextNode] placeholder image shouldn't draw for zero area strings

### DIFF
--- a/AsyncDisplayKit/ASTextNode.mm
+++ b/AsyncDisplayKit/ASTextNode.mm
@@ -903,7 +903,7 @@ static CGRect ASTextNodeAdjustRenderRectForShadowPadding(CGRect rendererRect, UI
   // FIXME: Replace this implementation with reusable CALayers that have .backgroundColor set.
   // This would completely eliminate the memory and performance cost of the backing store.
   CGSize size = self.calculatedSize;
-  if (size.width * size.height < FLT_EPSILON) {
+  if ((size.width * size.height) < FLT_EPSILON) {
     return nil;
   }
   

--- a/AsyncDisplayKit/ASTextNode.mm
+++ b/AsyncDisplayKit/ASTextNode.mm
@@ -903,7 +903,7 @@ static CGRect ASTextNodeAdjustRenderRectForShadowPadding(CGRect rendererRect, UI
   // FIXME: Replace this implementation with reusable CALayers that have .backgroundColor set.
   // This would completely eliminate the memory and performance cost of the backing store.
   CGSize size = self.calculatedSize;
-  if (CGSizeEqualToSize(size, CGSizeZero)) {
+  if (size.width * size.height < FLT_EPSILON) {
     return nil;
   }
   

--- a/AsyncDisplayKit/ASTextNode.mm
+++ b/AsyncDisplayKit/ASTextNode.mm
@@ -27,6 +27,8 @@
 #import "ASInternalHelpers.h"
 #import "ASLayout.h"
 
+#import "CGRect+ASConvenience.h"
+
 static const NSTimeInterval ASTextNodeHighlightFadeOutDuration = 0.15;
 static const NSTimeInterval ASTextNodeHighlightFadeInDuration = 0.1;
 static const CGFloat ASTextNodeHighlightLightOpacity = 0.11;
@@ -903,7 +905,7 @@ static CGRect ASTextNodeAdjustRenderRectForShadowPadding(CGRect rendererRect, UI
   // FIXME: Replace this implementation with reusable CALayers that have .backgroundColor set.
   // This would completely eliminate the memory and performance cost of the backing store.
   CGSize size = self.calculatedSize;
-  if ((size.width * size.height) < FLT_EPSILON) {
+  if ((size.width * size.height) < CGFLOAT_EPSILON) {
     return nil;
   }
   

--- a/AsyncDisplayKit/Details/CGRect+ASConvenience.h
+++ b/AsyncDisplayKit/Details/CGRect+ASConvenience.h
@@ -14,6 +14,14 @@
 #import "ASBaseDefines.h"
 #import "ASLayoutController.h"
 
+#ifndef CGFLOAT_EPSILON
+  #if CGFLOAT_IS_DOUBLE
+    #define CGFLOAT_EPSILON DBL_EPSILON
+  #else
+    #define CGFLOAT_EPSILON FLT_EPSILON
+  #endif
+#endif
+
 NS_ASSUME_NONNULL_BEGIN
 
 ASDISPLAYNODE_EXTERN_C_BEGIN


### PR DESCRIPTION
This fixes #1986.

<img width="1301" alt="screen shot 2016-08-14 at 12 08 13 pm" src="https://cloud.githubusercontent.com/assets/3419380/17651429/989e6e54-621b-11e6-9ba7-f8de06b406c1.png">

