### PR TITLE
Remove textStorageCreationBlock API

### DIFF
--- a/AsyncDisplayKit/ASTextNode+Beta.h
+++ b/AsyncDisplayKit/ASTextNode+Beta.h
@@ -20,12 +20,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nullable, nonatomic, copy) NSArray *pointSizeScaleFactors;
 
-#pragma mark - ASTextKit Customization
-/**
- A block to provide a hook to provide a custom NSLayoutManager to the ASTextKitRenderer
- */
-@property (nullable, nonatomic, copy) NSLayoutManager * (^layoutManagerCreationBlock)(void);
-
 /**
  @abstract Text margins for text laid out in the text node.
  @discussion defaults to UIEdgeInsetsZero.

--- a/AsyncDisplayKit/ASTextNode+Beta.h
+++ b/AsyncDisplayKit/ASTextNode+Beta.h
@@ -27,11 +27,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nullable, nonatomic, copy) NSLayoutManager * (^layoutManagerCreationBlock)(void);
 
 /**
- A block to provide a hook to provide a NSTextStorage to the TextKit's layout manager.
- */
-@property (nullable, nonatomic, copy) NSTextStorage * (^textStorageCreationBlock)(NSAttributedString *_Nullable attributedString);
-
-/**
  @abstract Text margins for text laid out in the text node.
  @discussion defaults to UIEdgeInsetsZero.
  This property can be useful for handling text which does not fit within the view by default. An example: like UILabel,

--- a/AsyncDisplayKit/ASTextNode.mm
+++ b/AsyncDisplayKit/ASTextNode.mm
@@ -244,7 +244,6 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
     .exclusionPaths = _exclusionPaths,
     // use the property getter so a subclass can provide these scale factors on demand if desired
     .pointSizeScaleFactors = self.pointSizeScaleFactors,
-    .layoutManagerCreationBlock = self.layoutManagerCreationBlock,
     .shadowOffset = _shadowOffset,
     .shadowColor = _cachedShadowUIColor,
     .shadowOpacity = _shadowOpacity,

--- a/AsyncDisplayKit/ASTextNode.mm
+++ b/AsyncDisplayKit/ASTextNode.mm
@@ -245,7 +245,6 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
     // use the property getter so a subclass can provide these scale factors on demand if desired
     .pointSizeScaleFactors = self.pointSizeScaleFactors,
     .layoutManagerCreationBlock = self.layoutManagerCreationBlock,
-    .textStorageCreationBlock = self.textStorageCreationBlock,
     .shadowOffset = _shadowOffset,
     .shadowColor = _cachedShadowUIColor,
     .shadowOpacity = _shadowOpacity,

--- a/AsyncDisplayKit/TextKit/ASTextKitAttributes.h
+++ b/AsyncDisplayKit/TextKit/ASTextKitAttributes.h
@@ -92,11 +92,6 @@ struct ASTextKitAttributes {
   id<NSLayoutManagerDelegate> layoutManagerDelegate;
 
   /**
-   An optional block that returns a custom NSTextStorage for the layout manager. 
-   */
-  NSTextStorage * (^textStorageCreationBlock)(NSAttributedString *attributedString);
-
-  /**
    We provide an explicit copy function so we can use aggregate initializer syntax while providing copy semantics for
    the NSObjects inside.
    */
@@ -116,7 +111,6 @@ struct ASTextKitAttributes {
       pointSizeScaleFactors,
       layoutManagerCreationBlock,
       layoutManagerDelegate,
-      textStorageCreationBlock,
     };
   };
 
