### PR TITLE
Skip Performance Tests By Default

### DIFF
--- a/AsyncDisplayKit.xcodeproj/xcshareddata/xcschemes/AsyncDisplayKit.xcscheme
+++ b/AsyncDisplayKit.xcodeproj/xcshareddata/xcschemes/AsyncDisplayKit.xcscheme
@@ -52,6 +52,11 @@
                BlueprintName = "AsyncDisplayKitTests"
                ReferencedContainer = "container:AsyncDisplayKit.xcodeproj">
             </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "ASTextNodePerformanceTests">
+               </Test>
+            </SkippedTests>
          </TestableReference>
       </Testables>
       <MacroExpansion>

--- a/AsyncDisplayKitTests/ASTextNodePerformanceTests.m
+++ b/AsyncDisplayKitTests/ASTextNodePerformanceTests.m
@@ -13,6 +13,10 @@
 #import "ASXCTExtensions.h"
 #include "CGRect+ASConvenience.h"
 
+/**
+ * NOTE: This test case is not run during the "test" action. You have to run it manually (click the little diamond.)
+ */
+
 @interface ASTextNodePerformanceTests : XCTestCase
 
 @end


### PR DESCRIPTION
This will skip the performance tests when you ⌘U or when the CI runs "xcodebuild test".

You can still run/profile them whenever you want by clicking the little diamond. In the future we may remove the expected performance ranges, but for now I'm leaving them.