### PR TITLE
[ASCollectionView] Add assert for data source implementing collectionView:constrainedSizeForNodeAtIndexPath: instead of delegate

### DIFF
--- a/AsyncDisplayKit/Details/ASCollectionViewFlowLayoutInspector.m
+++ b/AsyncDisplayKit/Details/ASCollectionViewFlowLayoutInspector.m
@@ -63,6 +63,9 @@ static inline ASSizeRange NodeConstrainedSizeForScrollDirection(ASCollectionView
 {
   if (_delegateFlags.implementsConstrainedSizeForNodeAtIndexPath) {
     return [collectionView.asyncDelegate collectionView:collectionView constrainedSizeForNodeAtIndexPath:indexPath];
+  } else {
+    // With 2.0 `collectionView:constrainedSizeForNodeAtIndexPath:` was moved to the delegate. Assert if not implemented on the delegate but on the data source
+    ASDisplayNodeAssert([collectionView.asyncDataSource respondsToSelector:@selector(collectionView:constrainedSizeForNodeAtIndexPath:)] == NO, @"collectionView:constrainedSizeForNodeAtIndexPath: was moved from the ASCollectionDataSource to the ASCollectionDataSource.");
   }
   
   return NodeConstrainedSizeForScrollDirection(collectionView);
@@ -143,6 +146,9 @@ static inline ASSizeRange NodeConstrainedSizeForScrollDirection(ASCollectionView
 {
   if (_delegateFlags.implementsConstrainedSizeForNodeAtIndexPath) {
     return [collectionView.asyncDelegate collectionView:collectionView constrainedSizeForNodeAtIndexPath:indexPath];
+  } else {
+    // With 2.0 `collectionView:constrainedSizeForNodeAtIndexPath:` was moved to the delegate. Assert if not implemented on the delegate but on the data source
+    ASDisplayNodeAssert([collectionView.asyncDataSource respondsToSelector:@selector(collectionView:constrainedSizeForNodeAtIndexPath:)] == NO, @"collectionView:constrainedSizeForNodeAtIndexPath: was moved from the ASCollectionDataSource to the ASCollectionDataSource.");
   }
   
   CGSize itemSize = _layout.itemSize;


### PR DESCRIPTION
With 2.0 `collectionView:constrainedSizeForNodeAtIndexPath:` was moved to the delegate. Assert if not implemented on the delegate but on the data source.