@@ -129,7 +123,6 @@ struct ASTextKitAttributes {
     && shadowRadius == other.shadowRadius
     && [pointSizeScaleFactors isEqualToArray:other.pointSizeScaleFactors]
     && layoutManagerCreationBlock == other.layoutManagerCreationBlock
-    && textStorageCreationBlock == other.textStorageCreationBlock
     && CGSizeEqualToSize(shadowOffset, other.shadowOffset)
     && ASObjectIsEqual(exclusionPaths, other.exclusionPaths)
     && ASObjectIsEqual(avoidTailTruncationSet, other.avoidTailTruncationSet)

--- a/AsyncDisplayKit/TextKit/ASTextKitAttributes.h
+++ b/AsyncDisplayKit/TextKit/ASTextKitAttributes.h
@@ -81,10 +81,6 @@ struct ASTextKitAttributes {
    An array of scale factors in descending order to apply to the text to try to make it fit into a constrained size.
    */
   NSArray *pointSizeScaleFactors;
-  /**
-   An optional block that returns a custom layout manager subclass. If nil, defaults to NSLayoutManager.
-   */
-  NSLayoutManager * (^layoutManagerCreationBlock)(void);
   
   /**
    An optional delegate for the NSLayoutManager
@@ -109,7 +105,6 @@ struct ASTextKitAttributes {
       shadowOpacity,
       shadowRadius,
       pointSizeScaleFactors,
-      layoutManagerCreationBlock,
       layoutManagerDelegate,
     };
   };
@@ -122,7 +117,6 @@ struct ASTextKitAttributes {
     && shadowOpacity == other.shadowOpacity
     && shadowRadius == other.shadowRadius
     && [pointSizeScaleFactors isEqualToArray:other.pointSizeScaleFactors]
-    && layoutManagerCreationBlock == other.layoutManagerCreationBlock
     && CGSizeEqualToSize(shadowOffset, other.shadowOffset)
     && ASObjectIsEqual(exclusionPaths, other.exclusionPaths)
     && ASObjectIsEqual(avoidTailTruncationSet, other.avoidTailTruncationSet)

--- a/AsyncDisplayKit/TextKit/ASTextKitAttributes.mm
+++ b/AsyncDisplayKit/TextKit/ASTextKitAttributes.mm
@@ -24,7 +24,6 @@ size_t ASTextKitAttributes::hash() const
     [truncationAttributedString hash],
     [avoidTailTruncationSet hash],
     std::hash<NSUInteger>()((NSUInteger) layoutManagerCreationBlock),
-    std::hash<NSUInteger>()((NSUInteger) textStorageCreationBlock),
     std::hash<NSInteger>()(lineBreakMode),
     std::hash<NSInteger>()(maximumNumberOfLines),
     [exclusionPaths hash],

--- a/AsyncDisplayKit/TextKit/ASTextKitAttributes.mm
+++ b/AsyncDisplayKit/TextKit/ASTextKitAttributes.mm
@@ -23,7 +23,6 @@ size_t ASTextKitAttributes::hash() const
     [attributedString hash],
     [truncationAttributedString hash],
     [avoidTailTruncationSet hash],
-    std::hash<NSUInteger>()((NSUInteger) layoutManagerCreationBlock),
     std::hash<NSInteger>()(lineBreakMode),
     std::hash<NSInteger>()(maximumNumberOfLines),
     [exclusionPaths hash],

--- a/AsyncDisplayKit/TextKit/ASTextKitContext.h
+++ b/AsyncDisplayKit/TextKit/ASTextKitContext.h
@@ -29,8 +29,7 @@
                           exclusionPaths:(NSArray *)exclusionPaths
                          constrainedSize:(CGSize)constrainedSize
               layoutManagerCreationBlock:(NSLayoutManager * (^)(void))layoutCreationBlock
-                   layoutManagerDelegate:(id<NSLayoutManagerDelegate>)layoutManagerDelegate
-                textStorageCreationBlock:(NSTextStorage * (^)(NSAttributedString *attributedString))textStorageCreationBlock;
+                   layoutManagerDelegate:(id<NSLayoutManagerDelegate>)layoutManagerDelegate;
 
 @property (nonatomic, assign, readwrite) CGSize constrainedSize;
 

--- a/AsyncDisplayKit/TextKit/ASTextKitContext.h
+++ b/AsyncDisplayKit/TextKit/ASTextKitContext.h
@@ -28,7 +28,6 @@
                     maximumNumberOfLines:(NSUInteger)maximumNumberOfLines
                           exclusionPaths:(NSArray *)exclusionPaths
                          constrainedSize:(CGSize)constrainedSize
-              layoutManagerCreationBlock:(NSLayoutManager * (^)(void))layoutCreationBlock
                    layoutManagerDelegate:(id<NSLayoutManagerDelegate>)layoutManagerDelegate;
 
 @property (nonatomic, assign, readwrite) CGSize constrainedSize;

--- a/AsyncDisplayKit/TextKit/ASTextKitContext.mm
+++ b/AsyncDisplayKit/TextKit/ASTextKitContext.mm
@@ -31,7 +31,6 @@
                          constrainedSize:(CGSize)constrainedSize
               layoutManagerCreationBlock:(NSLayoutManager * (^)(void))layoutCreationBlock
                    layoutManagerDelegate:(id<NSLayoutManagerDelegate>)layoutManagerDelegate
-                textStorageCreationBlock:(NSTextStorage * (^)(NSAttributedString *attributedString))textStorageCreationBlock
 
 {
   if (self = [super init]) {
@@ -42,11 +41,7 @@
     __instanceLock__ = std::make_shared<ASDN::Mutex>();
     
     // Create the TextKit component stack with our default configuration.
-    if (textStorageCreationBlock) {
-      _textStorage = textStorageCreationBlock(attributedString);
-    } else {
-      _textStorage = (attributedString ? [[NSTextStorage alloc] initWithAttributedString:attributedString] : [[NSTextStorage alloc] init]);
-    }
+    _textStorage = (attributedString ? [[NSTextStorage alloc] initWithAttributedString:attributedString] : [[NSTextStorage alloc] init]);
     _layoutManager = layoutCreationBlock ? layoutCreationBlock() : [[ASLayoutManager alloc] init];
     _layoutManager.usesFontLeading = NO;
     _layoutManager.delegate = layoutManagerDelegate;

--- a/AsyncDisplayKit/TextKit/ASTextKitContext.mm
+++ b/AsyncDisplayKit/TextKit/ASTextKitContext.mm
@@ -29,7 +29,6 @@
                     maximumNumberOfLines:(NSUInteger)maximumNumberOfLines
                           exclusionPaths:(NSArray *)exclusionPaths
                          constrainedSize:(CGSize)constrainedSize
-              layoutManagerCreationBlock:(NSLayoutManager * (^)(void))layoutCreationBlock
                    layoutManagerDelegate:(id<NSLayoutManagerDelegate>)layoutManagerDelegate
 
 {
@@ -42,7 +41,7 @@
     
     // Create the TextKit component stack with our default configuration.
     _textStorage = (attributedString ? [[NSTextStorage alloc] initWithAttributedString:attributedString] : [[NSTextStorage alloc] init]);
-    _layoutManager = layoutCreationBlock ? layoutCreationBlock() : [[ASLayoutManager alloc] init];
+    _layoutManager = [[ASLayoutManager alloc] init];
     _layoutManager.usesFontLeading = NO;
     _layoutManager.delegate = layoutManagerDelegate;
     [_textStorage addLayoutManager:_layoutManager];

--- a/AsyncDisplayKit/TextKit/ASTextKitFontSizeAdjuster.mm
+++ b/AsyncDisplayKit/TextKit/ASTextKitFontSizeAdjuster.mm
@@ -90,7 +90,7 @@
     static std::mutex __static_mutex;
     std::lock_guard<std::mutex> l(__static_mutex);
     
-    NSTextStorage *textStorage = _attributes.textStorageCreationBlock ? _attributes.textStorageCreationBlock(attributedString) : [[NSTextStorage alloc] initWithAttributedString:attributedString];
+    NSTextStorage *textStorage = [[NSTextStorage alloc] initWithAttributedString:attributedString];
     if (_sizingLayoutManager == nil) {
         _sizingLayoutManager = _attributes.layoutManagerCreationBlock ? _attributes.layoutManagerCreationBlock() : [[ASLayoutManager alloc] init];
         _sizingLayoutManager.usesFontLeading = NO;

--- a/AsyncDisplayKit/TextKit/ASTextKitFontSizeAdjuster.mm
+++ b/AsyncDisplayKit/TextKit/ASTextKitFontSizeAdjuster.mm
@@ -92,7 +92,7 @@
     
     NSTextStorage *textStorage = [[NSTextStorage alloc] initWithAttributedString:attributedString];
     if (_sizingLayoutManager == nil) {
-        _sizingLayoutManager = _attributes.layoutManagerCreationBlock ? _attributes.layoutManagerCreationBlock() : [[ASLayoutManager alloc] init];
+        _sizingLayoutManager = [[ASLayoutManager alloc] init]; 
         _sizingLayoutManager.usesFontLeading = NO;
     }
     [textStorage addLayoutManager:_sizingLayoutManager];

--- a/AsyncDisplayKit/TextKit/ASTextKitRenderer.mm
+++ b/AsyncDisplayKit/TextKit/ASTextKitRenderer.mm
@@ -100,7 +100,6 @@ static NSCharacterSet *_defaultAvoidTruncationCharacterSet()
                                              maximumNumberOfLines:attributes.maximumNumberOfLines
                                                    exclusionPaths:attributes.exclusionPaths
                                                   constrainedSize:shadowConstrainedSize
-                                       layoutManagerCreationBlock:attributes.layoutManagerCreationBlock
                                             layoutManagerDelegate:attributes.layoutManagerDelegate];
   }
   return _context;

--- a/AsyncDisplayKit/TextKit/ASTextKitRenderer.mm
+++ b/AsyncDisplayKit/TextKit/ASTextKitRenderer.mm
@@ -101,8 +101,7 @@ static NSCharacterSet *_defaultAvoidTruncationCharacterSet()
                                                    exclusionPaths:attributes.exclusionPaths
                                                   constrainedSize:shadowConstrainedSize
                                        layoutManagerCreationBlock:attributes.layoutManagerCreationBlock
-                                            layoutManagerDelegate:attributes.layoutManagerDelegate
-                                         textStorageCreationBlock:attributes.textStorageCreationBlock];
+                                            layoutManagerDelegate:attributes.layoutManagerDelegate];
   }
   return _context;
 }

--- a/AsyncDisplayKit/TextKit/ASTextKitTailTruncater.mm
+++ b/AsyncDisplayKit/TextKit/ASTextKitTailTruncater.mm
@@ -68,8 +68,7 @@
                                                                             exclusionPaths:nil
                                                                            constrainedSize:constrainedRect.size
                                                                       layoutManagerCreationBlock:nil
-                                                                     layoutManagerDelegate:nil
-                                                                  textStorageCreationBlock:nil];
+                                                                     layoutManagerDelegate:nil];
   __block CGRect truncationUsedRect;
 
   [truncationContext performBlockWithLockedTextKitComponents:^(NSLayoutManager *truncationLayoutManager, NSTextStorage *truncationTextStorage, NSTextContainer *truncationTextContainer) {

--- a/AsyncDisplayKit/TextKit/ASTextKitTailTruncater.mm
+++ b/AsyncDisplayKit/TextKit/ASTextKitTailTruncater.mm
@@ -67,7 +67,6 @@
                                                                       maximumNumberOfLines:1
                                                                             exclusionPaths:nil
                                                                            constrainedSize:constrainedRect.size
-                                                                      layoutManagerCreationBlock:nil
                                                                      layoutManagerDelegate:nil];
   __block CGRect truncationUsedRect;
 

--- a/AsyncDisplayKitTests/ASTextKitTruncationTests.mm
+++ b/AsyncDisplayKitTests/ASTextKitTruncationTests.mm
@@ -44,7 +44,6 @@
                                                             maximumNumberOfLines:0
                                                                   exclusionPaths:nil
                                                                  constrainedSize:constrainedSize
-                                                      layoutManagerCreationBlock:nil
                                                            layoutManagerDelegate:nil];
   __block NSRange textKitVisibleRange;
   [context performBlockWithLockedTextKitComponents:^(NSLayoutManager *layoutManager, NSTextStorage *textStorage, NSTextContainer *textContainer) {
@@ -68,7 +67,6 @@
                                                             maximumNumberOfLines:0
                                                                   exclusionPaths:nil
                                                                  constrainedSize:constrainedSize
-                                                      layoutManagerCreationBlock:nil
                                                            layoutManagerDelegate:nil];
   ASTextKitTailTruncater *tailTruncater = [[ASTextKitTailTruncater alloc] initWithContext:context
                                                                truncationAttributedString:[self _simpleTruncationAttributedString]
@@ -93,7 +91,6 @@
                                                             maximumNumberOfLines:0
                                                                   exclusionPaths:nil
                                                                  constrainedSize:constrainedSize
-                                                      layoutManagerCreationBlock:nil
                                                            layoutManagerDelegate:nil];
   ASTextKitTailTruncater *tailTruncater = [[ASTextKitTailTruncater alloc] initWithContext:context
                                                                truncationAttributedString:[self _simpleTruncationAttributedString]
@@ -117,7 +114,6 @@
                                                             maximumNumberOfLines:0
                                                                   exclusionPaths:nil
                                                                  constrainedSize:constrainedSize
-                                                      layoutManagerCreationBlock:nil
                                                            layoutManagerDelegate:nil];
   ASTextKitTailTruncater *tailTruncater = [[ASTextKitTailTruncater alloc] initWithContext:context
                                                                truncationAttributedString:[self _simpleTruncationAttributedString]
@@ -142,7 +138,6 @@
                                                           maximumNumberOfLines:0
                                                                 exclusionPaths:nil
                                                                constrainedSize:constrainedSize
-                                                    layoutManagerCreationBlock:nil
                                                          layoutManagerDelegate:nil];
   ASTextKitTailTruncater *tailTruncater = [[ASTextKitTailTruncater alloc] initWithContext:context
                                                                truncationAttributedString:[self _simpleTruncationAttributedString]
@@ -161,7 +156,6 @@
                                                             maximumNumberOfLines:0
                                                                   exclusionPaths:nil
                                                                  constrainedSize:constrainedSize
-                                                      layoutManagerCreationBlock:nil
                                                            layoutManagerDelegate:nil];
 
   ASTextKitTailTruncater *tailTruncater = [[ASTextKitTailTruncater alloc] initWithContext:context

--- a/AsyncDisplayKitTests/ASTextKitTruncationTests.mm
+++ b/AsyncDisplayKitTests/ASTextKitTruncationTests.mm
@@ -45,8 +45,7 @@
                                                                   exclusionPaths:nil
                                                                  constrainedSize:constrainedSize
                                                       layoutManagerCreationBlock:nil
-                                                           layoutManagerDelegate:nil
-                                                        textStorageCreationBlock:nil];
+                                                           layoutManagerDelegate:nil];
   __block NSRange textKitVisibleRange;
   [context performBlockWithLockedTextKitComponents:^(NSLayoutManager *layoutManager, NSTextStorage *textStorage, NSTextContainer *textContainer) {
     textKitVisibleRange = [layoutManager characterRangeForGlyphRange:[layoutManager glyphRangeForTextContainer:textContainer]
@@ -70,8 +69,7 @@
                                                                   exclusionPaths:nil
                                                                  constrainedSize:constrainedSize
                                                       layoutManagerCreationBlock:nil
-                                                           layoutManagerDelegate:nil
-                                                        textStorageCreationBlock:nil];
+                                                           layoutManagerDelegate:nil];
   ASTextKitTailTruncater *tailTruncater = [[ASTextKitTailTruncater alloc] initWithContext:context
                                                                truncationAttributedString:[self _simpleTruncationAttributedString]
                                                                    avoidTailTruncationSet:[NSCharacterSet characterSetWithCharactersInString:@""]];
@@ -96,8 +94,7 @@
                                                                   exclusionPaths:nil
                                                                  constrainedSize:constrainedSize
                                                       layoutManagerCreationBlock:nil
-                                                           layoutManagerDelegate:nil
-                                                        textStorageCreationBlock:nil];
+                                                           layoutManagerDelegate:nil];
   ASTextKitTailTruncater *tailTruncater = [[ASTextKitTailTruncater alloc] initWithContext:context
                                                                truncationAttributedString:[self _simpleTruncationAttributedString]
                                                                    avoidTailTruncationSet:[NSCharacterSet characterSetWithCharactersInString:@"."]];
@@ -121,8 +118,7 @@
                                                                   exclusionPaths:nil
                                                                  constrainedSize:constrainedSize
                                                       layoutManagerCreationBlock:nil
-                                                           layoutManagerDelegate:nil
-                                                        textStorageCreationBlock:nil];
+                                                           layoutManagerDelegate:nil];
   ASTextKitTailTruncater *tailTruncater = [[ASTextKitTailTruncater alloc] initWithContext:context
                                                                truncationAttributedString:[self _simpleTruncationAttributedString]
                                                                    avoidTailTruncationSet:[NSCharacterSet characterSetWithCharactersInString:@"."]];
@@ -147,8 +143,7 @@
                                                                 exclusionPaths:nil
                                                                constrainedSize:constrainedSize
                                                     layoutManagerCreationBlock:nil
-                                                         layoutManagerDelegate:nil
-                                                      textStorageCreationBlock:nil];
+                                                         layoutManagerDelegate:nil];
   ASTextKitTailTruncater *tailTruncater = [[ASTextKitTailTruncater alloc] initWithContext:context
                                                                truncationAttributedString:[self _simpleTruncationAttributedString]
                                                                    avoidTailTruncationSet:nil];
@@ -167,8 +162,7 @@
                                                                   exclusionPaths:nil
                                                                  constrainedSize:constrainedSize
                                                       layoutManagerCreationBlock:nil
-                                                           layoutManagerDelegate:nil
-                                                        textStorageCreationBlock:nil];
+                                                           layoutManagerDelegate:nil];
 
   ASTextKitTailTruncater *tailTruncater = [[ASTextKitTailTruncater alloc] initWithContext:context
                                                                truncationAttributedString:[self _simpleTruncationAttributedString]


### PR DESCRIPTION
This API was a hack. In the future we will be reusing NSTextStorage objects and we need to have control over how they are created. 

Pinterest is no longer using this API.

Ready for review @maicki @appleguy 