### PR TITLE
[ASDisplayNode] Failing Test Case: Rasterized Nodes Should Get Interface State Updates

### DIFF
--- a/AsyncDisplayKitTests/ASDisplayNodeTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeTests.m
@@ -1942,6 +1942,36 @@ static bool stringContainsPointer(NSString *description, id p) {
   XCTAssertEqual(contentsAfterRedisplay, node.contents);
 }
 
+// Underlying issue for: https://github.com/facebook/AsyncDisplayKit/issues/2205
+- (void)testThatNodesAreMarkedInvisibleWhenRemovedFromAVisibleRasterizedHierarchy
+{
+  ASCellNode *supernode = [[ASCellNode alloc] init];
+  supernode.shouldRasterizeDescendants = YES;
+  ASDisplayNode *node = [[ASDisplayNode alloc] init];
+  UIWindow *window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  [supernode addSubnode:node];
+  [window addSubnode:supernode];
+  [window makeKeyAndVisible];
+  XCTAssertTrue(node.isVisible);
+  [node removeFromSupernode];
+  XCTAssertFalse(node.isVisible);
+}
+
+// Underlying issue for: https://github.com/facebook/AsyncDisplayKit/issues/2205
+- (void)testThatNodesAreMarkedVisibleWhenAddedToARasterizedHierarchyAlreadyOnscreen
+{
+  ASCellNode *supernode = [[ASCellNode alloc] init];
+  supernode.shouldRasterizeDescendants = YES;
+  ASDisplayNode *node = [[ASDisplayNode alloc] init];
+  UIWindow *window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  [window addSubnode:supernode];
+  [window makeKeyAndVisible];
+  [supernode addSubnode:node];
+  XCTAssertTrue(node.isVisible);
+  [node removeFromSupernode];
+  XCTAssertFalse(node.isVisible);
+}
+
 // Underlying issue for: https://github.com/facebook/AsyncDisplayKit/issues/2011
 - (void)testThatLayerBackedSubnodesAreMarkedInvisibleBeforeDeallocWhenSupernodesViewIsRemovedFromHierarchyWhileBeingRetained
 {

--- a/AsyncDisplayKitTests/ASDisplayNodeTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeTests.m
@@ -1943,7 +1943,7 @@ static bool stringContainsPointer(NSString *description, id p) {
 }
 
 // Underlying issue for: https://github.com/facebook/AsyncDisplayKit/issues/2205
-- (void)testThatNodesAreMarkedInvisibleWhenRemovedFromAVisibleRasterizedHierarchy
+- (void)DISABLED_testThatNodesAreMarkedInvisibleWhenRemovedFromAVisibleRasterizedHierarchy
 {
   ASCellNode *supernode = [[ASCellNode alloc] init];
   supernode.shouldRasterizeDescendants = YES;
@@ -1958,7 +1958,7 @@ static bool stringContainsPointer(NSString *description, id p) {
 }
 
 // Underlying issue for: https://github.com/facebook/AsyncDisplayKit/issues/2205
-- (void)testThatNodesAreMarkedVisibleWhenAddedToARasterizedHierarchyAlreadyOnscreen
+- (void)DISABLED_testThatNodesAreMarkedVisibleWhenAddedToARasterizedHierarchyAlreadyOnscreen
 {
   ASCellNode *supernode = [[ASCellNode alloc] init];
   supernode.shouldRasterizeDescendants = YES;


### PR DESCRIPTION
This is the cause of #2205.