### PR TITLE
[ASImageNode] Use kCGBlendModeCopy when Possible

### DIFF
--- a/AsyncDisplayKit/ASImageNode.mm
+++ b/AsyncDisplayKit/ASImageNode.mm
@@ -464,9 +464,9 @@ static ASDN::Mutex cacheLock;
   // Another option is to have ASDisplayNode+AsyncDisplay coordinate these cases, and share the decoded buffer.
   // Details tracked in https://github.com/facebook/AsyncDisplayKit/issues/1068
   
-  // We want to use copy, but if our image has alpha and our context is dirty, we have to use normal.
   UIImage *image = key.image;
-  CGBlendMode blendMode = contextIsClean == NO && CGImageGetAlphaInfo(image.CGImage) != kCGImageAlphaNone ? kCGBlendModeNormal : kCGBlendModeCopy;
+  BOOL canUseCopy = (contextIsClean || CGImageGetAlphaInfo(image.CGImage) == kCGImageAlphaNone);
+  CGBlendMode blendMode = canUseCopy ? kCGBlendModeCopy : kCGBlendModeNormal;
   
   @synchronized(image) {
     [image drawInRect:key.imageDrawRect blendMode:blendMode alpha:1];


### PR DESCRIPTION
By default, images are drawn with the normal blending mode. kCGBlendModeCopy is a lot faster when you can use it.

~~Compare the following results from 30 seconds of Pinterest, the first using normal and the second using copy. Currently PINRemoteImage returns images that falsely have alpha components so for this test, I ALWAYS used copy. So this is basically a theoretical maximum. But most of our large images are JPEGs so we should be able to get close.~~

|                              | Normal | Copy   |
|------------------------------|--------|--------|
| ImageNode Drawing            | 3361ms | 1813ms |
| TextNode Drawing (reference) | 353ms  | 405ms  |
| Ratio                        | 9.5x   | 4.48x  |

~~So image drawing, which is the most expensive operation we do, is twice as fast using copy.~~

The test results above are probably skewed because the image caches were warmed, and so less progressive rendering happened. But it's way better.

@appleguy @levi @maicki 