### PR TITLE
[ASImageNode] Use kCGBlendModeCopy More Often

### DIFF
--- a/AsyncDisplayKit/ASImageNode.mm
+++ b/AsyncDisplayKit/ASImageNode.mm
@@ -465,7 +465,7 @@ static ASDN::Mutex cacheLock;
   // Details tracked in https://github.com/facebook/AsyncDisplayKit/issues/1068
   
   UIImage *image = key.image;
-  BOOL canUseCopy = (contextIsClean || CGImageGetAlphaInfo(image.CGImage) == kCGImageAlphaNone);
+  BOOL canUseCopy = (contextIsClean || ASImageAlphaInfoIsOpaque(CGImageGetAlphaInfo(image.CGImage)));
   CGBlendMode blendMode = canUseCopy ? kCGBlendModeCopy : kCGBlendModeNormal;
   
   @synchronized(image) {

--- a/AsyncDisplayKit/Private/ASInternalHelpers.h
+++ b/AsyncDisplayKit/Private/ASInternalHelpers.h
@@ -40,6 +40,17 @@ CGFloat ASRoundPixelValue(CGFloat f);
 
 ASDISPLAYNODE_EXTERN_C_END
 
+ASDISPLAYNODE_INLINE BOOL ASImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
+  switch (info) {
+    case kCGImageAlphaNone:
+    case kCGImageAlphaNoneSkipLast:
+    case kCGImageAlphaNoneSkipFirst:
+      return YES;
+    default:
+      return NO;
+  }
+}
+
 /**
  @summary Conditionally performs UIView geometry changes in the given block without animation.
  


### PR DESCRIPTION
This is a follow-up to #2197 that considers other CGImageAlphaInfo values that also indicate opaque.