### PR TITLE
[ASViewController] Propagate the traits on willTransitionToTraitCollection

### DIFF
--- a/AsyncDisplayKit/ASViewController.mm
+++ b/AsyncDisplayKit/ASViewController.mm
@@ -313,12 +313,13 @@ ASVisibilityDepthImplementation;
 {
   [super willTransitionToTraitCollection:newCollection withTransitionCoordinator:coordinator];
   
-  // here we take the new UITraitCollection and use it to create a new ASEnvironmentTraitCollection on self.node
-  // We will propagate when the corresponding viewWillTransitionToSize:withTransitionCoordinator: is called and we have the
-  // new windowSize. There are cases when viewWillTransitionToSize: is called when willTransitionToTraitCollection: is not.
-  // Since we do the propagation on viewWillTransitionToSize: our subnodes should always get the proper trait collection.
-  ASEnvironmentTraitCollection asyncTraitCollection = ASEnvironmentTraitCollectionFromUITraitCollection(newCollection);
-  self.node.environmentTraitCollection = asyncTraitCollection;
+  ASEnvironmentTraitCollection environmentTraitCollection = ASEnvironmentTraitCollectionFromUITraitCollection(newCollection);
+  // A call to willTransitionToTraitCollection:withTransitionCoordinator: is always followed by a call to viewWillTransitionToSize:withTransitionCoordinator:.
+  // However, it is not immediate and we may need the new trait collection before viewWillTransitionToSize:withTransitionCoordinator: is called. Our view already has the
+  // new bounds, so go ahead and set the containerSize and propagate the traits here. As long as nothing else in the traits changes (which it shouldn't)
+  // then we won't we will skip the propagation in viewWillTransitionToSize:withTransitionCoordinator:.
+  environmentTraitCollection.containerSize = self.view.bounds.size;
+  [self progagateNewEnvironmentTraitCollection:environmentTraitCollection];
 }
 
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator

--- a/AsyncDisplayKit/Details/ASEnvironment.mm
+++ b/AsyncDisplayKit/Details/ASEnvironment.mm
@@ -36,17 +36,17 @@ ASEnvironmentTraitCollection ASEnvironmentTraitCollectionMakeDefault()
 
 ASEnvironmentTraitCollection ASEnvironmentTraitCollectionFromUITraitCollection(UITraitCollection *traitCollection)
 {
-  ASEnvironmentTraitCollection asyncTraitCollection;
+  ASEnvironmentTraitCollection environmentTraitCollection = ASEnvironmentTraitCollectionMakeDefault();
   if (AS_AT_LEAST_IOS8) {
-    asyncTraitCollection.displayScale = traitCollection.displayScale;
-    asyncTraitCollection.horizontalSizeClass = traitCollection.horizontalSizeClass;
-    asyncTraitCollection.verticalSizeClass = traitCollection.verticalSizeClass;
-    asyncTraitCollection.userInterfaceIdiom = traitCollection.userInterfaceIdiom;
+    environmentTraitCollection.displayScale = traitCollection.displayScale;
+    environmentTraitCollection.horizontalSizeClass = traitCollection.horizontalSizeClass;
+    environmentTraitCollection.verticalSizeClass = traitCollection.verticalSizeClass;
+    environmentTraitCollection.userInterfaceIdiom = traitCollection.userInterfaceIdiom;
     if (AS_AT_LEAST_IOS9) {
-      asyncTraitCollection.forceTouchCapability = traitCollection.forceTouchCapability;
+      environmentTraitCollection.forceTouchCapability = traitCollection.forceTouchCapability;
     }
   }
-  return asyncTraitCollection;
+  return environmentTraitCollection;
 }
 
 BOOL ASEnvironmentTraitCollectionIsEqualToASEnvironmentTraitCollection(ASEnvironmentTraitCollection lhs, ASEnvironmentTraitCollection rhs)


### PR DESCRIPTION
Previously we were only propagating the trait collection on `viewWillTransitionToSize` since it is called shortly after `willTransitionToTraitCollection`. However, some important things can happen in that time “shortly after” (like collection view layout). As long as nothing changes from `willTransitionToTraitCollection` to `viewWillTransitionToSize` (which it shouldn’t) the traits will not be re-propagated anyhow.

Also make sure to use the `ASEnvironmentTraitCollectionMakeDefault` method when creating new envTraitCollection so the struct isn’t filled with junk.