### PR TITLE
[ASTextKitRenderer] Shift TextKit Teardown onto the Deallocation Queue

### DIFF
--- a/AsyncDisplayKit/TextKit/ASTextKitRenderer.mm
+++ b/AsyncDisplayKit/TextKit/ASTextKitRenderer.mm
@@ -129,9 +129,17 @@ static NSCharacterSet *_defaultAvoidTruncationCharacterSet()
     // truncater do it's job again for the new constrained size. This is necessary as after a truncation did happen
     // the context would use the truncated string and not the original string to truncate based on the new
     // constrained size
+    __block ASTextKitContext *ctx = _context;
+    __block ASTextKitTailTruncater *tru = _truncater;
+    __block ASTextKitFontSizeAdjuster *adj = _fontSizeAdjuster;
     _context = nil;
     _truncater = nil;
     _fontSizeAdjuster = nil;
+    ASPerformBlockOnDeallocationQueue(^{
+      ctx = nil;
+      tru = nil;
+      adj = nil;
+    });
   }
 }
 

--- a/AsyncDisplayKit/TextKit/ASTextKitRenderer.mm
+++ b/AsyncDisplayKit/TextKit/ASTextKitRenderer.mm
@@ -16,6 +16,7 @@
 #import "ASTextKitShadower.h"
 #import "ASTextKitTailTruncater.h"
 #import "ASTextKitFontSizeAdjuster.h"
+#import "ASInternalHelpers.h"
 
 //#define LOG(...) NSLog(__VA_ARGS__)
 #define LOG(...)


### PR DESCRIPTION
In the future we should try and reuse these, as setting them up is super expensive, but this brings a pretty serious benefit by letting layout continue in parallel with the teardown:

[BeforeAndAfterTextKitDeallocationQueue.trace.zip](https://github.com/facebook/AsyncDisplayKit/files/436083/BeforeAndAfterTextKitDeallocationQueue.trace.zip)

@appleguy @maicki 