### PR TITLE
Fix Equality in ASTextKitRendererKey

### DIFF
--- a/AsyncDisplayKit/ASTextNode.mm
+++ b/AsyncDisplayKit/ASTextNode.mm
@@ -76,7 +76,7 @@ ASDISPLAYNODE_INLINE NSUInteger ASHashFromCGSize(CGSize size)
     return YES;
   }
   
-  return _attributes.hash() == object.attributes.hash()
+  return _attributes == object.attributes
   && CGSizeEqualToSize(_constrainedSize, object.constrainedSize);
 }
 


### PR DESCRIPTION
A hash collision was causing some false positive cache hits.