### PR TITLE
[Layout] Don't use `automaticallyManageSubnodes` in ASTextCellNode

### DIFF
--- a/AsyncDisplayKit/ASCellNode.mm
+++ b/AsyncDisplayKit/ASCellNode.mm
@@ -338,8 +338,8 @@ static const CGFloat kASTextCellNodeDefaultVerticalPadding = 11.0f;
   if (self) {
     _textInsets = textInsets;
     _textAttributes = [textAttributes copy];
-    self.automaticallyManagesSubnodes = YES;
     _textNode = [[ASTextNode alloc] init];
+    [self addSubnode:_textNode];
   }
   return self;
 }

--- a/examples/ASDKgram/Sample/CommentsNode.m
+++ b/examples/ASDKgram/Sample/CommentsNode.m
@@ -34,6 +34,8 @@
 {
   self = [super init];
   if (self) {
+    self.automaticallyManagesSubnodes = YES;
+
     _commentNodes = [[NSMutableArray alloc] init];
   }
   return self;
@@ -53,7 +55,7 @@
 - (void)updateWithCommentFeedModel:(CommentFeedModel *)feed
 {
   _commentFeed = feed;
-  [self removeCommentLabels];
+  [_commentNodes removeAllObjects];
   
   if (_commentFeed) {
     [self createCommentLabels];
@@ -64,7 +66,7 @@
     
     if (addViewAllCommentsLabel) {
       commentLabelString         = [_commentFeed viewAllCommentsAttributedString];
-      [[_commentNodes objectAtIndex:labelsIndex] setAttributedString:commentLabelString];
+      [_commentNodes[labelsIndex] setAttributedText:commentLabelString];
       labelsIndex++;
     }
     
@@ -72,7 +74,7 @@
     
     for (int feedIndex = 0; feedIndex < numCommentsInFeed; feedIndex++) {
       commentLabelString         = [[_commentFeed objectAtIndex:feedIndex] commentAttributedString];
-      [[_commentNodes objectAtIndex:labelsIndex] setAttributedString:commentLabelString];
+      [_commentNodes[labelsIndex] setAttributedText:commentLabelString];
       labelsIndex++;
     }
     
@@ -82,15 +84,6 @@
 
 
 #pragma mark - Helper Methods
-
-- (void)removeCommentLabels
-{
-  for (ASTextNode *commentLabel in _commentNodes) {
-    [commentLabel removeFromSupernode];
-  }
-  
-  [_commentNodes removeAllObjects];
-}
 
 - (void)createCommentLabels
 {
@@ -105,7 +98,6 @@
     commentLabel.maximumNumberOfLines = 3;
     
     [_commentNodes addObject:commentLabel];
-    [self addSubnode:commentLabel];
   }
 }
 

--- a/examples/ASDKgram/Sample/PhotoCellNode.m
+++ b/examples/ASDKgram/Sample/PhotoCellNode.m
@@ -118,7 +118,7 @@
   
   ASStackLayoutSpec *headerSubStack = [ASStackLayoutSpec verticalStackLayoutSpec];
   headerSubStack.flexShrink         = YES;
-  if (_photoLocationLabel.attributedString) {
+  if (_photoLocationLabel.attributedText) {
     [headerSubStack setChildren:@[_userNameLabel, _photoLocationLabel]];
   } else {
     [headerSubStack setChildren:@[_userNameLabel]];


### PR DESCRIPTION
Don't use `automaticallyManageSubnodes` in `ASTextCellNode` as all subclasses will inherit this behavior. In ASDKGram the `CommentsNode` is a subclass of `ASTextCellNode` and in there we didn't expect ASM of the superclass so subnodes where added and removed explicitly. Currently asm does not support automatic and manual adding and removing of subnodes yet. This caused crashes in ASDKGram.

A PR will follow that will add error handling (throw exception to the user with information) for this case.