### PR TITLE
[Layout] Coalescing layout until UIKit callbacks

### DIFF
--- a/AsyncDisplayKit/ASCellNode+Internal.h
+++ b/AsyncDisplayKit/ASCellNode+Internal.h
@@ -25,6 +25,7 @@
  * @param node A node informing the delegate about the relayout.
  * @param sizeChanged `YES` if the node's `calculatedSize` changed during the relayout, `NO` otherwise.
  */
+- (void)nodeDidRelayout:(ASCellNode *)node;
 - (void)nodeDidRelayout:(ASCellNode *)node sizeChanged:(BOOL)sizeChanged;
 
 /*

--- a/AsyncDisplayKit/ASCellNode.mm
+++ b/AsyncDisplayKit/ASCellNode.mm
@@ -104,12 +104,12 @@
   _viewControllerNode.frame = self.bounds;
 }
 
-- (void)__setNeedsLayout
+- (void)__layout
 {
-  [super __setNeedsLayout];
+  [super __layout];
   
   ASDN::MutexLocker l(__instanceLock__);
-  [self didRelayoutFromOldSize:CGSizeZero toNewSize:self.calculatedSize];
+  [self didRelayout];
 }
 
 - (void)transitionLayoutAnimated:(BOOL)animated
@@ -159,12 +159,21 @@
   [self transitionLayoutWithSizeRange:constrainedSize animated:animated measurementCompletion:completion];
 }
 
+- (void)didRelayout
+{
+  [self didRelayoutSizeChanged:YES];
+}
+
 - (void)didRelayoutFromOldSize:(CGSize)oldSize toNewSize:(CGSize)newSize
+{
+  BOOL sizeChanged = !CGSizeEqualToSize(oldSize, newSize);
+  [self didRelayoutSizeChanged:sizeChanged];
+}
+
+- (void)didRelayoutSizeChanged:(BOOL)sizeChanged
 {
   if (_interactionDelegate != nil) {
     ASPerformBlockOnMainThread(^{
-      BOOL sizeChanged = !CGSizeEqualToSize(oldSize, newSize);
-      sizeChanged = YES;
       [_interactionDelegate nodeDidRelayout:self sizeChanged:sizeChanged];
     });
   }

--- a/AsyncDisplayKit/ASCellNode.mm
+++ b/AsyncDisplayKit/ASCellNode.mm
@@ -106,13 +106,10 @@
 
 - (void)__setNeedsLayout
 {
-  CGSize oldSize = self.calculatedSize;
   [super __setNeedsLayout];
   
-  //Adding this lock because lock used to be held when this method was called. Not sure if it's necessary for
-  //didRelayoutFromOldSize:toNewSize:
   ASDN::MutexLocker l(__instanceLock__);
-  [self didRelayoutFromOldSize:oldSize toNewSize:self.calculatedSize];
+  [self didRelayoutFromOldSize:CGSizeZero toNewSize:self.calculatedSize];
 }
 
 - (void)transitionLayoutAnimated:(BOOL)animated
@@ -167,6 +164,7 @@
   if (_interactionDelegate != nil) {
     ASPerformBlockOnMainThread(^{
       BOOL sizeChanged = !CGSizeEqualToSize(oldSize, newSize);
+      sizeChanged = YES;
       [_interactionDelegate nodeDidRelayout:self sizeChanged:sizeChanged];
     });
   }

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -1209,6 +1209,11 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   }
 }
 
+- (void)nodeDidRelayout:(ASCellNode *)node
+{
+  [self nodeDidRelayout:node sizeChanged:YES];
+}
+
 - (void)nodeDidRelayout:(ASCellNode *)node sizeChanged:(BOOL)sizeChanged
 {
   ASDisplayNodeAssertMainThread();

--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -647,6 +647,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)setNeedsLayout;
 
+
+- (void)layoutIfNeeded;
+
 @property (nonatomic, strong, nullable) id contents;                           // default=nil
 @property (nonatomic, assign)           BOOL clipsToBounds;                    // default==NO
 @property (nonatomic, getter=isOpaque)  BOOL opaque;                           // default==YES

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -674,7 +674,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   // Check if a new layout need's to be calculated or the pending layout can be used
   ASLayout *previousLayout = _calculatedLayout;
   ASLayout *newLayout = nil;
-  if (![self _isLayoutDirty:_pendingLayout] && CGSizeEqualToSize(self.threadSafeBounds.size, _pendingLayout.size)) {
+  if ([self _isLayoutDirty:_pendingLayout] == NO && CGSizeEqualToSize(self.threadSafeBounds.size, _pendingLayout.size)) {
     newLayout = _pendingLayout;
   } else {
     newLayout = [self measureWithSizeRange:constrainedSize];

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -449,11 +449,6 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   return !(_hierarchyState & ASHierarchyStateRasterized);
 }
 
-- (BOOL)__shouldSize
-{
-  return YES;
-}
-
 - (UIView *)_viewToLoad
 {
   UIView *view;
@@ -646,18 +641,39 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   return [self measureWithSizeRange:ASSizeRangeMake(CGSizeZero, constrainedSize)].size;
 }
 
+/// Calculates and creates a pending layout based on the given constrained size
 - (ASLayout *)measureWithSizeRange:(ASSizeRange)constrainedSize
 {
   ASDN::MutexLocker l(__instanceLock__);
-  if (! [self shouldMeasureWithSizeRange:constrainedSize]) {
-    ASDisplayNodeAssertNotNil(_calculatedLayout, @"-[ASDisplayNode measureWithSizeRange:] _layout should not be nil! %@", self);
-    return _calculatedLayout ? : [ASLayout layoutWithLayoutableObject:self constrainedSizeRange:constrainedSize size:CGSizeZero];
+  // TODO: Can we check if we can reuse the pending layout and don't need to calculate the layout again?
+  if ([self shouldMeasureLayout:_pendingLayout sizeRange:constrainedSize]) {
+    _pendingLayout = [self calculateLayoutThatFits:constrainedSize];
   }
   
+  return _pendingLayout;
+}
+
+/// Calculates and creates a layout and set it as the calculated layout with the given constrained size
+- (ASLayout *)measureAndCacheLayoutWithSizeRange:(ASSizeRange)constrainedSize
+{
+  ASDN::MutexLocker l(__instanceLock__);
+    
+  // Check if _calculatedLayout can be reused
+  if ([self shouldMeasureLayout:_calculatedLayout sizeRange:constrainedSize] == NO) {
+     ASDisplayNodeAssertNotNil(_calculatedLayout, @"-[ASDisplayNode measureWithSizeRange:] _layout should not be nil! %@", self);
+     return _calculatedLayout ? : [ASLayout layoutWithLayoutableObject:self constrainedSizeRange:constrainedSize size:CGSizeZero];
+  }
+
   [self cancelLayoutTransition];
 
+  // Check if a new layout need's to be calculated or the pending layout can be used
   ASLayout *previousLayout = _calculatedLayout;
-  ASLayout *newLayout = [self calculateLayoutThatFits:constrainedSize];
+  ASLayout *newLayout = nil;
+  if (![self _isLayoutDirty:_pendingLayout] && CGSizeEqualToSize(self.bounds.size, _pendingLayout.size)) {
+    newLayout = _pendingLayout;
+  } else {
+    newLayout = [self measureWithSizeRange:constrainedSize];
+  }
   
   _pendingLayoutTransition = [[ASLayoutTransition alloc] initWithNode:self
                                                         pendingLayout:newLayout
@@ -672,29 +688,19 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   return newLayout;
 }
 
-- (BOOL)shouldMeasureWithSizeRange:(ASSizeRange)constrainedSize
+- (BOOL)shouldMeasureLayout:(ASLayout *)layout sizeRange:(ASSizeRange)constrainedSize
 {
   ASDN::MutexLocker l(__instanceLock__);
-  if (![self __shouldSize]) {
-    return NO;
-  }
-  
-  if (ASHierarchyStateIncludesLayoutPending(_hierarchyState)) {
-    ASLayoutableContext context =  ASLayoutableGetCurrentContext();
-    if (ASLayoutableContextIsNull(context) || _pendingTransitionID != context.transitionID) {
-      return NO;
-    }
-  }
   
   // Only generate a new layout if:
   // - The current layout is dirty
   // - The passed constrained size is different than the layout's constrained size
-  return ([self _hasDirtyLayout] || !ASSizeRangeEqualToSizeRange(constrainedSize, _calculatedLayout.constrainedSizeRange));
+  return (layout == nil || layout.isDirty || !ASSizeRangeEqualToSizeRange(constrainedSize, layout.constrainedSizeRange));
 }
 
-- (BOOL)_hasDirtyLayout
+- (BOOL)_isLayoutDirty:(ASLayout *)layout
 {
-  return _calculatedLayout == nil || _calculatedLayout.isDirty;
+  return layout == nil || layout.isDirty;
 }
 
 - (ASLayoutableType)layoutableType
@@ -742,7 +748,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
                 measurementCompletion:(void (^)())completion
 {
   ASDisplayNodeAssertMainThread();
-  if (! [self shouldMeasureWithSizeRange:constrainedSize]) {
+  if ([self shouldMeasureLayout:_calculatedLayout sizeRange:constrainedSize] == NO) {
     return;
   }
   
@@ -1235,52 +1241,6 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   [self displayImmediately];
 }
 
-//Calling this with the lock held can lead to deadlocks. Always call *unlocked*
-- (void)__setNeedsLayout
-{
-  ASDisplayNodeAssertThreadAffinity(self);
-  
-  __instanceLock__.lock();
-  
-  if (_calculatedLayout == nil) {
-    // Can't proceed without a layout as no constrained size would be available
-    __instanceLock__.unlock();
-    return;
-  }
-    
-  [self invalidateCalculatedLayout];
-  
-  if (_supernode) {
-    ASDisplayNode *supernode = _supernode;
-    __instanceLock__.unlock();
-    // Cause supernode's layout to be invalidated
-    // We need to release the lock to prevent a deadlock
-    [supernode setNeedsLayout];
-    return;
-  }
-  
-  // This is the root node. Trigger a full measurement pass on *current* thread. Old constrained size is re-used.
-  [self measureWithSizeRange:_calculatedLayout.constrainedSizeRange];
-
-  CGRect oldBounds = self.bounds;
-  CGSize oldSize = oldBounds.size;
-  CGSize newSize = _calculatedLayout.size;
-  
-  if (! CGSizeEqualToSize(oldSize, newSize)) {
-    self.bounds = (CGRect){ oldBounds.origin, newSize };
-    
-    // Frame's origin must be preserved. Since it is computed from bounds size, anchorPoint
-    // and position (see frame setter in ASDisplayNode+UIViewBridge), position needs to be adjusted.
-    CGPoint anchorPoint = self.anchorPoint;
-    CGPoint oldPosition = self.position;
-    CGFloat xDelta = (newSize.width - oldSize.width) * anchorPoint.x;
-    CGFloat yDelta = (newSize.height - oldSize.height) * anchorPoint.y;
-    self.position = CGPointMake(oldPosition.x + xDelta, oldPosition.y + yDelta);
-  }
-  
-  __instanceLock__.unlock();
-}
-
 - (void)__setNeedsDisplay
 {
   BOOL nowDisplay = ASInterfaceStateIncludesDisplay(_interfaceState);
@@ -1291,22 +1251,52 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   }
 }
 
+//Calling this with the lock held can lead to deadlocks. Always call *unlocked*
+- (void)__setNeedsLayout
+{
+  ASDisplayNodeAssertThreadAffinity(self);
+  
+  __instanceLock__.lock();
+  
+  // Invalidate the current calculated layout so in the next layout pass it get's recalculated
+  [self invalidateCalculatedLayout];
+    
+  // TODO: Do we need that?
+  // Go down the subnodes and invalidate all calculated layouts so the next measure pass will not reuse any
+  // calculated layout
+  ASDisplayNodePerformBlockOnEveryNode(nil, self, ^(ASDisplayNode * _Nonnull node) {
+    [node invalidateCalculatedLayout];
+  });
+  
+  __instanceLock__.unlock();
+}
+
+- (void)__layoutIfNeeded
+{
+  ASDisplayNodeAssertThreadAffinity(self);
+  
+  // Prepare for immediate layout
+}
+
 // These private methods ensure that subclasses are not required to call super in order for _renderingSubnodes to be properly managed.
 
+// Called from [CALayer layoutSublayers:]: All layout related code should happen in there
 - (void)__layout
 {
   ASDisplayNodeAssertMainThread();
   ASDN::MutexLocker l(__instanceLock__);
   CGRect bounds = self.bounds;
 
-  [self measureNodeWithBoundsIfNecessary:bounds];
-
+  // Don't do anything if the bounds is zero
   if (CGRectEqualToRect(bounds, CGRectZero)) {
     // Performing layout on a zero-bounds view often results in frame calculations
     // with negative sizes after applying margins, which will cause
     // measureWithSizeRange: on subnodes to assert.
     return;
   }
+  
+  // Execute a measure pass if necessary with the current bounds size
+  [self measureAndCacheLayoutWithSizeRange:ASSizeRangeMake(bounds.size, bounds.size)];
   
   // Handle placeholder layer creation in case the size of the node changed after the initial placeholder layer
   // was created
@@ -1315,30 +1305,28 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   }
   _placeholderLayer.frame = bounds;
   
+  // Call the subclass hooks
   [self layout];
   [self layoutDidFinish];
 }
 
-- (void)measureNodeWithBoundsIfNecessary:(CGRect)bounds
+/// Default implementation of layout subclass hook uses the current calculated layout and applies the frame to all subnodes
+- (void)layout
 {
-  BOOL supportsRangedManagedInterfaceState = NO;
-  BOOL hasDirtyLayout = NO;
-  BOOL hasSupernode = NO;
-  {
-    ASDN::MutexLocker l(__instanceLock__);
-    supportsRangedManagedInterfaceState = [self supportsRangeManagedInterfaceState];
-    hasDirtyLayout = [self _hasDirtyLayout];
-    hasSupernode = (self.supernode != nil);
+  ASDisplayNodeAssertMainThread();
+
+  // If the layout is dirty we don't need to do a layout pass as it was invalided before
+  if ([self _isLayoutDirty:_calculatedLayout]) {
+    return;
   }
-  
-  // Normally measure will be called before layout occurs. If this doesn't happen, nothing is going to call it at all.
-  // We simply call measureWithSizeRange: using a size range equal to whatever bounds were provided to that element
-  if (!hasSupernode && !supportsRangedManagedInterfaceState && hasDirtyLayout) {
-    if (CGRectEqualToRect(bounds, CGRectZero)) {
-      LOG(@"Warning: No size given for node before node was trying to layout itself: %@. Please provide a frame for the node.", self);
-    } else {
-      [self measureWithSizeRange:ASSizeRangeMake(bounds.size, bounds.size)];
-    }
+
+  [self __layoutSublayouts];
+}
+
+- (void)__layoutSublayouts
+{
+  for (ASLayout *subnodeLayout in _calculatedLayout.sublayouts) {
+    ((ASDisplayNode *)subnodeLayout.layoutableObject).frame = [subnodeLayout frame];
   }
 }
 
@@ -2346,6 +2334,7 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
   // This will cause the next call to -measureWithSizeRange: to actually compute a new layout
   // instead of returning the current layout
   _calculatedLayout.dirty = YES;
+  _pendingLayout.dirty = YES;
 }
 
 - (void)__didLoad
@@ -2752,24 +2741,6 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
   }
   
   [layoutTransition commitTransition];
-}
-
-- (void)layout
-{
-  ASDisplayNodeAssertMainThread();
-
-  if ([self _hasDirtyLayout]) {
-    return;
-  }
-  
-  [self __layoutSublayouts];
-}
-
-- (void)__layoutSublayouts
-{
-  for (ASLayout *subnodeLayout in _calculatedLayout.sublayouts) {
-    ((ASDisplayNode *)subnodeLayout.layoutableObject).frame = [subnodeLayout frame];
-  }
 }
 
 #pragma mark - Display

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -669,7 +669,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   // Check if a new layout need's to be calculated or the pending layout can be used
   ASLayout *previousLayout = _calculatedLayout;
   ASLayout *newLayout = nil;
-  if (![self _isLayoutDirty:_pendingLayout] && CGSizeEqualToSize(self.bounds.size, _pendingLayout.size)) {
+  if (![self _isLayoutDirty:_pendingLayout] && CGSizeEqualToSize(self.threadSafeBounds.size, _pendingLayout.size)) {
     newLayout = _pendingLayout;
   } else {
     newLayout = [self measureWithSizeRange:constrainedSize];
@@ -1285,7 +1285,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
 {
   ASDisplayNodeAssertMainThread();
   ASDN::MutexLocker l(__instanceLock__);
-  CGRect bounds = self.bounds;
+  CGRect bounds = self.threadSafeBounds;
 
   // Don't do anything if the bounds is zero
   if (CGRectEqualToRect(bounds, CGRectZero)) {

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -1218,17 +1218,25 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
   }
 }
 
+- (void)nodeDidRelayout:(ASCellNode *)node
+{
+  [self nodeDidRelayout:node sizeChanged:YES];
+}
+
 - (void)nodeDidRelayout:(ASCellNode *)node sizeChanged:(BOOL)sizeChanged
 {
   ASDisplayNodeAssertMainThread();
-
-  // Mark the node as dirty
-  [_dirtyNodes addObject:node];
   
-  if (!sizeChanged || _queuedNodeHeightUpdate) {
+  if (!sizeChanged) {
     return;
   }
-
+  
+  [_dirtyNodes addObject:node];
+  
+  if (_queuedNodeHeightUpdate) {
+    return;
+  }
+  
   _queuedNodeHeightUpdate = YES;
   [self performSelector:@selector(requeryNodeHeights)
              withObject:nil
@@ -1236,7 +1244,7 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
                 inModes:@[ NSRunLoopCommonModes ]];
 }
 
-// Cause UITableView to requery for the new height of this node
+// Cause UITableView to requery for the new height of all _dirtyNodes
 - (void)requeryNodeHeights
 {
   _queuedNodeHeightUpdate = NO;

--- a/AsyncDisplayKit/Details/ASDataController.mm
+++ b/AsyncDisplayKit/Details/ASDataController.mm
@@ -157,6 +157,7 @@ NSString * const ASDataControllerRowNodeKind = @"_ASDataControllerRowNodeKind";
   CGRect frame = CGRectZero;
   frame.size = [node measureWithSizeRange:constrainedSize].size;
   node.frame = frame;
+  //[node setNeedsLayout];
 }
 
 /**

--- a/AsyncDisplayKit/Details/ASDataController.mm
+++ b/AsyncDisplayKit/Details/ASDataController.mm
@@ -157,7 +157,6 @@ NSString * const ASDataControllerRowNodeKind = @"_ASDataControllerRowNodeKind";
   CGRect frame = CGRectZero;
   frame.size = [node measureWithSizeRange:constrainedSize].size;
   node.frame = frame;
-  //[node setNeedsLayout];
 }
 
 /**

--- a/AsyncDisplayKit/Details/UIView+ASConvenience.h
+++ b/AsyncDisplayKit/Details/UIView+ASConvenience.h
@@ -41,6 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)setNeedsDisplay;
 - (void)setNeedsLayout;
+- (void)layoutIfNeeded;
 
 @end
 

--- a/AsyncDisplayKit/Details/_ASDisplayLayer.mm
+++ b/AsyncDisplayKit/Details/_ASDisplayLayer.mm
@@ -122,6 +122,12 @@
   ASDisplayNodeAssertMainThread();
   [super setNeedsLayout];
 }
+
+- (void)layoutIfNeeded
+{
+  ASDisplayNodeAssertMainThread();
+  [super layoutIfNeeded];
+}
 #endif
 
 - (void)layoutSublayers

--- a/AsyncDisplayKit/Details/_ASDisplayView.mm
+++ b/AsyncDisplayKit/Details/_ASDisplayView.mm
@@ -185,6 +185,17 @@
   [self.layer setNeedsDisplay];
 }
 
+- (void)layoutIfNeeded
+{
+  if (ASDisplayNodeThreadIsMain()) {
+    [super layoutIfNeeded];
+  } else {
+    dispatch_async(dispatch_get_main_queue(), ^ {
+      [super layoutIfNeeded];
+    });
+  }
+}
+
 - (UIViewContentMode)contentMode
 {
   return ASDisplayNodeUIContentModeFromCAContentsGravity(self.layer.contentsGravity);

--- a/AsyncDisplayKit/Private/ASDisplayNode+UIViewBridge.mm
+++ b/AsyncDisplayKit/Private/ASDisplayNode+UIViewBridge.mm
@@ -354,6 +354,34 @@ if (shouldApply) { _layer.layerProperty = (layerValueExpr); } else { ASDisplayNo
   }
 }
 
+- (void)layoutIfNeeded
+{
+  _bridge_prologue_write;
+  BOOL shouldApply = ASDisplayNodeShouldApplyBridgedWriteToView(self);
+  if (shouldApply) {
+    // The node is loaded and we're on main.
+    // Quite the opposite of setNeedsDisplay, we must call __setNeedsLayout before messaging
+    // the view or layer to ensure that measurement and implicitly added subnodes have been handled.
+    
+    // Calling __setNeedsLayout while holding the property lock can cause deadlocks
+    _bridge_prologue_write_unlock;
+    [self __layoutIfNeeded];
+    _bridge_prologue_write;
+    _messageToViewOrLayer(layoutIfNeeded);
+  } else if (__loaded(self)) {
+    // The node is loaded but we're not on main.
+    // We will call [self __setNeedsLayout] when we apply
+    // the pending state. We need to call it on main if the node is loaded
+    // to support implicit hierarchy management.
+    [ASDisplayNodeGetPendingState(self) layoutIfNeeded];
+  } else {
+    // The node is not loaded and we're not on main.
+    _bridge_prologue_write_unlock;
+    [self __layoutIfNeeded];
+    _bridge_prologue_write;
+  }
+}
+
 - (BOOL)isOpaque
 {
   _bridge_prologue_read;

--- a/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
+++ b/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
@@ -115,6 +115,7 @@ FOUNDATION_EXPORT NSString * const ASRenderingEngineDidDisplayNodesScheduledBefo
 
   ASEnvironmentState _environmentState;
   ASLayout *_calculatedLayout;
+  ASLayout *_pendingLayout;
 
 
   UIEdgeInsets _hitTestSlop;
@@ -184,12 +185,14 @@ FOUNDATION_EXPORT NSString * const ASRenderingEngineDidDisplayNodesScheduledBefo
 
 // Swizzle to extend the builtin functionality with custom logic
 - (BOOL)__shouldLoadViewOrLayer;
-- (BOOL)__shouldSize;
+//- (BOOL)__shouldSize;
 
 /**
  Invoked before a call to setNeedsLayout to the underlying view
  */
 - (void)__setNeedsLayout;
