### PR TITLE
[ASDisplayNode] Don't use the default layout transition animation of no animation is wanted

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -893,8 +893,14 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
  */
 - (void)animateLayoutTransition:(id<ASContextTransitioning>)context
 {
+  if ([context isAnimated] == NO) {
+    [self __layoutSublayouts];
+    [context completeTransition:YES];
+    return;
+  }
+ 
   ASDisplayNode *node = self;
-
+  
   NSAssert(node.isNodeLoaded == YES, @"Invalid node state");
   NSAssert([context isAnimated] == YES, @"Can't animate a non-animatable context");
   


### PR DESCRIPTION
This fixes a regression (found in Pinterest) with #2052.