### PR TITLE
[ASDataController] Ensure Supplementary Section Count Always Tracks Item Section Count

### DIFF
--- a/AsyncDisplayKit/Details/ASDataController.mm
+++ b/AsyncDisplayKit/Details/ASDataController.mm
@@ -399,7 +399,7 @@ NSString * const ASDataControllerRowNodeKind = @"_ASDataControllerRowNodeKind";
   NSArray<ASIndexedNodeContext *> *contexts = [self _populateFromDataSourceWithSectionIndexSet:sectionIndexSet];
   
   // Allow subclasses to perform setup before going into the edit transaction
-  [self prepareForReloadData];
+  [self prepareForReloadDataWithSectionCount:sectionCount];
   
   dispatch_group_async(_editingTransactionGroup, _editingTransactionQueue, ^{
     LOG(@"Edit Transaction - reloadData");
@@ -414,7 +414,7 @@ NSString * const ASDataControllerRowNodeKind = @"_ASDataControllerRowNodeKind";
       [self _deleteSectionsAtIndexSet:indexSet withAnimationOptions:animationOptions];
     }
     
-    [self willReloadData];
+    [self willReloadDataWithSectionCount:sectionCount];
     
     // Insert empty sections
     NSMutableArray *sections = [NSMutableArray arrayWithCapacity:sectionCount];
@@ -636,12 +636,12 @@ NSString * const ASDataControllerRowNodeKind = @"_ASDataControllerRowNodeKind";
 
 #pragma mark - Backing store manipulation optional hooks (Subclass API)
 
-- (void)prepareForReloadData
+- (void)prepareForReloadDataWithSectionCount:(NSInteger)newSectionCount
 {
   // Optional template hook for subclasses (See ASDataController+Subclasses.h)
 }
 
-- (void)willReloadData
+- (void)willReloadDataWithSectionCount:(NSInteger)newSectionCount
 {
   // Optional template hook for subclasses (See ASDataController+Subclasses.h)
 }

--- a/AsyncDisplayKit/Private/ASDataController+Subclasses.h
+++ b/AsyncDisplayKit/Private/ASDataController+Subclasses.h
@@ -95,7 +95,7 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCellNode *> *nodes, NS
  * The data source is locked at this point and accessing it is safe. Use this method to set up any nodes or
  * data stores before entering into editing the backing store on a background thread.
  */
- - (void)prepareForReloadData;
+ - (void)prepareForReloadDataWithSectionCount:(NSInteger)newSectionCount;
  
 /**
  * Notifies the subclass that the data controller is about to reload its data entirely
@@ -104,7 +104,7 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCellNode *> *nodes, NS
  * concrete implementation. This is a great place to perform new node creation like supplementary views
  * or header/footer nodes.
  */
-- (void)willReloadData;
+- (void)willReloadDataWithSectionCount:(NSInteger)newSectionCount;
 
 /**
  * Notifies the subclass to perform setup before sections are inserted in the data controller


### PR DESCRIPTION
This resolves an issue where, say you have 3 sections, but only 2 of them have headers. Before, we would only store 2 sections' worth of headers, but if you then delete section #2, we are out of bounds when we try to retrieve that section of headers.

This diff makes sure that even if only 2 sections have headers, we always have 3 arrays, so that items & supplementaries stay completely in sync.

This issue recently became more apparent because we removed the sectionsForSupplementaryNodeOfKind: method which, ironically, if implemented correctly would have caused the problem but was virtually always implemented just to return `numberOfSections`, masking it. In the future (ship task 193) we will continue to make changes to our storage of supplementary nodes, to support section-level supplementaries (even for sections that don't exist!) as well as item-level ones.