### PR TITLE
[ASDisplayNode] Clarify Some Special Logic Around Wrapper Nodes

### DIFF
--- a/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
+++ b/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
@@ -83,10 +83,10 @@ FOUNDATION_EXPORT NSString * const ASRenderingEngineDidDisplayNodesScheduledBefo
     
     // Prevent calling setNeedsDisplay on a layer that backs a UIImageView. Usually calling setNeedsDisplay on a CALayer
     // triggers a recreation of the contents of layer unfortunately calling it on a CALayer that backs a UIImageView
-    // it goes trough the normal flow to assign the contents to a layer via the CALayerDelegate methods. Unfortunately
+    // it goes through the normal flow to assign the contents to a layer via the CALayerDelegate methods. Unfortunately
     // UIImageView does not do recreate the layer contents the usual way, it actually does not implement some of the
     // methods at all instead it throws away the contents of the layer and nothing will show up.
-    unsigned canCallNeedsDisplayOfLayer:1;
+    unsigned canCallSetNeedsDisplayOfLayer:1;
 
     // whether custom drawing is enabled
     unsigned implementsInstanceDrawRect:1;


### PR DESCRIPTION
This clarifies some behavior that I found confusing when debugging. This does not change any behavior. Worked with @maicki to:

- Rename `canCallNeedsDisplayOfLayer` to `canCallSetNeedsDisplayOfLayer` to be clearer.
- Make the rationale around that flag clearer. The actual behavior of the code is the same.
   - We cannot clear the contents or setNeedsDisplay of UIImageView-wrapping nodes.
   - We can do both of the above on any other kind of node.
   - We must call `setNeedsDisplay` on all non-UIImageView wrapper nodes in `recursivelyTriggerDisplayForLayer`, but there's no need to call it on normal nodes