### PR TITLE
[_ASDisplayViewAccessiblity] Fix accessibility in scroll views

### DIFF
--- a/AsyncDisplayKit/Details/_ASDisplayViewAccessiblity.mm
+++ b/AsyncDisplayKit/Details/_ASDisplayViewAccessiblity.mm
@@ -86,10 +86,6 @@ static void CollectUIAccessibilityElementsForNode(ASDisplayNode *node, ASDisplay
     // we have to create a UIAccessibilityElement as no view for this node exists
     if (currentNode != containerNode && currentNode.isAccessibilityElement) {
       UIAccessibilityElement *accessibilityElement = [ASAccessibilityElement accessibilityElementWithContainer:container node:currentNode containerNode:containerNode];
-      // As the node hierarchy is flattened it's necessary to convert the frame for each subnode in the tree to the
-      // coordinate system of the supernode
-      CGRect frame = [containerNode convertRect:currentNode.bounds fromNode:currentNode];
-      accessibilityElement.accessibilityFrame = UIAccessibilityConvertFrameToScreenCoordinates(frame, container);
       [elements addObject:accessibilityElement];
     }
   });
@@ -115,9 +111,6 @@ static void CollectAccessibilityElementsForView(_ASDisplayView *view, NSMutableA
       if (subnode.isLayerBacked) {
         // No view for layer backed nodes exist. It's necessary to create a UIAccessibilityElement that represents this node
         UIAccessibilityElement *accessiblityElement = [ASAccessibilityElement accessibilityElementWithContainer:view node:subnode containerNode:node];
-        
-        CGRect frame = [node convertRect:subnode.bounds fromNode:subnode];
-        [accessiblityElement setAccessibilityFrame:UIAccessibilityConvertFrameToScreenCoordinates(frame, view)];
         [elements addObject:accessiblityElement];
       } else {
         // Accessiblity element is not layer backed just add the view as accessibility element


### PR DESCRIPTION
There are two changes here:

1. Because we can't reliably update the screen positions of accessibility elements
contained within a scroll view, we need to calculate them on demand, so we override
the accessibilityFrame method to do that.

2. Throwing away our calculated accessibility elements on frame change seemed to
cause the accessibility system to be confused.

Combining these two fixes together results in success, yay!