### PR TITLE
[ASDisplayNode] Dealloc _pendingViewState if range managed

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -106,15 +106,7 @@ _ASPendingState *ASDisplayNodeGetPendingState(ASDisplayNode *node)
   ASDN::MutexLocker l(node->__instanceLock__);
   _ASPendingState *result = node->_pendingViewState;
   if (result == nil) {
-    if (node.isNodeLoaded) {
-      if (node->_flags.layerBacked)
-        result = [_ASPendingState pendingViewStateFromLayer:node->_layer];
-      else
-        result = [_ASPendingState pendingViewStateFromView:node->_view];
-    } else {
-      result = [[_ASPendingState alloc] init];
-    }
-    
+    result = [[_ASPendingState alloc] init];
     node->_pendingViewState = result;
   }
   return result;

--- a/AsyncDisplayKit/Private/ASDisplayNode+UIViewBridge.mm
+++ b/AsyncDisplayKit/Private/ASDisplayNode+UIViewBridge.mm
@@ -54,7 +54,7 @@ ASDISPLAYNODE_INLINE BOOL ASDisplayNodeShouldApplyBridgedWriteToView(ASDisplayNo
   if (ASDisplayNodeThreadIsMain()) {
     return loaded;
   } else {
-    if (loaded && !node->_pendingViewState.hasChanges) {
+    if (loaded && !ASDisplayNodeGetPendingState(node).hasChanges) {
       [[ASPendingStateController sharedInstance] registerNode:node];
     }
     return NO;


### PR DESCRIPTION
_ASPendingState objects can add up very quickly when adding
many nodes. This is especially an issue in large collection views
and table views. This needs to be weighed against the cost of
reallocing a _ASPendingState. So in range managed nodes we
delete the pending state, otherwise we just clear it.

@Adlai-Holler @appleguy Does this patch make sense? Is it safe?

Profiling Pinterest and just scrolling down these start to add up.
With ~500 pin nodes and a total of 115MiB, pending state made
up 3.52MiB. With this patch, no matter how far you scroll, pending
state stays at about 500KiB.

Separately, I looked at allocation of nodes vs pending states
created when scrolling and they approximately matched when
scrolling the homefeed suggesting there's no cost to recreating them?