### PR TITLE
[ASDisplayNode] Remove Display Semaphore

### DIFF
--- a/AsyncDisplayKit/Details/Transactions/_ASAsyncTransaction.h
+++ b/AsyncDisplayKit/Details/Transactions/_ASAsyncTransaction.h
@@ -10,6 +10,7 @@
 
 #import <Foundation/Foundation.h>
 
+#define ASDISPLAYNODE_DELAY_DISPLAY 0
 
 @class _ASAsyncTransaction;
 

--- a/AsyncDisplayKit/Details/Transactions/_ASAsyncTransaction.mm
+++ b/AsyncDisplayKit/Details/Transactions/_ASAsyncTransaction.mm
@@ -214,11 +214,15 @@ void ASAsyncTransactionQueue::GroupImpl::schedule(NSInteger priority, dispatch_q
   
   ++_pendingOperations; // enter group
   
+#if ASDISPLAYNODE_DELAY_DISPLAY
+  NSUInteger maxThreads = 1;
+#else 
   NSUInteger maxThreads = [NSProcessInfo processInfo].activeProcessorCount * 2;
 
   // Bit questionable maybe - we can give main thread more CPU time during tracking;
   if ([[NSRunLoop mainRunLoop].currentMode isEqualToString:UITrackingRunLoopMode])
     --maxThreads;
+#endif
   
   if (entry._threadCount < maxThreads) { // we need to spawn another thread
 


### PR DESCRIPTION
Now that ASAsyncTransaction manages a thread pool, we don't need to use a semaphore to limit concurrent displays.

@appleguy should probably review this since he's the only one with super deep knowledge about this code. Obviously this isn't urgent, it'll be here whenever you have time. 