### PR TITLE
[ASStackLayoutable] Set .flexShrink to YES by default

### DIFF
--- a/AsyncDisplayKit/Details/ASEnvironment.h
+++ b/AsyncDisplayKit/Details/ASEnvironment.h
@@ -39,7 +39,7 @@ typedef struct ASEnvironmentLayoutOptionsState {
   CGFloat spacingBefore;// = 0;
   CGFloat spacingAfter;// = 0;
   BOOL flexGrow;// = NO;
-  BOOL flexShrink;// = NO;
+  BOOL flexShrink;// = NO; Default value is YES if created via ASEnvironmentLayoutOptionsStateMakeDefault
   ASRelativeDimension flexBasis;// = ASRelativeDimensionUnconstrained;
   ASStackLayoutAlignSelf alignSelf;// = ASStackLayoutAlignSelfAuto;
   CGFloat ascender;// = 0;
@@ -50,6 +50,7 @@ typedef struct ASEnvironmentLayoutOptionsState {
   
   struct ASEnvironmentStateExtensions _extensions;
 } ASEnvironmentLayoutOptionsState;
+/// Should be used to create an ASEnvironmentLayoutOptionsState
 extern ASEnvironmentLayoutOptionsState ASEnvironmentLayoutOptionsStateMakeDefault();
 
 

--- a/AsyncDisplayKit/Details/ASEnvironment.mm
+++ b/AsyncDisplayKit/Details/ASEnvironment.mm
@@ -15,6 +15,7 @@ ASEnvironmentLayoutOptionsState ASEnvironmentLayoutOptionsStateMakeDefault()
 {
   return (ASEnvironmentLayoutOptionsState) {
     // Default values can be defined in here
+    .flexShrink = YES
   };
 }
 

--- a/AsyncDisplayKit/Private/ASEnvironmentInternal.mm
+++ b/AsyncDisplayKit/Private/ASEnvironmentInternal.mm
@@ -127,7 +127,7 @@ ASEnvironmentState ASEnvironmentMergeObjectAndState(ASEnvironmentState environme
   if (propagation == ASEnvironmentStatePropagation::UP) {
 
    // Object is the parent and the state is the state of the child
-    const ASEnvironmentLayoutOptionsState defaultState = ASEnvironmentDefaultLayoutOptionsState;
+    const ASEnvironmentLayoutOptionsState defaultState = ASEnvironmentLayoutOptionsStateMakeDefault();
     ASEnvironmentLayoutOptionsState parentLayoutOptionsState = environmentState.layoutOptionsState;
     
     // For every field check if the parent value is equal to the default and if so propegate up the value of the passed

--- a/AsyncDisplayKitTests/ASStackLayoutSpecSnapshotTests.mm
+++ b/AsyncDisplayKitTests/ASStackLayoutSpecSnapshotTests.mm
@@ -43,6 +43,19 @@ static NSArray *defaultSubnodesWithSameSize(CGSize subnodeSize, BOOL flex)
   return subnodes;
 }
 
+- (void)testDefaultStackLayoutableFlexProperties
+{
+  ASDisplayNode *displayNode = [[ASDisplayNode alloc] init];
+  
+  XCTAssertEqual(displayNode.flexShrink, YES);
+  XCTAssertEqual(displayNode.flexGrow, NO);
+  
+  const ASRelativeDimension unconstrainedDimension = ASRelativeDimensionUnconstrained;
+  const ASRelativeDimension flexBasis = displayNode.flexBasis;
+  XCTAssertEqual(flexBasis.type, unconstrainedDimension.type);
+  XCTAssertEqual(flexBasis.value, unconstrainedDimension.value);
+}
+
 - (void)testStackLayoutSpecWithJustify:(ASStackLayoutJustifyContent)justify
                                   flex:(BOOL)flex
                              sizeRange:(ASSizeRange)sizeRange


### PR DESCRIPTION
To align with the CSS flex-shrink spec, let's set the default value of flexShrink to YES: http://www.w3.org/TR/css-flexbox-1/#propdef-flex-shrink

In PR #851 we would only set it for `ASTextNode`, but I would recommend we will set it for all `ASStackLayoutable` to `YES` by default.

CC @appleguy @nguyenhuy @Adlai-Holler @rcancro Thoughts?
<br>
***This PR is one of the initiatives to make the Layout API more clear. Every feedback is more than welcome!***