### PR TITLE
[ComponentKit] Added a CKComponent hosting node

### DIFF
--- a/AsyncDisplayKit/ASComponentHostingNode.h
+++ b/AsyncDisplayKit/ASComponentHostingNode.h
@@ -1,0 +1,63 @@
+//
+//  ASComponentHostingNode.h
+//  AsyncDisplayKit
+//
+//  Copyright (c) 2014-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under the BSD-style license found in the
+//  LICENSE file in the root directory of this source tree. An additional grant
+//  of patent rights can be found in the PATENTS file in the same directory.
+//
+
+#if __has_include(<ComponentKit/ComponentKit.h>)
+
+#import <AsyncDisplayKit/ASDisplayNode.h>
+#import <ComponentKit/CKUpdateMode.h>
+
+@protocol CKComponentProvider;
+@protocol CKComponentSizeRangeProviding;
+@protocol ASComponentHostingNodeDelegate;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ @abstract An ASDisplayNode that renders a component from ComponentKit.
+ */
+@interface ASComponentHostingNode : ASDisplayNode
+
+/**
+ @abstract The Designated initializer.
+ */
+- (instancetype)initWithComponentProvider:(Class<CKComponentProvider>)componentProvider
+                        sizeRangeProvider:(id<CKComponentSizeRangeProviding>)sizeRangeProvider;
+
+/**
+ @abstract Updates the model used to render the component. This is thread-safe.
+ */
+- (void)updateModel:(nullable id<NSObject>)model mode:(CKUpdateMode)mode;
+
+/**
+ @abstract Updates the context used to render the component. This is thread-safe.
+ */
+- (void)updateContext:(nullable id<NSObject>)context mode:(CKUpdateMode)mode;
+
+/**
+ @abstract Notified when the node's ideal size (measured by -calculateSizeThatFits:) may have changed.
+ */
+@property (nonatomic, nullable, weak) id<ASComponentHostingNodeDelegate> delegate;
+
+@end
+
+@protocol ASComponentHostingNodeDelegate <NSObject>
+
+/**
+ @abstract Called after the hosting node updates the component view to a new size.
+ @discussion The delegate can use this callback to appropriately resize the node frame to fit
+ the new component size. The node will not resize itself.
+ */
+- (void)componentHostingNodeDidInvalidateSize:(ASComponentHostingNode *)hostingNode;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif

