### PR TITLE
I didn't really understand NSProxy

### DIFF
--- a/AsyncDisplayKit/Details/ASWeakProxy.h
+++ b/AsyncDisplayKit/Details/ASWeakProxy.h
@@ -12,7 +12,7 @@
 
 #import <Foundation/Foundation.h>
 
-@interface ASWeakProxy : NSObject
+@interface ASWeakProxy : NSProxy
 
 @property (nonatomic, weak, readonly) id target;
 

--- a/AsyncDisplayKit/Details/ASWeakProxy.m
+++ b/AsyncDisplayKit/Details/ASWeakProxy.m
@@ -49,7 +49,7 @@
 
 - (void)forwardInvocation:(NSInvocation *)invocation
 {
-  // If we are down here this means _interceptor and _target where nil. Just don't do anything to prevent a crash
+  // If we are down here this means _target where nil. Just don't do anything to prevent a crash
 }
 
 @end

--- a/AsyncDisplayKit/Details/ASWeakProxy.m
+++ b/AsyncDisplayKit/Details/ASWeakProxy.m
@@ -16,7 +16,7 @@
 
 - (instancetype)initWithTarget:(id)target
 {
-  if (self = [super init]) {
+  if (self) {
     _target = target;
   }
   return self;
@@ -30,6 +30,26 @@
 - (id)forwardingTargetForSelector:(SEL)aSelector
 {
   return _target;
+}
+
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector
+{
+  // Check for a compiled definition for the selector
+  NSMethodSignature *methodSignature = [[_target class] instanceMethodSignatureForSelector:aSelector];
+  
+  // Unfortunately, in order to get this object to work properly, the use of a method which creates an NSMethodSignature
+  // from a C string. -methodSignatureForSelector is called when a compiled definition for the selector cannot be found.
+  // This is the place where we have to create our own dud NSMethodSignature. This is necessary because if this method
+  // returns nil, a selector not found exception is raised. The string argument to -signatureWithObjCTypes: outlines
+  // the return type and arguments to the message. To return a dud NSMethodSignature, pretty much any signature will
+  // suffice. Since the -forwardInvocation call will do nothing if the delegate does not respond to the selector,
+  // the dud NSMethodSignature simply gets us around the exception.
+  return methodSignature ?: [NSMethodSignature signatureWithObjCTypes:"@^v^c"];
+}
+
+- (void)forwardInvocation:(NSInvocation *)invocation
+{
+  // If we are down here this means _interceptor and _target where nil. Just don't do anything to prevent a crash
 }
 
 @end


### PR DESCRIPTION
But I think I do now :)

Previously I inherited from NSObject because I didn't think I needed
anything fancy, but it turns out NSProxy is *less* fancy than NSObject
and allows for overriding more methods. This change is probably purely
academic in that we don't use this class to forward NSObject specific
messages, but I believe this is the 'right thing'.