### PR TITLE
[ASViewController] Remeasure Node With New Constrained Size When Propagating Traits

### DIFF
--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -421,6 +421,7 @@
 		CC7FD9DF1BB5E962005CCB2B /* ASPhotosFrameworkImageRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = CC7FD9DD1BB5E962005CCB2B /* ASPhotosFrameworkImageRequest.m */; };
 		CC7FD9E11BB5F750005CCB2B /* ASPhotosFrameworkImageRequestTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CC7FD9E01BB5F750005CCB2B /* ASPhotosFrameworkImageRequestTests.m */; };
 		CC7FD9E21BB603FF005CCB2B /* ASPhotosFrameworkImageRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = CC7FD9DC1BB5E962005CCB2B /* ASPhotosFrameworkImageRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CCA221D31D6FA7EF00AF6A0F /* ASViewControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CCA221D21D6FA7EF00AF6A0F /* ASViewControllerTests.m */; };
 		CCB2F34D1D63CCC6004E6DE9 /* ASDisplayNodeSnapshotTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CCB2F34C1D63CCC6004E6DE9 /* ASDisplayNodeSnapshotTests.m */; };
 		CCF18FF41D2575E300DF5895 /* NSIndexSet+ASHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = CC4981BA1D1C7F65004E13CC /* NSIndexSet+ASHelpers.h */; };
 		D785F6631A74327E00291744 /* ASScrollNode.m in Sources */ = {isa = PBXBuildFile; fileRef = D785F6611A74327E00291744 /* ASScrollNode.m */; };