--- a/AsyncDisplayKit/ASComponentHostingNode.mm
+++ b/AsyncDisplayKit/ASComponentHostingNode.mm
@@ -1,0 +1,216 @@
+//
+//  ASComponentHostingNode.mm
+//  AsyncDisplayKit
+//
+//  Copyright (c) 2014-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under the BSD-style license found in the
+//  LICENSE file in the root directory of this source tree. An additional grant
+//  of patent rights can be found in the PATENTS file in the same directory.
+//
+
+#if __has_include(<ComponentKit/ComponentKit.h>)
+
+#import "ASComponentHostingNode.h"
+
+#import <ComponentKit/CKComponentLayout.h>
+#import <ComponentKit/CKComponentProvider.h>
+#import <ComponentKit/CKComponentRootView.h>
+#import <ComponentKit/CKComponentScopeRoot.h>
+#import <ComponentKit/CKComponentSizeRangeProviding.h>
+
+#import "ASAssert.h"
+#import "ASDisplayNode+Subclasses.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+struct ASComponentHostingViewInputs {
+  CKComponentScopeRoot *scopeRoot;
+  id<NSObject> _Nullable model;
+  id<NSObject> _Nullable context;
+  CKComponentStateUpdateMap stateUpdates;
+};
+
+@interface ASComponentHostingNode () <CKComponentStateListener>
+{
+  Class<CKComponentProvider> _componentProvider;
+  id<CKComponentSizeRangeProviding> _sizeRangeProvider;
+
+  CKComponent *_component;
+  ASDisplayNode *_containerNode;
+
+  CKComponentLayout _mountedLayout;
+  NSSet *_mountedComponents;
+
+  CKUpdateMode _requestedUpdateMode;
+  ASComponentHostingViewInputs _pendingInputs;
+  BOOL _componentNeedsUpdate;
+  BOOL _scheduledAsynchronousComponentUpdate;
+  BOOL _isSynchronouslyUpdatingComponent;
+}
+
+@end
+
+@implementation ASComponentHostingNode
+
+#pragma Mark - Lifecycle
+
+- (instancetype)initWithComponentProvider:(Class<CKComponentProvider>)componentProvider
+                        sizeRangeProvider:(id<CKComponentSizeRangeProviding>)sizeRangeProvider
+{
+  self = [super init];
+
+  _containerNode = [[ASDisplayNode alloc] initWithViewBlock:^{
+    return [CKComponentRootView new];
+  }];
+  [self addSubnode:_containerNode];
+
+  _componentProvider = componentProvider;
+  _sizeRangeProvider = sizeRangeProvider;
+
+  _pendingInputs = { .scopeRoot = [CKComponentScopeRoot rootWithListener:self] };
+  _componentNeedsUpdate = YES;
+  _requestedUpdateMode = CKUpdateModeAsynchronous;
+
+  [self _asynchronouslyUpdateComponentIfNeeded];
+
+  return self;
+}
+
+- (void)dealloc
+{
+  CKUnmountComponents(_mountedComponents);
+}
+
+#pragma mark - ASDisplayNode+Subclasses
+
+- (void)layout
+{
+  [super layout];
+
+  _containerNode.frame = self.bounds;
+  const CGSize size = self.calculatedSize;
+  if (_mountedLayout.component != _component || !CGSizeEqualToSize(_mountedLayout.size, size)) {
+    _mountedLayout = CKComputeComponentLayout(_component, {size, size}, size);
+  }
+  _mountedComponents = CKMountComponentLayout(_mountedLayout, _containerNode.view, _mountedComponents, nil);
+}
+
+- (CGSize)calculateSizeThatFits:(CGSize)constrainedSize
+{
+  const CKSizeRange componentConstrainedSize = [_sizeRangeProvider sizeRangeForBoundingSize:constrainedSize];
+  return CKComputeComponentLayout(_component, componentConstrainedSize, componentConstrainedSize.max).size;
+}
+
+#pragma mark - CKComponentStateListener
+
+- (void)componentScopeHandleWithIdentifier:(CKComponentScopeHandleIdentifier)globalIdentifier
+                            rootIdentifier:(CKComponentScopeRootIdentifier)rootIdentifier
+                     didReceiveStateUpdate:(nullable id (^)(_Nullable id))stateUpdate
+                                      mode:(CKUpdateMode)mode
+{
+  _pendingInputs.stateUpdates.insert({globalIdentifier, stateUpdate});
+  [self _setNeedsUpdateWithMode:mode];
+}
+
+#pragma mark - Accessors
+
+- (void)updateModel:(nullable id<NSObject>)model mode:(CKUpdateMode)mode
+{
+  _pendingInputs.model = model;
+  [self _setNeedsUpdateWithMode:mode];
+}
+
+- (void)updateContext:(nullable id<NSObject>)context mode:(CKUpdateMode)mode
+{
+  _pendingInputs.context = context;
+  [self _setNeedsUpdateWithMode:mode];
+}
+
+#pragma mark - Private
+
+- (void)_setNeedsUpdateWithMode:(CKUpdateMode)mode
+{
+  if (_componentNeedsUpdate && _requestedUpdateMode == CKUpdateModeSynchronous) {
+    return; // Already scheduled a synchronous update; nothing more to do.
+  }
+
+  _componentNeedsUpdate = YES;
+  _requestedUpdateMode = mode;
+
+  switch (mode) {
+    case CKUpdateModeAsynchronous:
+      [self _asynchronouslyUpdateComponentIfNeeded];
+      break;
+    case CKUpdateModeSynchronous:
+      [self _synchronouslyUpdateComponentIfNeeded];
+      [self _invalidateLayout];
+      break;
+  }
+}
+
+- (void)_asynchronouslyUpdateComponentIfNeeded
+{
+  if (_scheduledAsynchronousComponentUpdate) {
+    return;
+  }
+  _scheduledAsynchronousComponentUpdate = YES;
+
+  // Wait until the end of the run loop so that if multiple async updates are triggered we don't thrash.
+  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+    if (_requestedUpdateMode != CKUpdateModeAsynchronous) {
+      // A synchronous update was either scheduled or completed, so we can skip the async update.
+      _scheduledAsynchronousComponentUpdate = NO;
+      return;
+    }
+
+    if (!_componentNeedsUpdate) {
+      // A synchronous update snuck in and took care of it for us.
+      return;
+    }
+
+    _scheduledAsynchronousComponentUpdate = NO;
+    [self _updateComponent];
+    [self _invalidateLayout];
+  });
+}
+
+- (void)_synchronouslyUpdateComponentIfNeeded
+{
+  if (_componentNeedsUpdate == NO || _requestedUpdateMode == CKUpdateModeAsynchronous) {
+    return;
+  }
+
+  ASDisplayNodeAssert
+  (!_isSynchronouslyUpdatingComponent,
+   @"ASComponentHostingNode is not re-entrant. This is called by -layoutSubviews, so ensure "
+   @"that there is nothing that is triggering a nested call to -layoutSubviews.");
+
+  _isSynchronouslyUpdatingComponent = YES;
+  [self _updateComponent];
+  _isSynchronouslyUpdatingComponent = NO;
+}
+
+- (void)_updateComponent
+{
+  auto result = CKBuildComponent(_pendingInputs.scopeRoot, _pendingInputs.stateUpdates, ^{
+    return [_componentProvider componentForModel:_pendingInputs.model
+                                         context:_pendingInputs.context];
+  });
+
+  _pendingInputs.scopeRoot = result.scopeRoot;
+  _pendingInputs.stateUpdates = {};
+  _component = result.component;
+  _componentNeedsUpdate = NO;
+}
+
+- (void)_invalidateLayout
+{
+  [self invalidateCalculatedLayout];
+  [_delegate componentHostingNodeDidInvalidateSize:self];
+}
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif

