### PR TITLE
[ASViewController] Layout root node AFTER propagating all the traits

### DIFF
--- a/AsyncDisplayKit/ASViewController.mm
+++ b/AsyncDisplayKit/ASViewController.mm
@@ -291,12 +291,14 @@ ASVisibilityDepthImplementation;
   if (ASEnvironmentTraitCollectionIsEqualToASEnvironmentTraitCollection(environmentTraitCollection, oldEnvironmentTraitCollection) == NO) {
     environmentState.environmentTraitCollection = environmentTraitCollection;
     self.node.environmentState = environmentState;
-    [self.node setNeedsLayout];
     
     NSArray<id<ASEnvironment>> *children = [self.node children];
     for (id<ASEnvironment> child in children) {
       ASEnvironmentStatePropagateDown(child, environmentState.environmentTraitCollection);
     }
+    
+    // once we've propagated all the traits, layout this node.
+    [self.node setNeedsLayout];
   }
 }
 


### PR DESCRIPTION
Wait until all subnodes have the new trait collection before laying out the root node. The way I’m using `asyncTraitCollectionDidChange`, I sometimes call methods that call `setNeedsLayout` which causes a new layout pass to begin before the new trait collection has been propagated to all nodes. This leads to weird behavoir, like nodes being laid out twice in the same call stack or being laid out with the node's previous constrainedSize (instead of the new size from the bounds). 

This change won’t stop possibly unnecessary layout passes because of `asyncTraitCollectionDidChange`, but it will at least do a complete layout pass once we have propagated all traits.

Ultimately the solution to this problem (as Adlai pointed out) is to wait until the CA transaction commit to perform the actual layout.