@@ -1090,6 +1091,7 @@
 		CC7FD9DC1BB5E962005CCB2B /* ASPhotosFrameworkImageRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASPhotosFrameworkImageRequest.h; sourceTree = "<group>"; };
 		CC7FD9DD1BB5E962005CCB2B /* ASPhotosFrameworkImageRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASPhotosFrameworkImageRequest.m; sourceTree = "<group>"; };
 		CC7FD9E01BB5F750005CCB2B /* ASPhotosFrameworkImageRequestTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASPhotosFrameworkImageRequestTests.m; sourceTree = "<group>"; };
+		CCA221D21D6FA7EF00AF6A0F /* ASViewControllerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASViewControllerTests.m; sourceTree = "<group>"; };
 		CCB2F34C1D63CCC6004E6DE9 /* ASDisplayNodeSnapshotTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASDisplayNodeSnapshotTests.m; sourceTree = "<group>"; };
 		D3779BCFF841AD3EB56537ED /* Pods-AsyncDisplayKitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AsyncDisplayKitTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-AsyncDisplayKitTests/Pods-AsyncDisplayKitTests.release.xcconfig"; sourceTree = "<group>"; };
 		D785F6601A74327E00291744 /* ASScrollNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASScrollNode.h; sourceTree = "<group>"; };
@@ -1324,6 +1326,7 @@
 		058D09C5195D04C000B7D73C /* AsyncDisplayKitTests */ = {
 			isa = PBXGroup;
 			children = (
+				CCA221D21D6FA7EF00AF6A0F /* ASViewControllerTests.m */,
 				CC0AEEA31D66316E005D1C78 /* ASUICollectionViewTests.m */,
 				CCB2F34C1D63CCC6004E6DE9 /* ASDisplayNodeSnapshotTests.m */,
 				83A7D95D1D446A6E00BF333E /* ASWeakMapTests.m */,
@@ -2181,6 +2184,7 @@
 				CC3B208E1C3F7D0A00798563 /* ASWeakSetTests.m in Sources */,
 				F711994E1D20C21100568860 /* ASDisplayNodeExtrasTests.m in Sources */,
 				ACF6ED5D1B178DC700DA7C62 /* ASDimensionTests.mm in Sources */,
+				CCA221D31D6FA7EF00AF6A0F /* ASViewControllerTests.m in Sources */,
 				058D0A38195D057000B7D73C /* ASDisplayLayerTests.m in Sources */,
 				2538B6F31BC5D2A2003CA0B4 /* ASCollectionViewFlowLayoutInspectorTests.m in Sources */,
 				058D0A39195D057000B7D73C /* ASDisplayNodeAppearanceTests.m in Sources */,

--- a/AsyncDisplayKit/ASViewController.mm
+++ b/AsyncDisplayKit/ASViewController.mm
@@ -115,7 +115,12 @@ ASVisibilityDidMoveToParentViewController;
 {
   [super viewWillAppear:animated];
   _ensureDisplayed = YES;
+
+  // We do this early layout because we need to get any ASCollectionNodes etc. into the
+  // hierarchy before UIKit applies the scroll view inset adjustments, if you are using
+  // automatic subnode management.
   [_node measureWithSizeRange:[self nodeConstrainedSize]];
+
   [_node recursivelyFetchData];
   
   if (_parentManagesVisibilityDepth == NO) {
@@ -298,6 +303,8 @@ ASVisibilityDepthImplementation;
     }
     
     // once we've propagated all the traits, layout this node.
+    // Remeasure the node with the latest constrained size – old constrained size may be incorrect.
+    [self.node measureWithSizeRange:[self nodeConstrainedSize]];
     [self.node setNeedsLayout];
   }
 }

--- a/AsyncDisplayKitTests/ASViewControllerTests.m
+++ b/AsyncDisplayKitTests/ASViewControllerTests.m
@@ -1,0 +1,85 @@
+//
+//  ASViewControllerTests.m
+//  AsyncDisplayKit
+//
+//  Created by Adlai Holler on 8/25/16.
+//  Copyright © 2016 Facebook. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import <AsyncDisplayKit/AsyncDisplayKit.h>
+#import <OCMock/OCMock.h>
+
+@interface ASViewControllerTests : XCTestCase
+
+@end
+
+@implementation ASViewControllerTests
+
+- (void)testThatAutomaticSubnodeManagementScrollViewInsetsAreApplied
+{
+  UIWindow *window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  ASDisplayNode *node = [[ASDisplayNode alloc] init];
+  node.automaticallyManagesSubnodes = YES;
+  ASScrollNode *scrollNode = [[ASScrollNode alloc] init];
+  node.layoutSpecBlock = ^(ASDisplayNode *node, ASSizeRange constrainedSize){
+    return [ASInsetLayoutSpec insetLayoutSpecWithInsets:UIEdgeInsetsZero child:scrollNode];
+  };
+  ASViewController *vc = [[ASViewController alloc] initWithNode:node];
+  window.rootViewController = [[UINavigationController alloc] initWithRootViewController:vc];
+  [window makeKeyAndVisible];
+  [window layoutIfNeeded];
+  XCTAssertEqualObjects(NSStringFromCGRect(window.bounds), NSStringFromCGRect(node.frame));
+  XCTAssertNotEqual(scrollNode.view.contentInset.top, 0);
+}
+
+- (void)testThatViewControllerFrameIsRightAfterCustomTransitionWithNonextendedEdges
+{
+  UIWindow *window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  ASDisplayNode *node = [[ASDisplayNode alloc] init];
+
+  ASViewController *vc = [[ASViewController alloc] initWithNode:node];
+  vc.node.backgroundColor = [UIColor greenColor];
+  vc.edgesForExtendedLayout = UIRectEdgeNone;
+
+  UIViewController * oldVC = [[UIViewController alloc] init];
+  UINavigationController *nav = [[UINavigationController alloc] initWithRootViewController:oldVC];
+  id navDelegate = [OCMockObject niceMockForProtocol:@protocol(UINavigationControllerDelegate)];
+  id animator = [OCMockObject niceMockForProtocol:@protocol(UIViewControllerAnimatedTransitioning)];
+  [[[[navDelegate expect] ignoringNonObjectArgs] andReturn:animator] navigationController:[OCMArg any] animationControllerForOperation:UINavigationControllerOperationPush fromViewController:[OCMArg any] toViewController:[OCMArg any]];
+  [[[animator expect] andReturnValue:@0.3] transitionDuration:[OCMArg any]];
+  XCTestExpectation *e = [self expectationWithDescription:@"Transition completed"];
+  [[[animator expect] andDo:^(NSInvocation *invocation) {
+    __unsafe_unretained id<UIViewControllerContextTransitioning> _ctx;
+    [invocation getArgument:&_ctx atIndex:2];
+    __strong id<UIViewControllerContextTransitioning> ctx = _ctx;
+    UIView *container = [ctx containerView];
+    [container addSubview:vc.view];
+    vc.view.alpha = 0;
+    vc.view.frame = [ctx finalFrameForViewController:vc];
+    [UIView animateWithDuration:0.3 animations:^{
+      vc.view.alpha = 1;
+      oldVC.view.alpha = 0;
+    } completion:^(BOOL finished) {
+      [oldVC.view removeFromSuperview];
+      [ctx completeTransition:finished];
+      [e fulfill];
+    }];
+  }] animateTransition:[OCMArg any]];
+  nav.delegate = navDelegate;
+  window.rootViewController = nav;
+  [window makeKeyAndVisible];
+  [[NSRunLoop mainRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate date]];
+  [nav pushViewController:vc animated:YES];
+
+  [self waitForExpectationsWithTimeout:2 handler:nil];
+ 
+  CGFloat navHeight = CGRectGetMaxY([nav.navigationBar convertRect:nav.navigationBar.bounds toView:window]);
+  CGRect expectedRect, slice;
+  CGRectDivide(window.bounds, &slice, &expectedRect, navHeight, CGRectMinYEdge);
+  XCTAssertEqualObjects(NSStringFromCGRect(expectedRect), NSStringFromCGRect(node.frame));
+  [navDelegate verify];
+  [animator verify];
+}
+
+@end


### PR DESCRIPTION
This fixes an issue where view controllers that participate in custom transitions may be the wrong size at the end. It comes with a unit test!

The issue was, view controllers in custom transitions are fullscreen in viewWillAppear: and when they get their correct size, we then overwrite it by calling -setNeedsLayout in -propagateNewEnvironmentTraitCollection, which remeasures us against the old bad size.

The solution is to measure the VC against the new constrained size when the new environment trait collection goes down.

This fixes Martin's issue, and it should go into 6.10. @garrettmoon @maicki @rcancro 