### PR TITLE
Fix Case Where Node Is Deallocated While Visible

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -389,9 +389,11 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
 - (void)dealloc
 {
   ASDisplayNodeAssertMainThread();
+
+  NSLog(@"%@ dealloc.", self.name);
   // Synchronous nodes may not be able to call the hierarchy notifications, so only enforce for regular nodes.
   ASDisplayNodeAssert(_flags.synchronous || !ASInterfaceStateIncludesVisible(_interfaceState), @"Node should always be marked invisible before deallocating; interfaceState: %lu, %@", (unsigned long)_interfaceState, self);
-  
+
   self.asyncLayer.asyncDelegate = nil;
   _view.asyncdisplaykit_node = nil;
   _layer.asyncdisplaykit_node = nil;
@@ -1462,13 +1464,15 @@ static inline CATransform3D _calculateTransformFromReferenceToTarget(ASDisplayNo
 - (id<CAAction>)actionForLayer:(CALayer *)layer forKey:(NSString *)event
 {
   if (event == kCAOnOrderIn) {
+    NSLog(@"%@ order in.", self.name);
     [self __enterHierarchy];
   } else if (event == kCAOnOrderOut) {
+    NSLog(@"%@ order out.", self.name);
     [self __exitHierarchy];
   }
 
   ASDisplayNodeAssert(_flags.layerBacked, @"We shouldn't get called back here if there is no layer");
-  return (id<CAAction>)[NSNull null];
+  return (id)kCFNull;
 }
 
 #pragma mark - Managing the Node Hierarchy
@@ -2518,7 +2522,8 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
     oldState = _interfaceState;
     _interfaceState = newState;
   }
-  
+
+  NSLog(@"%@ moved to interface state %@", self.name, NSStringFromASInterfaceState(newState));
   if ((newState & ASInterfaceStateMeasureLayout) != (oldState & ASInterfaceStateMeasureLayout)) {
     // Trigger asynchronous measurement if it is not already cached or being calculated.
   }

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -389,11 +389,9 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
 - (void)dealloc
 {
   ASDisplayNodeAssertMainThread();
-
-  NSLog(@"%@ dealloc.", self.name);
   // Synchronous nodes may not be able to call the hierarchy notifications, so only enforce for regular nodes.
   ASDisplayNodeAssert(_flags.synchronous || !ASInterfaceStateIncludesVisible(_interfaceState), @"Node should always be marked invisible before deallocating; interfaceState: %lu, %@", (unsigned long)_interfaceState, self);
-
+  
   self.asyncLayer.asyncDelegate = nil;
   _view.asyncdisplaykit_node = nil;
   _layer.asyncdisplaykit_node = nil;
@@ -1464,10 +1462,8 @@ static inline CATransform3D _calculateTransformFromReferenceToTarget(ASDisplayNo
 - (id<CAAction>)actionForLayer:(CALayer *)layer forKey:(NSString *)event
 {
   if (event == kCAOnOrderIn) {
-    NSLog(@"%@ order in.", self.name);
     [self __enterHierarchy];
   } else if (event == kCAOnOrderOut) {
-    NSLog(@"%@ order out.", self.name);
     [self __exitHierarchy];
   }
 
@@ -2522,8 +2518,7 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
     oldState = _interfaceState;
     _interfaceState = newState;
   }
-
-  NSLog(@"%@ moved to interface state %@", self.name, NSStringFromASInterfaceState(newState));
+  
   if ((newState & ASInterfaceStateMeasureLayout) != (oldState & ASInterfaceStateMeasureLayout)) {
     // Trigger asynchronous measurement if it is not already cached or being calculated.
   }

--- a/AsyncDisplayKit/Details/_ASDisplayView.mm
+++ b/AsyncDisplayKit/Details/_ASDisplayView.mm
@@ -55,6 +55,7 @@
 
 - (void)willMoveToWindow:(UIWindow *)newWindow
 {
+  NSLog(@"%@ willMoveToWindow %@", self.asyncdisplaykit_node.name, newWindow);
   BOOL visible = (newWindow != nil);
   if (visible && !_node.inHierarchy) {
     [_node __enterHierarchy];
@@ -63,6 +64,7 @@
 
 - (void)didMoveToWindow
 {
+  NSLog(@"%@ didMoveToWindow %@", self.asyncdisplaykit_node.name, self.window);
   BOOL visible = (self.window != nil);
   if (!visible && _node.inHierarchy) {
     [_node __exitHierarchy];
@@ -71,6 +73,7 @@
 
 - (void)willMoveToSuperview:(UIView *)newSuperview
 {
+  NSLog(@"%@ willMoveToSuperview %@", self.asyncdisplaykit_node.name, newSuperview);
   // Keep the node alive while the view is in a view hierarchy.  This helps ensure that async-drawing views can always
   // display their contents as long as they are visible somewhere, and aids in lifecycle management because the
   // lifecycle of the node can be treated as the same as the lifecycle of the view (let the view hierarchy own the
@@ -122,6 +125,7 @@
 
 - (void)didMoveToSuperview
 {
+  NSLog(@"%@ didMoveToSuperview %@", self.asyncdisplaykit_node.name, self.superview);
   ASDisplayNode *supernode = _node.supernode;
   ASDisplayNodeAssert(!supernode.isLayerBacked, @"Shouldn't be possible for superview's node to be layer-backed.");
   

--- a/AsyncDisplayKitTests/ASCollectionViewTests.mm
+++ b/AsyncDisplayKitTests/ASCollectionViewTests.mm
@@ -17,7 +17,6 @@
 #import "ASDisplayNode+Beta.h"
 #import <vector>
 #import <OCMock/OCMock.h>
-#import "ASDisplayNodeExtras.h"
 
 @interface ASTextCellNodeWithSetSelectedCounter : ASTextCellNode
 
@@ -349,7 +348,11 @@
   } completion:nil]);
 }
 
-// https://github.com/facebook/AsyncDisplayKit/issues/2011
+/**
+ * https://github.com/facebook/AsyncDisplayKit/issues/2011
+ *
+ * If this ever becomes a pain to maintain, drop it. The underlying issue is tested by testThatLayerBackedSubnodesAreMarkedInvisibleBeforeDeallocWhenSupernodesViewIsRemovedFromHierarchyWhileBeingRetained
+ */
 - (void)testThatDisappearingSupplementariesWithLayerBackedNodesDontFailAssert
 {
   UIWindow *window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
@@ -393,30 +396,6 @@
     [self waitForExpectationsWithTimeout:1 handler:nil];
   }
 
-}
-
-// https://github.com/facebook/AsyncDisplayKit/issues/2011
-- (void)testLayerBackedVisiblityCallbacks
-{
-  UIWindow *window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
-
-  NS_VALID_UNTIL_END_OF_SCOPE UIView *suppNodeView = nil;
-    {
-        
-    }
-  NS_VALID_UNTIL_END_OF_SCOPE ASCellNode *suppNode = [[ASCellNode alloc] init];
-
-  suppNode.name = @"Node";
-
-  NS_VALID_UNTIL_END_OF_SCOPE ASDisplayNode *layerBacked = [[ASDisplayNode alloc] init];
-  layerBacked.layerBacked = YES;
-  [suppNode addSubnode:layerBacked];
-  layerBacked.name = @"Subnode";
-  [window addSubview:suppNode.view];
-  suppNode = nil;
-  layerBacked = nil;
-
-  [suppNodeView removeFromSuperview];
 }
 
 - (void)testThatNodeCalculatedSizesAreUpdatedBeforeFirstPrepareLayoutAfterRotation

--- a/AsyncDisplayKitTests/ASDisplayNodeTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeTests.m
@@ -1941,4 +1941,27 @@ static bool stringContainsPointer(NSString *description, id p) {
   XCTAssertEqual(contentsAfterRedisplay, node.contents);
 }
 
+// Underlying issue for: https://github.com/facebook/AsyncDisplayKit/issues/2011
+- (void)testThatLayerBackedSubnodesAreMarkedInvisibleBeforeDeallocWhenSupernodesViewIsRemovedFromHierarchyWhileBeingRetained
+{
+  UIWindow *window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+
+  NS_VALID_UNTIL_END_OF_SCOPE UIView *nodeView = nil;
+  {
+    NS_VALID_UNTIL_END_OF_SCOPE ASDisplayNode *node = [[ASDisplayNode alloc] init];
+    nodeView = node.view;
+    node.name = @"Node";
+
+    NS_VALID_UNTIL_END_OF_SCOPE ASDisplayNode *subnode = [[ASDisplayNode alloc] init];
+    subnode.layerBacked = YES;
+    [node addSubnode:subnode];
+    subnode.name = @"Subnode";
+    
+    [window addSubview:nodeView];
+  }
+
+  // nodeView must continue to be retained across this call, but the nodes must not.
+  XCTAssertNoThrow([nodeView removeFromSuperview]);
+}
+
 @end


### PR DESCRIPTION
See #2011 .

The issue is, if the view outlives the node and its subnodes, then its sublayers will not get the order-out action until after willMoveToSuperview.

So I moved the `__exitHierarchy` call from `willMoveToSuperview` to `didMoveToSuperview` which fixes the issue!