### PR TITLE
make inline functions in ASDisplayNodeExtras.h static 

### DIFF
--- a/AsyncDisplayKit/ASDisplayNodeExtras.h
+++ b/AsyncDisplayKit/ASDisplayNodeExtras.h
@@ -16,27 +16,27 @@
 
 // Because inline methods can't be extern'd and need to be part of the translation unit of code
 // that compiles with them to actually inline, we both declare and define these in the header.
-inline BOOL ASInterfaceStateIncludesVisible(ASInterfaceState interfaceState)
+static inline BOOL ASInterfaceStateIncludesVisible(ASInterfaceState interfaceState)
 {
   return ((interfaceState & ASInterfaceStateVisible) == ASInterfaceStateVisible);
 }
 
-inline BOOL ASInterfaceStateIncludesDisplay(ASInterfaceState interfaceState)
+static inline BOOL ASInterfaceStateIncludesDisplay(ASInterfaceState interfaceState)
 {
   return ((interfaceState & ASInterfaceStateDisplay) == ASInterfaceStateDisplay);
 }
 
-inline BOOL ASInterfaceStateIncludesFetchData(ASInterfaceState interfaceState)
+static inline BOOL ASInterfaceStateIncludesFetchData(ASInterfaceState interfaceState)
 {
   return ((interfaceState & ASInterfaceStateFetchData) == ASInterfaceStateFetchData);
 }
 
-inline BOOL ASInterfaceStateIncludesMeasureLayout(ASInterfaceState interfaceState)
+static inline BOOL ASInterfaceStateIncludesMeasureLayout(ASInterfaceState interfaceState)
 {
   return ((interfaceState & ASInterfaceStateMeasureLayout) == ASInterfaceStateMeasureLayout);
 }
 
-inline NSString * _Nonnull NSStringFromASInterfaceState(ASInterfaceState interfaceState)
+static inline NSString * _Nonnull NSStringFromASInterfaceState(ASInterfaceState interfaceState)
 {
   NSMutableArray *states = [NSMutableArray array];
   if (interfaceState == ASInterfaceStateNone) {

--- a/AsyncDisplayKit/ASDisplayNodeExtras.h
+++ b/AsyncDisplayKit/ASDisplayNodeExtras.h
@@ -16,27 +16,27 @@
 
 // Because inline methods can't be extern'd and need to be part of the translation unit of code
 // that compiles with them to actually inline, we both declare and define these in the header.
-static inline BOOL ASInterfaceStateIncludesVisible(ASInterfaceState interfaceState)
+ASDISPLAYNODE_INLINE BOOL ASInterfaceStateIncludesVisible(ASInterfaceState interfaceState)
 {
   return ((interfaceState & ASInterfaceStateVisible) == ASInterfaceStateVisible);
 }
 
-static inline BOOL ASInterfaceStateIncludesDisplay(ASInterfaceState interfaceState)
+ASDISPLAYNODE_INLINE BOOL ASInterfaceStateIncludesDisplay(ASInterfaceState interfaceState)
 {
   return ((interfaceState & ASInterfaceStateDisplay) == ASInterfaceStateDisplay);
 }
 
-static inline BOOL ASInterfaceStateIncludesFetchData(ASInterfaceState interfaceState)
+ASDISPLAYNODE_INLINE BOOL ASInterfaceStateIncludesFetchData(ASInterfaceState interfaceState)
 {
   return ((interfaceState & ASInterfaceStateFetchData) == ASInterfaceStateFetchData);
 }
 
-static inline BOOL ASInterfaceStateIncludesMeasureLayout(ASInterfaceState interfaceState)
+ASDISPLAYNODE_INLINE BOOL ASInterfaceStateIncludesMeasureLayout(ASInterfaceState interfaceState)
 {
   return ((interfaceState & ASInterfaceStateMeasureLayout) == ASInterfaceStateMeasureLayout);
 }
 
-static inline NSString * _Nonnull NSStringFromASInterfaceState(ASInterfaceState interfaceState)
+ASDISPLAYNODE_INLINE NSString * _Nonnull NSStringFromASInterfaceState(ASInterfaceState interfaceState)
 {
   NSMutableArray *states = [NSMutableArray array];
   if (interfaceState == ASInterfaceStateNone) {


### PR DESCRIPTION
Resolves linker errors and allows inline functions such as `ASInterfaceStateIncludesVisible` to be used outside of ASDK framework files.

Also according to this:
http://stackoverflow.com/questions/18623392/how-to-write-global-inline-functions-in-objective-c-using-c-syntax

Global inline functions should be static
