### PR TITLE
[ASDisplayNode] Renamed range update callbacks

### DIFF
--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -177,6 +177,7 @@
 		636EA1A41C7FF4EC00EE152F /* NSArray+Diffing.m in Sources */ = {isa = PBXBuildFile; fileRef = DBC452DA1C5BF64600B16017 /* NSArray+Diffing.m */; };
 		636EA1A51C7FF4EF00EE152F /* ASDefaultPlayButton.m in Sources */ = {isa = PBXBuildFile; fileRef = AEB7B0191C5962EA00662EF4 /* ASDefaultPlayButton.m */; };
 		680346941CE4052A0009FEB4 /* ASNavigationController.h in Headers */ = {isa = PBXBuildFile; fileRef = 68FC85DC1CE29AB700EDD713 /* ASNavigationController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		683489281D70DE3400327501 /* ASDisplayNode+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 683489271D70DE3400327501 /* ASDisplayNode+Deprecated.h */; };
 		68355B311CB5799E001D4E68 /* ASImageNode+AnimatedImage.mm in Sources */ = {isa = PBXBuildFile; fileRef = 68355B2E1CB5799E001D4E68 /* ASImageNode+AnimatedImage.mm */; };
 		68355B341CB579B9001D4E68 /* ASImageNode+AnimatedImage.mm in Sources */ = {isa = PBXBuildFile; fileRef = 68355B2E1CB5799E001D4E68 /* ASImageNode+AnimatedImage.mm */; };
 		68355B3A1CB57A5A001D4E68 /* ASPINRemoteImageDownloader.m in Sources */ = {isa = PBXBuildFile; fileRef = 68355B361CB57A5A001D4E68 /* ASPINRemoteImageDownloader.m */; };
@@ -943,6 +944,7 @@
 		4640521B1A3F83C40061C0BA /* ASFlowLayoutController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASFlowLayoutController.h; sourceTree = "<group>"; };
 		4640521C1A3F83C40061C0BA /* ASFlowLayoutController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASFlowLayoutController.mm; sourceTree = "<group>"; };
 		4640521D1A3F83C40061C0BA /* ASLayoutController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASLayoutController.h; sourceTree = "<group>"; };
+		683489271D70DE3400327501 /* ASDisplayNode+Deprecated.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ASDisplayNode+Deprecated.h"; sourceTree = "<group>"; };
 		68355B2E1CB5799E001D4E68 /* ASImageNode+AnimatedImage.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "ASImageNode+AnimatedImage.mm"; sourceTree = "<group>"; };
 		68355B361CB57A5A001D4E68 /* ASPINRemoteImageDownloader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASPINRemoteImageDownloader.m; sourceTree = "<group>"; };
 		68355B371CB57A5A001D4E68 /* ASImageContainerProtocolCategories.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASImageContainerProtocolCategories.h; sourceTree = "<group>"; };
@@ -1260,6 +1262,7 @@
 				058D09D8195D050800B7D73C /* ASDisplayNode.h */,
 				058D09D9195D050800B7D73C /* ASDisplayNode.mm */,
 				68B027791C1A79CC0041016B /* ASDisplayNode+Beta.h */,
+				683489271D70DE3400327501 /* ASDisplayNode+Deprecated.h */,
 				058D09DA195D050800B7D73C /* ASDisplayNode+Subclasses.h */,
 				058D09DB195D050800B7D73C /* ASDisplayNodeExtras.h */,
 				058D09DC195D050800B7D73C /* ASDisplayNodeExtras.mm */,
@@ -1802,6 +1805,7 @@
 				83A7D95C1D44548100BF333E /* ASWeakMap.h in Headers */,
 				B350622D1B010EFD0018CF92 /* ASScrollDirection.h in Headers */,
 				254C6B751BF94DF4003EC431 /* ASTextKitComponents.h in Headers */,
+				683489281D70DE3400327501 /* ASDisplayNode+Deprecated.h in Headers */,
 				B35062081B010EFD0018CF92 /* ASScrollNode.h in Headers */,
 				25E327571C16819500A2170C /* ASPagerNode.h in Headers */,
 				B35062551B010EFD0018CF92 /* ASSentinel.h in Headers */,
