### PR TITLE
[ASStackLayoutSpec] Set alignItems to ASStackLayoutAlignItemsStretch

### DIFF
--- a/AsyncDisplayKit/Layout/ASStackLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASStackLayoutSpec.mm
@@ -24,7 +24,7 @@
 
 - (instancetype)init
 {
-  return [self initWithDirection:ASStackLayoutDirectionHorizontal spacing:0.0 justifyContent:ASStackLayoutJustifyContentStart alignItems:ASStackLayoutAlignItemsStart children:nil];
+  return [self initWithDirection:ASStackLayoutDirectionHorizontal spacing:0.0 justifyContent:ASStackLayoutJustifyContentStart alignItems:ASStackLayoutAlignItemsStretch children:nil];
 }
 
 + (instancetype)stackLayoutSpecWithDirection:(ASStackLayoutDirection)direction spacing:(CGFloat)spacing justifyContent:(ASStackLayoutJustifyContent)justifyContent alignItems:(ASStackLayoutAlignItems)alignItems children:(NSArray *)children


### PR DESCRIPTION
To align with the CSS `align-items` property we should set alignItems to `ASStackLayoutAlignItemsStretch` instead of `ASStackLayoutAlignItemsStart`: https://drafts.csswg.org/css-flexbox-1/#propdef-align-items