+
+- (void)__layoutIfNeeded;
 
 /**
  Invoked after a call to setNeedsDisplay to the underlying view

--- a/AsyncDisplayKit/Private/_ASPendingState.mm
+++ b/AsyncDisplayKit/Private/_ASPendingState.mm
@@ -24,6 +24,7 @@ typedef struct {
   // Properties
   int needsDisplay:1;
   int needsLayout:1;
+  int layoutIfNeeded:1;
 
   // Flags indicating that a given property should be applied to the view at creation
   int setClipsToBounds:1;
@@ -253,6 +254,11 @@ static UIColor *defaultTintColor = nil;
 - (void)setNeedsLayout
 {
   _flags.needsLayout = YES;
+}
+
+- (void)layoutIfNeeded
+{
+  _flags.layoutIfNeeded = YES;
 }
 
 - (void)setClipsToBounds:(BOOL)flag
@@ -737,6 +743,9 @@ static UIColor *defaultTintColor = nil;
 
   if (flags.needsLayout)
     [layer setNeedsLayout];
+    
+  if (flags.layoutIfNeeded)
+    [layer layoutIfNeeded];
 
   if (flags.setAsyncTransactionContainer)
     layer.asyncdisplaykit_asyncTransactionContainer = asyncTransactionContainer;
@@ -862,6 +871,9 @@ static UIColor *defaultTintColor = nil;
 
   if (flags.needsLayout)
     [view setNeedsLayout];
+
+  if (flags.layoutIfNeeded)
+    [view layoutIfNeeded];
 
   if (flags.setAsyncTransactionContainer)
     view.asyncdisplaykit_asyncTransactionContainer = asyncTransactionContainer;
@@ -1073,6 +1085,7 @@ static UIColor *defaultTintColor = nil;
   || flags.setEdgeAntialiasingMask
   || flags.needsDisplay
   || flags.needsLayout
+  || flags.layoutIfNeeded
   || flags.setAsyncTransactionContainer
   || flags.setOpaque
   || flags.setIsAccessibilityElement

--- a/examples/ASDKgram/Sample/PhotoCellNode.m
+++ b/examples/ASDKgram/Sample/PhotoCellNode.m
@@ -190,7 +190,6 @@
 {
   if (photo.commentFeed.numberOfItemsInFeed > 0) {
     [_photoCommentsView updateWithCommentFeedModel:photo.commentFeed];
-    
     [self setNeedsLayout];
   }
 }

--- a/examples/ASDKgram/Sample/PhotoFeedNodeController.m
+++ b/examples/ASDKgram/Sample/PhotoFeedNodeController.m
@@ -51,7 +51,6 @@
     
     _tableNode.dataSource = self;
     _tableNode.delegate = self;
-    
   }
   
   return self;
@@ -100,7 +99,7 @@
     // immediately start second larger fetch
     [self loadPageWithContext:nil];
     
-  } numResultsToReturn:4];
+  } numResultsToReturn:1];
 }
 
 - (void)loadPageWithContext:(ASBatchContext *)context
@@ -180,9 +179,17 @@
 
 #pragma mark - ASTableDelegate methods
 
+/*- (BOOL)shouldBatchFetchForTableView:(ASTableView *)tableView
+{
+  return NO;
+}*/
+
 // Receive a message that the tableView is near the end of its data set and more data should be fetched if necessary.
 - (void)tableView:(ASTableView *)tableView willBeginBatchFetchWithContext:(ASBatchContext *)context
 {
+  //[context completeBatchFetching:YES];
+  //return;
+  
   [context beginBatchFetching];
   [self loadPageWithContext:context];
 }