@@ -1881,12 +1885,15 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 058D09D2195D04C000B7D73C /* Build configuration list for PBXNativeTarget "AsyncDisplayKitTests" */;
 			buildPhases = (
+				A5E2A5BB10F93572445AC844 /* 📦 Check Pods Manifest.lock */,
 				2E61B6A0DB0F436A9DDBE86F /* [CP] Check Pods Manifest.lock */,
 				058D09B8195D04C000B7D73C /* Sources */,
 				058D09B9195D04C000B7D73C /* Frameworks */,
 				058D09BA195D04C000B7D73C /* Resources */,
 				3B9D88CDF51B429C8409E4B6 /* [CP] Copy Pods Resources */,
 				B130AB1AC0A1E5162E211C19 /* [CP] Embed Pods Frameworks */,
+				76FDAFA9FB106E27BE016772 /* 📦 Embed Pods Frameworks */,
+				58AF99A9E1C99C30BB2F5335 /* 📦 Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -2015,6 +2022,51 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-AsyncDisplayKitTests/Pods-AsyncDisplayKitTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		58AF99A9E1C99C30BB2F5335 /* 📦 Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-AsyncDisplayKitTests/Pods-AsyncDisplayKitTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		76FDAFA9FB106E27BE016772 /* 📦 Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-AsyncDisplayKitTests/Pods-AsyncDisplayKitTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		A5E2A5BB10F93572445AC844 /* 📦 Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		B130AB1AC0A1E5162E211C19 /* [CP] Embed Pods Frameworks */ = {

--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -1885,15 +1885,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 058D09D2195D04C000B7D73C /* Build configuration list for PBXNativeTarget "AsyncDisplayKitTests" */;
 			buildPhases = (
-				A5E2A5BB10F93572445AC844 /* 📦 Check Pods Manifest.lock */,
 				2E61B6A0DB0F436A9DDBE86F /* [CP] Check Pods Manifest.lock */,
 				058D09B8195D04C000B7D73C /* Sources */,
 				058D09B9195D04C000B7D73C /* Frameworks */,
 				058D09BA195D04C000B7D73C /* Resources */,
 				3B9D88CDF51B429C8409E4B6 /* [CP] Copy Pods Resources */,
 				B130AB1AC0A1E5162E211C19 /* [CP] Embed Pods Frameworks */,
-				76FDAFA9FB106E27BE016772 /* 📦 Embed Pods Frameworks */,
-				58AF99A9E1C99C30BB2F5335 /* 📦 Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -2022,51 +2019,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-AsyncDisplayKitTests/Pods-AsyncDisplayKitTests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		58AF99A9E1C99C30BB2F5335 /* 📦 Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "📦 Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-AsyncDisplayKitTests/Pods-AsyncDisplayKitTests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		76FDAFA9FB106E27BE016772 /* 📦 Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "📦 Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-AsyncDisplayKitTests/Pods-AsyncDisplayKitTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		A5E2A5BB10F93572445AC844 /* 📦 Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "📦 Check Pods Manifest.lock";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		B130AB1AC0A1E5162E211C19 /* [CP] Embed Pods Frameworks */ = {

--- a/AsyncDisplayKit/ASCellNode.mm
+++ b/AsyncDisplayKit/ASCellNode.mm
@@ -253,14 +253,23 @@
   // To be overriden by subclasses
 }
 
-- (void)visibleStateDidChange:(BOOL)isVisible
+- (void)didEnterVisibleState
 {
-  [super visibleStateDidChange:isVisible];
-  
-  if (isVisible && self.neverShowPlaceholders) {
+  [super didEnterVisibleState];
+  if (self.neverShowPlaceholders) {
     [self recursivelyEnsureDisplaySynchronously:YES];
   }
-  
+  [self handleVisibilityChange:YES];
+}
+
+- (void)didExitVisibleState
+{
+  [super didExitVisibleState];
+  [self handleVisibilityChange:NO];
+}
+
+- (void)handleVisibilityChange:(BOOL)isVisible
+{
   // NOTE: This assertion is failing in some apps and will be enabled soon.
   // ASDisplayNodeAssert(self.isNodeLoaded, @"Node should be loaded in order for it to become visible or invisible.  If not in this situation, we shouldn't trigger creating the view.");
   UIView *view = self.view;
@@ -274,7 +283,7 @@
   }
   
   // If we did not convert, we'll pass along CGRectZero and a nil scrollView.  The EventInvisible call is thus equivalent to
-  // visibleStateDidChange:NO, but is more convenient for the developer than implementing multiple methods.
+  // didExitVisibileState, but is more convenient for the developer than implementing multiple methods.
   [self cellNodeVisibilityEvent:isVisible ? ASCellNodeVisibilityEventVisible : ASCellNodeVisibilityEventInvisible
                    inScrollView:scrollView
                   withCellFrame:cellFrame];

--- a/AsyncDisplayKit/ASCollectionNode.mm
+++ b/AsyncDisplayKit/ASCollectionNode.mm
@@ -179,10 +179,16 @@
 }
 
 #if ASRangeControllerLoggingEnabled
-- (void)visibleStateDidChange:(BOOL)isVisible
+- (void)didEnterVisibleState
 {
-  [super visibleStateDidChange:isVisible];
-  NSLog(@"%@ - visible: %d", self, isVisible);
+  [super didEnterVisibleState];
+  NSLog(@"%@ - visible: YES", self);
+}
+
+- (void)didExitVisibleState
+{
+  [super didExitVisibleState];
+  NSLog(@"%@ - visible: NO", self);
 }
 #endif
 

--- a/AsyncDisplayKit/ASDisplayNode+Deprecated.h
+++ b/AsyncDisplayKit/ASDisplayNode+Deprecated.h
@@ -1,0 +1,51 @@
+//
+//  ASDisplayNode+Deprecated.h
+//  AsyncDisplayKit
+//
+//  Created by Garrett Moon on 8/26/16.
+//  Copyright © 2016 Facebook. All rights reserved.
+//
+
+#ifndef ASDisplayNode_Deprecated_h
+#define ASDisplayNode_Deprecated_h
+
+#import "ASDisplayNode.h"
+
+@interface ASDisplayNode (Deprecated)
+
+/**
+ * @abstract Called whenever the visiblity of the node changed.
+ *
+ * @discussion Subclasses may use this to monitor when they become visible.
+ */
+- (void)visibilityDidChange:(BOOL)isVisible ASDISPLAYNODE_REQUIRES_SUPER ASDISPLAYNODE_DEPRECATED;
+
+/**
+ * @abstract Called whenever the visiblity of the node changed.
+ *
+ * @discussion Subclasses may use this to monitor when they become visible.
+ */
+- (void)visibleStateDidChange:(BOOL)isVisible ASDISPLAYNODE_REQUIRES_SUPER ASDISPLAYNODE_DEPRECATED;
+
+/**
+ * @abstract Called whenever the the node has entered or exited the display state.
+ *
+ * @discussion Subclasses may use this to monitor when a node should be rendering its content.
+ *
+ * @note This method can be called from any thread and should therefore be thread safe.
+ */
+- (void)displayStateDidChange:(BOOL)inDisplayState ASDISPLAYNODE_REQUIRES_SUPER ASDISPLAYNODE_DEPRECATED;
+
+/**
+ * @abstract Called whenever the the node has entered or left the load state.
+ *
+ * @discussion Subclasses may use this to monitor data for a node should be loaded, either from a local or remote source.
+ *
+ * @note This method can be called from any thread and should therefore be thread safe.
+ * @deprecated @see didEnterPreloadState @see didExitPreloadState
+ */
+- (void)loadStateDidChange:(BOOL)inLoadState ASDISPLAYNODE_REQUIRES_SUPER ASDISPLAYNODE_DEPRECATED;
+
+@end
+
+#endif /* ASDisplayNode_Deprecated_h */

--- a/AsyncDisplayKit/ASDisplayNode+Deprecated.h
+++ b/AsyncDisplayKit/ASDisplayNode+Deprecated.h
@@ -2,12 +2,13 @@
 //  ASDisplayNode+Deprecated.h
 //  AsyncDisplayKit
 //
-//  Created by Garrett Moon on 8/26/16.
-//  Copyright © 2016 Facebook. All rights reserved.
+//  Copyright (c) 2014-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under the BSD-style license found in the
+//  LICENSE file in the root directory of this source tree. An additional grant
+//  of patent rights can be found in the PATENTS file in the same directory.
 //
 
-#ifndef ASDisplayNode_Deprecated_h
-#define ASDisplayNode_Deprecated_h
+#pragma once
 
 #import "ASDisplayNode.h"
 
@@ -47,5 +48,3 @@
 - (void)loadStateDidChange:(BOOL)inLoadState ASDISPLAYNODE_REQUIRES_SUPER ASDISPLAYNODE_DEPRECATED;
 
 @end
-
-#endif /* ASDisplayNode_Deprecated_h */

--- a/AsyncDisplayKit/ASDisplayNode+Subclasses.h
+++ b/AsyncDisplayKit/ASDisplayNode+Subclasses.h
@@ -494,39 +494,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)asyncTraitCollectionDidChange;
 
-/**
- * @abstract Called whenever the visiblity of the node changed.
- *
- * @discussion Subclasses may use this to monitor when they become visible.
- */
-- (void)visibilityDidChange:(BOOL)isVisible ASDISPLAYNODE_REQUIRES_SUPER ASDISPLAYNODE_DEPRECATED;
-
-/**
- * @abstract Called whenever the visiblity of the node changed.
- *
- * @discussion Subclasses may use this to monitor when they become visible.
- */
-- (void)visibleStateDidChange:(BOOL)isVisible ASDISPLAYNODE_REQUIRES_SUPER ASDISPLAYNODE_DEPRECATED;
-
-/**
- * @abstract Called whenever the the node has entered or exited the display state.
- *
- * @discussion Subclasses may use this to monitor when a node should be rendering its content.
- *
- * @note This method can be called from any thread and should therefore be thread safe.
- */
-- (void)displayStateDidChange:(BOOL)inDisplayState ASDISPLAYNODE_REQUIRES_SUPER ASDISPLAYNODE_DEPRECATED;
-
-/**
- * @abstract Called whenever the the node has entered or left the load state.
- *
- * @discussion Subclasses may use this to monitor data for a node should be loaded, either from a local or remote source.
- *
- * @note This method can be called from any thread and should therefore be thread safe.
- * @deprecated @see didEnterPreloadState @see didExitPreloadState
- */
-- (void)loadStateDidChange:(BOOL)inLoadState ASDISPLAYNODE_REQUIRES_SUPER ASDISPLAYNODE_DEPRECATED;
-
 @end
 
 #define ASDisplayNodeAssertThreadAffinity(viewNode)   ASDisplayNodeAssert(!viewNode || ASDisplayNodeThreadIsMain() || !(viewNode).nodeLoaded, @"Incorrect display node thread affinity - this method should not be called off the main thread after the ASDisplayNode's view or layer have been created")

--- a/AsyncDisplayKit/ASDisplayNode+Subclasses.h
+++ b/AsyncDisplayKit/ASDisplayNode+Subclasses.h
@@ -242,7 +242,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @discussion Subclasses may use this to monitor when they become visible.
  *
- * @note This method can be called from any thread and should therefore be thread safe.
+ * @note this method is guaranteed to be called on main.
  */
 - (void)didEnterVisibleState ASDISPLAYNODE_REQUIRES_SUPER;
 
@@ -251,7 +251,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @discussion Subclasses may use this to monitor when they are no longer visible.
  *
- * @note This method can be called from any thread and should therefore be thread safe.
+ * @note this method is guaranteed to be called on main.
  */
 - (void)didExitVisibleState ASDISPLAYNODE_REQUIRES_SUPER;
 
@@ -260,7 +260,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @discussion Subclasses may use this to monitor when a node should be rendering its content.
  *
- * @note This method can be called from any thread and should therefore be thread safe.
+ * @note this method is guaranteed to be called on main.
  */
 - (void)didEnterDisplayState ASDISPLAYNODE_REQUIRES_SUPER;
 
@@ -269,7 +269,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @discussion Subclasses may use this to monitor when a node should no longer be rendering its content.
  *
- * @note This method can be called from any thread and should therefore be thread safe.
+ * @note this method is guaranteed to be called on main.
  */
 - (void)didExitDisplayState ASDISPLAYNODE_REQUIRES_SUPER;
 
@@ -278,7 +278,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @discussion Subclasses may use this to monitor data for a node should be preloaded, either from a local or remote source.
  *
- * @note This method can be called from any thread and should therefore be thread safe.
+ * @note this method is guaranteed to be called on main.
  */
 - (void)didEnterPreloadState ASDISPLAYNODE_REQUIRES_SUPER;
 
@@ -287,7 +287,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @discussion Subclasses may use this to monitor whether preloading data for a node should be canceled.
  *
- * @note This method can be called from any thread and should therefore be thread safe.
+ * @note this method is guaranteed to be called on main.
  */
 - (void)didExitPreloadState ASDISPLAYNODE_REQUIRES_SUPER;
 

--- a/AsyncDisplayKit/ASDisplayNode+Subclasses.h
+++ b/AsyncDisplayKit/ASDisplayNode+Subclasses.h
@@ -238,36 +238,58 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)interfaceStateDidChange:(ASInterfaceState)newState fromState:(ASInterfaceState)oldState ASDISPLAYNODE_REQUIRES_SUPER;
 
 /**
- * @abstract Called whenever the visiblity of the node changed.
+ * @abstract Called whenever the node becomes visible.
  *
  * @discussion Subclasses may use this to monitor when they become visible.
- */
-- (void)visibilityDidChange:(BOOL)isVisible ASDISPLAYNODE_REQUIRES_SUPER;
-
-/**
- * @abstract Called whenever the visiblity of the node changed.
  *
- * @discussion Subclasses may use this to monitor when they become visible.
+ * @note This method can be called from any thread and should therefore be thread safe.
  */
-- (void)visibleStateDidChange:(BOOL)isVisible ASDISPLAYNODE_REQUIRES_SUPER;
+- (void)didEnterVisibleState ASDISPLAYNODE_REQUIRES_SUPER;
 
 /**
- * @abstract Called whenever the the node has entered or exited the display state.
+ * @abstract Called whenever the node is no longer visible.
+ *
+ * @discussion Subclasses may use this to monitor when they are no longer visible.
+ *
+ * @note This method can be called from any thread and should therefore be thread safe.
+ */
+- (void)didExitVisibleState ASDISPLAYNODE_REQUIRES_SUPER;
+
+/**
+ * @abstract Called whenever the the node has entered the display state.
  *
  * @discussion Subclasses may use this to monitor when a node should be rendering its content.
  *
  * @note This method can be called from any thread and should therefore be thread safe.
  */
-- (void)displayStateDidChange:(BOOL)inDisplayState ASDISPLAYNODE_REQUIRES_SUPER;
+- (void)didEnterDisplayState ASDISPLAYNODE_REQUIRES_SUPER;
 
 /**
- * @abstract Called whenever the the node has entered or left the load state.
+ * @abstract Called whenever the the node has exited the display state.
  *
- * @discussion Subclasses may use this to monitor data for a node should be loaded, either from a local or remote source.  
+ * @discussion Subclasses may use this to monitor when a node should no longer be rendering its content.
  *
  * @note This method can be called from any thread and should therefore be thread safe.
  */
-- (void)loadStateDidChange:(BOOL)inLoadState ASDISPLAYNODE_REQUIRES_SUPER;
+- (void)didExitDisplayState ASDISPLAYNODE_REQUIRES_SUPER;
+
+/**
+ * @abstract Called whenever the the node has entered the preload state.
+ *
+ * @discussion Subclasses may use this to monitor data for a node should be preloaded, either from a local or remote source.
+ *
+ * @note This method can be called from any thread and should therefore be thread safe.
+ */
+- (void)didEnterPreloadState ASDISPLAYNODE_REQUIRES_SUPER;
+
+/**
+ * @abstract Called whenever the the node has exited the preload state.
+ *
+ * @discussion Subclasses may use this to monitor whether preloading data for a node should be canceled.
+ *
+ * @note This method can be called from any thread and should therefore be thread safe.
+ */
+- (void)didExitPreloadState ASDISPLAYNODE_REQUIRES_SUPER;
 
 /**
  * Called just before the view is added to a window.
@@ -471,6 +493,39 @@ NS_ASSUME_NONNULL_BEGIN
  * @discussion Subclasses can override this method to react to a trait collection change.
  */
 - (void)asyncTraitCollectionDidChange;
+
+/**
+ * @abstract Called whenever the visiblity of the node changed.
+ *
+ * @discussion Subclasses may use this to monitor when they become visible.
+ */
+- (void)visibilityDidChange:(BOOL)isVisible ASDISPLAYNODE_REQUIRES_SUPER ASDISPLAYNODE_DEPRECATED;
+
+/**
+ * @abstract Called whenever the visiblity of the node changed.
+ *
+ * @discussion Subclasses may use this to monitor when they become visible.
+ */
+- (void)visibleStateDidChange:(BOOL)isVisible ASDISPLAYNODE_REQUIRES_SUPER ASDISPLAYNODE_DEPRECATED;
+
+/**
+ * @abstract Called whenever the the node has entered or exited the display state.
+ *
+ * @discussion Subclasses may use this to monitor when a node should be rendering its content.
+ *
+ * @note This method can be called from any thread and should therefore be thread safe.
+ */
+- (void)displayStateDidChange:(BOOL)inDisplayState ASDISPLAYNODE_REQUIRES_SUPER ASDISPLAYNODE_DEPRECATED;
+
+/**
+ * @abstract Called whenever the the node has entered or left the load state.
+ *
+ * @discussion Subclasses may use this to monitor data for a node should be loaded, either from a local or remote source.
+ *
+ * @note This method can be called from any thread and should therefore be thread safe.
+ * @deprecated @see didEnterPreloadState @see didExitPreloadState
+ */
+- (void)loadStateDidChange:(BOOL)inLoadState ASDISPLAYNODE_REQUIRES_SUPER ASDISPLAYNODE_DEPRECATED;
 
 @end
 

--- a/AsyncDisplayKit/ASDisplayNode+Subclasses.h
+++ b/AsyncDisplayKit/ASDisplayNode+Subclasses.h
@@ -242,7 +242,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @discussion Subclasses may use this to monitor when they become visible.
  *
- * @note this method is guaranteed to be called on main.
+ * @note This method is guaranteed to be called on main.
  */
 - (void)didEnterVisibleState ASDISPLAYNODE_REQUIRES_SUPER;
 
@@ -251,7 +251,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @discussion Subclasses may use this to monitor when they are no longer visible.
  *
- * @note this method is guaranteed to be called on main.
+ * @note This method is guaranteed to be called on main.
  */
 - (void)didExitVisibleState ASDISPLAYNODE_REQUIRES_SUPER;
 
@@ -260,7 +260,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @discussion Subclasses may use this to monitor when a node should be rendering its content.
  *
- * @note this method is guaranteed to be called on main.
+ * @note This method is guaranteed to be called on main.
  */
 - (void)didEnterDisplayState ASDISPLAYNODE_REQUIRES_SUPER;
 
@@ -269,7 +269,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @discussion Subclasses may use this to monitor when a node should no longer be rendering its content.
  *
- * @note this method is guaranteed to be called on main.
+ * @note This method is guaranteed to be called on main.
  */
 - (void)didExitDisplayState ASDISPLAYNODE_REQUIRES_SUPER;
 
@@ -278,7 +278,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @discussion Subclasses may use this to monitor data for a node should be preloaded, either from a local or remote source.
  *
- * @note this method is guaranteed to be called on main.
+ * @note This method is guaranteed to be called on main.
  */
 - (void)didEnterPreloadState ASDISPLAYNODE_REQUIRES_SUPER;
 
@@ -287,7 +287,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @discussion Subclasses may use this to monitor whether preloading data for a node should be canceled.
  *
- * @note this method is guaranteed to be called on main.
+ * @note This method is guaranteed to be called on main.
  */
 - (void)didExitPreloadState ASDISPLAYNODE_REQUIRES_SUPER;
 

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -2454,12 +2454,14 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
 
 - (void)didEnterPreloadState
 {
-  //subclass override
+  [self fetchData];
 }
 
 - (void)didExitPreloadState
 {
-  //subclass override
+  if ([self supportsRangeManagedInterfaceState]) {
+    [self clearFetchedData];
+  }
 }
 
 /**
@@ -2508,12 +2510,8 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
   
   if (nowFetchData != wasFetchData) {
     if (nowFetchData) {
-      [self fetchData];
       [self didEnterPreloadState];
     } else {
-      if ([self supportsRangeManagedInterfaceState]) {
-        [self clearFetchedData];
-      }
       [self didExitPreloadState];
     }
   }

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -2479,6 +2479,9 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
 
 - (void)setInterfaceState:(ASInterfaceState)newState
 {
+  //This method is currently called on the main thread. The assert has been added here because all of the
+  //did(Enter|Exit)(Display|Visible|Preload)State methods currently guarantee calling on main.
+  ASDisplayNodeAssertMainThread();
   // It should never be possible for a node to be visible but not be allowed / expected to display.
   ASDisplayNodeAssertFalse(ASInterfaceStateIncludesVisible(newState) && !ASInterfaceStateIncludesDisplay(newState));
   ASInterfaceState oldState = ASInterfaceStateNone;

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -2432,22 +2432,32 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
   });
 }
 
-- (void)visibilityDidChange:(BOOL)isVisible
-{
-  // subclass override
-}
-
-- (void)visibleStateDidChange:(BOOL)isVisible
-{
-  // subclass override
-}
-
-- (void)displayStateDidChange:(BOOL)inDisplayState
+- (void)didEnterVisibleState
 {
   //subclass override
 }
 
-- (void)loadStateDidChange:(BOOL)inLoadState
+- (void)didExitVisibleState
+{
+  //subclass override
+}
+
+- (void)didEnterDisplayState
+{
+  //subclass override
+}
+
+- (void)didExitDisplayState
+{
+  //subclass override
+}
+
+- (void)didEnterPreloadState
+{
+  //subclass override
+}
+
+- (void)didExitPreloadState
 {
   //subclass override
 }
@@ -2496,12 +2506,12 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
   if (nowFetchData != wasFetchData) {
     if (nowFetchData) {
       [self fetchData];
-      [self loadStateDidChange:YES];
+      [self didEnterPreloadState];
     } else {
       if ([self supportsRangeManagedInterfaceState]) {
         [self clearFetchedData];
       }
-      [self loadStateDidChange:NO];
+      [self didExitPreloadState];
     }
   }
 
@@ -2546,7 +2556,11 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
       }
     }
     
-    [self displayStateDidChange:nowDisplay];
+    if (nowDisplay) {
+      [self didEnterDisplayState];
+    } else {
+      [self didExitDisplayState];
+    }
   }
 
   // Became visible or invisible.  When range-managed, this represents literal visibility - at least one pixel
@@ -2555,8 +2569,11 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
   BOOL wasVisible = ASInterfaceStateIncludesVisible(oldState);
 
   if (nowVisible != wasVisible) {
-    [self visibleStateDidChange:nowVisible];
-    [self visibilityDidChange:nowVisible];   //TODO: remove once this method has been deprecated
+    if (nowVisible) {
+      [self didEnterVisibleState];
+    } else {
+      [self didExitVisibleState];
+    }
   }
 
   [self interfaceStateDidChange:newState fromState:oldState];

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -2434,22 +2434,22 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
 
 - (void)didEnterVisibleState
 {
-  //subclass override
+  // subclass override
 }
 
 - (void)didExitVisibleState
 {
-  //subclass override
+  // subclass override
 }
 
 - (void)didEnterDisplayState
 {
-  //subclass override
+  // subclass override
 }
 
 - (void)didExitDisplayState
 {
-  //subclass override
+  // subclass override
 }
 
 - (void)didEnterPreloadState

--- a/AsyncDisplayKit/ASImageNode+AnimatedImage.mm
+++ b/AsyncDisplayKit/ASImageNode+AnimatedImage.mm
@@ -164,19 +164,23 @@ NSString *const ASAnimatedImageDefaultRunLoopMode = NSRunLoopCommonModes;
   [self.animatedImage clearAnimatedImageCache];
 }
 
-- (void)visibleStateDidChange:(BOOL)isVisible
+- (void)didEnterVisibleState
 {
-  [super visibleStateDidChange:isVisible];
-  
   ASDisplayNodeAssertMainThread();
-  if (isVisible) {
-    if (self.animatedImage.coverImageReady) {
-      self.image = self.animatedImage.coverImage;
-    }
-    [self startAnimating];
-  } else {
-    [self stopAnimating];
+  [super didEnterVisibleState];
+  
+  if (self.animatedImage.coverImageReady) {
+    self.image = self.animatedImage.coverImage;
   }
+  [self startAnimating];
+}
+
+- (void)didExitVisibleState
+{
+  ASDisplayNodeAssertMainThread();
+  [super didExitVisibleState];
+  
+  [self stopAnimating];
 }
 
 - (void)displayLinkFired:(CADisplayLink *)displayLink

--- a/AsyncDisplayKit/ASMultiplexImageNode.mm
+++ b/AsyncDisplayKit/ASMultiplexImageNode.mm
@@ -293,20 +293,30 @@ typedef void(^ASMultiplexImageLoadCompletionBlock)(UIImage *image, id imageIdent
   }
 }
 
-/* visibileStateDidChange in ASNetworkImageNode has a very similar implementation. Changes here are likely necessary
+/* didEnterVisibleState / didExitVisibleState in ASNetworkImageNode has a very similar implementation. Changes here are likely necessary
  in ASNetworkImageNode as well. */
-- (void)visibleStateDidChange:(BOOL)isVisible
+- (void)didEnterVisibleState
 {
-  [super visibleStateDidChange:isVisible];
+  [super didEnterVisibleState];
   
   if (_downloaderImplementsSetPriority) {
     ASDN::MutexLocker l(_downloadIdentifierLock);
     if (_downloadIdentifier != nil) {
-      if (isVisible) {
-        [_downloader setPriority:ASImageDownloaderPriorityVisible withDownloadIdentifier:_downloadIdentifier];
-      } else {
-        [_downloader setPriority:ASImageDownloaderPriorityPreload withDownloadIdentifier:_downloadIdentifier];
-      }
+      [_downloader setPriority:ASImageDownloaderPriorityVisible withDownloadIdentifier:_downloadIdentifier];
+    }
+  }
+  
+  [self _updateProgressImageBlockOnDownloaderIfNeeded];
+}
+
+- (void)didExitVisibleState
+{
+  [super didExitVisibleState];
+  
+  if (_downloaderImplementsSetPriority) {
+    ASDN::MutexLocker l(_downloadIdentifierLock);
+    if (_downloadIdentifier != nil) {
+      [_downloader setPriority:ASImageDownloaderPriorityPreload withDownloadIdentifier:_downloadIdentifier];
     }
   }
   

--- a/AsyncDisplayKit/ASNetworkImageNode.mm
+++ b/AsyncDisplayKit/ASNetworkImageNode.mm
@@ -281,21 +281,31 @@ static const CGSize kMinReleaseImageOnBackgroundSize = {20.0, 20.0};
 
 /* visibileStateDidChange in ASMultiplexImageNode has a very similar implementation. Changes here are likely necessary
  in ASMultiplexImageNode as well. */
-- (void)visibleStateDidChange:(BOOL)isVisible
+- (void)didEnterVisibleState
 {
-  [super visibleStateDidChange:isVisible];
-
+  [super didEnterVisibleState];
+  
   if (_downloaderFlags.downloaderImplementsSetPriority) {
     ASDN::MutexLocker l(__instanceLock__);
     if (_downloadIdentifier != nil) {
-      if (isVisible) {
-        [_downloader setPriority:ASImageDownloaderPriorityVisible withDownloadIdentifier:_downloadIdentifier];
-      } else {
-        [_downloader setPriority:ASImageDownloaderPriorityPreload withDownloadIdentifier:_downloadIdentifier];
-      }
+      [_downloader setPriority:ASImageDownloaderPriorityVisible withDownloadIdentifier:_downloadIdentifier];
     }
   }
+  
+  [self _updateProgressImageBlockOnDownloaderIfNeeded];
+}
 
+- (void)didExitVisibleState
+{
+  [super didExitVisibleState];
+  
+  if (_downloaderFlags.downloaderImplementsSetPriority) {
+    ASDN::MutexLocker l(__instanceLock__);
+    if (_downloadIdentifier != nil) {
+      [_downloader setPriority:ASImageDownloaderPriorityPreload withDownloadIdentifier:_downloadIdentifier];
+    }
+  }
+  
   [self _updateProgressImageBlockOnDownloaderIfNeeded];
 }
 

--- a/AsyncDisplayKit/ASTableNode.mm
+++ b/AsyncDisplayKit/ASTableNode.mm
@@ -133,10 +133,16 @@
 }
 
 #if ASRangeControllerLoggingEnabled
-- (void)visibleStateDidChange:(BOOL)isVisible
+- (void)didEnterVisibleState
 {
-  [super visibleStateDidChange:isVisible];
-  NSLog(@"%@ - visible: %d", self, isVisible);
+  [super didEnterVisibleState];
+  NSLog(@"%@ - visible: YES", self);
+}
+
+- (void)didExitVisibleState
+{
+  [super didExitVisibleState];
+  NSLog(@"%@ - visible: NO", self);
 }
 #endif
 

--- a/AsyncDisplayKit/ASVideoNode.mm
+++ b/AsyncDisplayKit/ASVideoNode.mm
@@ -436,22 +436,28 @@ static NSString * const kRate = @"rate";
   }
 }
 
