### PR TITLE
[Unit Tests] Add Text Layout Performance Tests

### DIFF
--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -426,6 +426,8 @@
 		CC7FD9DF1BB5E962005CCB2B /* ASPhotosFrameworkImageRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = CC7FD9DD1BB5E962005CCB2B /* ASPhotosFrameworkImageRequest.m */; };
 		CC7FD9E11BB5F750005CCB2B /* ASPhotosFrameworkImageRequestTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CC7FD9E01BB5F750005CCB2B /* ASPhotosFrameworkImageRequestTests.m */; };
 		CC7FD9E21BB603FF005CCB2B /* ASPhotosFrameworkImageRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = CC7FD9DC1BB5E962005CCB2B /* ASPhotosFrameworkImageRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CC8B05D61D73836400F54286 /* ASPerformanceTestContext.m in Sources */ = {isa = PBXBuildFile; fileRef = CC8B05D51D73836400F54286 /* ASPerformanceTestContext.m */; };
+		CC8B05D81D73979700F54286 /* ASTextNodePerformanceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CC8B05D71D73979700F54286 /* ASTextNodePerformanceTests.m */; };
 		CCA221D31D6FA7EF00AF6A0F /* ASViewControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CCA221D21D6FA7EF00AF6A0F /* ASViewControllerTests.m */; };
 		CCB2F34D1D63CCC6004E6DE9 /* ASDisplayNodeSnapshotTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CCB2F34C1D63CCC6004E6DE9 /* ASDisplayNodeSnapshotTests.m */; };
 		CCF18FF41D2575E300DF5895 /* NSIndexSet+ASHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = CC4981BA1D1C7F65004E13CC /* NSIndexSet+ASHelpers.h */; };