--- a/examples/ComponentHosting/Podfile
+++ b/examples/ComponentHosting/Podfile
@@ -1,0 +1,6 @@
+source 'https://github.com/CocoaPods/Specs.git'
+platform :ios, '7.0'
+target 'Sample' do
+  pod 'ComponentKit', :git => 'https://github.com/facebook/componentkit.git', :commit => '115d2012580f17276b5383cd1dad2b306b24aeb1'
+  pod 'AsyncDisplayKit', :path => '../..'
+end

--- a/examples/ComponentHosting/Sample.xcodeproj/project.pbxproj
+++ b/examples/ComponentHosting/Sample.xcodeproj/project.pbxproj
@@ -1,0 +1,383 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		1D9969D5BCB675C18C16D30F /* libPods-Sample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D17CDDB43027CC0D76FE89AC /* libPods-Sample.a */; };
+		544E2EAF1D6D2022003A56E0 /* Component.mm in Sources */ = {isa = PBXBuildFile; fileRef = 544E2EAC1D6D2022003A56E0 /* Component.mm */; };
+		544E2EB01D6D2022003A56E0 /* Node.mm in Sources */ = {isa = PBXBuildFile; fileRef = 544E2EAE1D6D2022003A56E0 /* Node.mm */; };
+		544E2EB31D6D2171003A56E0 /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 544E2EB11D6D2171003A56E0 /* Launch Screen.storyboard */; };
+		5456D6681D6D1DD000A6D502 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 5456D6671D6D1DD000A6D502 /* main.m */; };
+		5456D66B1D6D1DD000A6D502 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 5456D66A1D6D1DD000A6D502 /* AppDelegate.m */; };
+		5456D6731D6D1DD000A6D502 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5456D6721D6D1DD000A6D502 /* Assets.xcassets */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		0AB972CF5F2AA4F46F598521 /* Pods-Sample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Sample.release.xcconfig"; path = "Pods/Target Support Files/Pods-Sample/Pods-Sample.release.xcconfig"; sourceTree = "<group>"; };
+		544E2EAB1D6D2022003A56E0 /* Component.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Component.h; sourceTree = "<group>"; };
+		544E2EAC1D6D2022003A56E0 /* Component.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = Component.mm; sourceTree = "<group>"; };
+		544E2EAD1D6D2022003A56E0 /* Node.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Node.h; sourceTree = "<group>"; };
+		544E2EAE1D6D2022003A56E0 /* Node.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = Node.mm; sourceTree = "<group>"; };
+		544E2EB21D6D2171003A56E0 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = "Base.lproj/Launch Screen.storyboard"; sourceTree = "<group>"; };
+		5456D6631D6D1DCF00A6D502 /* Sample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Sample.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		5456D6671D6D1DD000A6D502 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		5456D6691D6D1DD000A6D502 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		5456D66A1D6D1DD000A6D502 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		5456D6721D6D1DD000A6D502 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		5456D6771D6D1DD000A6D502 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D17CDDB43027CC0D76FE89AC /* libPods-Sample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Sample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		D2475947954673935C309FBA /* Pods-Sample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Sample.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Sample/Pods-Sample.debug.xcconfig"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		5456D6601D6D1DCF00A6D502 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1D9969D5BCB675C18C16D30F /* libPods-Sample.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		48CFB1EB3AAE4D1DF9F95B14 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				D2475947954673935C309FBA /* Pods-Sample.debug.xcconfig */,
+				0AB972CF5F2AA4F46F598521 /* Pods-Sample.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+		5456D65A1D6D1DCF00A6D502 = {
+			isa = PBXGroup;
+			children = (
+				5456D6651D6D1DD000A6D502 /* Sample */,
+				5456D6641D6D1DCF00A6D502 /* Products */,
+				48CFB1EB3AAE4D1DF9F95B14 /* Pods */,
+				C023A8E753043BE203F5B9D0 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		5456D6641D6D1DCF00A6D502 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				5456D6631D6D1DCF00A6D502 /* Sample.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		5456D6651D6D1DD000A6D502 /* Sample */ = {
+			isa = PBXGroup;
+			children = (
+				5456D6691D6D1DD000A6D502 /* AppDelegate.h */,
+				5456D66A1D6D1DD000A6D502 /* AppDelegate.m */,
+				544E2EAB1D6D2022003A56E0 /* Component.h */,
+				544E2EAC1D6D2022003A56E0 /* Component.mm */,
+				544E2EAD1D6D2022003A56E0 /* Node.h */,
+				544E2EAE1D6D2022003A56E0 /* Node.mm */,
+				5456D6721D6D1DD000A6D502 /* Assets.xcassets */,
+				544E2EB11D6D2171003A56E0 /* Launch Screen.storyboard */,
+				5456D6771D6D1DD000A6D502 /* Info.plist */,
+				5456D6661D6D1DD000A6D502 /* Supporting Files */,
+			);
+			path = Sample;
+			sourceTree = "<group>";
+		};
+		5456D6661D6D1DD000A6D502 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				5456D6671D6D1DD000A6D502 /* main.m */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		C023A8E753043BE203F5B9D0 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				D17CDDB43027CC0D76FE89AC /* libPods-Sample.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		5456D6621D6D1DCF00A6D502 /* Sample */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5456D67A1D6D1DD000A6D502 /* Build configuration list for PBXNativeTarget "Sample" */;
+			buildPhases = (
+				02180849709B2808A8CA0BCB /* [CP] Check Pods Manifest.lock */,
+				5456D65F1D6D1DCF00A6D502 /* Sources */,
+				5456D6601D6D1DCF00A6D502 /* Frameworks */,
+				5456D6611D6D1DCF00A6D502 /* Resources */,
+				CB8EBA0A401CE4EFFCA74049 /* [CP] Embed Pods Frameworks */,
+				D3241C78F6C9B4F209D394E9 /* [CP] Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Sample;
+			productName = Sample;
+			productReference = 5456D6631D6D1DCF00A6D502 /* Sample.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		5456D65B1D6D1DCF00A6D502 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0730;
+				ORGANIZATIONNAME = "Facebook Inc.";
+				TargetAttributes = {
+					5456D6621D6D1DCF00A6D502 = {
+						CreatedOnToolsVersion = 7.3.1;
+					};
+				};
+			};
+			buildConfigurationList = 5456D65E1D6D1DCF00A6D502 /* Build configuration list for PBXProject "Sample" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 5456D65A1D6D1DCF00A6D502;
+			productRefGroup = 5456D6641D6D1DCF00A6D502 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				5456D6621D6D1DCF00A6D502 /* Sample */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		5456D6611D6D1DCF00A6D502 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				544E2EB31D6D2171003A56E0 /* Launch Screen.storyboard in Resources */,
+				5456D6731D6D1DD000A6D502 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		02180849709B2808A8CA0BCB /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		CB8EBA0A401CE4EFFCA74049 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Sample/Pods-Sample-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		D3241C78F6C9B4F209D394E9 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Sample/Pods-Sample-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		5456D65F1D6D1DCF00A6D502 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5456D66B1D6D1DD000A6D502 /* AppDelegate.m in Sources */,
+				544E2EB01D6D2022003A56E0 /* Node.mm in Sources */,
+				5456D6681D6D1DD000A6D502 /* main.m in Sources */,
+				544E2EAF1D6D2022003A56E0 /* Component.mm in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		544E2EB11D6D2171003A56E0 /* Launch Screen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				544E2EB21D6D2171003A56E0 /* Base */,
+			);
+			name = "Launch Screen.storyboard";
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		5456D6781D6D1DD000A6D502 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		5456D6791D6D1DD000A6D502 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		5456D67B1D6D1DD000A6D502 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = D2475947954673935C309FBA /* Pods-Sample.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				INFOPLIST_FILE = Sample/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.facebook.AsyncDisplayKit.Sample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Debug;
+		};
+		5456D67C1D6D1DD000A6D502 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 0AB972CF5F2AA4F46F598521 /* Pods-Sample.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				INFOPLIST_FILE = Sample/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.facebook.AsyncDisplayKit.Sample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		5456D65E1D6D1DCF00A6D502 /* Build configuration list for PBXProject "Sample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5456D6781D6D1DD000A6D502 /* Debug */,
+				5456D6791D6D1DD000A6D502 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		5456D67A1D6D1DD000A6D502 /* Build configuration list for PBXNativeTarget "Sample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5456D67B1D6D1DD000A6D502 /* Debug */,
+				5456D67C1D6D1DD000A6D502 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 5456D65B1D6D1DCF00A6D502 /* Project object */;
+}

