### PR TITLE
Make Description Functions Dealloc-Safe

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -3292,12 +3292,12 @@ static const char *ASDisplayNodeDrawingPriorityKey = "ASDrawingPriority";
     [result addObject:@{ @"frame" : [NSValue valueWithCGRect:_view.frame] }];
   } else if (_layer != nil) {
     [result addObject:@{ @"frame" : [NSValue valueWithCGRect:_layer.frame] }];
-  } else {
-    [result addObject:@{ @"frame" : [NSValue valueWithCGRect:self.frame] }];
+  } else if (_pendingViewState != nil) {
+    [result addObject:@{ @"frame" : [NSValue valueWithCGRect:_pendingViewState.frame] }];
   }
   
   // Check supernode so that if we are cell node we don't find self.
-  ASCellNode *cellNode = ASDisplayNodeFindFirstSupernodeOfClass(self.supernode, [ASCellNode class]);
+  ASCellNode *cellNode = ASDisplayNodeFindFirstSupernodeOfClass([self _deallocSafeSupernode], [ASCellNode class]);
   if (cellNode != nil) {
     [result addObject:@{ @"cellNode" : ASObjectDescriptionMakeTiny(cellNode) }];
   }

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -448,6 +448,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
     _layer.delegate = nil;
   _layer = nil;
 
+  // TODO: Remove this? If supernode isn't already nil, this method isn't dealloc-safe anyway.
   [self __setSupernode:nil];
   _pendingViewState = nil;
 

--- a/AsyncDisplayKit/Private/ASObjectDescriptionHelpers.h
+++ b/AsyncDisplayKit/Private/ASObjectDescriptionHelpers.h
@@ -36,11 +36,21 @@ NS_ASSUME_NONNULL_BEGIN
 
 ASDISPLAYNODE_EXTERN_C_BEGIN
 
-/// Returns e.g. <MYObject: 0xFFFFFFFF; name = "Object Name"; frame = (0 0; 50 50)>
-NSString *ASObjectDescriptionMake(id object, NSArray<NSDictionary *> * _Nullable propertyGroups);
+/**
+ * Returns e.g. <MYObject: 0xFFFFFFFF; name = "Object Name"; frame = (0 0; 50 50)>
+ *
+ * Note: `object` param is autoreleasing so that this function is dealloc-safe.
+ *   No, unsafe_unretained isn't acceptable here – the optimizer may deallocate object early.
+ */
+NSString *ASObjectDescriptionMake(__autoreleasing id object, NSArray<NSDictionary *> * _Nullable propertyGroups);
 
-/// Returns e.g. <MYObject: 0xFFFFFFFF>
-NSString *ASObjectDescriptionMakeTiny(id object);
+/**
+ * Returns e.g. <MYObject: 0xFFFFFFFF>
+ *
+ * Note: `object` param is autoreleasing so that this function is dealloc-safe.
+ *   No, unsafe_unretained isn't acceptable here – the optimizer may deallocate object early.
+ */
+NSString *ASObjectDescriptionMakeTiny(__autoreleasing id object);
 
 NSString * _Nullable ASStringWithQuotesIfMultiword(NSString * _Nullable string);
 

--- a/AsyncDisplayKit/Private/ASObjectDescriptionHelpers.m
+++ b/AsyncDisplayKit/Private/ASObjectDescriptionHelpers.m
@@ -37,7 +37,7 @@ NSString *ASGetDescriptionValueString(id object) {
   return [object description];
 }
 
-NSString *ASObjectDescriptionMake(id object, NSArray<NSDictionary *> *propertyGroups) {
+NSString *ASObjectDescriptionMake(__autoreleasing id object, NSArray<NSDictionary *> *propertyGroups) {
   NSMutableString *str = [NSMutableString stringWithFormat:@"<%@: %p", [object class], object];
 
   NSMutableArray *components = [NSMutableArray array];
@@ -54,7 +54,7 @@ NSString *ASObjectDescriptionMake(id object, NSArray<NSDictionary *> *propertyGr
   return str;
 }
 
-NSString *ASObjectDescriptionMakeTiny(id object) {
+NSString *ASObjectDescriptionMakeTiny(__autoreleasing id object) {
   return ASObjectDescriptionMake(object, nil);
 }
 


### PR DESCRIPTION
I believe that #2229 is caused by #2011 failing the assertion, and attempting to describe the node during dealloc.

The description method has not been dealloc-safe since #2208. This patch makes the description functions dealloc-safe.