--- a/examples/ASDKgram/Sample/PhotoFeedNodeController.m
+++ b/examples/ASDKgram/Sample/PhotoFeedNodeController.m
@@ -94,12 +94,12 @@
     [_activityIndicatorView stopAnimating];
     
     [self insertNewRowsInTableView:newPhotos];
-//    [self requestCommentsForPhotos:newPhotos];
+    //[self requestCommentsForPhotos:newPhotos];
     
     // immediately start second larger fetch
     [self loadPageWithContext:nil];
     
-  } numResultsToReturn:1];
+  } numResultsToReturn:4];
 }
 
 - (void)loadPageWithContext:(ASBatchContext *)context
@@ -187,9 +187,6 @@
 // Receive a message that the tableView is near the end of its data set and more data should be fetched if necessary.
 - (void)tableView:(ASTableView *)tableView willBeginBatchFetchWithContext:(ASBatchContext *)context
 {
-  //[context completeBatchFetching:YES];
-  //return;
-  
   [context beginBatchFetching];
   [self loadPageWithContext:context];
 }

--- a/examples/CustomCollectionView/Sample/ImageCellNode.m
+++ b/examples/CustomCollectionView/Sample/ImageCellNode.m
@@ -36,7 +36,6 @@
 
 - (CGSize)calculateSizeThatFits:(CGSize)constrainedSize
 {
-  [_imageNode measure:constrainedSize];
   return constrainedSize;
 }
 