@@ -1102,6 +1104,9 @@
 		CC7FD9DC1BB5E962005CCB2B /* ASPhotosFrameworkImageRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASPhotosFrameworkImageRequest.h; sourceTree = "<group>"; };
 		CC7FD9DD1BB5E962005CCB2B /* ASPhotosFrameworkImageRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASPhotosFrameworkImageRequest.m; sourceTree = "<group>"; };
 		CC7FD9E01BB5F750005CCB2B /* ASPhotosFrameworkImageRequestTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASPhotosFrameworkImageRequestTests.m; sourceTree = "<group>"; };
+		CC8B05D41D73836400F54286 /* ASPerformanceTestContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASPerformanceTestContext.h; sourceTree = "<group>"; };
+		CC8B05D51D73836400F54286 /* ASPerformanceTestContext.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASPerformanceTestContext.m; sourceTree = "<group>"; };
+		CC8B05D71D73979700F54286 /* ASTextNodePerformanceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASTextNodePerformanceTests.m; sourceTree = "<group>"; };
 		CCA221D21D6FA7EF00AF6A0F /* ASViewControllerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASViewControllerTests.m; sourceTree = "<group>"; };
 		CCB2F34C1D63CCC6004E6DE9 /* ASDisplayNodeSnapshotTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASDisplayNodeSnapshotTests.m; sourceTree = "<group>"; };
 		D3779BCFF841AD3EB56537ED /* Pods-AsyncDisplayKitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AsyncDisplayKitTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-AsyncDisplayKitTests/Pods-AsyncDisplayKitTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -1338,6 +1343,9 @@
 		058D09C5195D04C000B7D73C /* AsyncDisplayKitTests */ = {
 			isa = PBXGroup;
 			children = (
+				CC8B05D71D73979700F54286 /* ASTextNodePerformanceTests.m */,
+				CC8B05D41D73836400F54286 /* ASPerformanceTestContext.h */,
+				CC8B05D51D73836400F54286 /* ASPerformanceTestContext.m */,
 				69B225681D7265DA00B25B22 /* ASXCTExtensions.h */,
 				CC54A81D1D7008B300296A24 /* ASDispatchTests.m */,
 				CCA221D21D6FA7EF00AF6A0F /* ASViewControllerTests.m */,
@@ -2221,8 +2229,10 @@
 				CC7FD9E11BB5F750005CCB2B /* ASPhotosFrameworkImageRequestTests.m in Sources */,
 				052EE0661A159FEF002C6279 /* ASMultiplexImageNodeTests.m in Sources */,
 				058D0A3C195D057000B7D73C /* ASMutableAttributedStringBuilderTests.m in Sources */,
+				CC8B05D81D73979700F54286 /* ASTextNodePerformanceTests.m in Sources */,
 				697B315A1CFE4B410049936F /* ASEditableTextNodeTests.m in Sources */,
 				ACF6ED611B178DC700DA7C62 /* ASOverlayLayoutSpecSnapshotTests.mm in Sources */,
+				CC8B05D61D73836400F54286 /* ASPerformanceTestContext.m in Sources */,
 				CC0AEEA41D66316E005D1C78 /* ASUICollectionViewTests.m in Sources */,
 				69B225671D72535E00B25B22 /* ASDisplayNodeLayoutTests.mm in Sources */,
 				ACF6ED621B178DC700DA7C62 /* ASRatioLayoutSpecSnapshotTests.mm in Sources */,

--- a/AsyncDisplayKit/Details/CGRect+ASConvenience.h
+++ b/AsyncDisplayKit/Details/CGRect+ASConvenience.h
@@ -13,6 +13,7 @@
 
 #import "ASBaseDefines.h"
 #import "ASLayoutController.h"
+#include "tgmath.h"
 
 #ifndef CGFLOAT_EPSILON
   #if CGFLOAT_IS_DOUBLE
@@ -25,6 +26,11 @@
 NS_ASSUME_NONNULL_BEGIN
 
 ASDISPLAYNODE_EXTERN_C_BEGIN
+
+ASDISPLAYNODE_INLINE BOOL CGSizeEqualToSizeWithIn(CGSize size1, CGSize size2, CGFloat delta)
+{
+  return fabs(size1.width - size2.width) < delta && fabs(size1.height - size2.height) < delta;
+};
 
 struct ASDirectionalScreenfulBuffer {
   CGFloat positiveDirection; // Positive relative to iOS Core Animation layer coordinate space.

--- a/AsyncDisplayKitTests/ASPerformanceTestContext.h
+++ b/AsyncDisplayKitTests/ASPerformanceTestContext.h
@@ -1,0 +1,43 @@
+//
+//  ASPerformanceTestContext.h
+//  AsyncDisplayKit
+//
+//  Created by Adlai Holler on 8/28/16.
+//  Copyright © 2016 Facebook. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <XCTest/XCTestAssertionsImpl.h>
+
+#define ASXCTAssertRelativePerformanceInRange(test, caseName, min, max) \
+  _XCTPrimitiveAssertLessThanOrEqual(self, test.results[caseName].relativePerformance, @#caseName, max, @#max);\
+  _XCTPrimitiveAssertGreaterThanOrEqual(self, test.results[caseName].relativePerformance, @#caseName, min, @#min)
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef void (^ASTestPerformanceCaseBlock)(dispatch_block_t startMeasuring, dispatch_block_t stopMeasuring);
+
+@interface ASPerformanceTestResult : NSObject
+@property (nonatomic, readonly) NSTimeInterval timePer1000;
+@property (nonatomic, readonly) NSString *caseName;
+
+@property (nonatomic, readonly, getter=isReferenceCase) BOOL referenceCase;
+@property (nonatomic, readonly) float relativePerformance;
+
+@property (nonatomic, readonly) NSMutableDictionary *userInfo;
+@end
+
+@interface ASPerformanceTestContext : NSObject
+
+/**
+ * The first case you add here will be considered the reference case.
+ */
+- (void)addCaseWithName:(NSString *)caseName block:(__attribute((noescape)) ASTestPerformanceCaseBlock)block;
+
+@property (nonatomic, copy, readonly) NSDictionary<NSString *, ASPerformanceTestResult *> *results;
+
+- (BOOL)areAllUserInfosEqual;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/AsyncDisplayKitTests/ASPerformanceTestContext.m
+++ b/AsyncDisplayKitTests/ASPerformanceTestContext.m
@@ -1,0 +1,126 @@
+//
+//  ASPerformanceTestContext.m
+//  AsyncDisplayKit
+//
+//  Created by Adlai Holler on 8/28/16.
+//  Copyright © 2016 Facebook. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "ASPerformanceTestContext.h"
+#import "ASAssert.h"
+
+@interface ASPerformanceTestResult ()
+@property (nonatomic) NSTimeInterval timePer1000;
+@property (nonatomic) NSString *caseName;
+
+@property (nonatomic, getter=isReferenceCase) BOOL referenceCase;
+@property (nonatomic) float relativePerformance;
+@end
+
+@implementation ASPerformanceTestResult
+
+- (instancetype)init
+{
+  self = [super init];
+  if (self != nil) {
+    _userInfo = [NSMutableDictionary dictionary];
+  }
+  return self;
+}
+
+- (NSString *)description
+{
+  NSString *userInfoStr = [_userInfo.description stringByReplacingOccurrencesOfString:@"\n" withString:@" "];
+  return [NSString stringWithFormat:@"<%-20s: time-per-1000=%04.2f rel-perf=%04.2f user-info=%@>", _caseName.UTF8String, _timePer1000, _relativePerformance, userInfoStr];
+}
+
+@end
+
+@implementation ASPerformanceTestContext {
+  NSMutableDictionary *_results;
+  NSInteger _iterationCount;
+  ASPerformanceTestResult * _Nullable _referenceResult;
+}
+
+- (instancetype)init
+{
+  self = [super init];
+  if (self != nil) {
+    _iterationCount = 1E4;
+    _results = [[NSMutableDictionary alloc] init];
+  }
+  return self;
+}
+
+- (void)dealloc
+{
+  /**
+   * I know this seems wacky but it's a pain to have to put this in every single test method.
+   */
+  NSLog(@"%@", self.description);
+}
+
+- (BOOL)areAllUserInfosEqual
+{
+  ASDisplayNodeAssert(_results.count >= 2, nil);
+  NSEnumerator *resultsEnumerator = [_results objectEnumerator];
+  NSDictionary *userInfo = [[resultsEnumerator nextObject] userInfo];
+  for (ASPerformanceTestResult *otherResult in resultsEnumerator) {
+    if ([userInfo isEqualToDictionary:otherResult.userInfo] == NO) {
+      return NO;
+    }
+  }
+  return YES;
+}
+
+- (void)addCaseWithName:(NSString *)caseName block:(__attribute((noescape)) ASTestPerformanceCaseBlock)block
+{
+  ASDisplayNodeAssert(_results[caseName] == nil, @"Already have a case named %@", caseName);
+  ASPerformanceTestResult *result = [[ASPerformanceTestResult alloc] init];
+  result.caseName = caseName;
+  result.timePer1000 = [self _testPerformanceForCaseWithBlock:block] / (_iterationCount / 1000);
+  if (_referenceResult == nil) {
+    result.referenceCase = YES;
+    result.relativePerformance = 1.0f;
+    _referenceResult = result;
+  } else {
+    result.relativePerformance = _referenceResult.timePer1000 / result.timePer1000;
+  }
+  _results[caseName] = result;
+}
+
+/// Returns total work time
+- (CFTimeInterval)_testPerformanceForCaseWithBlock:(__attribute((noescape)) ASTestPerformanceCaseBlock)block
+{
+  __block CFTimeInterval time = 0;
+  for (NSInteger i = 0; i < _iterationCount; i++) {
+    __block CFAbsoluteTime start = 0;
+    __block BOOL calledStop = NO;
+    @autoreleasepool {
+      block(^{
+        ASDisplayNodeAssert(start == 0, @"Called startMeasuring block twice.");
+        start = CFAbsoluteTimeGetCurrent();
+      }, ^{
+        time += (CFAbsoluteTimeGetCurrent() - start);
+        ASDisplayNodeAssert(calledStop == NO, @"Called stopMeasuring block twice.");
+        ASDisplayNodeAssert(start != 0, @"Failed to call startMeasuring block");
+        calledStop = YES;
+      });
+    }
+
+    ASDisplayNodeAssert(calledStop, @"Failed to call stopMeasuring block.");
+  }
+  return time;
+}
+
+- (NSString *)description
+{
+  NSMutableString *str = [NSMutableString stringWithString:@"Results:\n"];
+  for (ASPerformanceTestResult *result in [_results objectEnumerator]) {
+    [str appendFormat:@"\t%@\n", result];
+  }
+  return str;
+}
+
+@end

--- a/AsyncDisplayKitTests/ASTextNodePerformanceTests.m
+++ b/AsyncDisplayKitTests/ASTextNodePerformanceTests.m
@@ -1,0 +1,180 @@
+//
+//  ASTextNodePerformanceTests.m
+//  AsyncDisplayKit
+//
+//  Created by Adlai Holler on 8/28/16.
+//  Copyright © 2016 Facebook. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "ASPerformanceTestContext.h"
+#import <AsyncDisplayKit/ASTextNode.h>
+#import "ASinternalHelpers.h"
+#import "ASXCTExtensions.h"
+#include "CGRect+ASConvenience.h"
+
+@interface ASTextNodePerformanceTests : XCTestCase
+
+@end
+
+@implementation ASTextNodePerformanceTests
+
+#pragma mark Performance Tests
+
+static NSString *const kTestCaseUIKit = @"UIKit";
+static NSString *const kTestCaseASDK = @"ASDK";
+static NSString *const kTestCaseUIKitPrivateCaching = @"UIKitPrivateCaching";
+static NSString *const kTestCaseUIKitWithNoContext = @"UIKitNoContext";
+static NSString *const kTestCaseUIKitWithFreshContext = @"UIKitFreshContext";
+static NSString *const kTestCaseUIKitWithReusedContext = @"UIKitReusedContext";
+
+- (void)testPerformance_TwoParagraphLatinNoTruncation
+{
+  NSAttributedString *text = [ASTextNodePerformanceTests twoParagraphLatinText];
+  
+  CGSize maxSize = CGSizeMake(355, CGFLOAT_MAX);
+  CGSize __block uiKitSize, __block asdkSize;
+  
+  ASPerformanceTestContext *ctx = [[ASPerformanceTestContext alloc] init];
+  [ctx addCaseWithName:kTestCaseUIKit block:^(dispatch_block_t  _Nonnull startMeasuring, dispatch_block_t  _Nonnull stopMeasuring) {
+    startMeasuring();
+    uiKitSize = [text boundingRectWithSize:maxSize options:NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingTruncatesLastVisibleLine context:nil].size;
+    stopMeasuring();
+  }];
+  uiKitSize.width = ASCeilPixelValue(uiKitSize.width);
+  uiKitSize.height = ASCeilPixelValue(uiKitSize.height);
+  ctx.results[kTestCaseUIKit].userInfo[@"size"] = NSStringFromCGSize(uiKitSize);
+  
+  [ctx addCaseWithName:kTestCaseASDK block:^(dispatch_block_t  _Nonnull startMeasuring, dispatch_block_t  _Nonnull stopMeasuring) {
+    ASTextNode *node = [[ASTextNode alloc] init];
+    startMeasuring();
+    node.attributedText = text;
+    asdkSize = [node measure:maxSize];
+    stopMeasuring();
+  }];
+  ctx.results[kTestCaseASDK].userInfo[@"size"] = NSStringFromCGSize(asdkSize);
+  
+  ASXCTAssertEqualSizes(uiKitSize, asdkSize);
+  ASXCTAssertRelativePerformanceInRange(ctx, kTestCaseASDK, 0.25, 0.5);
+}
+
+- (void)testPerformance_OneParagraphLatinWithTruncation
+{
+  NSAttributedString *text = [ASTextNodePerformanceTests oneParagraphLatinText];
+  
+  CGSize maxSize = CGSizeMake(355, 150);
+  CGSize __block uiKitSize, __block asdkSize;
+  
+  ASPerformanceTestContext *testCtx = [[ASPerformanceTestContext alloc] init];
+  [testCtx addCaseWithName:kTestCaseUIKit block:^(dispatch_block_t  _Nonnull startMeasuring, dispatch_block_t  _Nonnull stopMeasuring) {
+    startMeasuring();
+    uiKitSize = [text boundingRectWithSize:maxSize options:NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingTruncatesLastVisibleLine context:nil].size;
+    stopMeasuring();
+  }];
+  uiKitSize.width = ASCeilPixelValue(uiKitSize.width);
+  uiKitSize.height = ASCeilPixelValue(uiKitSize.height);
+  testCtx.results[kTestCaseUIKit].userInfo[@"size"] = NSStringFromCGSize(uiKitSize);
+  
+  [testCtx addCaseWithName:kTestCaseASDK block:^(dispatch_block_t  _Nonnull startMeasuring, dispatch_block_t  _Nonnull stopMeasuring) {
+    ASTextNode *node = [[ASTextNode alloc] init];
+    startMeasuring();
+    node.attributedText = text;
+    asdkSize = [node measure:maxSize];
+    stopMeasuring();
+  }];
+  testCtx.results[kTestCaseASDK].userInfo[@"size"] = NSStringFromCGSize(asdkSize);
+  
+  XCTAssert(CGSizeEqualToSizeWithIn(uiKitSize, asdkSize, 5));
+  ASXCTAssertRelativePerformanceInRange(testCtx, kTestCaseASDK, 0.1, 0.3);
+}
+
+- (void)testThatNotUsingAStringDrawingContextHasSimilarPerformanceToHavingOne
+{
+  ASPerformanceTestContext *ctx = [[ASPerformanceTestContext alloc] init];
+  
+  NSAttributedString *text = [ASTextNodePerformanceTests oneParagraphLatinText];
+  CGSize maxSize = CGSizeMake(355, 150);
+  NSStringDrawingOptions options = NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingTruncatesLastVisibleLine;
+  __block CGSize size;
+  // nil context
+  [ctx addCaseWithName:kTestCaseUIKitWithNoContext block:^(dispatch_block_t  _Nonnull startMeasuring, dispatch_block_t  _Nonnull stopMeasuring) {
+    startMeasuring();
+    size = [text boundingRectWithSize:maxSize options:options context:nil].size;
+    stopMeasuring();
+  }];
+  ctx.results[kTestCaseUIKitWithNoContext].userInfo[@"size"] = NSStringFromCGSize(size);
+  
+  // Fresh context
+  [ctx addCaseWithName:kTestCaseUIKitWithFreshContext block:^(dispatch_block_t  _Nonnull startMeasuring, dispatch_block_t  _Nonnull stopMeasuring) {
+    NSStringDrawingContext *stringDrawingCtx = [[NSStringDrawingContext alloc] init];
+    startMeasuring();
+      size = [text boundingRectWithSize:maxSize options:options context:stringDrawingCtx].size;
+    stopMeasuring();
+  }];
+  ctx.results[kTestCaseUIKitWithFreshContext].userInfo[@"size"] = NSStringFromCGSize(size);
+  
+  // Reused context
+  NSStringDrawingContext *stringDrawingCtx = [[NSStringDrawingContext alloc] init];
+  [ctx addCaseWithName:kTestCaseUIKitWithReusedContext block:^(dispatch_block_t  _Nonnull startMeasuring, dispatch_block_t  _Nonnull stopMeasuring) {
+    startMeasuring();
+      size = [text boundingRectWithSize:maxSize options:options context:stringDrawingCtx].size;
+    stopMeasuring();
+  }];
+  ctx.results[kTestCaseUIKitWithReusedContext].userInfo[@"size"] = NSStringFromCGSize(size);
+  
+  XCTAssertTrue([ctx areAllUserInfosEqual]);
+  ASXCTAssertRelativePerformanceInRange(ctx, kTestCaseUIKitWithReusedContext, 0.8, 1.2);
+  ASXCTAssertRelativePerformanceInRange(ctx, kTestCaseUIKitWithFreshContext, 0.8, 1.2);
+}
+
+- (void)testThatUIKitPrivateLayoutCachingIsAwesome
+{
+  NSAttributedString *text = [ASTextNodePerformanceTests oneParagraphLatinText];
+  ASPerformanceTestContext *ctx = [[ASPerformanceTestContext alloc] init];
+  CGSize maxSize = CGSizeMake(355, 150);
+  __block CGSize uncachedSize, cachedSize;
+  NSStringDrawingOptions options = NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingTruncatesLastVisibleLine;
+  
+  // No caching, reused ctx
+  NSStringDrawingContext *defaultCtx = [[NSStringDrawingContext alloc] init];
+  XCTAssertFalse([[defaultCtx valueForKey:@"cachesLayout"] boolValue]);
+  [ctx addCaseWithName:kTestCaseUIKit block:^(dispatch_block_t  _Nonnull startMeasuring, dispatch_block_t  _Nonnull stopMeasuring) {
+    startMeasuring();
+    uncachedSize = [text boundingRectWithSize:maxSize options:options context:defaultCtx].size;
+    stopMeasuring();
+  }];
+  XCTAssertFalse([[defaultCtx valueForKey:@"cachesLayout"] boolValue]);
+  ctx.results[kTestCaseUIKit].userInfo[@"size"] = NSStringFromCGSize(uncachedSize);
+  
+  // Caching
+  NSStringDrawingContext *cachingCtx = [[NSStringDrawingContext alloc] init];
+  [cachingCtx setValue:@YES forKey:@"cachesLayout"];
+  [ctx addCaseWithName:kTestCaseUIKitPrivateCaching block:^(dispatch_block_t  _Nonnull startMeasuring, dispatch_block_t  _Nonnull stopMeasuring) {
+    startMeasuring();
+    cachedSize = [text boundingRectWithSize:maxSize options:options context:cachingCtx].size;
+    stopMeasuring();
+  }];
+  ctx.results[kTestCaseUIKitPrivateCaching].userInfo[@"size"] = NSStringFromCGSize(cachedSize);
+  
+  XCTAssertTrue([ctx areAllUserInfosEqual]);
+  ASXCTAssertRelativePerformanceInRange(ctx, kTestCaseUIKitPrivateCaching, 1.5, FLT_MAX);
+}
+
+#pragma mark Fixture Data
+
++ (NSMutableAttributedString *)oneParagraphLatinText
+{
+  NSDictionary *attributes = @{
+                               NSFontAttributeName: [UIFont systemFontOfSize:14]
+                               };
+  return [[NSMutableAttributedString alloc] initWithString:@"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam gravida, metus non tincidunt tincidunt, arcu quam vulputate magna, nec semper libero mi in lorem. Quisque turpis erat, congue sit amet eros at, gravida gravida lacus. Maecenas maximus lectus in efficitur pulvinar. Nam elementum massa eget luctus condimentum. Curabitur egestas mauris urna. Fusce lacus ante, laoreet vitae leo quis, mattis aliquam est. Donec bibendum augue at elit lacinia lobortis. Cras imperdiet ac justo eget sollicitudin. Pellentesque malesuada nec tellus vitae dictum. Proin vestibulum tempus odio in condimentum. Interdum et malesuada fames ac ante ipsum primis in faucibus. Duis vel turpis at velit dignissim rutrum. Nunc lorem felis, molestie eget ornare id, luctus at nunc. Maecenas suscipit nisi sit amet nulla cursus, id eleifend odio laoreet." attributes:attributes];
+}
+
++ (NSMutableAttributedString *)twoParagraphLatinText
+{
+  NSDictionary *attributes = @{
+                               NSFontAttributeName: [UIFont systemFontOfSize:14]
+                               };
+  return [[NSMutableAttributedString alloc] initWithString:@"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam gravida, metus non tincidunt tincidunt, arcu quam vulputate magna, nec semper libero mi in lorem. Quisque turpis erat, congue sit amet eros at, gravida gravida lacus. Maecenas maximus lectus in efficitur pulvinar. Nam elementum massa eget luctus condimentum. Curabitur egestas mauris urna. Fusce lacus ante, laoreet vitae leo quis, mattis aliquam est. Donec bibendum augue at elit lacinia lobortis. Cras imperdiet ac justo eget sollicitudin. Pellentesque malesuada nec tellus vitae dictum. Proin vestibulum tempus odio in condimentum. Interdum et malesuada fames ac ante ipsum primis in faucibus. Duis vel turpis at velit dignissim rutrum. Nunc lorem felis, molestie eget ornare id, luctus at nunc. Maecenas suscipit nisi sit amet nulla cursus, id eleifend odio laoreet.\n\nPellentesque auctor pulvinar velit, venenatis elementum ex tempus eu. Vestibulum iaculis hendrerit tortor quis sagittis. Pellentesque quam sem, varius ac orci nec, tincidunt ultricies mauris. Aliquam est nunc, eleifend et posuere sed, vestibulum eu elit. Pellentesque pharetra bibendum finibus. Aliquam interdum metus ac feugiat congue. Donec suscipit neque quis mauris volutpat, at molestie tortor aliquam. Aenean posuere nulla a ex posuere finibus. Integer tincidunt quam urna, et vulputate enim tempor sit amet. Nullam ut tellus ac arcu fringilla cursus." attributes:attributes];
+}
+@end

--- a/AsyncDisplayKitTests/ASTextNodePerformanceTests.m
+++ b/AsyncDisplayKitTests/ASTextNodePerformanceTests.m
@@ -55,7 +55,7 @@ static NSString *const kTestCaseUIKitWithReusedContext = @"UIKitReusedContext";
   ctx.results[kTestCaseASDK].userInfo[@"size"] = NSStringFromCGSize(asdkSize);
   
   ASXCTAssertEqualSizes(uiKitSize, asdkSize);
-  ASXCTAssertRelativePerformanceInRange(ctx, kTestCaseASDK, 0.25, 0.5);
+  ASXCTAssertRelativePerformanceInRange(ctx, kTestCaseASDK, 0.2, 0.5);
 }
 
 - (void)testPerformance_OneParagraphLatinWithTruncation

--- a/AsyncDisplayKitTests/ASTextNodeTests.m
+++ b/AsyncDisplayKitTests/ASTextNodeTests.m
@@ -15,11 +15,8 @@
 #import <AsyncDisplayKit/ASTextNode.h>
 
 #import <XCTest/XCTest.h>
+#include "CGRect+ASConvenience.h"
 
-static BOOL CGSizeEqualToSizeWithIn(CGSize size1, CGSize size2, CGFloat delta)
-{
-  return fabs(size1.width - size2.width) < delta && fabs(size1.height - size2.height) < delta;
-}
 
 @interface ASTextNodeTestDelegate : NSObject <ASTextNodeDelegate>
 


### PR DESCRIPTION
This will hopefully help us monitor and improve our text layout performance. There is certainly a ton of room for improvement. 

The tests are currently single-threaded. In the future we could beef em up to be multithreaded. 

Ready for review @maicki @appleguy @garrettmoon @levi 

Here are the current results on my machine:

```
Test Suite 'Selected tests' started at 2016-08-28 15:26:24.649
Test Suite 'ASTextNodePerformanceTests' started at 2016-08-28 15:26:24.650
Test Case '-[ASTextNodePerformanceTests testPerformance_OneParagraphLatinWithTruncation]' started.
Results:
	<UIKit               : time-per-1000=0.06 rel-perf=1.00 user-info={     size = "{348, 134}"; }>
	<ASDK                : time-per-1000=0.47 rel-perf=0.13 user-info={     size = "{344, 134}"; }>
Test Case '-[ASTextNodePerformanceTests testPerformance_OneParagraphLatinWithTruncation]' passed (5.616 seconds).
Test Case '-[ASTextNodePerformanceTests testPerformance_TwoParagraphLatinNoTruncation]' started.
Results:
	<UIKit               : time-per-1000=0.13 rel-perf=1.00 user-info={     size = "{355, 468}"; }>
	<ASDK                : time-per-1000=0.48 rel-perf=0.27 user-info={     size = "{355, 468}"; }>
Test Case '-[ASTextNodePerformanceTests testPerformance_TwoParagraphLatinNoTruncation]' passed (6.506 seconds).
Test Case '-[ASTextNodePerformanceTests testThatNotUsingAStringDrawingContextHasSimilarPerformanceToHavingOne]' started.
Results:
	<UIKitFreshContext   : time-per-1000=0.06 rel-perf=1.02 user-info={     size = "{347.703125, 133.65625}"; }>
	<UIKitNoContext      : time-per-1000=0.06 rel-perf=1.00 user-info={     size = "{347.703125, 133.65625}"; }>
	<UIKitReusedContext  : time-per-1000=0.06 rel-perf=1.03 user-info={     size = "{347.703125, 133.65625}"; }>
Test Case '-[ASTextNodePerformanceTests testThatNotUsingAStringDrawingContextHasSimilarPerformanceToHavingOne]' passed (1.843 seconds).
Test Case '-[ASTextNodePerformanceTests testThatUIKitPrivateLayoutCachingIsAwesome]' started.
Results:
	<UIKit               : time-per-1000=0.06 rel-perf=1.00 user-info={     size = "{347.703125, 133.65625}"; }>
	<UIKitPrivateCaching : time-per-1000=0.03 rel-perf=2.39 user-info={     size = "{347.703125, 133.65625}"; }>
Test Case '-[ASTextNodePerformanceTests testThatUIKitPrivateLayoutCachingIsAwesome]' passed (0.895 seconds).
```