### PR TITLE
[ASDataController] Allocate & Measure Cell Nodes Async on Shared Queue

### DIFF
--- a/AsyncDisplayKit/Details/ASDataController.mm
+++ b/AsyncDisplayKit/Details/ASDataController.mm
@@ -127,18 +127,6 @@ NSString * const ASDataControllerRowNodeKind = @"_ASDataControllerRowNodeKind";
   return parallelProcessorCount;
 }
 
-+ (NSOperationQueue *)nodeLayoutQueue
-{
-  static NSOperationQueue *nodeLayoutQueue;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    nodeLayoutQueue = [[NSOperationQueue alloc] init];
-    nodeLayoutQueue.name = @"org.AsyncDisplayKit.ASDataController.nodeLayoutQueue";
-    nodeLayoutQueue.maxConcurrentOperationCount = [NSProcessInfo processInfo].processorCount * 2;
-  });
-  return nodeLayoutQueue;
-}
-
 #pragma mark - Cell Layout
 
 - (void)batchLayoutNodesFromContexts:(NSArray<ASIndexedNodeContext *> *)contexts batchCompletion:(ASDataControllerCompletionBlock)batchCompletionHandler
@@ -193,14 +181,10 @@ NSString * const ASDataControllerRowNodeKind = @"_ASDataControllerRowNodeKind";
     return nil;
   }
 
-  // Gather the allocation operations.
-  NSMutableArray<NSOperation *> *operations = [NSMutableArray arrayWithCapacity:nodeCount];
+  // Begin all the allocations.
   for (ASIndexedNodeContext *context in contexts) {
-    [operations addObject:context.nodeCreationOperation];
+    [context beginMeasuringNode];
   }
-
-  // Enqueue the allocation operations, and wait for them to finish.
-  [[ASDataController nodeLayoutQueue] addOperations:operations waitUntilFinished:YES];
 
   // Gather the nodes from the contexts.
   NSMutableArray<ASCellNode *> *nodes = [NSMutableArray arrayWithCapacity:nodeCount];

--- a/AsyncDisplayKit/Details/ASIndexedNodeContext.h
+++ b/AsyncDisplayKit/Details/ASIndexedNodeContext.h
@@ -25,14 +25,19 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, strong) NSIndexPath *indexPath;
 
 /**
- * The node created by `nodeCreationOperation`. This will be nil until the operation is finished.
+ * Begins measurement of the cell node, if it hasn't already begun.
  */
-@property (atomic, readonly, nullable, strong) ASCellNode *node;
+- (void)beginMeasuringNode;
 
 /**
- * An operation to allocate and measure the node.
+ * The cell node created by this context. Begins and waits for measurement if needed.
  */
-@property (nonatomic, readonly, strong) NSBlockOperation *nodeCreationOperation;
+@property (atomic, readonly, strong) ASCellNode *node;
+
+/**
+ * The node, if measurement has already completed.
+ */
+@property (atomic, readonly, nullable, strong) ASCellNode *nodeIfMeasured;
 
 + (NSArray<NSIndexPath *> *)indexPathsFromContexts:(NSArray<ASIndexedNodeContext *> *)contexts;
 

--- a/AsyncDisplayKit/Details/ASIndexedNodeContext.h
+++ b/AsyncDisplayKit/Details/ASIndexedNodeContext.h
@@ -13,22 +13,29 @@
 #import <AsyncDisplayKit/ASDataController.h>
 #import <AsyncDisplayKit/ASEnvironment.h>
 
-@interface ASIndexedNodeContext : NSObject
+NS_ASSUME_NONNULL_BEGIN
 
-@property (nonatomic, readonly, strong) NSIndexPath *indexPath;
-@property (nonatomic, readonly, assign) ASSizeRange constrainedSize;
-@property (nonatomic, readonly, assign) ASEnvironmentTraitCollection environmentTraitCollection;
+@interface ASIndexedNodeContext : NSObject
 
 - (instancetype)initWithNodeBlock:(ASCellNodeBlock)nodeBlock
                         indexPath:(NSIndexPath *)indexPath
                   constrainedSize:(ASSizeRange)constrainedSize
        environmentTraitCollection:(ASEnvironmentTraitCollection)environmentTraitCollection;
 
