### PR TITLE
Fix wrong annotation which is causing a warning at compile time

### DIFF
--- a/AsyncDisplayKit/ASViewController.h
+++ b/AsyncDisplayKit/ASViewController.h
@@ -78,7 +78,7 @@ typedef ASTraitCollection * _Nonnull (^ASDisplayTraitsForTraitWindowSizeBlock)(C
 
 - (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil AS_UNAVAILABLE("ASViewController requires using -initWithNode:");
 
-- (instancetype)initWithCoder:(NSCoder *)aDecoder AS_UNAVAILABLE("ASViewController requires using -initWithNode:");
+- (nullable instancetype)initWithCoder:(NSCoder *)aDecoder AS_UNAVAILABLE("ASViewController requires using -initWithNode:");
 
 @end
 


### PR DESCRIPTION
This wrong annotation was introduced by me in #2035, `- initWithCoder:` which is a failable initialiser needs a return type marked as `nullable`.