### PR TITLE
Remove numberOfSectionsForSupplementaryNodeOfKind: Method

### DIFF
--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -407,6 +407,7 @@
 		B350625E1B0111780018CF92 /* AssetsLibrary.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 051943121A1575630030A7D0 /* AssetsLibrary.framework */; };
 		B350625F1B0111800018CF92 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 058D09AF195D04C000B7D73C /* Foundation.framework */; };
 		C78F7E2B1BF7809800CDEAFC /* ASTableNode.h in Headers */ = {isa = PBXBuildFile; fileRef = B0F880581BEAEC7500D17647 /* ASTableNode.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CC0AEEA41D66316E005D1C78 /* ASUICollectionViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CC0AEEA31D66316E005D1C78 /* ASUICollectionViewTests.m */; };
 		CC3B20841C3F76D600798563 /* ASPendingStateController.h in Headers */ = {isa = PBXBuildFile; fileRef = CC3B20811C3F76D600798563 /* ASPendingStateController.h */; };
 		CC3B20851C3F76D600798563 /* ASPendingStateController.mm in Sources */ = {isa = PBXBuildFile; fileRef = CC3B20821C3F76D600798563 /* ASPendingStateController.mm */; };
 		CC3B20861C3F76D600798563 /* ASPendingStateController.mm in Sources */ = {isa = PBXBuildFile; fileRef = CC3B20821C3F76D600798563 /* ASPendingStateController.mm */; };