+@property (nonatomic, readonly, strong) NSIndexPath *indexPath;
+
 /**
- * Returns a node allocated by executing node block. Node block will be nil out immediately.
+ * The node created by `nodeCreationOperation`. This will be nil until the operation is finished.
  */
-- (ASCellNode *)allocateNode;
+@property (atomic, readonly, nullable, strong) ASCellNode *node;
+
+/**
+ * An operation to allocate and measure the node.
+ */
+@property (nonatomic, readonly, strong) NSBlockOperation *nodeCreationOperation;
 
 + (NSArray<NSIndexPath *> *)indexPathsFromContexts:(NSArray<ASIndexedNodeContext *> *)contexts;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/AsyncDisplayKit/Details/ASIndexedNodeContext.mm
+++ b/AsyncDisplayKit/Details/ASIndexedNodeContext.mm
@@ -14,14 +14,40 @@
 #import "ASEnvironmentInternal.h"
 #import "ASCellNode.h"
 #import "ASLayout.h"
+#import <stdatomic.h>
 
 @interface ASIndexedNodeContext ()
 
-@property (atomic, nullable, strong) ASCellNode *node;
+/// A readwrite variant of the same public property.
+@property (atomic, nullable, strong) ASCellNode *nodeIfMeasured;
+
+/// Our operation, if one has been enqueued and is still alive.
+@property (atomic, weak) NSOperation *nodeMeasurementOperation;
+
+/// Required node block used to allocate a cell node. Nil after measurement.
+@property (nonatomic, copy, nullable) ASCellNodeBlock nodeBlock;
 
 @end
 
-@implementation ASIndexedNodeContext
+@implementation ASIndexedNodeContext {
+  atomic_flag _hasEnqueuedOperation;
+
+  // Input params – constant
+  ASSizeRange _constrainedSize;
+  ASEnvironmentTraitCollection _environmentTraitCollection;
+}
+
++ (NSOperationQueue *)nodeMeasurementQueue
+{
+  static NSOperationQueue *nodeMeasurementQueue;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    nodeMeasurementQueue = [[NSOperationQueue alloc] init];
+    nodeMeasurementQueue.name = @"org.AsyncDisplayKit.cellNodeMeasurementQueue";
+    nodeMeasurementQueue.maxConcurrentOperationCount = [NSProcessInfo processInfo].processorCount * 2;
+  });
+  return nodeMeasurementQueue;
+}
 
 - (instancetype)initWithNodeBlock:(ASCellNodeBlock)nodeBlock
                         indexPath:(NSIndexPath *)indexPath
@@ -31,36 +57,70 @@
   NSAssert(nodeBlock != nil && indexPath != nil, @"Node block and index path must not be nil");
   self = [super init];
   if (self) {
+    _nodeBlock = nodeBlock;
     _indexPath = indexPath;
-
-    __weak __typeof(self) weakSelf = self;
-    _nodeCreationOperation = [NSBlockOperation blockOperationWithBlock:^{
-      __strong ASIndexedNodeContext *self = weakSelf;
-      if (self == nil) {
-        return;
-      }
-
-      // Allocate the node.
-      ASCellNode *node = nodeBlock();
-      if (node == nil) {
-        ASDisplayNodeAssertNotNil(node, @"Node block created nil node. indexPath: %@", indexPath);
-        node = [[ASCellNode alloc] init]; // Fallback to avoid crash for production apps.
-      }
-
-      // Propagate environment state down.
-      ASEnvironmentStatePropagateDown(node, environmentTraitCollection);
-
-      // Measure the node.
-      CGRect frame = CGRectZero;
-      frame.size = [node layoutThatFits:constrainedSize].size;
-      node.frame = frame;
-
-      // Set the resulting node on self.
-      self.node = node;
-    }];
+    _constrainedSize = constrainedSize;
+    _environmentTraitCollection = environmentTraitCollection;
   }
   return self;
 }
