### PR TITLE
[Layout] Add a size constraint to `ASLayoutable`

### DIFF
--- a/AsyncDisplayKit/ASButtonNode.mm
+++ b/AsyncDisplayKit/ASButtonNode.mm
@@ -491,11 +491,6 @@
     spec = [ASInsetLayoutSpec insetLayoutSpecWithInsets:contentEdgeInsets child:spec];
   }
   
-  if (CGSizeEqualToSize(self.preferredFrameSize, CGSizeZero) == NO) {
-    stack.sizeRange = ASRelativeSizeRangeMakeWithExactCGSize(self.preferredFrameSize);
-    spec = [ASStaticLayoutSpec staticLayoutSpecWithChildren:@[stack]];
-  }
-  
   if (_backgroundImageNode.image) {
     spec = [ASBackgroundLayoutSpec backgroundLayoutSpecWithChild:spec background:_backgroundImageNode];
   }

--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -607,8 +607,10 @@ NS_ASSUME_NONNULL_BEGIN
  * be expensive if result is not cached.
  *
  * @see [ASDisplayNode(Subclassing) calculateLayoutThatFits:]
+ *
+ * @deprecated Deprecated in version 2.0: Use ASCalculateRootLayout or ASCalculateLayout instead
  */
-- (ASLayout *)measureWithSizeRange:(ASSizeRange)constrainedSize; //ASDISPLAYNODE_DEPRECATED;
+- (ASLayout *)measureWithSizeRange:(ASSizeRange)constrainedSize ASDISPLAYNODE_DEPRECATED;
 
 @end
 

--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -939,7 +939,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @deprecated Deprecated in version 2.0: Use size and the helper function ASRelativeSizeRangeMakeWithExactCGSize(preferredFrameSize) if you want to have the same behavior.
  */
-@property (nonatomic, assign, readwrite) CGSize preferredFrameSize;// ASDISPLAYNODE_DEPRECATED;
+@property (nonatomic, assign, readwrite) CGSize preferredFrameSize ASDISPLAYNODE_DEPRECATED;
 
 - (void)reclaimMemory ASDISPLAYNODE_DEPRECATED;
 - (void)recursivelyReclaimMemory ASDISPLAYNODE_DEPRECATED;

--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -233,35 +233,17 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A new size that fits the receiver's subviews.
  *
- * @discussion Though this method does not set the bounds of the view, it does have side effects--caching both the 
+ * @discussion Though this method does not set the bounds of the view, it does have side effects--caching both the
  * constraint and the result.
  *
- * @warning Subclasses must not override this; it calls -measureWithSizeRange: with zero min size. 
- * -measureWithSizeRange: caches results from -calculateLayoutThatFits:.  Calling this method may 
+ * @warning Subclasses must not override this; it calls -measureWithSizeRange: with zero min size.
+ * -measureWithSizeRange: caches results from -calculateLayoutThatFits:.  Calling this method may
  * be expensive if result is not cached.
  *
  * @see measureWithSizeRange:
  * @see [ASDisplayNode(Subclassing) calculateLayoutThatFits:]
  */
-- (CGSize)measure:(CGSize)constrainedSize;
-
-/**
- * @abstract Asks the node to measure a layout based on given size range.
- *
- * @param constrainedSize The minimum and maximum sizes the receiver should fit in.
- *
- * @return An ASLayout instance defining the layout of the receiver (and its children, if the box layout model is used).
- *
- * @discussion Though this method does not set the bounds of the view, it does have side effects--caching both the
- * constraint and the result.
- *
- * @warning Subclasses must not override this; it caches results from -calculateLayoutThatFits:.  Calling this method may
- * be expensive if result is not cached.
- *
- * @see [ASDisplayNode(Subclassing) calculateLayoutThatFits:]
- */
-- (ASLayout *)measureWithSizeRange:(ASSizeRange)constrainedSize;
-
+- (CGSize)sizeThatFits:(CGSize)constrainedSize;
 
 /**
  * @abstract Provides a way to declare a block to provide an ASLayoutSpec without having to subclass ASDisplayNode and
@@ -295,16 +277,6 @@ NS_ASSUME_NONNULL_BEGIN
  * @return The minimum and maximum constrained sizes used by calculateLayoutThatFits:.
  */
 @property (nonatomic, readonly, assign) ASSizeRange constrainedSizeForCalculatedLayout;
-
-/**
- * @abstract Provides a default intrinsic content size for calculateSizeThatFits:. This is useful when laying out
- * a node that either has no intrinsic content size or should be laid out at a different size than its intrinsic content
- * size. For example, this property could be set on an ASImageNode to display at a size different from the underlying
- * image size.
- *
- * @return The preferred frame size of this node
- */
-@property (nonatomic, assign, readwrite) CGSize preferredFrameSize;
 
 /** @name Managing the nodes hierarchy */
 
@@ -599,12 +571,50 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (CGRect)convertRect:(CGRect)rect fromNode:(nullable ASDisplayNode *)node;
 
+
+#pragma mark - Deprecated
+
+/**
+ * @abstract Asks the node to measure and return the size that best fits its subnodes.
+ *
+ * @param constrainedSize The maximum size the receiver should fit in.
+ *
+ * @return A new size that fits the receiver's subviews.
+ *
+ * @discussion Though this method does not set the bounds of the view, it does have side effects--caching both the 
+ * constraint and the result.
+ *
+ * @warning Subclasses must not override this; it calls -measureWithSizeRange: with zero min size. 
+ * -measureWithSizeRange: caches results from -calculateLayoutThatFits:.  Calling this method may 
+ * be expensive if result is not cached.
+ *
+ * @see measureWithSizeRange:
+ * @see [ASDisplayNode(Subclassing) calculateLayoutThatFits:]
+ */
+- (CGSize)measure:(CGSize)constrainedSize; //ASDISPLAYNODE_DEPRECATED;
+
+/**
+ * @abstract Asks the node to measure a layout based on given size range.
+ *
+ * @param constrainedSize The minimum and maximum sizes the receiver should fit in.
+ *
+ * @return An ASLayout instance defining the layout of the receiver (and its children, if the box layout model is used).
+ *
+ * @discussion Though this method does not set the bounds of the view, it does have side effects--caching both the
+ * constraint and the result.
+ *
+ * @warning Subclasses must not override this; it caches results from -calculateLayoutThatFits:.  Calling this method may
+ * be expensive if result is not cached.
+ *
+ * @see [ASDisplayNode(Subclassing) calculateLayoutThatFits:]
+ */
+- (ASLayout *)measureWithSizeRange:(ASSizeRange)constrainedSize; //ASDISPLAYNODE_DEPRECATED;
+
 @end
 
 /**
  * Convenience methods for debugging.
  */
-
 @interface ASDisplayNode (Debugging) <ASLayoutableAsciiArtProtocol>
 
 /**
@@ -918,6 +928,18 @@ NS_ASSUME_NONNULL_BEGIN
  * @deprecated Deprecated in version 2.0: Use automaticallyManagesSubnodes
  */
 @property (nonatomic, assign) BOOL usesImplicitHierarchyManagement ASDISPLAYNODE_DEPRECATED;
+
+/**
+ * @abstract Provides a default intrinsic content size for calculateSizeThatFits:. This is useful when laying out
+ * a node that either has no intrinsic content size or should be laid out at a different size than its intrinsic content
+ * size. For example, this property could be set on an ASImageNode to display at a size different from the underlying
+ * image size.
+ *
+ * @return The preferred frame size of this node
+ *
+ * @deprecated Deprecated in version 2.0: Use size and the helper function ASRelativeSizeRangeMakeWithExactCGSize(preferredFrameSize) if you want to have the same behavior.
+ */
+@property (nonatomic, assign, readwrite) CGSize preferredFrameSize;// ASDISPLAYNODE_DEPRECATED;
 
 - (void)reclaimMemory ASDISPLAYNODE_DEPRECATED;
 - (void)recursivelyReclaimMemory ASDISPLAYNODE_DEPRECATED;

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -640,7 +640,10 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
 
 - (CGSize)sizeThatFits:(CGSize)constrainedSize
 {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   return [self measureWithSizeRange:ASSizeRangeMake(CGSizeZero, constrainedSize)].size;
+#pragma clang diagnostic pop
 }
 
 - (BOOL)shouldCalculateLayoutWithConstrainedSize:(ASSizeRange)constrainedSize

--- a/AsyncDisplayKit/ASImageNode.mm
+++ b/AsyncDisplayKit/ASImageNode.mm
@@ -14,10 +14,12 @@
 
 #import "_ASDisplayLayer.h"
 #import "ASAssert.h"
+#import "ASDimension.h"
 #import "ASDisplayNode+Subclasses.h"
 #import "ASDisplayNodeInternal.h"
 #import "ASDisplayNodeExtras.h"
 #import "ASDisplayNode+Beta.h"
+#import "ASLayout.h"
 #import "ASTextNode.h"
 #import "ASImageNode+AnimatedImagePrivate.h"
 
@@ -184,13 +186,11 @@ struct ASImageNodeDrawParameters {
 - (CGSize)calculateSizeThatFits:(CGSize)constrainedSize
 {
   ASDN::MutexLocker l(__instanceLock__);
-  // if a preferredFrameSize is set, call the superclass to return that instead of using the image size.
-  if (CGSizeEqualToSize(self.preferredFrameSize, CGSizeZero) == NO)
-    return [super calculateSizeThatFits:constrainedSize];
-  else if (_image)
-    return _image.size;
-  else
-    return CGSizeZero;
+  if (_image == nil) {
+      return constrainedSize;
+  }
+
+  return _image.size;
 }
 
 #pragma mark - Setter / Getter

--- a/AsyncDisplayKit/ASMapNode.mm
+++ b/AsyncDisplayKit/ASMapNode.mm
@@ -361,21 +361,14 @@
 
 - (CGSize)calculateSizeThatFits:(CGSize)constrainedSize
 {
-  CGSize size = self.preferredFrameSize;
-  if (CGSizeEqualToSize(size, CGSizeZero)) {
-    size = constrainedSize;
-    
-    // FIXME: Need a better way to allow maps to take up the right amount of space in a layout (sizeRange, etc)
-    // These fallbacks protect against inheriting a constrainedSize that contains a CGFLOAT_MAX value.
-    if (!isValidForLayout(size.width)) {
-      size.width = 100.0;
-    }
-    if (!isValidForLayout(size.height)) {
-      size.height = 100.0;
-    }
+  // FIXME: Need a better way to allow maps to take up the right amount of space in a layout (sizeRange, etc)
+  // These fallbacks protect against inheriting a constrainedSize that contains a CGFLOAT_MAX value.
+  if (!isValidForLayout(constrainedSize.width) || !isValidForLayout(constrainedSize.height)) {
+    //ASDisplayNodeAssert(NO, @"Invalid width or height in ASMapNode");
+    constrainedSize = CGSizeZero;
   }
-  [self setSnapshotSizeWithReloadIfNeeded:size];
-  return size;
+  [self setSnapshotSizeWithReloadIfNeeded:constrainedSize];
+  return constrainedSize;
 }
 
 - (void)calculatedLayoutDidChange

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -1130,7 +1130,7 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
                                       CGSizeMake(_nodesConstrainedWidth, delegateConstrainedSize.max.height));
   } else {
     constrainedSize = ASSizeRangeMake(CGSizeMake(_nodesConstrainedWidth, 0),
-                                      CGSizeMake(_nodesConstrainedWidth, FLT_MAX));
+                                      CGSizeMake(_nodesConstrainedWidth, CGFLOAT_MAX));
   }
   return constrainedSize;
 }
@@ -1186,7 +1186,7 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     // Also, in many cases, some nodes may not need to be re-measured at all, such as when user enters and then immediately leaves editing mode.
     // To avoid premature optimization and making such assumption, as well as to keep ASTableView simple, re-measurement is strictly done on main.
     [self beginUpdates];
-    CGSize calculatedSize = [[node measureWithSizeRange:constrainedSize] size];
+    const CGSize calculatedSize = ASCalculateRootLayout(node, constrainedSize).size;
     node.frame = CGRectMake(0, 0, calculatedSize.width, calculatedSize.height);
     [self endUpdates];
   }

--- a/AsyncDisplayKit/ASTextNode.mm
+++ b/AsyncDisplayKit/ASTextNode.mm
@@ -26,6 +26,7 @@
 
 #import "ASInternalHelpers.h"
 #import "ASLayout.h"
+#import "ASDimension.h"
 
 #import "CGRect+ASConvenience.h"
 
@@ -401,7 +402,7 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
   size.width += (_textContainerInset.left + _textContainerInset.right);
   size.height += (_textContainerInset.top + _textContainerInset.bottom);
   
-  return size;
+  return CGSizeMake(fminf(size.width, constrainedSize.width), fminf(size.height, constrainedSize.height));
 }
 
 #pragma mark - Modifying User Text

--- a/AsyncDisplayKit/ASVideoNode.mm
+++ b/AsyncDisplayKit/ASVideoNode.mm
@@ -240,18 +240,14 @@ static NSString * const kRate = @"rate";
   ASDN::MutexLocker l(__instanceLock__);
   CGSize calculatedSize = constrainedSize;
   
-  // if a preferredFrameSize is set, call the superclass to return that instead of using the image size.
-  if (CGSizeEqualToSize(self.preferredFrameSize, CGSizeZero) == NO)
-    calculatedSize = self.preferredFrameSize;
- 
   // Prevent crashes through if infinite width or height
   if (isinf(calculatedSize.width) || isinf(calculatedSize.height)) {
-    ASDisplayNodeAssert(NO, @"Infinite width or height in ASVideoNode");
+    //ASDisplayNodeAssert(NO, @"Infinite width or height in ASVideoNode");
     calculatedSize = CGSizeZero;
   }
   
   if (_playerNode) {
-    _playerNode.preferredFrameSize = calculatedSize;
+    _playerNode.size = ASRelativeSizeRangeMakeWithExactCGSize(calculatedSize);
     [_playerNode measure:calculatedSize];
   }
   

--- a/AsyncDisplayKit/ASVideoPlayerNode.mm
+++ b/AsyncDisplayKit/ASVideoPlayerNode.mm
@@ -324,7 +324,7 @@ static void *ASVideoPlayerNodeContext = &ASVideoPlayerNodeContext;
 {
   if (_playbackButtonNode == nil) {
     _playbackButtonNode = [[ASDefaultPlaybackButton alloc] init];
-    _playbackButtonNode.preferredFrameSize = CGSizeMake(16.0, 22.0);
+    _playbackButtonNode.size = ASRelativeSizeRangeMakeWithExactCGSize(CGSizeMake(16.0, 22.0));
     if (_delegateFlags.delegatePlaybackButtonTint) {
       _playbackButtonNode.tintColor = [_delegate videoPlayerNodePlaybackButtonTint:self];
     } else {
@@ -598,7 +598,7 @@ static void *ASVideoPlayerNodeContext = &ASVideoPlayerNodeContext;
       
       return spinnnerView;
     }];
-    _spinnerNode.preferredFrameSize = CGSizeMake(44.0, 44.0);
+    _spinnerNode.size = ASRelativeSizeRangeMakeWithExactCGSize(CGSizeMake(44.0, 44.0));
 
     [self addSubnode:_spinnerNode];
     [self setNeedsLayout];
@@ -689,20 +689,19 @@ static void *ASVideoPlayerNodeContext = &ASVideoPlayerNodeContext;
   return controls;
 }
 
+
 #pragma mark - Layout