@@ -1076,6 +1077,7 @@
 		B35061DA1B010EDF0018CF92 /* AsyncDisplayKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AsyncDisplayKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B35061DD1B010EDF0018CF92 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = "../AsyncDisplayKit-iOS/Info.plist"; sourceTree = "<group>"; };
 		BDC2D162BD55A807C1475DA5 /* Pods-AsyncDisplayKitTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AsyncDisplayKitTests.profile.xcconfig"; path = "Pods/Target Support Files/Pods-AsyncDisplayKitTests/Pods-AsyncDisplayKitTests.profile.xcconfig"; sourceTree = "<group>"; };
+		CC0AEEA31D66316E005D1C78 /* ASUICollectionViewTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASUICollectionViewTests.m; sourceTree = "<group>"; };
 		CC3B20811C3F76D600798563 /* ASPendingStateController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASPendingStateController.h; sourceTree = "<group>"; };
 		CC3B20821C3F76D600798563 /* ASPendingStateController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASPendingStateController.mm; sourceTree = "<group>"; };
 		CC3B20871C3F7A5400798563 /* ASWeakSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASWeakSet.h; sourceTree = "<group>"; };
@@ -1322,6 +1324,7 @@
 		058D09C5195D04C000B7D73C /* AsyncDisplayKitTests */ = {
 			isa = PBXGroup;
 			children = (
+				CC0AEEA31D66316E005D1C78 /* ASUICollectionViewTests.m */,
 				CCB2F34C1D63CCC6004E6DE9 /* ASDisplayNodeSnapshotTests.m */,
 				83A7D95D1D446A6E00BF333E /* ASWeakMapTests.m */,
 				DBC453211C5FD97200B16017 /* ASDisplayNodeImplicitHierarchyTests.m */,
@@ -2195,6 +2198,7 @@
 				058D0A3C195D057000B7D73C /* ASMutableAttributedStringBuilderTests.m in Sources */,
 				697B315A1CFE4B410049936F /* ASEditableTextNodeTests.m in Sources */,
 				ACF6ED611B178DC700DA7C62 /* ASOverlayLayoutSpecSnapshotTests.mm in Sources */,
+				CC0AEEA41D66316E005D1C78 /* ASUICollectionViewTests.m in Sources */,
 				ACF6ED621B178DC700DA7C62 /* ASRatioLayoutSpecSnapshotTests.mm in Sources */,
 				7AB338691C55B97B0055FDE8 /* ASRelativeLayoutSpecSnapshotTests.mm in Sources */,
 				254C6B541BF8FF2A003EC431 /* ASTextKitTests.mm in Sources */,

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -1033,11 +1033,6 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   return [self.layoutInspector collectionView:self supplementaryNodesOfKind:kind inSection:section];
 }
 
-- (NSUInteger)dataController:(ASCollectionDataController *)dataController numberOfSectionsForSupplementaryNodeOfKind:(NSString *)kind;
-{
-  return [self.layoutInspector collectionView:self numberOfSectionsForSupplementaryNodeOfKind:kind];
-}
-
 #pragma mark - ASRangeControllerDataSource
 
 - (ASRangeController *)rangeController

--- a/AsyncDisplayKit/Details/ASCollectionDataController.h
+++ b/AsyncDisplayKit/Details/ASCollectionDataController.h
@@ -26,8 +26,6 @@
 
 - (NSArray *)supplementaryNodeKindsInDataController:(ASCollectionDataController *)dataController;
 
-- (NSUInteger)dataController:(ASCollectionDataController *)dataController numberOfSectionsForSupplementaryNodeOfKind:(NSString *)kind;
-
 - (NSUInteger)dataController:(ASCollectionDataController *)dataController supplementaryNodesOfKind:(NSString *)kind inSection:(NSUInteger)section;
 
 @optional

--- a/AsyncDisplayKit/Details/ASCollectionDataController.mm
+++ b/AsyncDisplayKit/Details/ASCollectionDataController.mm
@@ -65,7 +65,7 @@
     [self deleteSectionsOfKind:kind atIndexSet:indexSet completion:nil];
     
     // Insert each section
-    NSUInteger sectionCount = [self.collectionDataSource dataController:self numberOfSectionsForSupplementaryNodeOfKind:kind];
+    NSUInteger sectionCount = self.itemCountsFromDataSource.size();
     NSMutableArray *sections = [NSMutableArray arrayWithCapacity:sectionCount];
     for (int i = 0; i < sectionCount; i++) {
       [sections addObject:[NSMutableArray array]];
@@ -194,7 +194,7 @@
   ASEnvironmentTraitCollection environmentTraitCollection = environment.environmentTraitCollection;
   
   id<ASCollectionDataControllerSource> source = self.collectionDataSource;
-  NSUInteger sectionCount = [source dataController:self numberOfSectionsForSupplementaryNodeOfKind:kind];
+  NSUInteger sectionCount = self.itemCountsFromDataSource.size();
   for (NSUInteger i = 0; i < sectionCount; i++) {
     NSUInteger rowCount = [source dataController:self supplementaryNodesOfKind:kind inSection:i];
     for (NSUInteger j = 0; j < rowCount; j++) {

--- a/AsyncDisplayKit/Details/ASCollectionViewFlowLayoutInspector.h
+++ b/AsyncDisplayKit/Details/ASCollectionViewFlowLayoutInspector.h
@@ -34,11 +34,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (ASSizeRange)collectionView:(ASCollectionView *)collectionView constrainedSizeForSupplementaryNodeOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath;
 
 /**
- * Asks the inspector for the number of supplementary sections in the collection view for the given kind.
- */
-- (NSUInteger)collectionView:(ASCollectionView *)collectionView numberOfSectionsForSupplementaryNodeOfKind:(NSString *)kind;
-
-/**
  * Asks the inspector for the number of supplementary views for the given kind in the specified section.
  */
 - (NSUInteger)collectionView:(ASCollectionView *)collectionView supplementaryNodesOfKind:(NSString *)kind inSection:(NSUInteger)section;
@@ -56,6 +51,16 @@ NS_ASSUME_NONNULL_BEGIN
  * @discussion A great time to update perform selector caches!
  */
 - (void)didChangeCollectionViewDataSource:(nullable id<ASCollectionDataSource>)dataSource;
+
+#pragma mark Deprecated Methods
+
+/**
+ * Asks the inspector for the number of supplementary sections in the collection view for the given kind.
+ *
+ * @deprecated This method will not be called, and it is only deprecated as a reminder to remove it.
+ * Supplementary elements must exist in the same sections as regular collection view items i.e. -numberOfSectionsInCollectionView:
+ */
+- (NSUInteger)collectionView:(ASCollectionView *)collectionView numberOfSectionsForSupplementaryNodeOfKind:(NSString *)kind ASDISPLAYNODE_DEPRECATED;
 
 @end
 

--- a/AsyncDisplayKit/Details/ASCollectionViewFlowLayoutInspector.m
+++ b/AsyncDisplayKit/Details/ASCollectionViewFlowLayoutInspector.m
@@ -74,12 +74,6 @@ static inline ASSizeRange NodeConstrainedSizeForScrollDirection(ASCollectionView
   return ASSizeRangeMake(CGSizeZero, CGSizeZero);
 }
 
-- (NSUInteger)collectionView:(ASCollectionView *)collectionView numberOfSectionsForSupplementaryNodeOfKind:(NSString *)kind
-{
-  ASDisplayNodeAssert(NO, @"To support supplementary nodes in ASCollectionView, it must have a layoutInspector for layout inspection. (See ASCollectionViewFlowLayoutInspector for an example.)");
-  return 0;
-}
-
 - (NSUInteger)collectionView:(ASCollectionView *)collectionView supplementaryNodesOfKind:(NSString *)kind inSection:(NSUInteger)section
 {
   ASDisplayNodeAssert(NO, @"To support supplementary nodes in ASCollectionView, it must have a layoutInspector for layout inspection. (See ASCollectionViewFlowLayoutInspector for an example.)");
@@ -169,15 +163,6 @@ static inline ASSizeRange NodeConstrainedSizeForScrollDirection(ASCollectionView
     constrainedSize = CGSizeMake(supplementarySize.width, CGRectGetHeight(collectionView.bounds));
   }
   return ASSizeRangeMake(CGSizeZero, constrainedSize);
-}
-
-- (NSUInteger)collectionView:(ASCollectionView *)collectionView numberOfSectionsForSupplementaryNodeOfKind:(NSString *)kind
-{
-  if (_dataSourceFlags.implementsNumberOfSectionsInCollectionView) {
-    return [collectionView.asyncDataSource numberOfSectionsInCollectionView:collectionView];
-  } else {
-    return 1;
-  }
 }
 
 - (NSUInteger)collectionView:(ASCollectionView *)collectionView supplementaryNodesOfKind:(NSString *)kind inSection:(NSUInteger)section

--- a/AsyncDisplayKitTests/ASCollectionViewFlowLayoutInspectorTests.m
+++ b/AsyncDisplayKitTests/ASCollectionViewFlowLayoutInspectorTests.m
@@ -294,34 +294,6 @@
   collectionView.asyncDelegate = nil;
 }
 
-#pragma mark - #collectionView:numberOfSectionsForSupplementaryNodeOfKind:
-
-- (void)testThatItRespondsWithTheDefaultNumberOfSections
-{
-  UICollectionViewFlowLayout *layout = [[UICollectionViewFlowLayout alloc] init];
-  ASCollectionView *collectionView = [[ASCollectionView alloc] initWithFrame:CGRectZero collectionViewLayout:layout];
-  ASCollectionViewFlowLayoutInspector *inspector = [[ASCollectionViewFlowLayoutInspector alloc] initWithCollectionView:collectionView flowLayout:layout];
-  NSUInteger sections = [inspector collectionView:collectionView numberOfSectionsForSupplementaryNodeOfKind:UICollectionElementKindSectionHeader];
-  XCTAssert(sections == 1, @"should return 1 by default");
-  
-  collectionView.asyncDataSource = nil;
-  collectionView.asyncDelegate = nil;
-}
-
-- (void)testThatItProvidesTheNumberOfSectionsInTheDataSource
-{
-  InspectorTestDataSource *dataSource = [[InspectorTestDataSource alloc] init];
-  UICollectionViewFlowLayout *layout = [[UICollectionViewFlowLayout alloc] init];
-  ASCollectionView *collectionView = [[ASCollectionView alloc] initWithFrame:CGRectZero collectionViewLayout:layout];
-  collectionView.asyncDataSource = dataSource;
-  ASCollectionViewFlowLayoutInspector *inspector = [[ASCollectionViewFlowLayoutInspector alloc] initWithCollectionView:collectionView flowLayout:layout];
-  NSUInteger sections = [inspector collectionView:collectionView numberOfSectionsForSupplementaryNodeOfKind:UICollectionElementKindSectionHeader];
-  XCTAssert(sections == 2, @"should return 2");
-  
-  collectionView.asyncDataSource = nil;
-  collectionView.asyncDelegate = nil;
-}
-
 #pragma mark - #collectionView:supplementaryNodesOfKind:inSection:
 
 - (void)testThatItReturnsOneWhenAValidSizeIsImplementedOnTheDelegate

--- a/AsyncDisplayKitTests/ASUICollectionViewTests.m
+++ b/AsyncDisplayKitTests/ASUICollectionViewTests.m
@@ -15,9 +15,11 @@
 
 @implementation ASUICollectionViewTests
 
-/// Test that collection view throws an exception if your layout specifies
-/// supplementaries in sections that are out of bounds (e.g. in section 5
-/// when there's only 3 sections).
+/**
+ * Test that collection view throws an exception if your layout specifies
+ * supplementaries in sections that are out of bounds (e.g. in section 5
+ * when there's only 3 sections).
+ */
 - (void)testThatSupplementariesMustBeWithinNormalSections
 {
   NSInteger sectionCount = 2;

--- a/AsyncDisplayKitTests/ASUICollectionViewTests.m
+++ b/AsyncDisplayKitTests/ASUICollectionViewTests.m
@@ -1,0 +1,48 @@
+//
+//  ASUICollectionViewTests.m
+//  AsyncDisplayKit
+//
+//  Created by Adlai Holler on 8/18/16.
+//  Copyright © 2016 Facebook. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import <OCMock/OCMock.h>
+
+@interface ASUICollectionViewTests : XCTestCase
+
+@end
+
+@implementation ASUICollectionViewTests
+
+/// Test that collection view throws an exception if your layout specifies
+/// supplementaries in sections that are out of bounds (e.g. in section 5
+/// when there's only 3 sections).
+- (void)testThatSupplementariesMustBeWithinNormalSections
+{
+  NSInteger sectionCount = 2;
+  NSIndexPath *indexPath = [NSIndexPath indexPathForItem:0 inSection:sectionCount];
+  UICollectionViewLayoutAttributes *attr = [UICollectionViewLayoutAttributes layoutAttributesForSupplementaryViewOfKind:@"SuppKind" withIndexPath:indexPath];
+  UICollectionViewLayout *layout = [[UICollectionViewLayout alloc] init];
+  id layoutMock = [OCMockObject partialMockForObject:layout];
+
+  [[[[layoutMock expect] ignoringNonObjectArgs] andReturn:@[ attr ]]  layoutAttributesForElementsInRect:CGRectZero];
+  UICollectionView *cv = [[UICollectionView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) collectionViewLayout:layoutMock];
+  [cv registerClass:[UICollectionReusableView class] forSupplementaryViewOfKind:@"SuppKind" withReuseIdentifier:@"ReuseID"];
+
+  id dataSource = [OCMockObject niceMockForProtocol:@protocol(UICollectionViewDataSource)];
+  [[[dataSource expect] andDo:^(NSInvocation *invocation) {
+    NSIndexPath *indexPath = nil;
+    [invocation getArgument:&indexPath atIndex:4];
+    id view = [cv dequeueReusableSupplementaryViewOfKind:@"SuppKind" withReuseIdentifier:@"ReuseID" forIndexPath:indexPath];
+    [invocation setReturnValue:(__bridge void * _Nonnull)(view)];
+  }] collectionView:cv viewForSupplementaryElementOfKind:@"SuppKind" atIndexPath:indexPath];
+  [[[dataSource expect] andReturnValue:[NSNumber numberWithInteger:sectionCount]] numberOfSectionsInCollectionView:cv];
+
+  cv.dataSource = dataSource;
+  XCTAssertThrowsSpecificNamed([cv layoutIfNeeded], NSException, NSInternalInconsistencyException);
+  [dataSource verify];
+  [layoutMock verify];
+}
+
+@end


### PR DESCRIPTION
This adds a test that confirms UICollectionView will throw an exception for supplementary nodes that are outside of the normal `-numberOfSections` range.

This means that there is only one set of sections, so this method is a misconception. Deprecated as a reminder to remove, and we'll never call it.

This is probably the first of many changes to our collection view stuff