@@ -44,7 +43,7 @@
 {
   [super layout];
   
-  _imageNode.frame = CGRectMake(0, 0, _imageNode.calculatedSize.width, _imageNode.calculatedSize.height);
+  _imageNode.frame = CGRectMake(0, 0, self.bounds.size.width, self.bounds.size.height);
 }
 
 @end


### PR DESCRIPTION
### Description:
Currently there are two problems with ASDK's layout process:
* It’s a must to call `measureWithSizeRange:` that triggers the creation of an ASLayout. If this method will never be called on a node no measure and layout pass will happen and it will appear as it it is blank
* Calling `setNeedsLayout` triggers a measurement and layout pass *synchronously* the following way:
    1. Walks up the whole tree and invalidate all layouts until it hits the root node
    2. Starting from the root node it starts measuring the nodes based on the constrained size AND applies the layout immediately for all nodes
    3. It changes the size of itself based on the calculated layout instead of just layout of subviews!

The behavior of Nodes described above is hugely confusing for developers that are used to use UIKit and e.g. setting a frame will trigger a layout.

The behavior I think we should like to have is the based on the following two passes:

1. **Measurement pass**:
    - Will measure (calling `measure:` or `measureWithSizeRange:`)  the node based on a given constrained size.
    - It will has the side effect to create an internal (pending) `ASLayout`.
    - The measurement pass needs to be thread safe as it should be able to measure from a background thread.
2. **Layout pass**:
    - A measurement pass (calling `measure:` or `measureWithSizeRange:`) should just create the internal cached `ASLayout` and return the size for the given size range. There should no layout happen especially, not setting the bounds for the root container
    - `-setNeedsLayout:` only invalidates the layout for the node and all subnodes and call's through to the backing `UIView` / `CALayer` method to let UIKit / CA. Eventually a `-layoutSubview` / `-layoutSublayer` call will happen
    - Bounds changes or if `-layoutSubview` / `-layoutSublayer` is called from the backing `UIView` / `CALayer` we should either apply the pending / cached layout or do a measurement pass before if the size of the pending layout is not equal to the nodes bounds as it changed in the meantime and do a layout (set all frames for subnodes) afterwards

We have to be careful with this PR though as this will change the behavior in terms of layout nodes.

### TODOS:
- [x] Automatic cell sizing in ASTableView
- [ ] Automatic cell sizing in ASCollectionView
- [ ] Add / Adjust unit tests
- [ ] Change sample apps

<br>
***This PR is one of the initiatives to make the Layout API more clear. Every feedback is more than welcome!***