### PR TITLE
[Layout] Assert if subnodes where modified during layoutSpecThatFits:

### DIFF
--- a/AsyncDisplayKit/Private/ASInternalHelpers.h
+++ b/AsyncDisplayKit/Private/ASInternalHelpers.h
@@ -18,6 +18,9 @@ ASDISPLAYNODE_EXTERN_C_BEGIN
 BOOL ASSubclassOverridesSelector(Class superclass, Class subclass, SEL selector);
 BOOL ASSubclassOverridesClassSelector(Class superclass, Class subclass, SEL selector);
 
+/// Replace a method from the given class with a block and returns the original method IMP
+IMP ASReplaceMethodWithBlock(Class c, SEL origSEL, id block);
+
 /// Dispatches the given block to the main queue if not already running on the main thread
 void ASPerformBlockOnMainThread(void (^block)());
 

--- a/AsyncDisplayKit/Private/ASInternalHelpers.m
+++ b/AsyncDisplayKit/Private/ASInternalHelpers.m
@@ -33,6 +33,25 @@ BOOL ASSubclassOverridesClassSelector(Class superclass, Class subclass, SEL sele
   return (superclassIMP != subclassIMP);
 }
 
+IMP ASReplaceMethodWithBlock(Class c, SEL origSEL, id block)
+{
+  NSCParameterAssert(block);
+  
+  // Get original method
+  Method origMethod = class_getInstanceMethod(c, origSEL);
+  NSCParameterAssert(origMethod);
+  
+  // Convert block to IMP trampoline and replace method implementation
+  IMP newIMP = imp_implementationWithBlock(block);
+  
+  // Try adding the method if not yet in the current class
+  if (!class_addMethod(c, origSEL, newIMP, method_getTypeEncoding(origMethod))) {
+    return method_setImplementation(origMethod, newIMP);
+  } else {
+    return method_getImplementation(origMethod);
+  }
+}
+
 void ASPerformBlockOnMainThread(void (^block)())
 {
   if (block == nil){

--- a/AsyncDisplayKitTests/ASDisplayNodeLayoutTests.mm
+++ b/AsyncDisplayKitTests/ASDisplayNodeLayoutTests.mm
@@ -34,4 +34,35 @@
   ASXCTAssertEqualSizes(displayNode.calculatedSize, CGSizeMake(100, 100), @"Automatic measurement pass should be happened in layout");
 }
 
+#if DEBUG
+- (void)testNotAllowAddingSubnodesInLayoutSpecThatFits
+{
+  ASDisplayNode *displayNode = [ASDisplayNode new];
+  ASDisplayNode *someOtherNode = [ASDisplayNode new];
+  
+  displayNode.layoutSpecBlock = ^(ASDisplayNode * _Nonnull node, ASSizeRange constrainedSize) {
+    [node addSubnode:someOtherNode];
+    return [ASInsetLayoutSpec insetLayoutSpecWithInsets:UIEdgeInsetsZero child:someOtherNode];
+  };
+  
+  XCTAssertThrows([displayNode measure:CGSizeMake(100, 100)], @"Should throw if subnode was added in layoutSpecThatFits:");
+}
+
+- (void)testNotAllowModifyingSubnodesInLayoutSpecThatFits
+{
+  ASDisplayNode *displayNode = [ASDisplayNode new];
+  ASDisplayNode *someOtherNode = [ASDisplayNode new];
+  
+  [displayNode addSubnode:someOtherNode];
+  
+  displayNode.layoutSpecBlock = ^(ASDisplayNode * _Nonnull node, ASSizeRange constrainedSize) {
+    [someOtherNode removeFromSupernode];
+    [node addSubnode:[ASDisplayNode new]];
+    return [ASInsetLayoutSpec insetLayoutSpecWithInsets:UIEdgeInsetsZero child:someOtherNode];
+  };
+  
+  XCTAssertThrows([displayNode measure:CGSizeMake(100, 100)], @"Should throw if subnodes where modified in layoutSpecThatFits:");
+}
+#endif
+
 @end


### PR DESCRIPTION
It's not allowed to modify submodes in `layoutSpecThatFits:` or in the `layoutSpecBlock` block. This PR adds an assertion if DEBUG enabled to assert if this is happening.