### PR TITLE
[ASViewController] Add asyncTraitCollectionDidChange to ASViewController

### DIFF
--- a/AsyncDisplayKit/ASViewController.h
+++ b/AsyncDisplayKit/ASViewController.h
@@ -60,6 +60,13 @@ typedef ASTraitCollection * _Nonnull (^ASDisplayTraitsForTraitWindowSizeBlock)(C
  */
 - (ASSizeRange)nodeConstrainedSize;
 
+/**
+ * @abstract Called when the node's ASTraitCollection changes
+ *
+ * @discussion Subclasses can override this method to react to a trait collection change.
+ */
+- (void)asyncTraitCollectionDidChange;
+
 @end
 
 @interface ASViewController (ASRangeControllerUpdateRangeProtocol)

--- a/AsyncDisplayKit/ASViewController.mm
+++ b/AsyncDisplayKit/ASViewController.mm
@@ -259,6 +259,11 @@ ASVisibilityDepthImplementation;
 
 #pragma mark - ASEnvironmentTraitCollection
 
+- (void)asyncTraitCollectionDidChange
+{
+
+}
+
 - (ASEnvironmentTraitCollection)environmentTraitCollectionForUITraitCollection:(UITraitCollection *)traitCollection
 {
   if (self.overrideDisplayTraitsWithTraitCollection) {
@@ -292,6 +297,7 @@ ASVisibilityDepthImplementation;
     environmentState.environmentTraitCollection = environmentTraitCollection;
     self.node.environmentState = environmentState;
     [self.node setNeedsLayout];
+    [self asyncTraitCollectionDidChange];
     
     NSArray<id<ASEnvironment>> *children = [self.node children];
     for (id<ASEnvironment> child in children) {


### PR DESCRIPTION
This is consistent with UIViewController but also gets called in more cases than traitCollectionDidChange since our trait collection registers a change as any size change.