+
+#pragma mark - Public API
+
+- (void)beginMeasuringNode
+{
+  if (atomic_flag_test_and_set(&_hasEnqueuedOperation)) {
+    return;
+  }
+
+  __weak __typeof(self) weakSelf = self;
+  NSOperation *operation = [NSBlockOperation blockOperationWithBlock:^{
+    [weakSelf measureCellNodeOperationBody];
+  }];
+  self.nodeMeasurementOperation = operation;
+  [[ASIndexedNodeContext nodeMeasurementQueue] addOperation:operation];
+}
+
+- (ASCellNode *)node
+{
+  [self _ensureNodeMeasured];
+  return self.nodeIfMeasured;
+}
+
+#pragma mark - Private API
+
+/**
+ * This method is executed once per context, to perform the measurement.
+ */
+- (void)measureCellNodeOperationBody
+{
+  // Allocate the node.
+  ASCellNode *node = self.nodeBlock();
+  self.nodeBlock = nil;
+  if (node == nil) {
+    ASDisplayNodeAssertNotNil(node, @"Node block created nil node. indexPath: %@", _indexPath);
+    node = [[ASCellNode alloc] init]; // Fallback to avoid crash for production apps.
+  }
+
+  // Propagate environment state down.
+  ASEnvironmentStatePropagateDown(node, _environmentTraitCollection);
+
+  // Measure the node.
+  CGRect frame = CGRectZero;
+  frame.size = [node layoutThatFits:_constrainedSize].size;
+  node.frame = frame;
+
+  // Set resulting node.
+  self.nodeIfMeasured = node;
+}
+
+- (void)_ensureNodeMeasured
+{
+  [self beginMeasuringNode];
+  [self.nodeMeasurementOperation waitUntilFinished];
+}
+
+#pragma mark - Helpers
 
 + (NSArray<NSIndexPath *> *)indexPathsFromContexts:(NSArray<ASIndexedNodeContext *> *)contexts
 {

--- a/AsyncDisplayKit/Private/ASDispatch.h
+++ b/AsyncDisplayKit/Private/ASDispatch.h
@@ -14,7 +14,7 @@
  * Note: The actual number of threads may be lower than threadCount, if libdispatch
  * decides the system can't handle it. In reality this rarely happens.
  */
-static void ASDispatchApply(size_t iterationCount, dispatch_queue_t queue, NSUInteger threadCount, void(^work)(size_t i)) {
+__unused static void ASDispatchApply(size_t iterationCount, dispatch_queue_t queue, NSUInteger threadCount, void(^work)(size_t i)) {
   if (threadCount == 0) {
     threadCount = [NSProcessInfo processInfo].activeProcessorCount * 2;
   }


### PR DESCRIPTION
In the future we want to support creating ASCellNodes on demand, after inserting the item/row into the UITableView/UICollectionView.

To support this, we need to make our cell node allocation & layout asynchronous. It is critical that this process be wait-onable, and that we can limit the total number of concurrent layouts. It's nice if this process supports changing priorities for tasks on-the-fly.

As a first step, I've built this on NSOperation. NSOperation has an unfortunate amount of overhead, but it supports all the features mentioned above and I don't think the overhead will be very significant in practice. We will likely replace NSOperation for this usage in the future, and we'll keep that in mind as we build.

Obviously this is a small step but I'm confident it moves us in the right direction.

- For laying-out nodes, replace the synchronous ASDispatchApply call with enqueuing onto a shared "node layout" operation queue.
- Have ASIndexedNodeContext own the creation operation and the finished node.
  - Likely that ASIndexedNodeContext evolves into a sort of `ASCollectionItem` object, that survives beyond the initial insertion of the item.

Ready for review @appleguy @levi 

P.S. Sorry for the mess in ASIndexedNodeContext.h but the init method came after the properties so, y'know. Scorched earth policy. 😛 