### PR TITLE
[ASPagerNode] Fix methods from ASCollectionDelegate are not passed through to pager delegate

### DIFF
--- a/AsyncDisplayKit/ASPagerNode.m
+++ b/AsyncDisplayKit/ASPagerNode.m
@@ -63,7 +63,8 @@
   [super didLoad];
   
   ASCollectionView *cv = self.view;
-  cv.asyncDelegate = self;
+  cv.asyncDataSource = _proxyDataSource ?: self;
+  cv.asyncDelegate = _proxyDelegate ?: self;
 #if TARGET_OS_IOS
   cv.pagingEnabled = YES;
   cv.scrollsToTop = NO;

--- a/AsyncDisplayKit/Details/ASDelegateProxy.m
+++ b/AsyncDisplayKit/Details/ASDelegateProxy.m
@@ -91,8 +91,7 @@
           selector == @selector(collectionView:nodeForItemAtIndexPath:) ||
           selector == @selector(collectionView:nodeBlockForItemAtIndexPath:) ||
           selector == @selector(collectionView:numberOfItemsInSection:) ||
-          selector == @selector(collectionView:constrainedSizeForNodeAtIndexPath:) ||
-          selector == @selector(scrollViewWillEndDragging:withVelocity:targetContentOffset:)
+          selector == @selector(collectionView:constrainedSizeForNodeAtIndexPath:)
           );
 }
 


### PR DESCRIPTION
This is a fix for a regression caused by #2065.