--- a/examples/ComponentHosting/Sample.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/examples/ComponentHosting/Sample.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:Sample.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/examples/ComponentHosting/Sample.xcworkspace/contents.xcworkspacedata
+++ b/examples/ComponentHosting/Sample.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:Sample.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/examples/ComponentHosting/Sample/AppDelegate.h
+++ b/examples/ComponentHosting/Sample/AppDelegate.h
@@ -1,0 +1,15 @@
+//
+//  AppDelegate.h
+//  Sample
+//
+//  Created by Gautham Badhrinathan on 8/23/16.
+//  Copyright © 2016 Facebook Inc. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
+
+@property (strong, nonatomic) UIWindow *window;
+
+@end

--- a/examples/ComponentHosting/Sample/AppDelegate.m
+++ b/examples/ComponentHosting/Sample/AppDelegate.m
@@ -1,0 +1,66 @@
+//
+//  AppDelegate.m
+//  Sample
+//
+//  Created by Gautham Badhrinathan on 8/23/16.
+//  Copyright © 2016 Facebook Inc. All rights reserved.
+//
+
+#import "AppDelegate.h"
+
+#import <AsyncDisplayKit/ASDisplayNode.h>
+#import <AsyncDisplayKit/ASViewController.h>
+
+#if __has_include(<ComponentKit/ComponentKit.h>)
+#import "Node.h"
+#endif
+
+@interface AppDelegate ()
+
+@end
+
+@implementation AppDelegate {
+  UIWindow *_window;
+}
+
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+  // Override point for customization after application launch.
+
+  ASDisplayNode *node =
+#if __has_include(<ComponentKit/ComponentKit.h>)
+  [Node new];
+#else
+  [ASDisplayNode new];
+#endif
+
+  _window = [UIWindow new];
+  _window.rootViewController = [[ASViewController alloc] initWithNode:node];
+  [_window makeKeyAndVisible];
+
+  return YES;
+}
+
+- (void)applicationWillResignActive:(UIApplication *)application {
+  // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+  // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
+}
+
+- (void)applicationDidEnterBackground:(UIApplication *)application {
+  // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
+  // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+}
+
+- (void)applicationWillEnterForeground:(UIApplication *)application {
+  // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
+}
+
+- (void)applicationDidBecomeActive:(UIApplication *)application {
+  // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+}
+
+- (void)applicationWillTerminate:(UIApplication *)application {
+  // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+}
+
+@end

--- a/examples/ComponentHosting/Sample/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/examples/ComponentHosting/Sample/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,73 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "83.5x83.5",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/examples/ComponentHosting/Sample/Base.lproj/Launch Screen.storyboard
+++ b/examples/ComponentHosting/Sample/Base.lproj/Launch Screen.storyboard
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="Llm-lL-Icb"/>
+                        <viewControllerLayoutGuide type="bottom" id="xb3-aO-Qok"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  Copyright © 2016 Facebook Inc. All rights reserved." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="obG-Y5-kRd">
+                                <rect key="frame" x="20" y="559" width="560" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Sample" textAlignment="center" lineBreakMode="middleTruncation" baselineAdjustment="alignBaselines" minimumFontSize="18" translatesAutoresizingMaskIntoConstraints="NO" id="GJd-Yh-RWb">
+                                <rect key="frame" x="20" y="180" width="560" height="43"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="36"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstAttribute="centerX" secondItem="obG-Y5-kRd" secondAttribute="centerX" id="5cz-MP-9tL"/>
+                            <constraint firstAttribute="centerX" secondItem="GJd-Yh-RWb" secondAttribute="centerX" id="Q3B-4B-g5h"/>
+                            <constraint firstItem="obG-Y5-kRd" firstAttribute="leading" secondItem="Ze5-6b-2t3" secondAttribute="leading" constant="20" symbolic="YES" id="SfN-ll-jLj"/>
+                            <constraint firstAttribute="bottom" secondItem="obG-Y5-kRd" secondAttribute="bottom" constant="20" id="Y44-ml-fuU"/>
+                            <constraint firstItem="GJd-Yh-RWb" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="bottom" multiplier="1/3" constant="1" id="moa-c2-u7t"/>
+                            <constraint firstItem="GJd-Yh-RWb" firstAttribute="leading" secondItem="Ze5-6b-2t3" secondAttribute="leading" constant="20" symbolic="YES" id="x7j-FC-K8j"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/examples/ComponentHosting/Sample/Component.h
+++ b/examples/ComponentHosting/Sample/Component.h
@@ -1,0 +1,17 @@
+//
+//  Component.h
+//  Sample
+//
+//  Created by Gautham Badhrinathan on 8/23/16.
+//  Copyright © 2016 Facebook Inc. All rights reserved.
+//
+
+#if __has_include(<ComponentKit/ComponentKit.h>)
+
+#import <ComponentKit/ComponentKit.h>
+
+@interface Component : CKComponent
+
+@end
+
+#endif

--- a/examples/ComponentHosting/Sample/Component.mm
+++ b/examples/ComponentHosting/Sample/Component.mm
@@ -1,0 +1,53 @@
+//
+//  Component.m
+//  Sample
+//
+//  Created by Gautham Badhrinathan on 8/23/16.
+//  Copyright © 2016 Facebook Inc. All rights reserved.
+//
+
+#if __has_include(<ComponentKit/ComponentKit.h>)
+
+#import <Foundation/Foundation.h>
+#import <ComponentKit/CKComponentSubclass.h>
+
+#import "Component.h"
+
+@implementation Component
+
++ (NSNumber *)initialState
+{
+  return @NO;
+}
+
++ (instancetype)new
+{
+  CKComponentScope scope(self);
+  NSNumber *state = scope.state();
+
+  return
+  [super
+   newWithView:{
+     [UIView class],
+     {
+       {@selector(setUserInteractionEnabled:), @YES},
+       {@selector(setBackgroundColor:), state.boolValue ? [UIColor redColor] : [UIColor cyanColor]},
+       CKComponentTapGestureAttribute(@selector(_didTapOnSelf)),
+     }
+   }
+   size:{
+     state.boolValue ? 200 : 100,
+     state.boolValue ? 200 : 100,
+   }];
+}
+
+- (void)_didTapOnSelf
+{
+  [self updateState:^(NSNumber *state) {
+    return @(!state.boolValue);
+  } mode:CKUpdateModeAsynchronous];
+}
+
+@end
+
+#endif

--- a/examples/ComponentHosting/Sample/Info.plist
+++ b/examples/ComponentHosting/Sample/Info.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>Launch Screen</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/examples/ComponentHosting/Sample/Node.h
+++ b/examples/ComponentHosting/Sample/Node.h
@@ -1,0 +1,17 @@
+//
+//  Node.h
+//  Sample
+//
+//  Created by Gautham Badhrinathan on 8/23/16.
+//  Copyright © 2016 Facebook Inc. All rights reserved.
+//
+
+#if __has_include(<ComponentKit/ComponentKit.h>)
+
+#import <AsyncDisplayKit/AsyncDisplayKit.h>
+
+@interface Node : ASDisplayNode
+
+@end
+
+#endif

--- a/examples/ComponentHosting/Sample/Node.mm
+++ b/examples/ComponentHosting/Sample/Node.mm
@@ -1,0 +1,67 @@
+//
+//  Node.m
+//  Sample
+//
+//  Created by Gautham Badhrinathan on 8/23/16.
+//  Copyright © 2016 Facebook Inc. All rights reserved.
+//
+
+#if __has_include(<ComponentKit/ComponentKit.h>)
+
+#import "Node.h"
+
+#import <AsyncDisplayKit/ASComponentHostingNode.h>
+#import <ComponentKit/ComponentKit.h>
+
+#import "Component.h"
+
+@interface Node () <CKComponentProvider, ASComponentHostingNodeDelegate>
+
+@property (nonatomic, strong, readonly) ASComponentHostingNode *hostingNode;
+
+@end
+
+@implementation Node
+
+- (instancetype)init
+{
+  if (self = [super init]) {
+    _hostingNode =
+    [[ASComponentHostingNode alloc]
+     initWithComponentProvider:[self class]
+     sizeRangeProvider:
+     [CKComponentFlexibleSizeRangeProvider
+      providerWithFlexibility:CKComponentSizeRangeFlexibleWidthAndHeight]];
+    _hostingNode.delegate = self;
+    [self addSubnode:_hostingNode];
+  }
+  return self;
+}
+
+- (void)layout
+{
+  [super layout];
+
+  CGSize hostingNodeSize = [_hostingNode measure:self.bounds.size];
+  _hostingNode.frame = {
+    .origin = {
+      .x = (CGRectGetWidth(self.bounds) - hostingNodeSize.width) / 2,
+      .y = (CGRectGetHeight(self.bounds) - hostingNodeSize.height) / 2,
+    },
+    .size = hostingNodeSize,
+  };
+}
+
++ (CKComponent *)componentForModel:(id<NSObject>)model context:(id<NSObject>)context
+{
+  return [Component new];
+}
+
+- (void)componentHostingNodeDidInvalidateSize:(ASComponentHostingNode *)hostingNode
+{
+  [self setNeedsLayout];
+}
+
+@end
+
+#endif

--- a/examples/ComponentHosting/Sample/main.m
+++ b/examples/ComponentHosting/Sample/main.m
@@ -1,0 +1,16 @@
+//
+//  main.m
+//  ASCKTest
+//
+//  Created by Gautham Badhrinathan on 8/23/16.
+//  Copyright © 2016 Facebook Inc. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import "AppDelegate.h"
+
+int main(int argc, char * argv[]) {
+  @autoreleasepool {
+      return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));
+  }
+}


### PR DESCRIPTION
This let's you host a [`CKComponent`](https://github.com/facebook/componentkit/) within an `ASDisplay` node in a performant way. This is more or less based on [`CKComponentHostingView`](https://github.com/facebook/componentkit/blob/master/ComponentKit/HostingView/CKComponentHostingView.h).

`examples/ComponentHosting` contains a sample project that shows how this can be used within an node tree.

Note: `ASComponentHostingNode` is compiled only if `ComponentKit` is included in the project.