-- (void)visibleStateDidChange:(BOOL)isVisible
+- (void)didEnterVisibleState
 {
-  [super visibleStateDidChange:isVisible];
+  [super didEnterVisibleState];
   
   ASDN::MutexLocker l(__instanceLock__);
   
-  if (isVisible) {
-    if (_shouldBePlaying || _shouldAutoplay) {
-      [self play];
-    }
-  } else if (_shouldBePlaying) {
+  if (_shouldBePlaying || _shouldAutoplay) {
+    [self play];
+  }
+}
+
+- (void)didExitVisibleState
+{
+  [super didExitVisibleState];
+  
+  ASDN::MutexLocker l(__instanceLock__);
+  
+  if (_shouldBePlaying) {
     [self pause];
     _shouldBePlaying = YES;
   }
 }
-
 
 #pragma mark - Video Properties
 

--- a/AsyncDisplayKit/ASVideoPlayerNode.mm
+++ b/AsyncDisplayKit/ASVideoPlayerNode.mm
@@ -211,13 +211,13 @@ static void *ASVideoPlayerNodeContext = &ASVideoPlayerNodeContext;
   }
 }
 
-- (void)visibleStateDidChange:(BOOL)isVisible
+- (void)didEnterVisibleState
 {
-  [super visibleStateDidChange:isVisible];
-
+  [super didEnterVisibleState];
+  
   ASDN::MutexLocker l(__instanceLock__);
-
-  if (isVisible && _loadAssetWhenNodeBecomesVisible) {
+  
+  if (_loadAssetWhenNodeBecomesVisible) {
     if (_asset != _videoNode.asset) {
       _videoNode.asset = _asset;
     }

--- a/AsyncDisplayKitTests/ASDisplayNodeTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeTests.m
@@ -92,8 +92,8 @@ for (ASDisplayNode *n in @[ nodes ]) {\
 @property (nonatomic) BOOL displayRangeStateChangedToYES;
 @property (nonatomic) BOOL displayRangeStateChangedToNO;
 
-@property (nonatomic) BOOL loadStateChangedToYES;
-@property (nonatomic) BOOL loadStateChangedToNO;
+@property (nonatomic) BOOL preloadStateChangedToYES;
+@property (nonatomic) BOOL preloadStateChangedToNO;
 @end
 
 @interface ASTestResponderNode : ASTestDisplayNode
@@ -118,26 +118,28 @@ for (ASDisplayNode *n in @[ nodes ]) {\
   self.hasFetchedData = NO;
 }
 
-- (void)displayStateDidChange:(BOOL)inDisplayState
+- (void)didEnterDisplayState
 {
-  [super displayStateDidChange:inDisplayState];
-  
-  if (inDisplayState) {
-    self.displayRangeStateChangedToYES = YES;
-  } else {
-    self.displayRangeStateChangedToNO = YES;
-  }
+  [super didEnterDisplayState];
+  self.displayRangeStateChangedToYES = YES;
 }
 
-- (void)loadStateDidChange:(BOOL)inLoadState
+- (void)didExitDisplayState
 {
-  [super loadStateDidChange:inLoadState];
-  
-  if (inLoadState) {
-    self.loadStateChangedToYES = YES;
-  } else {
-    self.loadStateChangedToNO = YES;
-  }
+  [super didExitDisplayState];
+  self.displayRangeStateChangedToNO = YES;
+}
+
+- (void)didEnterPreloadState
+{
+  [super didEnterPreloadState];
+  self.preloadStateChangedToYES = YES;
+}
+
+- (void)didExitPreloadState
+{
+  [super didExitPreloadState];
+  self.preloadStateChangedToNO = YES;
 }
 
 - (void)dealloc
@@ -1972,23 +1974,23 @@ static bool stringContainsPointer(NSString *description, const void *p) {
   XCTAssert([node displayRangeStateChangedToNO]);
 }
 
-- (void)testDidEnterFetchDataIsCalledWhenNodesEnterFetchDataRange
+- (void)testDidEnterPreloadIsCalledWhenNodesEnterFetchDataRange
 {
   ASTestDisplayNode *node = [[[ASTestDisplayNode alloc] init] autorelease];
   
   [node recursivelySetInterfaceState:ASInterfaceStateFetchData];
   
-  XCTAssert([node loadStateChangedToYES]);
+  XCTAssert([node preloadStateChangedToYES]);
 }
 
-- (void)testDidExitFetchDataIsCalledWhenNodesExitFetchDataRange
+- (void)testDidExitPreloadIsCalledWhenNodesExitFetchDataRange
 {
   ASTestDisplayNode *node = [[[ASTestDisplayNode alloc] init] autorelease];
   
   [node recursivelySetInterfaceState:ASInterfaceStateFetchData];
   [node recursivelySetInterfaceState:ASInterfaceStateDisplay];
 
-  XCTAssert([node loadStateChangedToNO]);
+  XCTAssert([node preloadStateChangedToNO]);
 }
 
 @end

--- a/AsyncDisplayKitTests/ASVideoNodeTests.m
+++ b/AsyncDisplayKitTests/ASVideoNodeTests.m
@@ -233,7 +233,7 @@
   }];
   _videoNode.playerNode.layer.frame = CGRectZero;
   
-  [_videoNode visibleStateDidChange:YES];
+  [_videoNode didEnterVisibleState];
 
   XCTAssertTrue(_videoNode.shouldBePlaying);
 }


### PR DESCRIPTION
We finally settled on

didEnter/ExitDisplayState
didEnter/ExitPreloadState
didEnter/ExitVisibleState

This change is meant to unify the range update methods to relate to each
other and hopefully be a bit more self explanatory.