### PR TITLE
[ASCollectionView] Relayout Nodes as Soon as Bounds Changes

### DIFF
--- a/AsyncDisplayKit/Details/_ASDisplayLayer.h
+++ b/AsyncDisplayKit/Details/_ASDisplayLayer.h
@@ -70,6 +70,20 @@ typedef BOOL(^asdisplaynode_iscancelled_block_t)(void);
 @end
 
 /**
+ * Optional methods that the view associated with an _ASDisplayLayer can implement. 
+ * This is distinguished from _ASDisplayLayerDelegate in that it points to the _view_
+ * not the node. Unfortunately this is required by ASCollectionView, since we currently
+ * can't guarantee that an ASCollectionNode exists for it.
+ */
+@protocol ASCALayerExtendedDelegate
+
+@optional
+
+- (void)layer:(CALayer *)layer didChangeBoundsWithOldValue:(CGRect)oldBounds newValue:(CGRect)newBounds;
+
+@end
+
+/**
  Implement one of +displayAsyncLayer:parameters:isCancelled: or +drawRect:withParameters:isCancelled: to provide drawing for your node.
  Use -drawParametersForAsyncLayer: to copy any properties that are involved in drawing into an immutable object for use on the display queue.
  display/drawRect implementations MUST be thread-safe, as they can be called on the displayQueue (async) or the main thread (sync/displayImmediately)

--- a/AsyncDisplayKit/Details/_ASDisplayLayer.mm
+++ b/AsyncDisplayKit/Details/_ASDisplayLayer.mm
@@ -25,6 +25,10 @@
   ASDN::RecursiveMutex _displaySuspendedLock;
   BOOL _displaySuspended;
 
+  struct {
+    BOOL delegateDidChangeBounds:1;
+  } _delegateFlags;
+
   id<_ASDisplayLayerDelegate> __weak _asyncDelegate;
 }
 
@@ -50,6 +54,12 @@
 {
   ASDN::MutexLocker l(_asyncDelegateLock);
   return _asyncDelegate;
+}
+
+- (void)setDelegate:(id)delegate
+{
+  [super setDelegate:delegate];
+  _delegateFlags.delegateDidChangeBounds = [delegate respondsToSelector:@selector(layer:didChangeBoundsWithOldValue:newValue:)];
 }
 
 - (void)setAsyncDelegate:(id<_ASDisplayLayerDelegate>)asyncDelegate
@@ -82,8 +92,15 @@
 
 - (void)setBounds:(CGRect)bounds
 {
-  [super setBounds:bounds];
-  self.asyncdisplaykit_node.threadSafeBounds = bounds;
+  if (_delegateFlags.delegateDidChangeBounds) {
+    CGRect oldBounds = self.bounds;
+    [super setBounds:bounds];
+    self.asyncdisplaykit_node.threadSafeBounds = bounds;
+    [self.delegate layer:self didChangeBoundsWithOldValue:oldBounds newValue:bounds];
+  } else {
+    [super setBounds:bounds];
+    self.asyncdisplaykit_node.threadSafeBounds = bounds;
+  }
 }
 
 #if DEBUG // These override is strictly to help detect application-level threading errors.  Avoid method overhead in release.


### PR DESCRIPTION
We previously waited until `layoutSubviews` but that's too late as @rcancro discovered.

I added a failing test case that ensures everything is up-to-date before the first relayout after a rotation.

I expect this to be somewhat controversial because I did something unusual. In order for ASCollectionView to find out about the bounds change before UICollectionView requeries the layout object, I added an optional `ASCALayerExtendedDelegate` protocol. Basically if your view responds to these methods, ASDisplayLayer will call them. I can't use our _ASDisplayLayerDelegate because collection views may not have nodes.

I considered adding an _ASCollectionLayer class with special functionality but decided this more general solution was better.

I also renamed some ivars in ASCollectionView for clarity:
  - `_maxSizeForNodesConstrainedSize` -> `_lastBoundsSizeUsedForMeasuringNodes`
    - This value is not actually used as the max size for nodes constrained size.
  - `_ignoreMaxSizeChange` -> `_ignoreNextBoundsSizeChangeForMeasuringNodes`
    - The ignore only lasts for one change, and it's about bounds size for the particular purpose of remeasuring nodes.

Ready for review @maicki @levi @appleguy @rcancro !