-- (ASLayoutSpec*)layoutSpecThatFits:(ASSizeRange)constrainedSize
+
+- (ASLayoutSpec *)layoutSpecThatFits:(ASSizeRange)constrainedSize
 {
   CGSize maxSize = constrainedSize.max;
-  if (!CGSizeEqualToSize(self.preferredFrameSize, CGSizeZero)) {
-    maxSize = self.preferredFrameSize;
-  }
 
   // Prevent crashes through if infinite width or height
   if (isinf(maxSize.width) || isinf(maxSize.height)) {
     ASDisplayNodeAssert(NO, @"Infinite width or height in ASVideoPlayerNode");
     maxSize = CGSizeZero;
   }
-  _videoNode.preferredFrameSize = maxSize;
+  //_videoNode.size = ASRelativeSizeRangeMakeWithExactCGSize(maxSize);
 
   ASLayoutSpec *layoutSpec;
 
@@ -728,9 +727,9 @@ static void *ASVideoPlayerNodeContext = &ASVideoPlayerNodeContext;
   return [ASStaticLayoutSpec staticLayoutSpecWithChildren:children];
 }
 
-- (ASLayoutSpec*)defaultLayoutSpecThatFits:(CGSize)maxSize
+- (ASLayoutSpec *)defaultLayoutSpecThatFits:(CGSize)maxSize
 {
-  _scrubberNode.preferredFrameSize = CGSizeMake(maxSize.width, 44.0);
+  _scrubberNode.size = ASRelativeSizeRangeMakeWithExactCGSize(CGSizeMake(maxSize.width, 44.0));
 
   ASLayoutSpec *spacer = [[ASLayoutSpec alloc] init];
   spacer.flexGrow = YES;

--- a/AsyncDisplayKit/ASViewController.mm
+++ b/AsyncDisplayKit/ASViewController.mm
@@ -15,6 +15,7 @@
 #import "ASAvailability.h"
 #import "ASDisplayNodeInternal.h"
 #import "ASDisplayNode+FrameworkPrivate.h"
+#import "ASLayout.h"
 #import "ASTraitCollection.h"
 #import "ASEnvironmentInternal.h"
 #import "ASRangeControllerUpdateRangeProtocol+Beta.h"
@@ -93,7 +94,7 @@
 - (void)viewWillLayoutSubviews
 {
   [super viewWillLayoutSubviews];
-  [_node measureWithSizeRange:[self nodeConstrainedSize]];
+  ASCalculateRootLayout(_node, [self nodeConstrainedSize]);
   
   if (!AS_AT_LEAST_IOS9) {
     [self _legacyHandleViewDidLayoutSubviews];
@@ -115,7 +116,7 @@ ASVisibilityDidMoveToParentViewController;
 {
   [super viewWillAppear:animated];
   _ensureDisplayed = YES;
-  [_node measureWithSizeRange:[self nodeConstrainedSize]];
+  ASCalculateRootLayout(_node, [self nodeConstrainedSize]);
   [_node recursivelyFetchData];
   
   if (_parentManagesVisibilityDepth == NO) {

--- a/AsyncDisplayKit/Details/ASCollectionViewFlowLayoutInspector.m
+++ b/AsyncDisplayKit/Details/ASCollectionViewFlowLayoutInspector.m
@@ -22,9 +22,9 @@
 static inline ASSizeRange NodeConstrainedSizeForScrollDirection(ASCollectionView *collectionView) {
   CGSize maxSize = collectionView.bounds.size;
   if (ASScrollDirectionContainsHorizontalDirection(collectionView.scrollableDirections)) {
-    maxSize.width = FLT_MAX;
+    maxSize.width = CGFLOAT_MAX;
   } else {
-    maxSize.height = FLT_MAX;
+    maxSize.height = CGFLOAT_MAX;
   }
   return ASSizeRangeMake(CGSizeZero, maxSize);
 }

--- a/AsyncDisplayKit/Details/ASDataController.mm
+++ b/AsyncDisplayKit/Details/ASDataController.mm
@@ -154,7 +154,7 @@ NSString * const ASDataControllerRowNodeKind = @"_ASDataControllerRowNodeKind";
 - (void)_layoutNode:(ASCellNode *)node withConstrainedSize:(ASSizeRange)constrainedSize
 {
   CGRect frame = CGRectZero;
-  frame.size = [node measureWithSizeRange:constrainedSize].size;
+  frame.size = ASCalculateRootLayout(node, constrainedSize).size;
   node.frame = frame;
 }
 

--- a/AsyncDisplayKit/Details/Transactions/_ASAsyncTransactionContainer.h
+++ b/AsyncDisplayKit/Details/Transactions/_ASAsyncTransactionContainer.h
@@ -8,7 +8,6 @@
 //  of patent rights can be found in the PATENTS file in the same directory.
 //
 
-#import <CoreGraphics/CoreGraphics.h>
 #import <UIKit/UIKit.h>
 
 

--- a/AsyncDisplayKit/Layout/ASBackgroundLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASBackgroundLayoutSpec.mm
@@ -39,16 +39,19 @@ static NSUInteger const kBackgroundChildIndex = 1;
 }
 
 /**
- First layout the contents, then fit the background image.
+ * First layout the contents, then fit the background image.
  */
-- (ASLayout *)measureWithSizeRange:(ASSizeRange)constrainedSize
+- (ASLayout *)calculateLayoutThatFits:(ASSizeRange)constrainedSize
+                restrictedToSizeRange:(ASRelativeSizeRange)size
+                 relativeToParentSize:(CGSize)parentSize
 {
-  ASLayout *contentsLayout = [[self child] measureWithSizeRange:constrainedSize];
+  ASLayout *contentsLayout = [self.child calculateLayoutThatFits:constrainedSize parentSize:parentSize];
 
   NSMutableArray *sublayouts = [NSMutableArray arrayWithCapacity:2];
   if (self.background) {
     // Size background to exactly the same size.
-    ASLayout *backgroundLayout = [self.background measureWithSizeRange:{contentsLayout.size, contentsLayout.size}];
+    ASLayout *backgroundLayout = [self.background calculateLayoutThatFits:{contentsLayout.size, contentsLayout.size}
+                                                               parentSize:parentSize];
     backgroundLayout.position = CGPointZero;
     [sublayouts addObject:backgroundLayout];
   }
@@ -56,7 +59,7 @@ static NSUInteger const kBackgroundChildIndex = 1;
   [sublayouts addObject:contentsLayout];
 
   return [ASLayout layoutWithLayoutableObject:self
-                         constrainedSizeRange:constrainedSize
+                              constrainedSize:constrainedSize
                                          size:contentsLayout.size
                                    sublayouts:sublayouts];
 }

--- a/AsyncDisplayKit/Layout/ASDimension.h
+++ b/AsyncDisplayKit/Layout/ASDimension.h
@@ -12,12 +12,23 @@
 #import <UIKit/UIKit.h>
 #import <AsyncDisplayKit/ASBaseDefines.h>
 
-/** A dimension relative to constraints to be provided in the future. */
+/**
+ * A dimension relative to constraints to be provided in the future.
+ * A RelativeDimension can be one of three types:
+ *
+ * "Auto" - This indicated "I have no opinion" and may be resolved in whatever way makes most sense given the circumstances.
+ *
+ * "Points" - Just a number. It will always resolve to exactly this amount.
+ *
+ * "Percent" - Multiplied to a provided parent amount to resolve a final amount.
+ */
 typedef NS_ENUM(NSInteger, ASRelativeDimensionType) {
   /** Just a number. It will always resolve to exactly this amount. This is the default type. */
   ASRelativeDimensionTypePoints,
   /** Multiplied to a provided parent amount to resolve a final amount. */
   ASRelativeDimensionTypeFraction,
+  /** This indicated "I have no opinion" and may be resolved in whatever way makes most sense given the circumstances. */
+  ASRelativeDimensionTypeAuto,
 };
 
 typedef struct {
@@ -32,6 +43,7 @@ typedef struct {
 } ASSizeRange;
 
 extern ASRelativeDimension const ASRelativeDimensionUnconstrained;
+extern ASRelativeDimension const ASRelativeDimensionAuto;
 
 #define isValidForLayout(x) ((isnormal(x) || x == 0.0) && x >= 0.0 && x < (CGFLOAT_MAX / 2.0))
 
@@ -52,14 +64,14 @@ extern BOOL ASRelativeDimensionEqualToRelativeDimension(ASRelativeDimension lhs,
 
 extern NSString *NSStringFromASRelativeDimension(ASRelativeDimension dimension);
 
-extern CGFloat ASRelativeDimensionResolve(ASRelativeDimension dimension, CGFloat parent);
+extern CGFloat ASRelativeDimensionResolve(ASRelativeDimension dimension, CGFloat autoSize, CGFloat parent);
 
 #pragma mark - ASSizeRange
 
 extern ASSizeRange ASSizeRangeMake(CGSize min, CGSize max);
 
 /** Creates an ASSizeRange with the provided size as both min and max */
-extern ASSizeRange ASSizeRangeMakeExactSize(CGSize size);
+extern ASSizeRange ASSizeRangeMakeWithExactCGSize(CGSize size);
 
 /** Clamps the provided CGSize between the [min, max] bounds of this ASSizeRange. */
 extern CGSize ASSizeRangeClamp(ASSizeRange sizeRange, CGSize size);
@@ -73,6 +85,12 @@ extern ASSizeRange ASSizeRangeIntersect(ASSizeRange sizeRange, ASSizeRange other
 extern BOOL ASSizeRangeEqualToSizeRange(ASSizeRange lhs, ASSizeRange rhs);
 
 extern NSString *NSStringFromASSizeRange(ASSizeRange sizeRange);
+
+
+#pragma mark - Deprecated
+
+/** Function is deprecated please use ASSizeRangeMakeWithExactCGSize*/
+extern ASSizeRange ASSizeRangeMakeExactSize(CGSize size);
 
 NS_ASSUME_NONNULL_END
 ASDISPLAYNODE_EXTERN_C_END

--- a/AsyncDisplayKit/Layout/ASDimension.mm
+++ b/AsyncDisplayKit/Layout/ASDimension.mm
@@ -12,6 +12,7 @@
 #import "ASAssert.h"
 
 ASRelativeDimension const ASRelativeDimensionUnconstrained = {};
+ASRelativeDimension const ASRelativeDimensionAuto = {ASRelativeDimensionTypeAuto, 0};
 
 #pragma mark - ASRelativeDimension
 
@@ -55,16 +56,20 @@ NSString *NSStringFromASRelativeDimension(ASRelativeDimension dimension)
       return [NSString stringWithFormat:@"%.0fpt", dimension.value];
     case ASRelativeDimensionTypeFraction:
       return [NSString stringWithFormat:@"%.0f%%", dimension.value * 100.0];
+    case ASRelativeDimensionTypeAuto:
+      return @"Auto";
   }
 }
 
-CGFloat ASRelativeDimensionResolve(ASRelativeDimension dimension, CGFloat parent)
+CGFloat ASRelativeDimensionResolve(ASRelativeDimension dimension, CGFloat autoSize, CGFloat parent)
 {
   switch (dimension.type) {
     case ASRelativeDimensionTypePoints:
       return dimension.value;
     case ASRelativeDimensionTypeFraction:
       return dimension.value * parent;
+    case ASRelativeDimensionTypeAuto:
+      return autoSize;
   }
 }
 
@@ -83,7 +88,7 @@ ASSizeRange ASSizeRangeMake(CGSize min, CGSize max)
   ASSizeRange sizeRange; sizeRange.min = min; sizeRange.max = max; return sizeRange;
 }
 
-ASSizeRange ASSizeRangeMakeExactSize(CGSize size)
+ASSizeRange ASSizeRangeMakeWithExactCGSize(CGSize size)
 {
   return ASSizeRangeMake(size, size);
 }
@@ -136,4 +141,11 @@ NSString * NSStringFromASSizeRange(ASSizeRange sizeRange)
   return [NSString stringWithFormat:@"<ASSizeRange: min=%@, max=%@>",
           NSStringFromCGSize(sizeRange.min),
           NSStringFromCGSize(sizeRange.max)];
+}
+
+#pragma mark - Deprecated
+
+ASSizeRange ASSizeRangeMakeExactSize(CGSize size)
+{
+  return ASSizeRangeMakeWithExactCGSize(size);
 }

--- a/AsyncDisplayKit/Layout/ASInsetLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASInsetLayoutSpec.mm
@@ -67,7 +67,9 @@ static CGFloat centerInset(CGFloat outer, CGFloat inner)
  Inset will compute a new constrained size for it's child after applying insets and re-positioning
  the child to respect the inset.
  */
-- (ASLayout *)measureWithSizeRange:(ASSizeRange)constrainedSize
+- (ASLayout *)calculateLayoutThatFits:(ASSizeRange)constrainedSize
+                restrictedToSizeRange:(ASRelativeSizeRange)size
+                 relativeToParentSize:(CGSize)parentSize
 {
   const CGFloat insetsX = (finiteOrZero(_insets.left) + finiteOrZero(_insets.right));
   const CGFloat insetsY = (finiteOrZero(_insets.top) + finiteOrZero(_insets.bottom));
@@ -91,11 +93,16 @@ static CGFloat centerInset(CGFloat outer, CGFloat inner)
   if (self.child == nil) {
     ASDisplayNodeAssert(NO, @"Inset spec measured without a child. The spec will do nothing.");
     return [ASLayout layoutWithLayoutableObject:self
-                           constrainedSizeRange:constrainedSize
+                                constrainedSize:constrainedSize
                                            size:CGSizeZero];
   }
   
-  ASLayout *sublayout = [self.child measureWithSizeRange:insetConstrainedSize];
+  const CGSize insetParentSize = {
+    MAX(0, parentSize.width - insetsX),
+    MAX(0, parentSize.height - insetsY)
+  };
+  
+  ASLayout *sublayout = [self.child calculateLayoutThatFits:insetConstrainedSize parentSize:insetParentSize];
 
   const CGSize computedSize = ASSizeRangeClamp(constrainedSize, {
     finite(sublayout.size.width + _insets.left + _insets.right, constrainedSize.max.width),
@@ -114,7 +121,7 @@ static CGFloat centerInset(CGFloat outer, CGFloat inner)
   sublayout.position = CGPointMake(x, y);
   
   return [ASLayout layoutWithLayoutableObject:self
-                         constrainedSizeRange:constrainedSize
+                              constrainedSize:constrainedSize
                                          size:computedSize
                                    sublayouts:@[sublayout]];
 }

--- a/AsyncDisplayKit/Layout/ASLayout.h
+++ b/AsyncDisplayKit/Layout/ASLayout.h
@@ -22,6 +22,21 @@ extern CGPoint const CGPointNull;
 extern BOOL CGPointIsNull(CGPoint point);
 
 /**
+ Safely calculates the layout of the given root layoutable by guarding against nil nodes.
+ @param rootLayoutable The root node to calculate the layout for.
+ @param sizeRange The size range to calculate the root layout within.
+ */
+ASLayout *ASCalculateRootLayout(id<ASLayoutable> rootLayoutable, const ASSizeRange sizeRange);
+
+/**
+ Safely computes the layout of the given node by guarding against nil nodes.
+ @param component The component to calculate the layout for.
+ @param sizeRange The size range to calculate the node layout within.
+ @param parentSize The parent size of the node to calculate the layout for.
+ */
+ASLayout *ASCalculateLayout(id<ASLayoutable> layoutable, const ASSizeRange sizeRange, const CGSize parentSize);
+
+/**
  * A node in the layout tree that represents the size and position of the object that created it (ASLayoutable).
  */
 @interface ASLayout : NSObject
@@ -51,7 +66,7 @@ extern BOOL CGPointIsNull(CGPoint point);
 /**
  * The size range that was use to determine the size of the layout.
  */
-@property (nonatomic, readonly) ASSizeRange constrainedSizeRange;
+@property (nonatomic, readonly) ASSizeRange constrainedSize;
 
 /**
  * Array of ASLayouts. Each must have a valid non-null position.
@@ -69,11 +84,12 @@ extern BOOL CGPointIsNull(CGPoint point);
  */
 @property (nonatomic, readonly) CGRect frame;
 
+
 /**
  * Designated initializer
  */
 - (instancetype)initWithLayoutableObject:(id<ASLayoutable>)layoutableObject
-                    constrainedSizeRange:(ASSizeRange)sizeRange
+                         constrainedSize:(ASSizeRange)constrainedSize
                                     size:(CGSize)size
                                 position:(CGPoint)position
                               sublayouts:(NSArray *)sublayouts NS_DESIGNATED_INITIALIZER;
@@ -87,7 +103,7 @@ extern BOOL CGPointIsNull(CGPoint point);
  * @param sublayouts       Sublayouts belong to the new layout.
  */
 + (instancetype)layoutWithLayoutableObject:(id<ASLayoutable>)layoutableObject
-                      constrainedSizeRange:(ASSizeRange)sizeRange
+                           constrainedSize:(ASSizeRange)constrainedSize
                                       size:(CGSize)size
                                   position:(CGPoint)position
                                 sublayouts:(nullable NSArray<ASLayout *> *)sublayouts;
@@ -98,12 +114,12 @@ extern BOOL CGPointIsNull(CGPoint point);
  * or for ASLayoutSpec subclasses that are referencing the "self" level in the layout tree,
  * or for creating a sublayout of which the position is yet to be determined.
  *
- * @param layoutableObject The backing ASLayoutable object.
- * @param size The size of this layout.
- * @param sublayouts Sublayouts belong to the new layout.
+ * @param layoutableObject  The backing ASLayoutable object.
+ * @param size              The size of this layout.
+ * @param sublayouts        Sublayouts belong to the new layout.
  */
 + (instancetype)layoutWithLayoutableObject:(id<ASLayoutable>)layoutableObject
-                      constrainedSizeRange:(ASSizeRange)sizeRange
+                           constrainedSize:(ASSizeRange)constrainedSize
                                       size:(CGSize)size
                                 sublayouts:(nullable NSArray<ASLayout *> *)sublayouts;
 
@@ -113,28 +129,29 @@ extern BOOL CGPointIsNull(CGPoint point);
  * or a sublayout of which the position is yet to be determined.
  *
  * @param layoutableObject The backing ASLayoutable object.
- * @param size The size of this layout.
+ * @param size             The size of this layout.
  */
 + (instancetype)layoutWithLayoutableObject:(id<ASLayoutable>)layoutableObject
-                      constrainedSizeRange:(ASSizeRange)sizeRange
+                           constrainedSize:(ASSizeRange)constrainedSize
                                       size:(CGSize)size;
 
 /**
  * Convenience initializer that is flattened and has CGPointNull position.
- *
+
  * @param layoutableObject The backing ASLayoutable object.
- * @param size The size of this layout.
- * @param sublayouts Sublayouts belong to the new layout.
+ * @param size             The size of this layout.
+ * @param sublayouts       Sublayouts belong to the new layout.
  */
 + (instancetype)flattenedLayoutWithLayoutableObject:(id<ASLayoutable>)layoutableObject
-                               constrainedSizeRange:(ASSizeRange)sizeRange
+                                    constrainedSize:(ASSizeRange)constrainedSize
                                                size:(CGSize)size
                                          sublayouts:(nullable NSArray<ASLayout *> *)sublayouts;
 
 /**
  * Convenience initializer that creates a layout based on the values of the given layout, with a new position
- * @param layout    The layout to use to create the new layout
- * @param position  The position of the new layout
+ *
+ * @param layout           The layout to use to create the new layout
+ * @param position         The position of the new layout
  */
 + (instancetype)layoutWithLayout:(ASLayout *)layout position:(CGPoint)position;
 
@@ -144,6 +161,42 @@ extern BOOL CGPointIsNull(CGPoint point);
 - (ASLayout *)filteredNodeLayoutTree;
 
 @end
+
+#pragma mark - Deprecated
+
+@interface ASLayout (Deprecated)
+
+@property (nonatomic, readonly) ASSizeRange constrainedSizeRange;
+
+- (instancetype)initWithLayoutableObject:(id<ASLayoutable>)layoutableObject
+                    constrainedSizeRange:(ASSizeRange)sizeRange
+                                    size:(CGSize)size
+                                position:(CGPoint)position
+                              sublayouts:(NSArray *)sublayouts;
+
++ (instancetype)layoutWithLayoutableObject:(id<ASLayoutable>)layoutableObject
+                      constrainedSizeRange:(ASSizeRange)sizeRange
+                                      size:(CGSize)size
+                                  position:(CGPoint)position
+                                sublayouts:(nullable NSArray<ASLayout *> *)sublayouts;
+
++ (instancetype)layoutWithLayoutableObject:(id<ASLayoutable>)layoutableObject
+                      constrainedSizeRange:(ASSizeRange)sizeRange
+                                      size:(CGSize)size
+                                sublayouts:(nullable NSArray<ASLayout *> *)sublayouts;
+
++ (instancetype)layoutWithLayoutableObject:(id<ASLayoutable>)layoutableObject
+                      constrainedSizeRange:(ASSizeRange)sizeRange
+                                      size:(CGSize)size;
+
++ (instancetype)flattenedLayoutWithLayoutableObject:(id<ASLayoutable>)layoutableObject
+                               constrainedSizeRange:(ASSizeRange)sizeRange
+                                               size:(CGSize)size
+                                         sublayouts:(nullable NSArray<ASLayout *> *)sublayouts;
+
+@end
+
+#pragma mark - Debugging
 
 @interface ASLayout (Debugging)
 

--- a/AsyncDisplayKit/Layout/ASLayout.h
+++ b/AsyncDisplayKit/Layout/ASLayout.h
@@ -17,6 +17,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+ASDISPLAYNODE_EXTERN_C_BEGIN
+
 extern CGPoint const CGPointNull;
 
 extern BOOL CGPointIsNull(CGPoint point);
@@ -26,7 +28,7 @@ extern BOOL CGPointIsNull(CGPoint point);
  * @param rootLayoutable The root node to calculate the layout for.
  * @param sizeRange The size range to calculate the root layout within.
  */
-ASLayout *ASCalculateRootLayout(id<ASLayoutable> rootLayoutable, const ASSizeRange sizeRange);
+extern ASLayout *ASCalculateRootLayout(id<ASLayoutable> rootLayoutable, const ASSizeRange sizeRange);
 
 /**
  * Safely computes the layout of the given node by guarding against nil nodes.
@@ -34,7 +36,9 @@ ASLayout *ASCalculateRootLayout(id<ASLayoutable> rootLayoutable, const ASSizeRan
  * @param sizeRange The size range to calculate the node layout within.
  * @param parentSize The parent size of the node to calculate the layout for.
  */
-ASLayout *ASCalculateLayout(id<ASLayoutable> layoutable, const ASSizeRange sizeRange, const CGSize parentSize);
+extern ASLayout *ASCalculateLayout(id<ASLayoutable> layoutable, const ASSizeRange sizeRange, const CGSize parentSize);
+
+ASDISPLAYNODE_EXTERN_C_END
 
 /**
  * A node in the layout tree that represents the size and position of the object that created it (ASLayoutable).

--- a/AsyncDisplayKit/Layout/ASLayout.h
+++ b/AsyncDisplayKit/Layout/ASLayout.h
@@ -22,17 +22,17 @@ extern CGPoint const CGPointNull;
 extern BOOL CGPointIsNull(CGPoint point);
 
 /**
- Safely calculates the layout of the given root layoutable by guarding against nil nodes.
- @param rootLayoutable The root node to calculate the layout for.
- @param sizeRange The size range to calculate the root layout within.
+ * Safely calculates the layout of the given root layoutable by guarding against nil nodes.
+ * @param rootLayoutable The root node to calculate the layout for.
+ * @param sizeRange The size range to calculate the root layout within.
  */
 ASLayout *ASCalculateRootLayout(id<ASLayoutable> rootLayoutable, const ASSizeRange sizeRange);
 
 /**
- Safely computes the layout of the given node by guarding against nil nodes.
- @param component The component to calculate the layout for.
- @param sizeRange The size range to calculate the node layout within.
- @param parentSize The parent size of the node to calculate the layout for.
+ * Safely computes the layout of the given node by guarding against nil nodes.
+ * @param component The component to calculate the layout for.
+ * @param sizeRange The size range to calculate the node layout within.
+ * @param parentSize The parent size of the node to calculate the layout for.
  */
 ASLayout *ASCalculateLayout(id<ASLayoutable> layoutable, const ASSizeRange sizeRange, const CGSize parentSize);
 

--- a/AsyncDisplayKit/Layout/ASLayout.mm
+++ b/AsyncDisplayKit/Layout/ASLayout.mm
@@ -52,7 +52,7 @@ static inline NSString * descriptionIndents(NSUInteger indents)
 @dynamic frame, type;
 
 - (instancetype)initWithLayoutableObject:(id<ASLayoutable>)layoutableObject
-                    constrainedSizeRange:(ASSizeRange)sizeRange
+                         constrainedSize:(ASSizeRange)constrainedSize
                                     size:(CGSize)size
                                 position:(CGPoint)position
                               sublayouts:(NSArray *)sublayouts
@@ -74,7 +74,7 @@ static inline NSString * descriptionIndents(NSUInteger indents)
     } else {
       size = CGSizeMake(ASCeilPixelValue(size.width), ASCeilPixelValue(size.height));
     }
-    _constrainedSizeRange = sizeRange;
+    _constrainedSize = constrainedSize;
     _size = size;
     _dirty = NO;
     
@@ -98,57 +98,58 @@ static inline NSString * descriptionIndents(NSUInteger indents)
 #pragma mark - Class Constructors
 
 + (instancetype)layoutWithLayoutableObject:(id<ASLayoutable>)layoutableObject
-                      constrainedSizeRange:(ASSizeRange)sizeRange
+                           constrainedSize:(ASSizeRange)constrainedSize
                                       size:(CGSize)size
                                   position:(CGPoint)position
                                 sublayouts:(NSArray *)sublayouts
 {
   return [[self alloc] initWithLayoutableObject:layoutableObject
-                           constrainedSizeRange:sizeRange
+                                constrainedSize:constrainedSize
                                            size:size
                                        position:position
                                      sublayouts:sublayouts];
 }
 
 + (instancetype)layoutWithLayoutableObject:(id<ASLayoutable>)layoutableObject
-                      constrainedSizeRange:(ASSizeRange)sizeRange
+                           constrainedSize:(ASSizeRange)sizeRange
                                       size:(CGSize)size
                                 sublayouts:(NSArray *)sublayouts
 {
   return [self layoutWithLayoutableObject:layoutableObject
-                     constrainedSizeRange:sizeRange
+                          constrainedSize:sizeRange
                                      size:size
                                  position:CGPointNull
                                sublayouts:sublayouts];
 }
 
 + (instancetype)layoutWithLayoutableObject:(id<ASLayoutable>)layoutableObject
-                      constrainedSizeRange:(ASSizeRange)sizeRange
+                           constrainedSize:(ASSizeRange)sizeRange
                                       size:(CGSize)size
 {
   return [self layoutWithLayoutableObject:layoutableObject
-                     constrainedSizeRange:sizeRange
+                          constrainedSize:sizeRange
                                      size:size
                                  position:CGPointNull
                                sublayouts:nil];
 }
 
 + (instancetype)flattenedLayoutWithLayoutableObject:(id<ASLayoutable>)layoutableObject
-                               constrainedSizeRange:(ASSizeRange)sizeRange
+                                    constrainedSize:(ASSizeRange)sizeRange
                                                size:(CGSize)size
                                          sublayouts:(nullable NSArray<ASLayout *> *)sublayouts
 {
   return [self layoutWithLayoutableObject:layoutableObject
-                     constrainedSizeRange:sizeRange
+                          constrainedSize:sizeRange
                                      size:size
                                  position:CGPointNull
                                sublayouts:sublayouts];
 }
 
+
 + (instancetype)layoutWithLayout:(ASLayout *)layout position:(CGPoint)position
 {
   return [self layoutWithLayoutableObject:layout.layoutableObject
-                     constrainedSizeRange:layout.constrainedSizeRange
+                          constrainedSize:layout.constrainedSize
                                      size:layout.size
                                  position:position
                                sublayouts:layout.sublayouts];
@@ -187,7 +188,7 @@ static inline NSString * descriptionIndents(NSUInteger indents)
   }
 
   return [ASLayout layoutWithLayoutableObject:_layoutableObject
-                         constrainedSizeRange:_constrainedSizeRange
+                              constrainedSize:_constrainedSize
                                          size:_size
                                    sublayouts:flattenedSublayouts];
 }
@@ -232,7 +233,7 @@ static inline NSString * descriptionIndents(NSUInteger indents)
 - (NSString *)description
 {
     return [NSString stringWithFormat:@"<<ASLayout: %p>, layoutable = %@, position = %@; size = %@; constrainedSizeRange = %@>",
-            self, self.layoutableObject, NSStringFromCGPoint(self.position), NSStringFromCGSize(self.size), NSStringFromASSizeRange(self.constrainedSizeRange)];
+            self, self.layoutableObject, NSStringFromCGPoint(self.position), NSStringFromCGSize(self.size), NSStringFromASSizeRange(self.constrainedSize)];
 }
 
 - (NSString *)recursiveDescription
@@ -253,3 +254,89 @@ static inline NSString * descriptionIndents(NSUInteger indents)
 }
 
 @end
+
+@implementation ASLayout (Deprecated)
+
+- (ASSizeRange)constrainedSizeRange
+{
+  return _constrainedSize;
+}
+
+- (instancetype)initWithLayoutableObject:(id<ASLayoutable>)layoutableObject
+                    constrainedSizeRange:(ASSizeRange)constrainedSize
+                                    size:(CGSize)size
+                                position:(CGPoint)position
+                              sublayouts:(NSArray *)sublayouts
+{
+  return [self initWithLayoutableObject:layoutableObject
+                        constrainedSize:constrainedSize
+                                   size:size
+                               position:position
+                             sublayouts:sublayouts];
+}
+
++ (instancetype)layoutWithLayoutableObject:(id<ASLayoutable>)layoutableObject
+                      constrainedSizeRange:(ASSizeRange)constrainedSize
+                                      size:(CGSize)size
+                                  position:(CGPoint)position
+                                sublayouts:(NSArray *)sublayouts
+{
+  return [[self alloc] initWithLayoutableObject:layoutableObject
+                                constrainedSize:constrainedSize
+                                           size:size
+                                       position:position
+                                     sublayouts:sublayouts];
+}
+
++ (instancetype)layoutWithLayoutableObject:(id<ASLayoutable>)layoutableObject
+                      constrainedSizeRange:(ASSizeRange)sizeRange
+                                      size:(CGSize)size
+                                sublayouts:(NSArray *)sublayouts
+{
+  return [self layoutWithLayoutableObject:layoutableObject
+                     constrainedSizeRange:sizeRange
+                                     size:size
+                                 position:CGPointNull
+                               sublayouts:sublayouts];
+}
+
++ (instancetype)layoutWithLayoutableObject:(id<ASLayoutable>)layoutableObject
+                      constrainedSizeRange:(ASSizeRange)sizeRange
+                                      size:(CGSize)size
+{
+  return [self layoutWithLayoutableObject:layoutableObject
+                     constrainedSizeRange:sizeRange
+                                     size:size
+                                 position:CGPointNull
+                               sublayouts:nil];
+}
+
++ (instancetype)flattenedLayoutWithLayoutableObject:(id<ASLayoutable>)layoutableObject
+                               constrainedSizeRange:(ASSizeRange)sizeRange
+                                               size:(CGSize)size
+                                         sublayouts:(nullable NSArray<ASLayout *> *)sublayouts
+{
+  return [self layoutWithLayoutableObject:layoutableObject
+                     constrainedSizeRange:sizeRange
+                                     size:size
+                                 position:CGPointNull
+                               sublayouts:sublayouts];
+}
+
+@end
+
+ASLayout *ASCalculateLayout(id<ASLayoutable> layoutable, const ASSizeRange sizeRange, const CGSize parentSize)
+{
+  // TODO: sizeRange: This breaks TrashTester test but we should enable we it?  
+  //ASDisplayNodeCAssertNotNil(layoutable, @"Not valid layoutable passed in.");
+  
+  return layoutable ? [layoutable calculateLayoutThatFits:sizeRange parentSize:parentSize] : nil;
+}
+
+ASLayout *ASCalculateRootLayout(id<ASLayoutable> rootLayoutable, const ASSizeRange sizeRange)
+{
+  ASLayout *layout = ASCalculateLayout(rootLayoutable, sizeRange, sizeRange.max);
+  // TODO: sizeRange: Add validation?
+  return layout;
+}
+

--- a/AsyncDisplayKit/Layout/ASLayout.mm
+++ b/AsyncDisplayKit/Layout/ASLayout.mm
@@ -336,7 +336,7 @@ ASLayout *ASCalculateLayout(id<ASLayoutable> layoutable, const ASSizeRange sizeR
 ASLayout *ASCalculateRootLayout(id<ASLayoutable> rootLayoutable, const ASSizeRange sizeRange)
 {
   ASLayout *layout = ASCalculateLayout(rootLayoutable, sizeRange, sizeRange.max);
-  // TODO: sizeRange: Add validation?
+  // TODO: sizeRange: Add specific validation?
   return layout;
 }
 

--- a/AsyncDisplayKit/Layout/ASLayoutValidation.mm
+++ b/AsyncDisplayKit/Layout/ASLayoutValidation.mm
@@ -75,16 +75,7 @@ static NSString *ASLayoutValidationWrappingAssertMessage(SEL selector, id obj, C
     ASRelativeSizeRange sizeRange = sublayoutLayoutable.sizeRange;
     ASRelativeSizeRange zeroSizeRange = ASRelativeSizeRangeMakeWithExactCGSize(CGSizeZero);
     
-    // Currently setting the preferredFrameSize also updates the sizeRange. Create a size range based on the
-    // preferredFrameSize and check it if it's the same as the current sizeRange to be sure it was not changed manually
-    CGSize preferredFrameSize = CGSizeZero;
-    if ([sublayoutLayoutable respondsToSelector:@selector(preferredFrameSize)]) {
-      preferredFrameSize = [((ASDisplayNode *)sublayoutLayoutable) preferredFrameSize];
-    }
-    ASRelativeSizeRange preferredFrameSizeRange = ASRelativeSizeRangeMakeWithExactCGSize(preferredFrameSize);
-    
-    if (ASRelativeSizeRangeEqualToRelativeSizeRange(sizeRange, zeroSizeRange) == NO &&
-        ASRelativeSizeRangeEqualToRelativeSizeRange(sizeRange, preferredFrameSizeRange) == NO) {
+    if (ASRelativeSizeRangeEqualToRelativeSizeRange(sizeRange, zeroSizeRange) == NO) {
       assertMessage = ASLayoutValidationWrappingAssertMessage(@selector(sizeRange), sublayoutLayoutable, stackContainerClass);
     } else if (!CGPointEqualToPoint(sublayoutLayoutable.layoutPosition, CGPointZero)) {
       assertMessage = ASLayoutValidationWrappingAssertMessage(@selector(layoutPosition), sublayoutLayoutable, stackContainerClass);

--- a/AsyncDisplayKit/Layout/ASLayoutable.h
+++ b/AsyncDisplayKit/Layout/ASLayoutable.h
@@ -21,6 +21,13 @@
 @class ASLayout;
 @class ASLayoutSpec;
 
+/** A constant that indicates that the parent's size is not yet determined in a given dimension. */
+extern CGFloat const ASLayoutableParentDimensionUndefined;
+
+/** A constant that indicates that the parent's size is not yet determined in either dimension. */
+extern CGSize const ASLayoutableParentSizeUndefined;
+
+/** Type of ASLayoutable  */
 typedef NS_ENUM(NSUInteger, ASLayoutableType) {
   ASLayoutableTypeLayoutSpec,
   ASLayoutableTypeDisplayNode
@@ -47,25 +54,71 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol ASLayoutable <ASEnvironment, ASStackLayoutable, ASStaticLayoutable, ASLayoutablePrivate, ASLayoutableExtensibility>
 
 /**
+ * @abstract A size constraint that should apply to this ASLayoutable.
+ */
+@property (nonatomic, assign, readwrite) ASRelativeSizeRange size;
+
+/**
  * @abstract Returns type of layoutable
  */
-@property (nonatomic, readonly) ASLayoutableType layoutableType;
+@property (nonatomic, assign, readonly) ASLayoutableType layoutableType;
 
 /**
  * @abstract Returns if the layoutable can be used to layout in an asynchronous way on a background thread.
  */
-@property (nonatomic, readonly) BOOL canLayoutAsynchronous;
+@property (nonatomic, assign, readonly) BOOL canLayoutAsynchronous;
+
+
+#pragma mark - Calculate layout
 
 /**
- * @abstract Calculate a layout based on given size range.
+ * Call this on children layoutables to compute their layouts within your implementation of -calculateLayoutThatFits:.
  *
- * @param constrainedSize The minimum and maximum sizes the receiver should fit in.
+ * @warning You may not override this method. Override -calculateLayoutThatFits: instead.
+ * @warning In almost all cases, prefer the use of ASCalculateLayout in ASLayout
  *
- * @return An ASLayout instance defining the layout of the receiver and its children.
+ * @param constrainedSize Specifies a minimum and maximum size. The receiver must choose a size that is in this range.
+ * @param parentSize The parent node's size. If the parent component does not have a final size in a given dimension,
+ *                  then it should be passed as ASLayoutableParentDimensionUndefined (for example, if the parent's width
+ *                  depends on the child's size).
+ *
+ * @return A struct defining the layout of the receiver and its children.
  */
-- (ASLayout *)measureWithSizeRange:(ASSizeRange)constrainedSize;
+- (ASLayout *)calculateLayoutThatFits:(ASSizeRange)constrainedSize parentSize:(CGSize)parentSize;
+
+/**
+ * Override this method to compute your nodes's layout.
+ *
+ * @discussion Why do you need to override -calculateLayoutThatFits: instead of -calculateLayoutThatFits:parentSize:?
+ * The base implementation of -calculateLayoutThatFits:parentSize: does the following for you:
+ * 1. First, it uses the parentSize parameter to resolve the nodes's size (the one assigned to the sizeRange property).
+ * 2. Then, it intersects the resolved size with the constrainedSize parameter. If the two don't intersect,
+ *    constrainedSize wins. This allows a component to always override its childrens' sizes when computing its layout.
+ *    (The analogy for UIView: you might return a certain size from -sizeThatFits:, but a parent view can always override
+ *    that size and set your frame to any size.)
+ *
+ * @param constrainedSize A min and max size. This is computed as described in the description. The ASLayout you
+ *                        return MUST have a size between these two sizes.
+ */
+- (ASLayout *)calculateLayoutThatFits:(ASSizeRange)constrainedSize;
+
+/**
+ * ASLayoutable's implementation of -calculateLayoutThatFits:parentSize: calls this method to resolve the component's size
+ * against parentSize, intersect it with constrainedSize, and call -calculateLayoutThatFits: with the result.
+ *
+ * In certain advanced cases, you may want to customize this logic. Overriding this method allows you to receive all
+ * three parameters and do the computation yourself.
+ *
+ * @warning Overriding this method should be done VERY rarely.
+ */
+- (ASLayout *)calculateLayoutThatFits:(ASSizeRange)constrainedSize
+                restrictedToSizeRange:(ASRelativeSizeRange)size
+                 relativeToParentSize:(CGSize)parentSize;
+
+
 
 #pragma mark - Layout options from the Layoutable Protocols
+
 
 #pragma mark - ASStackLayoutable
 /**
@@ -115,14 +168,34 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, readwrite) CGFloat descender;
 
+
 #pragma mark - ASStaticLayoutable
+
 /**
- If specified, the child's size is restricted according to this size. Fractions are resolved relative to the static layout spec.
+ * @abstract If specified, the child's size is restricted according to this size. Fractions are resolved relative to the static layout spec.
+ *
+ * If you define a sizeRange you have to wrap the Layoutable within a ASStaticLayoutSpec otherwise it will not have any effect.
+ *
+ * The default is ASRelativeDimensionUnconstrained, which sets the child's min size to zero and max size to the maximum available space it can consume without overflowing the spec's size.
  */
 @property (nonatomic, assign) ASRelativeSizeRange sizeRange;
 
-/** The position of this object within its parent spec. */
+/**
+ * @abstract The position of this object within its parent spec.
+ */
 @property (nonatomic, assign) CGPoint layoutPosition;
+
+
+#pragma mark - Deprecated
+
+/**
+ * @abstract Calculate a layout based on given size range.
+ *
+ * @param constrainedSize The minimum and maximum sizes the receiver should fit in.
+ *
+ * @return An ASLayout instance defining the layout of the receiver and its children.
+ */
+- (ASLayout *)measureWithSizeRange:(ASSizeRange)constrainedSize; //ASDISPLAYNODE_DEPRECATED;
 
 @end
 

--- a/AsyncDisplayKit/Layout/ASLayoutable.h
+++ b/AsyncDisplayKit/Layout/ASLayoutable.h
@@ -194,8 +194,10 @@ NS_ASSUME_NONNULL_BEGIN
  * @param constrainedSize The minimum and maximum sizes the receiver should fit in.
  *
  * @return An ASLayout instance defining the layout of the receiver and its children.
+ *
+ * @deprecated Deprecated in version 2.0: Use ASCalculateRootLayout or ASCalculateLayout instead
  */
-- (ASLayout *)measureWithSizeRange:(ASSizeRange)constrainedSize; //ASDISPLAYNODE_DEPRECATED;
+- (ASLayout *)measureWithSizeRange:(ASSizeRange)constrainedSize ASDISPLAYNODE_DEPRECATED;
 
 @end
 

--- a/AsyncDisplayKit/Layout/ASLayoutable.mm
+++ b/AsyncDisplayKit/Layout/ASLayoutable.mm
@@ -12,9 +12,14 @@
 
 #import "ASLayoutablePrivate.h"
 #import "ASEnvironmentInternal.h"
+
 #import "ASDisplayNodeInternal.h"
+#import "ASLayoutSpec.h"
 
 #import <map>
+
+CGFloat const ASLayoutableParentDimensionUndefined = NAN;
+CGSize const ASLayoutableParentSizeUndefined = {ASLayoutableParentDimensionUndefined, ASLayoutableParentDimensionUndefined};
 
 int32_t const ASLayoutableContextInvalidTransitionID = 0;
 int32_t const ASLayoutableContextDefaultTransitionID = ASLayoutableContextInvalidTransitionID + 1;
@@ -79,3 +84,7 @@ void ASLayoutableClearCurrentContext()
   ASDN::StaticMutexLocker l(_layoutableContextLock);
   layoutableContextMap.erase(key);
 }
+
+#pragma mark - 
+
+

--- a/AsyncDisplayKit/Layout/ASLayoutablePrivate.h
+++ b/AsyncDisplayKit/Layout/ASLayoutablePrivate.h
@@ -8,7 +8,7 @@
 //  of patent rights can be found in the PATENTS file in the same directory.
 //
 
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 @class ASLayoutSpec;
 @protocol ASLayoutable;

--- a/AsyncDisplayKit/Layout/ASOverlayLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASOverlayLayoutSpec.mm
@@ -47,19 +47,22 @@ static NSUInteger const kOverlayChildIndex = 1;
 /**
  First layout the contents, then fit the overlay on top of it.
  */
-- (ASLayout *)measureWithSizeRange:(ASSizeRange)constrainedSize
+- (ASLayout *)calculateLayoutThatFits:(ASSizeRange)constrainedSize
+                restrictedToSizeRange:(ASRelativeSizeRange)size
+                 relativeToParentSize:(CGSize)parentSize
 {
-  ASLayout *contentsLayout = [self.child measureWithSizeRange:constrainedSize];
+  ASLayout *contentsLayout = [self.child calculateLayoutThatFits:constrainedSize parentSize:parentSize];
   contentsLayout.position = CGPointZero;
   NSMutableArray *sublayouts = [NSMutableArray arrayWithObject:contentsLayout];
   if (self.overlay) {
-    ASLayout *overlayLayout = [self.overlay measureWithSizeRange:{contentsLayout.size, contentsLayout.size}];
+    ASLayout *overlayLayout = [self.overlay calculateLayoutThatFits:{contentsLayout.size, contentsLayout.size}
+                                                         parentSize:contentsLayout.size];
     overlayLayout.position = CGPointZero;
     [sublayouts addObject:overlayLayout];
   }
   
   return [ASLayout layoutWithLayoutableObject:self
-                         constrainedSizeRange:constrainedSize
+                              constrainedSize:constrainedSize
                                          size:contentsLayout.size
                                    sublayouts:sublayouts];
 }

--- a/AsyncDisplayKit/Layout/ASRatioLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASRatioLayoutSpec.mm
@@ -50,12 +50,14 @@
 - (ASLayout *)calculateLayoutThatFits:(ASSizeRange)constrainedSize
 {
   std::vector<CGSize> sizeOptions;
+  // TODO: sizeRange: isValidForLayout() call should not be necessary if INFINITY is used
   if (!isinf(constrainedSize.max.width) && isValidForLayout(constrainedSize.max.width)) {
     sizeOptions.push_back(ASSizeRangeClamp(constrainedSize, {
       constrainedSize.max.width,
       ASFloorPixelValue(_ratio * constrainedSize.max.width)
     }));
   }
+  // TODO: sizeRange: isValidForLayout() call should not be necessary if INFINITY is used
   if (!isinf(constrainedSize.max.height) && isValidForLayout(constrainedSize.max.width)) {
     sizeOptions.push_back(ASSizeRangeClamp(constrainedSize, {
       ASFloorPixelValue(constrainedSize.max.height / _ratio),

--- a/AsyncDisplayKit/Layout/ASRatioLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASRatioLayoutSpec.mm
@@ -47,16 +47,16 @@
   _ratio = ratio;
 }
 
-- (ASLayout *)measureWithSizeRange:(ASSizeRange)constrainedSize
+- (ASLayout *)calculateLayoutThatFits:(ASSizeRange)constrainedSize
 {
   std::vector<CGSize> sizeOptions;
-  if (!isinf(constrainedSize.max.width)) {
+  if (!isinf(constrainedSize.max.width) && isValidForLayout(constrainedSize.max.width)) {
     sizeOptions.push_back(ASSizeRangeClamp(constrainedSize, {
       constrainedSize.max.width,
       ASFloorPixelValue(_ratio * constrainedSize.max.width)
     }));
   }
-  if (!isinf(constrainedSize.max.height)) {
+  if (!isinf(constrainedSize.max.height) && isValidForLayout(constrainedSize.max.width)) {
     sizeOptions.push_back(ASSizeRangeClamp(constrainedSize, {
       ASFloorPixelValue(constrainedSize.max.height / _ratio),
       constrainedSize.max.height
@@ -70,10 +70,11 @@
 
   // If there is no max size in *either* dimension, we can't apply the ratio, so just pass our size range through.
   const ASSizeRange childRange = (bestSize == sizeOptions.end()) ? constrainedSize : ASSizeRangeMake(*bestSize, *bestSize);
-  ASLayout *sublayout = [self.child measureWithSizeRange:childRange];
+  const CGSize parentSize = (bestSize == sizeOptions.end()) ? ASLayoutableParentSizeUndefined : *bestSize;
+  ASLayout *sublayout = [self.child calculateLayoutThatFits:childRange parentSize:parentSize];
   sublayout.position = CGPointZero;
   return [ASLayout layoutWithLayoutableObject:self
-                         constrainedSizeRange:constrainedSize
+                              constrainedSize:constrainedSize
                                          size:sublayout.size
                                    sublayouts:@[sublayout]];
 }

--- a/AsyncDisplayKit/Layout/ASRelativeLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASRelativeLayoutSpec.mm
@@ -57,6 +57,7 @@
   // If we have a finite size in any direction, pass this so that the child can
   // resolve percentages against it. Otherwise pass ASLayoutableParentDimensionUndefined
   // as the size will depend on the content
+  // TODO: sizeRange: isValidForLayout() call should not be necessary if INFINITY is used
   CGSize size = {
     isinf(constrainedSize.max.width) || !isValidForLayout(constrainedSize.max.width) ? ASLayoutableParentDimensionUndefined : constrainedSize.max.width,
     isinf(constrainedSize.max.height) || !isValidForLayout(constrainedSize.max.height) ? ASLayoutableParentDimensionUndefined : constrainedSize.max.height

--- a/AsyncDisplayKit/Layout/ASRelativeLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASRelativeLayoutSpec.mm
@@ -52,11 +52,14 @@
   _sizingOption = sizingOption;
 }
 
-- (ASLayout *)measureWithSizeRange:(ASSizeRange)constrainedSize
+- (ASLayout *)calculateLayoutThatFits:(ASSizeRange)constrainedSize
 {
+  // If we have a finite size in any direction, pass this so that the child can
+  // resolve percentages against it. Otherwise pass ASLayoutableParentDimensionUndefined
+  // as the size will depend on the content
   CGSize size = {
-    constrainedSize.max.width,
-    constrainedSize.max.height
+    isinf(constrainedSize.max.width) || !isValidForLayout(constrainedSize.max.width) ? ASLayoutableParentDimensionUndefined : constrainedSize.max.width,
+    isinf(constrainedSize.max.height) || !isValidForLayout(constrainedSize.max.height) ? ASLayoutableParentDimensionUndefined : constrainedSize.max.height
   };
   
   BOOL reduceWidth = (_horizontalPosition & ASRelativeLayoutSpecPositionCenter) != 0 ||
@@ -70,7 +73,8 @@
     reduceWidth ? 0 : constrainedSize.min.width,
     reduceHeight ? 0 : constrainedSize.min.height,
   };
-  ASLayout *sublayout = [self.child measureWithSizeRange:ASSizeRangeMake(minChildSize, constrainedSize.max)];
+  
+  ASLayout *sublayout = [self.child calculateLayoutThatFits:ASSizeRangeMake(minChildSize, constrainedSize.max) parentSize:size];
   
   // If we have an undetermined height or width, use the child size to define the layout
   // size
@@ -95,7 +99,7 @@
   };
   
   return [ASLayout layoutWithLayoutableObject:self
-                         constrainedSizeRange:constrainedSize
+                              constrainedSize:constrainedSize
                                          size:size
                                    sublayouts:@[sublayout]];
 }

--- a/AsyncDisplayKit/Layout/ASRelativeSize.h
+++ b/AsyncDisplayKit/Layout/ASRelativeSize.h
@@ -31,6 +31,7 @@ typedef struct {
 } ASRelativeSizeRange;
 
 extern ASRelativeSizeRange const ASRelativeSizeRangeUnconstrained;
+extern ASRelativeSizeRange const ASRelativeSizeRangeAuto;
 
 ASDISPLAYNODE_EXTERN_C_BEGIN
 NS_ASSUME_NONNULL_BEGIN
@@ -46,7 +47,7 @@ extern ASRelativeSize ASRelativeSizeMakeWithCGSize(CGSize size);
 extern ASRelativeSize ASRelativeSizeMakeWithFraction(CGFloat fraction);
 
 /** Resolve this relative size relative to a parent size. */
-extern CGSize ASRelativeSizeResolveSize(ASRelativeSize relativeSize, CGSize parentSize);
+extern CGSize ASRelativeSizeResolveSize(ASRelativeSize relativeSize, CGSize parentSize, CGSize autoSize);
 
 extern BOOL ASRelativeSizeEqualToRelativeSize(ASRelativeSize lhs, ASRelativeSize rhs);
 
@@ -55,6 +56,12 @@ extern NSString *NSStringFromASRelativeSize(ASRelativeSize size);
 #pragma mark - ASRelativeSizeRange
 
 extern ASRelativeSizeRange ASRelativeSizeRangeMake(ASRelativeSize min, ASRelativeSize max);
+
+extern ASRelativeSizeRange ASRelativeSizeRangeMakeWithRelativeDimensions(ASRelativeDimension minWidthDimension,
+                                                                         ASRelativeDimension minHeightDimension,
+                                                                         ASRelativeDimension maxWidthDimension,
+                                                                         ASRelativeDimension maxHeightDimension);
+
 
 #pragma mark Convenience constructors to provide an exact size (min == max).
 extern ASRelativeSizeRange ASRelativeSizeRangeMakeWithExactRelativeSize(ASRelativeSize exact);

--- a/AsyncDisplayKit/Layout/ASRelativeSize.mm
+++ b/AsyncDisplayKit/Layout/ASRelativeSize.mm
@@ -11,6 +11,8 @@
 #import "ASRelativeSize.h"
 
 ASRelativeSizeRange const ASRelativeSizeRangeUnconstrained = {};
+ASRelativeSizeRange const ASRelativeSizeRangeAuto = {{ASRelativeDimensionAuto, ASRelativeDimensionAuto},
+                                                     {ASRelativeDimensionAuto, ASRelativeDimensionAuto}};
 
 #pragma mark - ASRelativeSize
 
@@ -31,10 +33,10 @@ ASRelativeSize ASRelativeSizeMakeWithFraction(CGFloat fraction)
                             ASRelativeDimensionMakeWithFraction(fraction));
 }
 
-CGSize ASRelativeSizeResolveSize(ASRelativeSize relativeSize, CGSize parentSize)
+CGSize ASRelativeSizeResolveSize(ASRelativeSize relativeSize, CGSize parentSize, CGSize autoSize)
 {
-  return CGSizeMake(ASRelativeDimensionResolve(relativeSize.width, parentSize.width),
-                    ASRelativeDimensionResolve(relativeSize.height, parentSize.height));
+  return CGSizeMake(ASRelativeDimensionResolve(relativeSize.width, autoSize.width, parentSize.width),
+                    ASRelativeDimensionResolve(relativeSize.height, autoSize.height, parentSize.height));
 }
 
 BOOL ASRelativeSizeEqualToRelativeSize(ASRelativeSize lhs, ASRelativeSize rhs)
@@ -55,6 +57,16 @@ NSString *NSStringFromASRelativeSize(ASRelativeSize size)
 ASRelativeSizeRange ASRelativeSizeRangeMake(ASRelativeSize min, ASRelativeSize max)
 {
   ASRelativeSizeRange sizeRange; sizeRange.min = min; sizeRange.max = max; return sizeRange;
+}
+
+ASRelativeSizeRange ASRelativeSizeRangeMakeWithRelativeDimensions(ASRelativeDimension minWidthDimension,
+                                                                  ASRelativeDimension minHeightDimension,
+                                                                  ASRelativeDimension maxWidthDimension,
+                                                                  ASRelativeDimension maxHeightDimension)
+{
+  return ASRelativeSizeRangeMake(ASRelativeSizeMake(minWidthDimension, minHeightDimension),
+                                 ASRelativeSizeMake(maxWidthDimension, maxHeightDimension));
+  
 }
 
 ASRelativeSizeRange ASRelativeSizeRangeMakeWithExactRelativeSize(ASRelativeSize exact)
@@ -83,9 +95,8 @@ BOOL ASRelativeSizeRangeEqualToRelativeSizeRange(ASRelativeSizeRange lhs, ASRela
   return ASRelativeSizeEqualToRelativeSize(lhs.min, rhs.min) && ASRelativeSizeEqualToRelativeSize(lhs.max, rhs.max);
 }
 
-ASSizeRange ASRelativeSizeRangeResolve(ASRelativeSizeRange relativeSizeRange,
-                                                CGSize parentSize)
+ASSizeRange ASRelativeSizeRangeResolve(ASRelativeSizeRange relativeSizeRange, CGSize parentSize)
 {
-  return ASSizeRangeMake(ASRelativeSizeResolveSize(relativeSizeRange.min, parentSize),
-                         ASRelativeSizeResolveSize(relativeSizeRange.max, parentSize));
+  return ASSizeRangeMake(ASRelativeSizeResolveSize(relativeSizeRange.min, parentSize, {0, 0}),
+                         ASRelativeSizeResolveSize(relativeSizeRange.max, parentSize, {CGFLOAT_MAX, CGFLOAT_MAX}));
 }

--- a/AsyncDisplayKit/Layout/ASStackLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASStackLayoutSpec.mm
@@ -118,11 +118,11 @@
   _baselineRelativeArrangement = baselineRelativeArrangement;
 }
 
-- (ASLayout *)measureWithSizeRange:(ASSizeRange)constrainedSize
+- (ASLayout *)calculateLayoutThatFits:(ASSizeRange)constrainedSize
 {
   if (self.children.count == 0) {
     return [ASLayout layoutWithLayoutableObject:self
-                           constrainedSizeRange:constrainedSize
+                                constrainedSize:constrainedSize
                                            size:constrainedSize.min];
   }
   
@@ -162,7 +162,7 @@
   }
   
   return [ASLayout layoutWithLayoutableObject:self
-                         constrainedSizeRange:constrainedSize
+                              constrainedSize:constrainedSize
                                          size:ASSizeRangeClamp(constrainedSize, finalSize)
                                    sublayouts:sublayouts];
 }

--- a/AsyncDisplayKit/Layout/ASStaticLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASStaticLayoutSpec.mm
@@ -36,7 +36,7 @@
 
 - (ASLayout *)calculateLayoutThatFits:(ASSizeRange)constrainedSize
 {
-  // TODO: sizeRange: isValidForLayout() call should not be necessary
+  // TODO: sizeRange: isValidForLayout() call should not be necessary if INFINITY is used
   CGSize size = {
     (isinf(constrainedSize.max.width) || !isValidForLayout(constrainedSize.max.width)) ? ASLayoutableParentDimensionUndefined : constrainedSize.max.width,
     (isinf(constrainedSize.max.height) || !isValidForLayout(constrainedSize.max.height)) ? ASLayoutableParentDimensionUndefined : constrainedSize.max.height

--- a/AsyncDisplayKit/Layout/ASStaticLayoutable.h
+++ b/AsyncDisplayKit/Layout/ASStaticLayoutable.h
@@ -18,11 +18,17 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol ASStaticLayoutable
 
 /**
- If specified, the child's size is restricted according to this size. Fractions are resolved relative to the static layout spec.
+ * @abstract If specified, the child's size is restricted according to this size. Fractions are resolved relative to the static layout spec.
+ *
+ * If you define a sizeRange you have to wrap the Layoutable within a ASStaticLayoutSpec otherwise it will not have any effect.
+ *
+ * The default is ASRelativeDimensionUnconstrained, which sets the child's min size to zero and max size to the maximum available space it can consume without overflowing the spec's size.
  */
 @property (nonatomic, assign) ASRelativeSizeRange sizeRange;
 
-/** The position of this object within its parent spec. */
+/**
+ * @abstract The position of this object within its parent spec.
+ */
 @property (nonatomic, assign) CGPoint layoutPosition;
 
 @end

--- a/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
+++ b/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
@@ -104,6 +104,9 @@ FOUNDATION_EXPORT NSString * const ASRenderingEngineDidDisplayNodesScheduledBefo
   
 @protected
   ASDisplayNode * __weak _supernode;
+  
+  ASRelativeSizeRange _size;
+  CGSize _preferredFrameSize;
 
   ASSentinel *_displaySentinel;
 

--- a/AsyncDisplayKit/Private/ASInternalHelpers.h
+++ b/AsyncDisplayKit/Private/ASInternalHelpers.h
@@ -9,7 +9,6 @@
 //
 
 #import <UIKit/UIKit.h>
-#import <CoreGraphics/CGBase.h>
 
 #import <AsyncDisplayKit/ASBaseDefines.h>
 

--- a/AsyncDisplayKit/Private/ASLayoutTransition.mm
+++ b/AsyncDisplayKit/Private/ASLayoutTransition.mm
@@ -172,9 +172,9 @@ static inline BOOL ASLayoutCanTransitionAsynchronous(ASLayout *layout) {
 {
   ASDN::MutexSharedLocker l(__instanceLock__);
   if ([key isEqualToString:ASTransitionContextFromLayoutKey]) {
-    return _previousLayout.constrainedSizeRange;
+    return _previousLayout.constrainedSize;
   } else if ([key isEqualToString:ASTransitionContextToLayoutKey]) {
-    return _pendingLayout.constrainedSizeRange;
+    return _pendingLayout.constrainedSize;
   } else {
     return ASSizeRangeMake(CGSizeZero, CGSizeZero);
   }

--- a/AsyncDisplayKit/Private/ASStackUnpositionedLayout.mm
+++ b/AsyncDisplayKit/Private/ASStackUnpositionedLayout.mm
@@ -23,13 +23,14 @@ static ASLayout *crossChildLayout(const id<ASLayoutable> child,
                                   const CGFloat stackMin,
                                   const CGFloat stackMax,
                                   const CGFloat crossMin,
-                                  const CGFloat crossMax)
+                                  const CGFloat crossMax,
+                                  const CGSize size)
 {
   const ASStackLayoutAlignItems alignItems = alignment(child.alignSelf, style.alignItems);
   // stretched children will have a cross dimension of at least crossMin
   const CGFloat childCrossMin = alignItems == ASStackLayoutAlignItemsStretch ? crossMin : 0;
   const ASSizeRange childSizeRange = directionSizeRange(style.direction, stackMin, stackMax, childCrossMin, crossMax);
-  ASLayout *layout = [child measureWithSizeRange:childSizeRange];
+  ASLayout *layout = [child calculateLayoutThatFits:childSizeRange parentSize:size];
   ASDisplayNodeCAssertNotNil(layout, @"ASLayout returned from measureWithSizeRange: must not be nil: %@", child);
   return layout ? : [ASLayout layoutWithLayoutableObject:child constrainedSizeRange:childSizeRange size:CGSizeZero];
 }
@@ -67,7 +68,8 @@ static ASLayout *crossChildLayout(const id<ASLayoutable> child,
  @param style the layout style of the overall stack layout
  */
 static void stretchChildrenAlongCrossDimension(std::vector<ASStackUnpositionedItem> &layouts,
-                                               const ASStackLayoutSpecStyle &style)
+                                               const ASStackLayoutSpecStyle &style,
+                                               const CGSize size)
 {
   // Find the maximum cross dimension size among child layouts
   const auto it = std::max_element(layouts.begin(), layouts.end(),
@@ -77,19 +79,16 @@ static void stretchChildrenAlongCrossDimension(std::vector<ASStackUnpositionedIt
 
   const CGFloat childCrossMax = it == layouts.end() ? 0 : crossDimension(style.direction, it->layout.size);
   for (auto &l : layouts) {
-    const id<ASLayoutable> child = l.child;
-    const CGSize size = l.layout.size;
-    
-    const ASStackLayoutAlignItems alignItems = alignment(child.alignSelf, style.alignItems);
+    const ASStackLayoutAlignItems alignItems = alignment(l.child.alignSelf, style.alignItems);
 
-    const CGFloat cross = crossDimension(style.direction, size);
-    const CGFloat stack = stackDimension(style.direction, size);
+    const CGFloat cross = crossDimension(style.direction, l.layout.size);
+    const CGFloat stack = stackDimension(style.direction, l.layout.size);
 
     // restretch all stretchable children along the cross axis using the new min. set their max size to childCrossMax,
     // not crossMax, so that if any of them would choose a larger size just because the min size increased (weird!)
     // they are forced to choose the same width as all the other children.
     if (alignItems == ASStackLayoutAlignItemsStretch && std::fabs(cross - childCrossMax) > 0.01) {
-      l.layout = crossChildLayout(child, style, stack, stack, childCrossMax, childCrossMax);
+      l.layout = crossChildLayout(l.child, style, stack, stack, childCrossMax, childCrossMax, size);
     }
   }
 }
@@ -217,7 +216,8 @@ ASDISPLAYNODE_INLINE BOOL useOptimizedFlexing(const std::vector<id<ASLayoutable>
  */
 static void layoutFlexibleChildrenAtZeroSize(std::vector<ASStackUnpositionedItem> &items,
                                              const ASStackLayoutSpecStyle &style,
-                                             const ASSizeRange &sizeRange)
+                                             const ASSizeRange &sizeRange,
+                                             const CGSize size)
 {
   for (ASStackUnpositionedItem &item : items) {
     const id<ASLayoutable> child = item.child;
@@ -227,7 +227,8 @@ static void layoutFlexibleChildrenAtZeroSize(std::vector<ASStackUnpositionedItem
                                      0,
                                      0,
                                      crossDimension(style.direction, sizeRange.min),
-                                     crossDimension(style.direction, sizeRange.max));
+                                     crossDimension(style.direction, sizeRange.max),
+                                     size);
     }
   }
 }
@@ -247,6 +248,7 @@ static void layoutFlexibleChildrenAtZeroSize(std::vector<ASStackUnpositionedItem
 static void flexChildrenAlongStackDimension(std::vector<ASStackUnpositionedItem> &items,
                                             const ASStackLayoutSpecStyle &style,
                                             const ASSizeRange &sizeRange,
+                                            const CGSize size,
                                             const BOOL useOptimizedFlexing)
 {
   const CGFloat stackDimensionSum = computeStackDimensionSum(items, style);
@@ -258,7 +260,7 @@ static void flexChildrenAlongStackDimension(std::vector<ASStackUnpositionedItem>
   if (flexibleChildren == 0) {
     // If optimized flexing was used then we have to clean up the unsized children, and lay them out at zero size
     if (useOptimizedFlexing) {
-      layoutFlexibleChildrenAtZeroSize(items, style, sizeRange);
+      layoutFlexibleChildrenAtZeroSize(items, style, sizeRange, size);
     }
     return;
   }
@@ -280,7 +282,8 @@ static void flexChildrenAlongStackDimension(std::vector<ASStackUnpositionedItem>
                                      MAX(flexedStackSize, 0),
                                      MAX(flexedStackSize, 0),
                                      crossDimension(style.direction, sizeRange.min),
-                                     crossDimension(style.direction, sizeRange.max));
+                                     crossDimension(style.direction, sizeRange.max),
+                                     size);
       isFirstFlex = NO;
     }
   }
@@ -298,23 +301,24 @@ static std::vector<ASStackUnpositionedItem> layoutChildrenAlongUnconstrainedStac
 {
   const CGFloat minCrossDimension = crossDimension(style.direction, sizeRange.min);
   const CGFloat maxCrossDimension = crossDimension(style.direction, sizeRange.max);
-  
   return AS::map(children, [&](id<ASLayoutable> child) -> ASStackUnpositionedItem {
-    const ASRelativeDimension flexBasis = child.flexBasis;
-    const BOOL isUnconstrainedFlexBasis = ASRelativeDimensionEqualToRelativeDimension(ASRelativeDimensionUnconstrained, flexBasis);
-    const CGFloat exactStackDimension = ASRelativeDimensionResolve(flexBasis, stackDimension(style.direction, size));
-
     if (useOptimizedFlexing && isFlexibleInBothDirections(child)) {
-      return { child, [ASLayout layoutWithLayoutableObject:child constrainedSizeRange:sizeRange size:{0, 0}] };
+      return { child, [ASLayout layoutWithLayoutableObject:child constrainedSize:sizeRange size:{0, 0}] };
     } else {
+        
+      ASRelativeDimension flexBasis = child.flexBasis;
+      const BOOL isUnconstrainedFlexBasis = ASRelativeDimensionEqualToRelativeDimension(ASRelativeDimensionUnconstrained, flexBasis);
+      // TODO: sizeRange: We don't need this anymore if ASRelativeDimensionAuto is used as default for .flexBasis
+      flexBasis = isUnconstrainedFlexBasis ? ASRelativeDimensionAuto : flexBasis;
       return {
         child,
         crossChildLayout(child,
                          style,
-                         isUnconstrainedFlexBasis ? 0 : exactStackDimension,
-                         isUnconstrainedFlexBasis ? INFINITY : exactStackDimension,
+                         ASRelativeDimensionResolve(flexBasis, 0, stackDimension(style.direction, size)),
+                         ASRelativeDimensionResolve(flexBasis, INFINITY, stackDimension(style.direction, size)),
                          minCrossDimension,
-                         maxCrossDimension)
+                         maxCrossDimension,
+                         size)
       };
     }
   });
@@ -324,9 +328,11 @@ ASStackUnpositionedLayout ASStackUnpositionedLayout::compute(const std::vector<i
                                                              const ASStackLayoutSpecStyle &style,
                                                              const ASSizeRange &sizeRange)
 {
+  // If we have a fixed size in either dimension, pass it to children so they can resolve percentages against it.
+  // Otherwise, we pass ASLayoutableParentDimensionUndefined since it will depend on the content.
   const CGSize size = {
-    sizeRange.max.width,
-    sizeRange.max.height
+    (sizeRange.min.width == sizeRange.max.width) ? sizeRange.min.width : ASLayoutableParentDimensionUndefined,
+    (sizeRange.min.height == sizeRange.max.height) ? sizeRange.min.height : ASLayoutableParentDimensionUndefined,
   };
 
   // We may be able to avoid some redundant layout passes
@@ -341,8 +347,8 @@ ASStackUnpositionedLayout ASStackUnpositionedLayout::compute(const std::vector<i
                                                                                               size,
                                                                                               optimizedFlexing);
 
-  flexChildrenAlongStackDimension(items, style, sizeRange, optimizedFlexing);
-  stretchChildrenAlongCrossDimension(items, style);
+  flexChildrenAlongStackDimension(items, style, sizeRange, size, optimizedFlexing);
+  stretchChildrenAlongCrossDimension(items, style, size);
 
   const CGFloat stackDimensionSum = computeStackDimensionSum(items, style);
   return {items, stackDimensionSum, computeViolation(stackDimensionSum, style, sizeRange)};

--- a/AsyncDisplayKit/TextKit/ASTextKitComponents.h
+++ b/AsyncDisplayKit/TextKit/ASTextKitComponents.h
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  @abstract Creates the stack of TextKit components.
  @param attributedSeedString The attributed string to seed the returned text storage with, or nil to receive an blank text storage.
- @param textContainerSize The size of the text-container. Typically, size specifies the constraining width of the layout, and FLT_MAX for height. Pass CGSizeZero if these components will be hooked up to a UITextView, which will manage the text container's size itself.
+ @param textContainerSize The size of the text-container. Typically, size specifies the constraining width of the layout, and CGFLOAT_MAX for height. Pass CGSizeZero if these components will be hooked up to a UITextView, which will manage the text container's size itself.
  @return An `ASTextKitComponents` containing the created components. The text view component will be nil.
  @discussion The returned components will be hooked up together, so they are ready for use as a system upon return.
  */
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  @abstract Creates the stack of TextKit components.
  @param textStorage The NSTextStorage to use.
- @param textContainerSize The size of the text-container. Typically, size specifies the constraining width of the layout, and FLT_MAX for height. Pass CGSizeZero if these components will be hooked up to a UITextView, which will manage the text container's size itself.
+ @param textContainerSize The size of the text-container. Typically, size specifies the constraining width of the layout, and CGFLOAT_MAX for height. Pass CGSizeZero if these components will be hooked up to a UITextView, which will manage the text container's size itself.
  @param layoutManager The NSLayoutManager to use.
  @return An `ASTextKitComponents` containing the created components. The text view component will be nil.
  @discussion The returned components will be hooked up together, so they are ready for use as a system upon return.

--- a/AsyncDisplayKit/TextKit/ASTextKitComponents.m
+++ b/AsyncDisplayKit/TextKit/ASTextKitComponents.m
@@ -56,7 +56,7 @@
   // If our text-view's width is already the constrained width, we can use our existing TextKit stack for this sizing calculation.
   // Otherwise, we create a temporary stack to size for `constrainedWidth`.
   if (CGRectGetWidth(components.textView.bounds) != constrainedWidth) {
-    components = [ASTextKitComponents componentsWithAttributedSeedString:components.textStorage textContainerSize:CGSizeMake(constrainedWidth, FLT_MAX)];
+    components = [ASTextKitComponents componentsWithAttributedSeedString:components.textStorage textContainerSize:CGSizeMake(constrainedWidth, CGFLOAT_MAX)];
   }
 
   // Force glyph generation and layout, which may not have happened yet (and isn't triggered by -usedRectForTextContainer:).

--- a/AsyncDisplayKit/TextKit/ASTextKitFontSizeAdjuster.mm
+++ b/AsyncDisplayKit/TextKit/ASTextKitFontSizeAdjuster.mm
@@ -99,7 +99,7 @@
     if (_sizingTextContainer == nil) {
         // make this text container unbounded in height so that the layout manager will compute the total
         // number of lines and not stop counting when height runs out.
-        _sizingTextContainer = [[NSTextContainer alloc] initWithSize:CGSizeMake(_constrainedSize.width, FLT_MAX)];
+        _sizingTextContainer = [[NSTextContainer alloc] initWithSize:CGSizeMake(_constrainedSize.width, CGFLOAT_MAX)];
         _sizingTextContainer.lineFragmentPadding = 0;
         
         // use 0 regardless of what is in the attributes so that we get an accurate line count
@@ -156,7 +156,7 @@
       
       NSRange longestWordRange = [str rangeOfString:longestWordNeedingResize];
       NSMutableAttributedString *attrString = [textStorage attributedSubstringFromRange:longestWordRange].mutableCopy;
-      CGSize longestWordSize = [attrString boundingRectWithSize:CGSizeMake(FLT_MAX, FLT_MAX) options:NSStringDrawingUsesLineFragmentOrigin context:nil].size;
+      CGSize longestWordSize = [attrString boundingRectWithSize:CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX) options:NSStringDrawingUsesLineFragmentOrigin context:nil].size;
       
       // check if the longest word is larger than our constrained width
       if (longestWordSize.width > _constrainedSize.width) {

--- a/AsyncDisplayKitTests/ASDisplayNodeImplicitHierarchyTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeImplicitHierarchyTests.m
@@ -16,6 +16,7 @@
 #import "ASDisplayNode+Beta.h"
 #import "ASDisplayNode+Subclasses.h"
 
+#import "ASLayout.h"
 #import "ASStaticLayoutSpec.h"
 #import "ASStackLayoutSpec.h"
 
@@ -77,7 +78,7 @@
     
     return [ASStaticLayoutSpec staticLayoutSpecWithChildren:@[stack1, stack2, node5]];
   };
-  [node measureWithSizeRange:ASSizeRangeMake(CGSizeZero, CGSizeZero)];
+  ASCalculateRootLayout(node, ASSizeRangeMake(CGSizeZero, CGSizeZero));
   XCTAssertEqual(node.subnodes[0], node5);
   XCTAssertEqual(node.subnodes[1], node1);
   XCTAssertEqual(node.subnodes[2], node2);
@@ -104,13 +105,13 @@
     }
   };
   
-  [node measureWithSizeRange:ASSizeRangeMake(CGSizeZero, CGSizeZero)];
+  ASCalculateRootLayout(node, ASSizeRangeMake(CGSizeZero, CGSizeZero));
   XCTAssertEqual(node.subnodes[0], node1);
   XCTAssertEqual(node.subnodes[1], node2);
   
   node.layoutState = @2;
   [node invalidateCalculatedLayout];
-  [node measureWithSizeRange:ASSizeRangeMake(CGSizeZero, CGSizeZero)];
+  ASCalculateRootLayout(node, ASSizeRangeMake(CGSizeZero, CGSizeZero));
 
   XCTAssertEqual(node.subnodes[0], node1);
   XCTAssertEqual(node.subnodes[1], node3);
@@ -140,12 +141,12 @@
   
   dispatch_async(dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
     
-    [node measureWithSizeRange:ASSizeRangeMake(CGSizeZero, CGSizeZero)];
+    ASCalculateRootLayout(node, ASSizeRangeMake(CGSizeZero, CGSizeZero));
     XCTAssertEqual(node.subnodes[0], node1);
     
     node.layoutState = @2;
     [node invalidateCalculatedLayout];
-    [node measureWithSizeRange:ASSizeRangeMake(CGSizeZero, CGSizeZero)];
+    ASCalculateRootLayout(node, ASSizeRangeMake(CGSizeZero, CGSizeZero));
     
     // Dispatch back to the main thread to let the insertion / deletion of subnodes happening
     dispatch_async(dispatch_get_main_queue(), ^{
@@ -185,7 +186,7 @@
   
   XCTestExpectation *expectation = [self expectationWithDescription:@"Fix IHM layout transition also if one node is already loaded"];
   
-  [node measureWithSizeRange:ASSizeRangeMake(CGSizeZero, CGSizeZero)];
+  ASCalculateRootLayout(node, ASSizeRangeMake(CGSizeZero, CGSizeZero));
   XCTAssertEqual(node.subnodes[0], node1);
   
   node.layoutState = @2;

--- a/AsyncDisplayKitTests/ASEditableTextNodeTests.m
+++ b/AsyncDisplayKitTests/ASEditableTextNodeTests.m
@@ -138,18 +138,6 @@ static BOOL CGSizeEqualToSizeWithIn(CGSize size1, CGSize size2, CGFloat delta)
   XCTAssertTrue(secureEditableTextNode.textView.secureTextEntry == YES,                                @"textView's isSecureTextEntry should be YES.");
 }
 
-- (void)testSetPreferredFrameSize
-{
-  CGSize preferredFrameSize = CGSizeMake(100, 100);
-  _editableTextNode.preferredFrameSize = preferredFrameSize;
-  
-  CGSize calculatedSize = [_editableTextNode measure:CGSizeZero];
-  XCTAssertTrue(calculatedSize.width != preferredFrameSize.width, @"Calculated width (%f) should be equal to preferred width (%f)", calculatedSize.width, preferredFrameSize.width);
-  XCTAssertTrue(calculatedSize.width != preferredFrameSize.width, @"Calculated height (%f) should be equal to preferred height (%f)", calculatedSize.width, preferredFrameSize.width);
-  
-  _editableTextNode.preferredFrameSize = CGSizeZero;
-}
-
 - (void)testCalculatedSizeIsGreaterThanOrEqualToConstrainedSize
 {
   for (NSInteger i = 10; i < 500; i += 50) {

--- a/AsyncDisplayKitTests/ASLayoutSpecSnapshotTestsHelper.m
+++ b/AsyncDisplayKitTests/ASLayoutSpecSnapshotTestsHelper.m
@@ -39,7 +39,7 @@
   
   node.layoutSpecUnderTest = layoutSpec;
   
-  [node measureWithSizeRange:sizeRange];
+  ASCalculateRootLayout(node, sizeRange);
   ASSnapshotVerifyNode(node, identifier);
 }
 

--- a/AsyncDisplayKitTests/ASStaticLayoutSpecSnapshotTests.m
+++ b/AsyncDisplayKitTests/ASStaticLayoutSpecSnapshotTests.m
@@ -22,12 +22,12 @@
 
 - (void)testSizingBehaviour
 {
-  [self testWithSizeRange:ASSizeRangeMake(CGSizeMake(150, 200), CGSizeMake(FLT_MAX, FLT_MAX))
+  [self testWithSizeRange:ASSizeRangeMake(CGSizeMake(150, 200), CGSizeMake(INFINITY, INFINITY))
                identifier:@"underflowChildren"];
   [self testWithSizeRange:ASSizeRangeMake(CGSizeZero, CGSizeMake(50, 100))
                identifier:@"overflowChildren"];
   // Expect the spec to wrap its content because children sizes are between constrained size
-  [self testWithSizeRange:ASSizeRangeMake(CGSizeZero, CGSizeMake(FLT_MAX / 2, FLT_MAX / 2))
+  [self testWithSizeRange:ASSizeRangeMake(CGSizeZero, CGSizeMake(INFINITY / 2, INFINITY / 2))
                identifier:@"wrappedChildren"];
 }
 

--- a/AsyncDisplayKitTests/ASTextNodeSnapshotTests.m
+++ b/AsyncDisplayKitTests/ASTextNodeSnapshotTests.m
@@ -10,8 +10,8 @@
 //
 
 #import "ASSnapshotTestCase.h"
-
 #import <AsyncDisplayKit/AsyncDisplayKit.h>
+#import "ASLayout.h"
 
 @interface ASTextNodeSnapshotTests : ASSnapshotTestCase
 
@@ -25,7 +25,7 @@
   ASTextNode *textNode = [[ASTextNode alloc] init];
   textNode.attributedText = [[NSAttributedString alloc] initWithString:@"judar"
                                                             attributes:@{NSFontAttributeName : [UIFont italicSystemFontOfSize:24]}];
-  [textNode measureWithSizeRange:ASSizeRangeMake(CGSizeZero, CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX))];
+  ASCalculateRootLayout(textNode, ASSizeRangeMake(CGSizeZero, CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX)));
   textNode.textContainerInset = UIEdgeInsetsMake(0, 2, 0, 2);
   
   ASSnapshotVerifyNode(textNode, nil);
@@ -40,7 +40,7 @@
   textNode.attributedText = [[NSAttributedString alloc] initWithString:@"yolo"
                                                             attributes:@{ NSFontAttributeName : [UIFont systemFontOfSize:30] }];
 
-  [textNode measureWithSizeRange:ASSizeRangeMake(CGSizeZero, CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX))];
+  ASCalculateRootLayout(textNode, ASSizeRangeMake(CGSizeZero, CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX)));
   textNode.frame = CGRectMake(50, 50, textNode.calculatedSize.width, textNode.calculatedSize.height);
   textNode.textContainerInset = UIEdgeInsetsMake(5, 10, 10, 5);
 

--- a/examples/ASDKTube/Sample/Nodes/VideoContentCell.m
+++ b/examples/ASDKTube/Sample/Nodes/VideoContentCell.m
@@ -65,7 +65,7 @@
     [self addSubnode:_likeButtonNode];
 
     _muteButtonNode = [[ASButtonNode alloc] init];
-    _muteButtonNode.preferredFrameSize = CGSizeMake(16.0, 22.0);
+    _muteButtonNode.size = ASRelativeSizeRangeMakeWithExactCGSize(CGSizeMake(16.0, 22.0));
     [_muteButtonNode addTarget:self action:@selector(didTapMuteButton) forControlEvents:ASControlNodeEventTouchUpInside];
 
     _videoPlayerNode = [[ASVideoPlayerNode alloc] initWithUrl:_videoModel.url loadAssetWhenNodeBecomesVisible:YES];
@@ -89,9 +89,9 @@
 - (ASLayoutSpec*)layoutSpecThatFits:(ASSizeRange)constrainedSize
 {
   CGFloat fullWidth = [UIScreen mainScreen].bounds.size.width;
-  _videoPlayerNode.preferredFrameSize = CGSizeMake(fullWidth, fullWidth * 9 / 16);
-  _avatarNode.preferredFrameSize = CGSizeMake(AVATAR_IMAGE_HEIGHT, AVATAR_IMAGE_HEIGHT);
-  _likeButtonNode.preferredFrameSize = CGSizeMake(50.0, 26.0);
+  _videoPlayerNode.size = ASRelativeSizeRangeMakeWithExactCGSize(CGSizeMake(fullWidth, fullWidth * 9 / 16));
+  _avatarNode.size = ASRelativeSizeRangeMakeWithExactCGSize(CGSizeMake(AVATAR_IMAGE_HEIGHT, AVATAR_IMAGE_HEIGHT));
+  _likeButtonNode.size = ASRelativeSizeRangeMakeWithExactCGSize(CGSizeMake(50.0, 26.0));
 
   ASStackLayoutSpec *headerStack  = [ASStackLayoutSpec horizontalStackLayoutSpec];
   headerStack.spacing = HORIZONTAL_BUFFER;
@@ -104,15 +104,15 @@
   ASStackLayoutSpec *bottomControlsStack  = [ASStackLayoutSpec horizontalStackLayoutSpec];
   bottomControlsStack.spacing = HORIZONTAL_BUFFER;
   bottomControlsStack.alignItems = ASStackLayoutAlignItemsCenter;
-  [bottomControlsStack setChildren:@[ _likeButtonNode]];
+  bottomControlsStack.children = @[_likeButtonNode];
 
-  UIEdgeInsets bottomControlsInsets       = UIEdgeInsetsMake(HORIZONTAL_BUFFER, HORIZONTAL_BUFFER, HORIZONTAL_BUFFER, HORIZONTAL_BUFFER);
+  UIEdgeInsets bottomControlsInsets = UIEdgeInsetsMake(HORIZONTAL_BUFFER, HORIZONTAL_BUFFER, HORIZONTAL_BUFFER, HORIZONTAL_BUFFER);
   ASInsetLayoutSpec *bottomControlsInset  = [ASInsetLayoutSpec insetLayoutSpecWithInsets:bottomControlsInsets child:bottomControlsStack];
 
 
-  ASStackLayoutSpec *verticalStack   = [ASStackLayoutSpec verticalStackLayoutSpec];
-  verticalStack.alignItems           = ASStackLayoutAlignItemsStretch;
-  [verticalStack setChildren:@[ headerInset, _videoPlayerNode, bottomControlsInset ]];
+  ASStackLayoutSpec *verticalStack = [ASStackLayoutSpec verticalStackLayoutSpec];
+  verticalStack.alignItems = ASStackLayoutAlignItemsStretch;
+  verticalStack.children = @[headerInset, _videoPlayerNode, bottomControlsInset];
   return verticalStack;
 }
 
@@ -183,7 +183,9 @@
 
   if (controls[ @(ASVideoPlayerNodeControlTypeScrubber) ]) {
     ASDisplayNode *scrubber = controls[ @(ASVideoPlayerNodeControlTypeScrubber) ];
-    scrubber.preferredFrameSize = CGSizeMake(maxSize.width, 44.0);
+    scrubber.size = ASRelativeSizeRangeMake(ASRelativeSizeMakeWithCGSize(CGSizeMake(0.0, 44.0)),
+                                            ASRelativeSizeMakeWithCGSize(CGSizeMake(maxSize.width, 44.0)));
+    scrubber.flexGrow = YES;
   }
 
   NSArray *controlBarControls = [self controlsForControlBar:controls];

--- a/examples/ASDKgram/Sample/PhotoCellNode.m
+++ b/examples/ASDKgram/Sample/PhotoCellNode.m
@@ -126,7 +126,7 @@
   
   // header stack
   
-  _userAvatarImageView.preferredFrameSize        = CGSizeMake(USER_IMAGE_HEIGHT, USER_IMAGE_HEIGHT);     // constrain avatar image frame size
+  _userAvatarImageView.size = ASRelativeSizeRangeMakeWithExactCGSize(CGSizeMake(USER_IMAGE_HEIGHT, USER_IMAGE_HEIGHT));     // constrain avatar image frame size
   _photoTimeIntervalSincePostLabel.spacingBefore = HORIZONTAL_BUFFER;                                    // to remove double spaces around spacer
   
   ASLayoutSpec *spacer           = [[ASLayoutSpec alloc] init];    // FIXME: long locations overflow post time - set max size?
@@ -155,7 +155,7 @@
   
   // vertical stack
   CGFloat cellWidth                  = constrainedSize.max.width;
-  _photoImageView.preferredFrameSize = CGSizeMake(cellWidth, cellWidth);              // constrain photo frame size
+  _photoImageView.size = ASRelativeSizeRangeMakeWithExactCGSize(CGSizeMake(cellWidth, cellWidth));              // constrain photo frame size
   
   ASStackLayoutSpec *verticalStack   = [ASStackLayoutSpec verticalStackLayoutSpec];
   verticalStack.alignItems           = ASStackLayoutAlignItemsStretch;                // stretch headerStack to fill horizontal space

--- a/examples/CatDealsCollectionView/Sample/LoadingNode.m
+++ b/examples/CatDealsCollectionView/Sample/LoadingNode.m
@@ -53,7 +53,7 @@ static CGFloat kFixedHeight = 200.0f;
     [spinner startAnimating];
     return spinner;
   }];
-  _loadingSpinner.preferredFrameSize = CGSizeMake(50, 50);
+  _loadingSpinner.size = ASRelativeSizeRangeMakeWithExactCGSize(CGSizeMake(50, 50));
   
   
   // add it as a subnode, and we're done

--- a/examples/HorizontalWithinVerticalScrolling/Sample/HorizontalScrollCellNode.mm
+++ b/examples/HorizontalWithinVerticalScrolling/Sample/HorizontalScrollCellNode.mm
@@ -64,6 +64,7 @@ static const CGFloat kInnerPadding = 10.0f;
 - (void)didLoad
 {
   [super didLoad];
+  
   _collectionNode.view.asyncDelegate = self;
   _collectionNode.view.asyncDataSource = self;
 }
@@ -75,21 +76,22 @@ static const CGFloat kInnerPadding = 10.0f;
 
 - (ASCellNodeBlock)collectionView:(ASCollectionView *)collectionView nodeBlockForItemAtIndexPath:(NSIndexPath *)indexPath
 {
+  CGSize elementSize = _elementSize;
   return ^{
     RandomCoreGraphicsNode *elementNode = [[RandomCoreGraphicsNode alloc] init];
-    elementNode.preferredFrameSize = _elementSize;
+    elementNode.size = ASRelativeSizeRangeMakeWithExactCGSize(elementSize);
     return elementNode;
   };
 }
 
 - (ASLayoutSpec *)layoutSpecThatFits:(ASSizeRange)constrainedSize
 {
-  _collectionNode.preferredFrameSize = CGSizeMake(self.bounds.size.width, _elementSize.height);
+  CGSize collectionNodeSize = CGSizeMake(constrainedSize.max.width, _elementSize.height);
+  _collectionNode.size = ASRelativeSizeRangeMakeWithExactCGSize(collectionNodeSize);
   
   ASInsetLayoutSpec *insetSpec = [[ASInsetLayoutSpec alloc] init];
   insetSpec.insets = UIEdgeInsetsMake(kOuterPadding, 0.0, kOuterPadding, 0.0);
   insetSpec.child = _collectionNode;
-  
   return insetSpec;
 }
 

--- a/examples/HorizontalWithinVerticalScrolling/Sample/ViewController.m
+++ b/examples/HorizontalWithinVerticalScrolling/Sample/ViewController.m
@@ -68,13 +68,11 @@
   _tableView.frame = self.view.bounds;
 }
 
-#pragma mark -
-#pragma mark ASTableView.
+#pragma mark - ASTableView.
 
 - (ASCellNode *)tableView:(ASTableView *)tableView nodeForRowAtIndexPath:(NSIndexPath *)indexPath
 {
-  HorizontalScrollCellNode *node = [[HorizontalScrollCellNode alloc] initWithElementSize:CGSizeMake(100, 100)];
-  return node;
+  return [[HorizontalScrollCellNode alloc] initWithElementSize:CGSizeMake(100, 100)];
 }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section

--- a/examples/Kittens/Sample/KittenNode.mm
+++ b/examples/Kittens/Sample/KittenNode.mm
@@ -142,13 +142,14 @@ static const CGFloat kInnerPadding = 10.0f;
 #if UseAutomaticLayout
 - (ASLayoutSpec *)layoutSpecThatFits:(ASSizeRange)constrainedSize
 {
-  _imageNode.preferredFrameSize = _isImageEnlarged ? CGSizeMake(2.0 * kImageSize, 2.0 * kImageSize) : CGSizeMake(kImageSize, kImageSize);
+  CGSize imageSize = _isImageEnlarged ? CGSizeMake(2.0 * kImageSize, 2.0 * kImageSize) : CGSizeMake(kImageSize, kImageSize);
+  _imageNode.size = ASRelativeSizeRangeMakeWithExactCGSize(imageSize);
   _textNode.flexShrink = YES;
   
   ASStackLayoutSpec *stackSpec = [[ASStackLayoutSpec alloc] init];
   stackSpec.direction = ASStackLayoutDirectionHorizontal;
   stackSpec.spacing = kInnerPadding;
-  [stackSpec setChildren:!_swappedTextAndImage ? @[_imageNode, _textNode] : @[_textNode, _imageNode]];
+  stackSpec.children = !_swappedTextAndImage ? @[_imageNode, _textNode] : @[_textNode, _imageNode];
   
   ASInsetLayoutSpec *insetSpec = [[ASInsetLayoutSpec alloc] init];
   insetSpec.insets = UIEdgeInsetsMake(kOuterPadding, kOuterPadding, kOuterPadding, kOuterPadding);

--- a/examples/SocialAppLayout/Sample/PostNode.m
+++ b/examples/SocialAppLayout/Sample/PostNode.m
@@ -20,6 +20,7 @@
 #import "TextStyles.h"
 #import "LikesNode.h"
 #import "CommentsNode.h"
+#import "ASRelativeSize.h"
 
 #define PostNodeDividerColor [UIColor lightGrayColor]
 
@@ -237,14 +238,25 @@
     [mainStackContent addObject:nameStack];
     [mainStackContent addObject:_postNode];
     
-    if (![_post.media isEqualToString:@""]) {
-        CGFloat imageRatio = (_mediaNode.image != nil ? _mediaNode.image.size.height / _mediaNode.image.size.width : 0.5);
-        ASRatioLayoutSpec *imagePlace = [ASRatioLayoutSpec ratioLayoutSpecWithRatio:imageRatio child:_mediaNode];
-        imagePlace.spacingAfter = 3.0;
-        imagePlace.spacingBefore = 3.0;
+    
+    if (![_post.media isEqualToString:@""]){
         
-        [mainStackContent addObject:imagePlace];
-        
+        // 1. Way: Only add the media node if an image is present
+        if (_mediaNode.image != nil) {
+            
+            // 2. Way: Add the media node but set the size based if image is already loaded
+            /*CGSize maxSize = _mediaNode.image != nil ? constrainedSize.max : CGSizeZero;
+            _mediaNode.size = ASRelativeSizeRangeMake(ASRelativeSizeMakeWithCGSize(CGSizeZero),
+                                                      ASRelativeSizeMakeWithCGSize(maxSize));*/
+            
+            
+            CGFloat imageRatio = (_mediaNode.image != nil ? _mediaNode.image.size.height / _mediaNode.image.size.width : 0.5);
+            ASRatioLayoutSpec *imagePlace = [ASRatioLayoutSpec ratioLayoutSpecWithRatio:imageRatio child:_mediaNode];
+            imagePlace.spacingAfter = 3.0;
+            imagePlace.spacingBefore = 3.0;
+            
+            [mainStackContent addObject:imagePlace];
+        }
     }
     [mainStackContent addObject:controlsStack];
     

--- a/examples/Swift/Sample/AppDelegate.swift
+++ b/examples/Swift/Sample/AppDelegate.swift
@@ -25,7 +25,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
     let window = UIWindow(frame: UIScreen.mainScreen().bounds)
     window.backgroundColor = UIColor.whiteColor()
-    window.rootViewController = ViewController()
+    window.rootViewController = UINavigationController(rootViewController: ViewController());
     window.makeKeyAndVisible()
     self.window = window
     return true

--- a/examples/Swift/Sample/TailLoadingCellNode.swift
+++ b/examples/Swift/Sample/TailLoadingCellNode.swift
@@ -54,7 +54,10 @@ final class SpinnerNode: ASDisplayNode {
 
   override init() {
     super.init(viewBlock: { UIActivityIndicatorView(activityIndicatorStyle: .Gray) }, didLoadBlock: nil)
-    preferredFrameSize.height = 32
+    
+    // Height based on the view we are wrapping and a static width of 32.0
+    size = ASRelativeSizeRangeMake(ASRelativeSizeMakeWithCGSize(CGSizeMake(0, 32)),
+                                   ASRelativeSizeMakeWithCGSize(CGSizeMake(CGFloat.max, 32)));
   }
 
   override func didLoad() {

--- a/examples/Swift/Sample/ViewController.swift
+++ b/examples/Swift/Sample/ViewController.swift
@@ -134,7 +134,8 @@ final class ViewController: ASViewController, ASTableDataSource, ASTableDelegate
     }
   }
 
-  private static func handleAction(action: Action, var fromState state: State) -> State {
+  private static func handleAction(action: Action, fromState state: State) -> State {
+    var state = state
     switch action {
     case .BeginBatchFetch:
       state.fetchingMore = true

--- a/examples/VerticalWithinHorizontalScrolling/Sample/GradientTableNode.mm
+++ b/examples/VerticalWithinHorizontalScrolling/Sample/GradientTableNode.mm
@@ -68,7 +68,7 @@
 - (ASCellNode *)tableView:(ASTableView *)tableView nodeForRowAtIndexPath:(NSIndexPath *)indexPath
 {
   RandomCoreGraphicsNode *elementNode = [[RandomCoreGraphicsNode alloc] init];
-  elementNode.preferredFrameSize = _elementSize;
+  elementNode.size = ASRelativeSizeRangeMakeWithExactCGSize(_elementSize);
   elementNode.indexPath = [NSIndexPath indexPathForRow:indexPath.row inSection:_pageNumber];
   return elementNode;
 }

--- a/examples/VerticalWithinHorizontalScrolling/Sample/RandomCoreGraphicsNode.m
+++ b/examples/VerticalWithinHorizontalScrolling/Sample/RandomCoreGraphicsNode.m
@@ -71,17 +71,11 @@
   _indexPathTextNode.attributedString = [[NSAttributedString alloc] initWithString:[indexPath description] attributes:nil];
 }
 
-//- (ASLayoutSpec *)layoutSpecThatFits:(ASSizeRange)constrainedSize
-//{
-//  ASStackLayoutSpec *stackSpec = [ASStackLayoutSpec stackLayoutSpecWithDirection:ASStackLayoutDirectionVertical spacing:0 justifyContent:ASStackLayoutJustifyContentStart alignItems:ASStackLayoutAlignItemsStart children:@[_indexPathTextNode]];
-//  stackSpec.flexGrow = YES;
-//  return stackSpec;
-//}
-
 - (void)layout
 {
-  _indexPathTextNode.frame = self.bounds;
   [super layout];
+  
+  _indexPathTextNode.frame = self.bounds;
 }
 
 #if 0

--- a/examples/Videos/Sample/ViewController.m
+++ b/examples/Videos/Sample/ViewController.m
@@ -49,20 +49,27 @@
   ASVideoNode *hlsVideoNode = self.hlsVideoNode;
   [_rootNode addSubnode:hlsVideoNode];
   
+  CGSize mainScreenBoundsSize = [UIScreen mainScreen].bounds.size;
+  
   _rootNode.layoutSpecBlock = ^ASLayoutSpec *(ASDisplayNode * _Nonnull node, ASSizeRange constrainedSize) {
+    
+    // Layout all nodes absolute in a static layout spec
     guitarVideoNode.layoutPosition = CGPointMake(0, 0);
-    guitarVideoNode.preferredFrameSize = CGSizeMake([UIScreen mainScreen].bounds.size.width, [UIScreen mainScreen].bounds.size.height/3);
+    guitarVideoNode.sizeRange = ASRelativeSizeRangeMakeWithExactCGSize(CGSizeMake(mainScreenBoundsSize.width, mainScreenBoundsSize.height / 3.0));
     
-    nicCageVideoNode.layoutPosition = CGPointMake([UIScreen mainScreen].bounds.size.width/2, [UIScreen mainScreen].bounds.size.height/3);
-    nicCageVideoNode.preferredFrameSize = CGSizeMake([UIScreen mainScreen].bounds.size.width/2, [UIScreen mainScreen].bounds.size.height/3);
+    nicCageVideoNode.layoutPosition = CGPointMake(mainScreenBoundsSize.width / 2.0,
+                                                  mainScreenBoundsSize.height / 3.0);
+    nicCageVideoNode.sizeRange = ASRelativeSizeRangeMakeWithExactCGSize(CGSizeMake(mainScreenBoundsSize.width/2, mainScreenBoundsSize.height / 3.0));
     
-    simonVideoNode.layoutPosition = CGPointMake(0, [UIScreen mainScreen].bounds.size.height - ([UIScreen mainScreen].bounds.size.height/3));
-    simonVideoNode.preferredFrameSize = CGSizeMake([UIScreen mainScreen].bounds.size.width/2, [UIScreen mainScreen].bounds.size.height/3);
+    simonVideoNode.layoutPosition = CGPointMake(0.0,
+                                                mainScreenBoundsSize.height - (mainScreenBoundsSize.height / 3.0));
+    simonVideoNode.sizeRange = ASRelativeSizeRangeMakeWithExactCGSize(CGSizeMake(mainScreenBoundsSize.width/2, mainScreenBoundsSize.height / 3.0));
     
-    hlsVideoNode.layoutPosition = CGPointMake(0, [UIScreen mainScreen].bounds.size.height/3);
-    hlsVideoNode.preferredFrameSize = CGSizeMake([UIScreen mainScreen].bounds.size.width/2, [UIScreen mainScreen].bounds.size.height/3);
+    hlsVideoNode.layoutPosition = CGPointMake(0.0, mainScreenBoundsSize.height / 3.0);
+    hlsVideoNode.sizeRange = ASRelativeSizeRangeMakeWithExactCGSize(CGSizeMake(mainScreenBoundsSize.width / 2.0, mainScreenBoundsSize.height / 3.0));
     
-    return [ASStaticLayoutSpec staticLayoutSpecWithChildren:@[guitarVideoNode, nicCageVideoNode, simonVideoNode, hlsVideoNode]];
+    NSArray *children = @[guitarVideoNode, nicCageVideoNode, simonVideoNode, hlsVideoNode];
+    return [ASStaticLayoutSpec staticLayoutSpecWithChildren:children];
   };
   
   [self.view addSubnode:_rootNode];

--- a/examples_extra/ASTraitCollection/Sample/KittenNode.m
+++ b/examples_extra/ASTraitCollection/Sample/KittenNode.m
@@ -77,7 +77,7 @@ static const CGFloat kInnerPadding = 10.0f;
   // kitten image, with a solid background colour serving as placeholder
   _imageNode = [[ASNetworkImageNode alloc] init];
   _imageNode.backgroundColor = ASDisplayNodeDefaultPlaceholderColor();
-  _imageNode.preferredFrameSize = _kittenSize;
+  _imageNode.size = ASRelativeSizeRangeMakeWithExactCGSize(_kittenSize);
   [_imageNode addTarget:self action:@selector(imageTapped:) forControlEvents:ASControlNodeEventTouchUpInside];
   
   CGFloat scale = [UIScreen mainScreen].scale;

--- a/examples_extra/SynchronousConcurrency/Sample/AsyncTableViewController.m
+++ b/examples_extra/SynchronousConcurrency/Sample/AsyncTableViewController.m
@@ -30,24 +30,12 @@
 
 @implementation AsyncTableViewController
 
-#pragma mark -
-#pragma mark UIViewController.
+#pragma mark - UIViewController.
 
 - (instancetype)init
 {
   if (!(self = [super init]))
     return nil;
-
-  _tableView = [[ASTableView alloc] initWithFrame:CGRectZero style:UITableViewStylePlain];
-  _tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
-  _tableView.asyncDataSource = self;
-  _tableView.asyncDelegate = self;
-  
-  ASRangeTuningParameters tuningParameters;
-  tuningParameters.leadingBufferScreenfuls = 0.5;
-  tuningParameters.trailingBufferScreenfuls = 1.0;
-  [_tableView setTuningParameters:tuningParameters forRangeType:ASLayoutRangeTypePreload];
-  [_tableView setTuningParameters:tuningParameters forRangeType:ASLayoutRangeTypeRender];
   
   self.tabBarItem = [[UITabBarItem alloc] initWithTabBarSystemItem:UITabBarSystemItemFeatured tag:0];
   self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemRedo
@@ -66,22 +54,30 @@
 {
   [super viewDidLoad];
 
+  _tableView = [[ASTableView alloc] initWithFrame:self.view.bounds style:UITableViewStylePlain];
+  _tableView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+  _tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
+  _tableView.asyncDataSource = self;
+  _tableView.asyncDelegate = self;
+  
+  ASRangeTuningParameters tuningParameters;
+  tuningParameters.leadingBufferScreenfuls = 0.5;
+  tuningParameters.trailingBufferScreenfuls = 1.0;
+  [_tableView setTuningParameters:tuningParameters forRangeType:ASLayoutRangeTypePreload];
+  [_tableView setTuningParameters:tuningParameters forRangeType:ASLayoutRangeTypeRender];
+  
   [self.view addSubview:_tableView];
 }
 
-- (void)viewWillLayoutSubviews
-{
-  _tableView.frame = self.view.bounds;
-}
+#pragma mark - ASTableView.
 
-#pragma mark -
-#pragma mark ASTableView.
-
-- (ASCellNode *)tableView:(ASTableView *)tableView nodeForRowAtIndexPath:(NSIndexPath *)indexPath
+- (ASCellNodeBlock)tableView:(ASTableView *)tableView nodeBlockForRowAtIndexPath:(NSIndexPath *)indexPath
 {
-  RandomCoreGraphicsNode *elementNode = [[RandomCoreGraphicsNode alloc] init];
-  elementNode.preferredFrameSize = CGSizeMake(320, 100);
-  return elementNode;
+  return ^{
+    RandomCoreGraphicsNode *elementNode = [[RandomCoreGraphicsNode alloc] init];
+    elementNode.size = ASRelativeSizeRangeMakeWithExactCGSize(CGSizeMake(320, 100));
+    return elementNode;
+  };
 }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section

--- a/examples_extra/SynchronousConcurrency/Sample/RandomCoreGraphicsNode.m
+++ b/examples_extra/SynchronousConcurrency/Sample/RandomCoreGraphicsNode.m
@@ -92,6 +92,8 @@
 
 - (void)layout
 {
+  [super layout];
+  
   CGSize boundsSize = self.bounds.size;
   CGSize textSize = _textNode.calculatedSize;
   CGRect textRect = CGRectMake(roundf((boundsSize.width - textSize.width) / 2.0),

--- a/examples_extra/SynchronousKittens/Sample/KittenNode.mm
+++ b/examples_extra/SynchronousKittens/Sample/KittenNode.mm
@@ -140,7 +140,9 @@ static const CGFloat kInnerPadding = 10.0f;
 #if UseAutomaticLayout
 - (ASLayoutSpec *)layoutSpecThatFits:(ASSizeRange)constrainedSize
 {
-  _imageNode.preferredFrameSize = _isImageEnlarged ? CGSizeMake(2.0 * kImageSize, 2.0 * kImageSize) : CGSizeMake(kImageSize, kImageSize);
+  CGSize imageSize = _isImageEnlarged ? CGSizeMake(2.0 * kImageSize, 2.0 * kImageSize)
+                                      : CGSizeMake(kImageSize, kImageSize);
+  _imageNode.size = ASRelativeSizeRangeMakeWithExactCGSize(imageSize);
   _textNode.flexShrink = YES;
   
   ASStackLayoutSpec *stackSpec = [[ASStackLayoutSpec alloc] init];

--- a/examples_extra/VideoTableView/Sample/NicCageNode.mm
+++ b/examples_extra/VideoTableView/Sample/NicCageNode.mm
@@ -165,7 +165,9 @@ static const CGFloat kInnerPadding = 10.0f;
 #if UseAutomaticLayout
 - (ASLayoutSpec *)layoutSpecThatFits:(ASSizeRange)constrainedSize
 {
-  _videoNode.preferredFrameSize = _isImageEnlarged ? CGSizeMake(2.0 * kImageSize, 2.0 * kImageSize) : CGSizeMake(kImageSize, kImageSize);
+  CGSize videoNodeSize = _isImageEnlarged ? CGSizeMake(2.0 * kImageSize, 2.0 * kImageSize)
+                                          : CGSizeMake(kImageSize, kImageSize);
+  _videoNode.size = ASRelativeSizeRangeMakeWithExactCGSize(videoNodeSize);
   _textNode.flexShrink = YES;
   
   ASStackLayoutSpec *stackSpec = [[ASStackLayoutSpec alloc] init];


### PR DESCRIPTION
## This PR will likely be replaced by #2110

### Goal:
The main goal is to add a constrained size to the `ASLayoutable` protocol. This will be represented by a new `-[ASLayoutable size]` property. In comparison to `-[ASDisplayNode preferredFrameSize]` this size can be set on every `ASLayoutable` and not only on a `ASDisplayNode` object.

### Changes:
- Add `-[ASLayoutable size]`
- Deprecate `-[ASDisplayNode preferredFrameSize]` and remove support for it in `ASTextNode`, `ASImageNode`, `ASButtonNode`
- Merged `-[ASLayoutable calculateLayoutThatFits:` and `-[ASLayoutable measureWithSizeRange:]` (more details in the header description for this methods, but here is a tldr):
  - Changed behavior of `-[ASLayoutable calculateLayoutThatFits:]`: Call this on children layoutables to compute their layouts within your implementation of `-[ASLayoutable calculateLayoutThatFits:]`.
  - Introduce `-[ASLayoutable calculateLayoutThatFits:parentSize:]`: Override this method to compute your nodes's layout.
  - Introduce `-[ASLayoutable calculateLayoutThatFits:restrictedToSizeRange:relativeToParentSize:]`: ASLayoutable's implementation of `-calculateLayoutThatFits:parentSize:` calls this method to resolve the component's size against `parentSize`, intersect it with `constrainedSize`, and call `-calculateLayoutThatFits:` with the result. In certain advanced cases, you may want to customize this logic. Overriding this method allows you to receive all three parameters and do the computation yourself.
- Deprecate `-[ASDisplayNode measure:]`: Naming is not optimal and familiar for developers
- Deprecate `-[ASLayoutable measureWithSizeRange:]` use `ASCalculateRootLayout ()` instead
- Add `ASCalculateRootLayout()`: Safely calculates the layout of the given root layoutable by guarding against nil nodes.
- Add `ASCalculateLayout()`: Safely computes the layout of the given node by guarding against nil nodes.
- Rename `-[ASLayout constrainedSizeRange]` to `-[ASLayout constrainedSize]` to align with all other places we use a 'constrainedSize'
- Ported all 'examples/' over to use `-[ASDisplayNode size]`

### TODOS:
- [ ] Find a better API for `-[ASDisplayNode measure:]`. Current suggestions include:
  - -(CGSize)sizeThatFits:(ASSizeRange)constrainedSize;
  - -(CGSize)sizeWithSizeRange:(ASSizeRange)constrainedSize;
  - -(CGSize)sizeWithFittingSize:(ASSizeRange)constrainedSize;
  - -(CGSize)layoutSizeThatFits:(ASSizeRange)constrainedSize;
  - -(CGSize)layoutSizeFittingSize:(ASSizeRange)constrainedSize;
  - -(CGSize)layoutSizeWithSizeRange:(ASSizeRange)constrainedSize;
- [ ] Add deprecation warning to `-[ASDisplayNode measure:]` after new naming
- [x] Remove `-[ASDisplayNode preferredFrameSize]` and move over to `-[ASDisplayNode size]` for 'examples_extra/'
- [x] Add deprecation warning to `-[ASDisplayNode preferredFrameSize]`
- [x] Add deprecation warning to `-[ASLayoutable measureWithSizeRange:]`
- [x] Remove Unit Tests for `-[ASDisplayNode preferredFrameSize]`
- [ ] Add Unit Tests for `-[ASLayoutable size]`
- [ ] Look for // TODO: sizeRange: for further open tasks

<br>
***This PR is one of the initiatives to make the Layout API more clear. Every feedback is more than welcome!***