### PR TITLE
[ASDisplayNode] Add Event Tracing to Help Debugging

### DIFF
--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -428,7 +428,7 @@
 		CC446A311D80AAE00071FD03 /* ASObjectDescriptionHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = CC446A2E1D80AAE00071FD03 /* ASObjectDescriptionHelpers.m */; };
 		CC4981B31D1A02BE004E13CC /* ASTableViewThrashTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CC4981B21D1A02BE004E13CC /* ASTableViewThrashTests.m */; };
 		CC4981BD1D1C7F65004E13CC /* NSIndexSet+ASHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = CC4981BB1D1C7F65004E13CC /* NSIndexSet+ASHelpers.m */; };
-		CC4C2A771D88E3BF0039ACAB /* ASTraceEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = CC4C2A751D88E3BF0039ACAB /* ASTraceEvent.h */; };
+		CC4C2A771D88E3BF0039ACAB /* ASTraceEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = CC4C2A751D88E3BF0039ACAB /* ASTraceEvent.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CC4C2A781D88E3BF0039ACAB /* ASTraceEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = CC4C2A761D88E3BF0039ACAB /* ASTraceEvent.m */; };
 		CC4C2A791D88E3BF0039ACAB /* ASTraceEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = CC4C2A761D88E3BF0039ACAB /* ASTraceEvent.m */; };
 		CC4C2A7A1D8902350039ACAB /* ASTraceEvent.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = CC4C2A751D88E3BF0039ACAB /* ASTraceEvent.h */; };

--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -428,6 +428,9 @@
 		CC446A311D80AAE00071FD03 /* ASObjectDescriptionHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = CC446A2E1D80AAE00071FD03 /* ASObjectDescriptionHelpers.m */; };
 		CC4981B31D1A02BE004E13CC /* ASTableViewThrashTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CC4981B21D1A02BE004E13CC /* ASTableViewThrashTests.m */; };
 		CC4981BD1D1C7F65004E13CC /* NSIndexSet+ASHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = CC4981BB1D1C7F65004E13CC /* NSIndexSet+ASHelpers.m */; };
+		CC4C2A771D88E3BF0039ACAB /* ASTraceEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = CC4C2A751D88E3BF0039ACAB /* ASTraceEvent.h */; };
+		CC4C2A781D88E3BF0039ACAB /* ASTraceEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = CC4C2A761D88E3BF0039ACAB /* ASTraceEvent.m */; };
+		CC4C2A791D88E3BF0039ACAB /* ASTraceEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = CC4C2A761D88E3BF0039ACAB /* ASTraceEvent.m */; };
 		CC54A81C1D70079800296A24 /* ASDispatch.h in Headers */ = {isa = PBXBuildFile; fileRef = CC54A81B1D70077A00296A24 /* ASDispatch.h */; };
 		CC54A81E1D7008B300296A24 /* ASDispatchTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CC54A81D1D7008B300296A24 /* ASDispatchTests.m */; };
 		CC7FD9DF1BB5E962005CCB2B /* ASPhotosFrameworkImageRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = CC7FD9DD1BB5E962005CCB2B /* ASPhotosFrameworkImageRequest.m */; };
@@ -1111,6 +1114,8 @@
 		CC4981B21D1A02BE004E13CC /* ASTableViewThrashTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASTableViewThrashTests.m; sourceTree = "<group>"; };
 		CC4981BA1D1C7F65004E13CC /* NSIndexSet+ASHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSIndexSet+ASHelpers.h"; sourceTree = "<group>"; };
 		CC4981BB1D1C7F65004E13CC /* NSIndexSet+ASHelpers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSIndexSet+ASHelpers.m"; sourceTree = "<group>"; };
+		CC4C2A751D88E3BF0039ACAB /* ASTraceEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTraceEvent.h; sourceTree = "<group>"; };
+		CC4C2A761D88E3BF0039ACAB /* ASTraceEvent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASTraceEvent.m; sourceTree = "<group>"; };
 		CC54A81B1D70077A00296A24 /* ASDispatch.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ASDispatch.h; sourceTree = "<group>"; };
 		CC54A81D1D7008B300296A24 /* ASDispatchTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASDispatchTests.m; sourceTree = "<group>"; };
 		CC7FD9DC1BB5E962005CCB2B /* ASPhotosFrameworkImageRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASPhotosFrameworkImageRequest.h; sourceTree = "<group>"; };
@@ -1428,6 +1433,8 @@
 		058D09E1195D050800B7D73C /* Details */ = {
 			isa = PBXGroup;
 			children = (
+				CC4C2A751D88E3BF0039ACAB /* ASTraceEvent.h */,
+				CC4C2A761D88E3BF0039ACAB /* ASTraceEvent.m */,
 				058D09E2195D050800B7D73C /* _ASDisplayLayer.h */,
 				058D09E3195D050800B7D73C /* _ASDisplayLayer.mm */,
 				058D09E4195D050800B7D73C /* _ASDisplayView.h */,
@@ -1860,6 +1867,7 @@
 				34EFC7701B701CFA00AD841F /* ASStackLayoutDefines.h in Headers */,
 				764D83D51C8EA515009B4FB8 /* AsyncDisplayKit+Debug.h in Headers */,
 				E5711A2C1C840C81009619D4 /* ASIndexedNodeContext.h in Headers */,
+				CC4C2A771D88E3BF0039ACAB /* ASTraceEvent.h in Headers */,
 				254C6B7B1BF94DF4003EC431 /* ASTextKitRenderer+Positioning.h in Headers */,
 				CC7FD9E21BB603FF005CCB2B /* ASPhotosFrameworkImageRequest.h in Headers */,
 				DE4843DC1C93EAC100A1F33B /* ASLayoutTransition.h in Headers */,
@@ -2183,6 +2191,7 @@
 				257754AE1BEE44CD00737CA5 /* ASTextKitRenderer+Positioning.mm in Sources */,
 				ACF6ED2E1B17843500DA7C62 /* ASRatioLayoutSpec.mm in Sources */,
 				AC47D9461B3BB41900AAEE9D /* ASRelativeSize.mm in Sources */,
+				CC4C2A781D88E3BF0039ACAB /* ASTraceEvent.m in Sources */,
 				205F0E121B371BD7007741D0 /* ASScrollDirection.m in Sources */,
 				9C8898BB1C738B9800D6B02E /* ASTextKitFontSizeAdjuster.mm in Sources */,
 				D785F6631A74327E00291744 /* ASScrollNode.m in Sources */,
@@ -2365,6 +2374,7 @@
 				B35062271B010EFD0018CF92 /* ASRangeController.mm in Sources */,
 				0442850A1BAA63FE00D16268 /* ASBatchFetching.m in Sources */,
 				68FC85E61CE29B9400EDD713 /* ASNavigationController.m in Sources */,
+				CC4C2A791D88E3BF0039ACAB /* ASTraceEvent.m in Sources */,
 				34EFC76F1B701CF700AD841F /* ASRatioLayoutSpec.mm in Sources */,
 				254C6B8B1BF94F8A003EC431 /* ASTextKitShadower.mm in Sources */,
 				34EFC7661B701CD200AD841F /* ASRelativeSize.mm in Sources */,

--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -431,6 +431,7 @@
 		CC4C2A771D88E3BF0039ACAB /* ASTraceEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = CC4C2A751D88E3BF0039ACAB /* ASTraceEvent.h */; };
 		CC4C2A781D88E3BF0039ACAB /* ASTraceEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = CC4C2A761D88E3BF0039ACAB /* ASTraceEvent.m */; };
 		CC4C2A791D88E3BF0039ACAB /* ASTraceEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = CC4C2A761D88E3BF0039ACAB /* ASTraceEvent.m */; };
+		CC4C2A7A1D8902350039ACAB /* ASTraceEvent.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = CC4C2A751D88E3BF0039ACAB /* ASTraceEvent.h */; };
 		CC54A81C1D70079800296A24 /* ASDispatch.h in Headers */ = {isa = PBXBuildFile; fileRef = CC54A81B1D70077A00296A24 /* ASDispatch.h */; };
 		CC54A81E1D7008B300296A24 /* ASDispatchTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CC54A81D1D7008B300296A24 /* ASDispatchTests.m */; };
 		CC7FD9DF1BB5E962005CCB2B /* ASPhotosFrameworkImageRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = CC7FD9DD1BB5E962005CCB2B /* ASPhotosFrameworkImageRequest.m */; };
@@ -649,6 +650,7 @@
 			dstPath = "include/$(PRODUCT_NAME)";
 			dstSubfolderSpec = 16;
 			files = (
+				CC4C2A7A1D8902350039ACAB /* ASTraceEvent.h in CopyFiles */,
 				CC88F7AE1D80AF5E000D6D4E /* ASObjectDescriptionHelpers.h in CopyFiles */,
 				F7CE6C981D2CDB5800BE4C15 /* ASInternalHelpers.h in CopyFiles */,
 				F7CE6CB71D2CE2D000BE4C15 /* ASLayoutableExtensibility.h in CopyFiles */,

--- a/AsyncDisplayKit/ASDisplayNode+Beta.h
+++ b/AsyncDisplayKit/ASDisplayNode+Beta.h
@@ -10,6 +10,7 @@
 
 #import "ASDisplayNode.h"
 #import "ASLayoutRangeType.h"
+#import "ASTraceEvent.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -17,6 +18,20 @@ ASDISPLAYNODE_EXTERN_C_BEGIN
 void ASPerformBlockOnMainThread(void (^block)());
 void ASPerformBlockOnBackgroundThread(void (^block)()); // DISPATCH_QUEUE_PRIORITY_DEFAULT
 ASDISPLAYNODE_EXTERN_C_END
+
+#ifndef ASDISPLAYNODE_EVENTLOG_CAPACITY
+#define ASDISPLAYNODE_EVENTLOG_CAPACITY 20
+#endif
+
+#ifndef ASDISPLAYNODE_EVENTLOG_ENABLE
+#define ASDISPLAYNODE_EVENTLOG_ENABLE DEBUG
+#endif
+
+#if ASDISPLAYNODE_EVENTLOG_ENABLE
+#define ASDisplayNodeLogEvent(node, ...) [node _logEventWithBacktrace:[NSThread callStackSymbols] format:__VA_ARGS__]
+#else
+#define ASDisplayNodeLogEvent(node, ...)
+#endif
 
 /**
  * Bitmask to indicate what performance measurements the cell should record.
@@ -109,6 +124,20 @@ extern NSString *const ASDisplayNodeLayoutGenerationNumberOfPassesKey;
  * enabling .neverShowPlaceholders on ASCellNodes so that the navigation operation is blocked on redisplay completing, etc.
  */
 + (void)setRangeModeForMemoryWarnings:(ASLayoutRangeMode)rangeMode;
+
+#if ASDISPLAYNODE_EVENTLOG_ENABLE
+
+/**
+ * The primitive event tracing method. You shouldn't call this. Use the ASDisplayNodeLogEvent macro instead.
+ */
+- (void)_logEventWithBacktrace:(NSArray<NSString *> *)backtrace format:(NSString *)format, ... NS_FORMAT_FUNCTION(2, 3);
+
+/**
+ * @abstract The most recent trace events for this node. Max count is ASDISPLAYNODE_EVENTLOG_CAPACITY.
+ */
+@property (readonly, copy) NSArray *eventLog;
+
+#endif
 
 @end
 

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -308,6 +308,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
 - (void)_initializeInstance
 {
   [self _staticInitialize];
+  _eventLogHead = -1;
   _contentsScaleForDisplay = ASScreenScale();
   _displaySentinel = [[ASSentinel alloc] init];
   
@@ -323,6 +324,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   
   _flags.canClearContentsOfLayer = YES;
   _flags.canCallSetNeedsDisplayOfLayer = YES;
+  ASDisplayNodeLogEvent(self, @"init");
 }
 
 - (instancetype)init
@@ -428,7 +430,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
 {
   ASDisplayNodeAssertMainThread();
   // Synchronous nodes may not be able to call the hierarchy notifications, so only enforce for regular nodes.
-  ASDisplayNodeAssert(_flags.synchronous || !ASInterfaceStateIncludesVisible(_interfaceState), @"Node should always be marked invisible before deallocating; interfaceState: %lu, %@", (unsigned long)_interfaceState, self);
+  ASDisplayNodeAssert(_flags.synchronous || !ASInterfaceStateIncludesVisible(_interfaceState), @"Node should always be marked invisible before deallocating. Node: %@", self);
   
   self.asyncLayer.asyncDelegate = nil;
   _view.asyncdisplaykit_node = nil;
@@ -578,6 +580,51 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
     [self __didLoad];
   }
 }
+
+#if ASDISPLAYNODE_EVENTLOG_ENABLE
+- (void)_logEventWithBacktrace:(NSArray<NSString *> *)backtrace format:(NSString *)format, ...
+{
+  va_list args;
+  va_start(args, format);
+  ASTraceEvent *event = [[ASTraceEvent alloc] initWithObject:self
+                                                   backtrace:backtrace
+                                                      format:format
+                                                   arguments:args];
+  va_end(args);
+
+  ASDN::MutexLocker l(__instanceLock__);
+  // Create the array if needed.
+  if (_eventLog == nil) {
+    _eventLog = [NSMutableArray arrayWithCapacity:ASDISPLAYNODE_EVENTLOG_CAPACITY];
+  }
+
+	// Increment the head index.
+  _eventLogHead = (_eventLogHead + 1) % ASDISPLAYNODE_EVENTLOG_CAPACITY;
+  if (_eventLogHead < _eventLog.count) {
+    [_eventLog replaceObjectAtIndex:_eventLogHead withObject:event];
+  } else {
+    [_eventLog insertObject:event atIndex:_eventLogHead];
+  }
+}
+
+- (NSArray<ASTraceEvent *> *)eventLog
+{
+  ASDN::MutexLocker l(__instanceLock__);
+  NSUInteger tail = (_eventLogHead + 1);
+  NSUInteger count = _eventLog.count;
+
+  NSMutableArray<ASTraceEvent *> *result = [NSMutableArray array];
+
+  // Start from `tail` and go through array, wrapping around when we exceed end index.
+  for (NSUInteger actualIndex = 0; actualIndex < ASDISPLAYNODE_EVENTLOG_CAPACITY; actualIndex++) {
+    NSInteger ringIndex = (tail + actualIndex) % ASDISPLAYNODE_EVENTLOG_CAPACITY;
+    if (ringIndex < count) {
+      [result addObject:_eventLog[ringIndex]];
+    }
+  }
+  return result;
+}
+#endif
 
 - (UIView *)view
 {
@@ -1639,6 +1686,7 @@ static bool disableNotificationsForMovingBetweenParents(ASDisplayNode *from, ASD
     _subnodes = [[NSMutableArray alloc] init];
   }
 
+  ASDisplayNodeLogEvent(self, @"%@ %@", NSStringFromSelector(_cmd), subnode);
   [_subnodes addObject:subnode];
   
   // This call will apply our .hierarchyState to the new subnode.
@@ -1694,6 +1742,7 @@ static bool disableNotificationsForMovingBetweenParents(ASDisplayNode *from, ASD
   
   if (!_subnodes)
     _subnodes = [[NSMutableArray alloc] init];
+  ASDisplayNodeLogEvent(self, @"%@: %@", NSStringFromSelector(_cmd), subnode);
   [_subnodes insertObject:subnode atIndex:subnodeIndex];
   [subnode __setSupernode:self];
   
@@ -1938,6 +1987,7 @@ static NSInteger incrementIfFound(NSInteger i) {
     return;
   }
 
+  ASDisplayNodeLogEvent(self, @"%@: %@", NSStringFromSelector(_cmd), subnode);
   [_subnodes removeObjectIdenticalTo:subnode];
 
   [subnode __setSupernode:nil];
@@ -2150,6 +2200,7 @@ static NSInteger incrementIfFound(NSInteger i) {
   }
   
   if (supernodeDidChange) {
+    ASDisplayNodeLogEvent(self, @"supernodeDidChange: %@, oldValue = %@", ASObjectDescriptionMakeTiny(newSupernode), ASObjectDescriptionMakeTiny(oldSupernode));
     // Hierarchy state
     ASHierarchyState stateToEnterOrExit = (newSupernode ? newSupernode.hierarchyState
                                                         : oldSupernode.hierarchyState);
@@ -2415,11 +2466,13 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
       ASLayoutableValidateLayout(layout);
 #endif
     }
+    ASDisplayNodeLogEvent(self, @"computedLayout: %@", layout);
     return [layout filteredNodeLayoutTree];
   } else {
     // If neither -layoutSpecThatFits: nor -calculateSizeThatFits: is overridden by subclassses, preferredFrameSize should be used,
     // assume that the default implementation of -calculateSizeThatFits: returns it.
     CGSize size = [self calculateSizeThatFits:constrainedSize.max];
+    ASDisplayNodeLogEvent(self, @"calculatedSize: %@", NSStringFromCGSize(size));
     return [ASLayout layoutWithLayoutable:self size:ASSizeRangeClamp(constrainedSize, size) sublayouts:nil];
   }
 }
@@ -2558,6 +2611,7 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
 {
   ASDN::MutexLocker l(__instanceLock__);
   
+  ASDisplayNodeLogEvent(self, @"didLoad");
   for (ASDisplayNodeDidLoadBlock block in _onDidLoadBlocks) {
     block(self);
   }
@@ -2758,8 +2812,10 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
   
   if (nowPreload != wasPreload) {
     if (nowPreload) {
+      ASDisplayNodeLogEvent(self, @"didEnterPreloadState: %@", NSStringFromASInterfaceState(newState));
       [self didEnterPreloadState];
     } else {
+      ASDisplayNodeLogEvent(self, @"didExitPreloadState: %@", NSStringFromASInterfaceState(newState));
       [self didExitPreloadState];
     }
   }
@@ -2806,8 +2862,10 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
     }
     
     if (nowDisplay) {
+      ASDisplayNodeLogEvent(self, @"didEnterDisplayState: %@", NSStringFromASInterfaceState(newState));
       [self didEnterDisplayState];
     } else {
+      ASDisplayNodeLogEvent(self, @"didExitDisplayState: %@", NSStringFromASInterfaceState(newState));
       [self didExitDisplayState];
     }
   }
@@ -2819,8 +2877,10 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
 
   if (nowVisible != wasVisible) {
     if (nowVisible) {
+      ASDisplayNodeLogEvent(self, @"didEnterVisibleState: %@", NSStringFromASInterfaceState(newState));
       [self didEnterVisibleState];
     } else {
+      ASDisplayNodeLogEvent(self, @"didExitVisibleState: %@", NSStringFromASInterfaceState(newState));
       [self didExitVisibleState];
     }
   }
@@ -2848,6 +2908,7 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
   if (interfaceState == ASInterfaceStateNone) {
     return; // This method is a no-op with a 0-bitfield argument, so don't bother recursing.
   }
+  ASDisplayNodeLogEvent(self, @"%@ %@", NSStringFromSelector(_cmd), NSStringFromASInterfaceState(interfaceState));
   ASDisplayNodePerformBlockOnEveryNode(nil, self, ^(ASDisplayNode *node) {
     node.interfaceState &= (~interfaceState);
   });
@@ -2922,10 +2983,8 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
       }
     }
   }
-  
-  if (newState != oldState) {
-    LOG(@"setHierarchyState: oldState = %lu, newState = %lu", (unsigned long)oldState, (unsigned long)newState);
-  }
+
+  ASDisplayNodeLogEvent(self, @"setHierarchyState: oldState = %@, newState = %@", NSStringFromASHierarchyState(oldState), NSStringFromASHierarchyState(newState));
 }
 
 - (void)enterHierarchyState:(ASHierarchyState)hierarchyState
@@ -2972,6 +3031,7 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
 {
   ASDisplayNodeAssertMainThread();
 
+  ASDisplayNodeLogEvent(self, @"displayWillStart");
   // in case current node takes longer to display than it's subnodes, treat it as a dependent node
   [self _pendingNodeWillDisplay:self];
 
@@ -2982,6 +3042,7 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
 {
   ASDisplayNodeAssertMainThread();
   
+  ASDisplayNodeLogEvent(self, @"displayDidFinish");
   [self _pendingNodeDidDisplay:self];
 
   [_supernode subnodeDisplayDidFinish:self];
@@ -3340,15 +3401,15 @@ static const char *ASDisplayNodeDrawingPriorityKey = "ASDrawingPriority";
   }
 
   if (self.layerBacked) {
-    CALayer *rootLayer = self.layer;
+    CALayer *rootLayer = _layer;
     CALayer *nextLayer = rootLayer;
     while ((nextLayer = rootLayer.superlayer) != nil) {
       rootLayer = nextLayer;
     }
 
-    return [self.layer convertRect:self.threadSafeBounds toLayer:rootLayer];
+    return [_layer convertRect:self.threadSafeBounds toLayer:rootLayer];
   } else {
-    return [self.view convertRect:self.threadSafeBounds toView:nil];
+    return [_view convertRect:self.threadSafeBounds toView:nil];
   }
 }
 
@@ -3398,6 +3459,7 @@ static const char *ASDisplayNodeDrawingPriorityKey = "ASDrawingPriority";
 {
   if (ASEnvironmentTraitCollectionIsEqualToASEnvironmentTraitCollection(environmentTraitCollection, _environmentState.environmentTraitCollection) == NO) {
     _environmentState.environmentTraitCollection = environmentTraitCollection;
+    ASDisplayNodeLogEvent(self, @"asyncTraitCollectionDidChange: %@", NSStringFromASEnvironmentTraitCollection(environmentTraitCollection));
     [self asyncTraitCollectionDidChange];
   }
 }
@@ -3413,7 +3475,7 @@ ASEnvironmentLayoutExtensibilityForwarding
 
 - (void)asyncTraitCollectionDidChange
 {
-
+  // Subclass override
 }
 
 #if TARGET_OS_TV

--- a/AsyncDisplayKit/ASDisplayNodeExtras.h
+++ b/AsyncDisplayKit/ASDisplayNodeExtras.h
@@ -36,7 +36,7 @@ ASDISPLAYNODE_INLINE BOOL ASInterfaceStateIncludesMeasureLayout(ASInterfaceState
   return ((interfaceState & ASInterfaceStateMeasureLayout) == ASInterfaceStateMeasureLayout);
 }
 
-ASDISPLAYNODE_INLINE NSString * _Nonnull NSStringFromASInterfaceState(ASInterfaceState interfaceState)
+__unused static NSString * _Nonnull NSStringFromASInterfaceState(ASInterfaceState interfaceState)
 {
   NSMutableArray *states = [NSMutableArray array];
   if (interfaceState == ASInterfaceStateNone) {

--- a/AsyncDisplayKit/Details/ASEnvironment.h
+++ b/AsyncDisplayKit/Details/ASEnvironment.h
@@ -76,7 +76,7 @@ extern ASEnvironmentTraitCollection ASEnvironmentTraitCollectionMakeDefault();
 
 extern ASEnvironmentTraitCollection ASEnvironmentTraitCollectionFromUITraitCollection(UITraitCollection *traitCollection);
 extern BOOL ASEnvironmentTraitCollectionIsEqualToASEnvironmentTraitCollection(ASEnvironmentTraitCollection lhs, ASEnvironmentTraitCollection rhs);
-
+extern NSString *NSStringFromASEnvironmentTraitCollection(ASEnvironmentTraitCollection traits);
 #pragma mark - ASEnvironmentState
 
 typedef struct ASEnvironmentState {

--- a/AsyncDisplayKit/Details/ASEnvironment.mm
+++ b/AsyncDisplayKit/Details/ASEnvironment.mm
@@ -10,6 +10,7 @@
 
 #import "ASEnvironmentInternal.h"
 #import "ASAvailability.h"
+#import "ASObjectDescriptionHelpers.h"
 
 ASEnvironmentLayoutOptionsState ASEnvironmentLayoutOptionsStateMakeDefault()
 {
@@ -58,6 +59,57 @@ BOOL ASEnvironmentTraitCollectionIsEqualToASEnvironmentTraitCollection(ASEnviron
     lhs.userInterfaceIdiom == rhs.userInterfaceIdiom &&
     lhs.forceTouchCapability == rhs.forceTouchCapability &&
     CGSizeEqualToSize(lhs.containerSize, rhs.containerSize);
+}
+
+// Named so as not to conflict with a hidden Apple function, in case compiler decides not to inline
+ASDISPLAYNODE_INLINE NSString *AS_NSStringFromUIUserInterfaceIdiom(UIUserInterfaceIdiom idiom) {
+  switch (idiom) {
+    case UIUserInterfaceIdiomTV:
+      return @"TV";
+    case UIUserInterfaceIdiomPad:
+      return @"Pad";
+    case UIUserInterfaceIdiomPhone:
+      return @"Phone";
+    case UIUserInterfaceIdiomCarPlay:
+      return @"CarPlay";
+    default:
+      return @"Unspecified";
+  }
+}
+
+// Named so as not to conflict with a hidden Apple function, in case compiler decides not to inline
+ASDISPLAYNODE_INLINE NSString *AS_NSStringFromUIForceTouchCapability(UIForceTouchCapability capability) {
+  switch (capability) {
+    case UIForceTouchCapabilityAvailable:
+      return @"Available";
+    case UIForceTouchCapabilityUnavailable:
+      return @"Unavailable";
+    default:
+      return @"Unknown";
+  }
+}
+
+// Named so as not to conflict with a hidden Apple function, in case compiler decides not to inline
+ASDISPLAYNODE_INLINE NSString *AS_NSStringFromUIUserInterfaceSizeClass(UIUserInterfaceSizeClass sizeClass) {
+  switch (sizeClass) {
+    case UIUserInterfaceSizeClassCompact:
+      return @"Compact";
+    case UIUserInterfaceSizeClassRegular:
+      return @"Regular";
+    default:
+      return @"Unspecified";
+  }
+}
+
+NSString *NSStringFromASEnvironmentTraitCollection(ASEnvironmentTraitCollection traits)
+{
+  NSMutableArray<NSDictionary *> *props = [NSMutableArray array];
+  [props addObject:@{ @"userInterfaceIdiom": AS_NSStringFromUIUserInterfaceIdiom(traits.userInterfaceIdiom) }];
+  [props addObject:@{ @"containerSize": NSStringFromCGSize(traits.containerSize) }];
+  [props addObject:@{ @"horizontalSizeClass": AS_NSStringFromUIUserInterfaceSizeClass(traits.horizontalSizeClass) }];
+  [props addObject:@{ @"verticalSizeClass": AS_NSStringFromUIUserInterfaceSizeClass(traits.verticalSizeClass) }];
+  [props addObject:@{ @"forceTouchCapability": AS_NSStringFromUIForceTouchCapability(traits.forceTouchCapability) }];
+  return ASObjectDescriptionMakeWithoutObject(props);
 }
 
 ASEnvironmentState ASEnvironmentStateMakeDefault()

--- a/AsyncDisplayKit/Details/ASTraceEvent.h
+++ b/AsyncDisplayKit/Details/ASTraceEvent.h
@@ -1,0 +1,25 @@
+//
+//  ASTraceEvent.h
+//  AsyncDisplayKit
+//
+//  Created by Adlai Holler on 9/13/16.
+//  Copyright © 2016 Facebook. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface ASTraceEvent : NSObject
+
+/**
+ * This method is dealloc safe.
+ */
+- (instancetype)initWithObject:(id)object
+                     backtrace:(NSArray<NSString *> *)backtrace
+                        format:(NSString *)format
+                     arguments:(va_list)arguments NS_FORMAT_FUNCTION(3,0);
+
+@property (nonatomic, readonly) NSArray<NSString *> *backtrace;
+@property (nonatomic, strong, readonly) NSString *message;
+@property (nonatomic, readonly) NSTimeInterval timestamp;
+
+@end

--- a/AsyncDisplayKit/Details/ASTraceEvent.m
+++ b/AsyncDisplayKit/Details/ASTraceEvent.m
@@ -1,0 +1,60 @@
+//
+//  ASTraceEvent.m
+//  AsyncDisplayKit
+//
+//  Created by Adlai Holler on 9/13/16.
+//  Copyright © 2016 Facebook. All rights reserved.
+//
+
+#import "ASTraceEvent.h"
+#import <QuartzCore/QuartzCore.h>
+#import "ASObjectDescriptionHelpers.h"
+
+@interface ASTraceEvent ()
+@property (nonatomic, strong, readonly) NSString *objectDescription;
+@property (nonatomic, strong, readonly) NSString *threadDescription;
+@end
+
+@implementation ASTraceEvent
+
+- (instancetype)initWithObject:(id)object backtrace:(NSArray<NSString *> *)backtrace format:(NSString *)format arguments:(va_list)args
+{
+  self = [super init];
+  if (self != nil) {
+    static NSTimeInterval refTime;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+      refTime = CACurrentMediaTime();
+    });
+    
+    // Create the format string passed to us.
+    _message = [[NSString alloc] initWithFormat:format arguments:args];
+    
+    _objectDescription = ASObjectDescriptionMakeTiny(object);
+	  
+    NSThread *thread = [NSThread currentThread];
+    NSString *threadDescription = thread.name;
+    if (threadDescription.length == 0) {
+      if ([thread isMainThread]) {
+        threadDescription = @"Main";
+      } else {
+        // Want these to be 4-chars to line up with "Main". It's possible that a collision could happen
+        // here but it's so unbelievably likely to impact development, the risk is acceptable.
+        NSString *ptrString = [NSString stringWithFormat:@"%p", thread];
+        threadDescription = [ptrString substringFromIndex:MAX(0, ptrString.length - 4)];
+      }
+    }
+    _threadDescription = threadDescription;
+    
+    _backtrace = backtrace;
+    _timestamp = CACurrentMediaTime() - refTime;
+  }
+  return self;
+}
+
+- (NSString *)description
+{
+  return [NSString stringWithFormat:@"<%@ (%@) t=%7.3f: %@>", _objectDescription, _threadDescription, _timestamp, _message];
+}
+
+@end

--- a/AsyncDisplayKit/Private/ASDisplayNode+FrameworkPrivate.h
+++ b/AsyncDisplayKit/Private/ASDisplayNode+FrameworkPrivate.h
@@ -50,14 +50,45 @@ typedef NS_OPTIONS(NSUInteger, ASHierarchyState)
   ASHierarchyStateLayoutPending           = 1 << 3
 };
 
-inline BOOL ASHierarchyStateIncludesLayoutPending(ASHierarchyState hierarchyState)
+ASDISPLAYNODE_INLINE BOOL ASHierarchyStateIncludesLayoutPending(ASHierarchyState hierarchyState)
 {
   return ((hierarchyState & ASHierarchyStateLayoutPending) == ASHierarchyStateLayoutPending);
 }
 
-inline BOOL ASHierarchyStateIncludesRangeManaged(ASHierarchyState hierarchyState)
+ASDISPLAYNODE_INLINE BOOL ASHierarchyStateIncludesRangeManaged(ASHierarchyState hierarchyState)
 {
     return ((hierarchyState & ASHierarchyStateRangeManaged) == ASHierarchyStateRangeManaged);
+}
+
+ASDISPLAYNODE_INLINE BOOL ASHierarchyStateIncludesRasterized(ASHierarchyState hierarchyState)
+{
+	return ((hierarchyState & ASHierarchyStateRasterized) == ASHierarchyStateRasterized);
+}
+
+ASDISPLAYNODE_INLINE BOOL ASHierarchyStateIncludesTransitioningSupernodes(ASHierarchyState hierarchyState)
+{
+	return ((hierarchyState & ASHierarchyStateTransitioningSupernodes) == ASHierarchyStateTransitioningSupernodes);
+}
+
+__unused static NSString * _Nonnull NSStringFromASHierarchyState(ASHierarchyState hierarchyState)
+{
+	NSMutableArray *states = [NSMutableArray array];
+	if (hierarchyState == ASHierarchyStateNormal) {
+		[states addObject:@"Normal"];
+	}
+	if (ASHierarchyStateIncludesRangeManaged(hierarchyState)) {
+		[states addObject:@"RangeManaged"];
+	}
+	if (ASHierarchyStateIncludesLayoutPending(hierarchyState)) {
+		[states addObject:@"LayoutPending"];
+	}
+	if (ASHierarchyStateIncludesRasterized(hierarchyState)) {
+		[states addObject:@"Rasterized"];
+	}
+	if (ASHierarchyStateIncludesTransitioningSupernodes(hierarchyState)) {
+		[states addObject:@"TransitioningSupernodes"];
+	}
+	return [NSString stringWithFormat:@"{ %@ }", [states componentsJoinedByString:@" | "]];
 }
 
 @interface ASDisplayNode ()

--- a/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
+++ b/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
@@ -121,7 +121,10 @@ FOUNDATION_EXPORT NSString * const ASRenderingEngineDidDisplayNodesScheduledBefo
 
   UIEdgeInsets _hitTestSlop;
   NSMutableArray *_subnodes;
-  
+  NSMutableArray<ASTraceEvent *> *_eventLog;
+  // The index of the most recent log entry. -1 until first entry.
+  NSInteger _eventLogHead;
+
   // Main thread only
   BOOL _automaticallyManagesSubnodes;
   _ASTransitionContext *_pendingLayoutTransitionContext;

--- a/AsyncDisplayKit/Private/ASObjectDescriptionHelpers.h
+++ b/AsyncDisplayKit/Private/ASObjectDescriptionHelpers.h
@@ -36,12 +36,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 ASDISPLAYNODE_EXTERN_C_BEGIN
 
-/**
- * Returns e.g. <MYObject: 0xFFFFFFFF; name = "Object Name"; frame = (0 0; 50 50)>
- *
- * Note: `object` param is autoreleasing so that this function is dealloc-safe.
- *   No, unsafe_unretained isn't acceptable here – the optimizer may deallocate object early.
- */
+/// Useful for structs etc. Returns e.g. { position = (0 0); frame = (0 0; 50 50) }
+NSString *ASObjectDescriptionMakeWithoutObject(NSArray<NSDictionary *> * _Nullable propertyGroups);
+
+/// Returns e.g. <MYObject: 0xFFFFFFFF; name = "Object Name"; frame = (0 0; 50 50)>
 NSString *ASObjectDescriptionMake(__autoreleasing id object, NSArray<NSDictionary *> * _Nullable propertyGroups);
 
 /**

--- a/AsyncDisplayKit/Private/ASObjectDescriptionHelpers.m
+++ b/AsyncDisplayKit/Private/ASObjectDescriptionHelpers.m
@@ -10,7 +10,8 @@
 #import <UIKit/UIKit.h>
 #import "NSIndexSet+ASHelpers.h"
 
-NSString *ASGetDescriptionValueString(id object) {
+NSString *ASGetDescriptionValueString(id object)
+{
   if ([object isKindOfClass:[NSValue class]]) {
     // Use shortened NSValue descriptions
     NSValue *value = object;
@@ -37,18 +38,33 @@ NSString *ASGetDescriptionValueString(id object) {
   return [object description];
 }
 
-NSString *ASObjectDescriptionMake(__autoreleasing id object, NSArray<NSDictionary *> *propertyGroups) {
-  NSMutableString *str = [NSMutableString stringWithFormat:@"<%@: %p", [object class], object];
-
+NSString *_ASObjectDescriptionMakePropertyList(NSArray<NSDictionary *> * _Nullable propertyGroups)
+{
   NSMutableArray *components = [NSMutableArray array];
   for (NSDictionary *properties in propertyGroups) {
     [properties enumerateKeysAndObjectsUsingBlock:^(id  _Nonnull key, id  _Nonnull obj, BOOL * _Nonnull stop) {
       [components addObject:[NSString stringWithFormat:@"%@ = %@", key, ASGetDescriptionValueString(obj)]];
     }];
   }
-  if (components.count > 0) {
-    [str appendString:@"; "];
-    [str appendString:[components componentsJoinedByString:@"; "]];
+  return [components componentsJoinedByString:@"; "];
+}
+
+NSString *ASObjectDescriptionMakeWithoutObject(NSArray<NSDictionary *> * _Nullable propertyGroups)
+{
+  return [NSString stringWithFormat:@"{ %@ }", _ASObjectDescriptionMakePropertyList(propertyGroups)];
+}
+
+NSString *ASObjectDescriptionMake(__autoreleasing id object, NSArray<NSDictionary *> *propertyGroups)
+{
+  if (object == nil) {
+    return @"(null)";
+  }
+
+  NSMutableString *str = [NSMutableString stringWithFormat:@"<%@: %p", [object class], object];
+
+  NSString *propList = _ASObjectDescriptionMakePropertyList(propertyGroups);
+  if (propList.length > 0) {
+    [str appendFormat:@"; %@", propList];
   }
   [str appendString:@">"];
   return str;


### PR DESCRIPTION
When trying to debug issues like #2242 or the recent retain crashes, it can be extremely valuable to know the history of a node. So now you can define `ASDISPLAYNODE_EVENTLOG_ENABLE` (on in debug by default), and we will save the last `ASDISPLAYNODE_EVENTLOG_CAPACITY` (default 20) events for each node in a ring buffer. 

Subclasses can log custom events with `ASDisplayNodeLogEvent(self, @"myEvent: %@", myArg);`

Obviously this shouldn't be used in production. It's designed to be pretty efficient and so will probably not affect debugging.

This was tremendously helpful in isolating #2242 and I think it will serve us very well in future development.

Events:
- init
- didLoad
- supernodeDidChange
- add/removeSubnode
- interfaceState changes
- hierarchyState changes
- size/layout calculations
- displayStart/displayFinish

### Samples from `Kittens.app`
#### `po myNode.eventLog`

```
<<ASTextNode: 0x7f825b835800> (Main) t=  0.005: init>,
<<ASTextNode: 0x7f825b835800> (Main) t=  0.005: supernodeDidChange: <KittenNode: 0x7f825b83b400>, oldValue = (null)>,
<<ASTextNode: 0x7f825b835800> (a170) t=  0.010: setHierarchyState: oldState = { Normal }, newState = { RangeManaged }>,
<<ASTextNode: 0x7f825b835800> (a170) t=  0.035: calculatedSize: {1282.3920000000001, 160.76999999999998}>,
<<ASTextNode: 0x7f825b835800> (a170) t=  0.040: calculatedSize: {198, 664.05000000000041}>,
<<ASTextNode: 0x7f825b835800> (Main) t=  0.055: didLoad>,
<<ASTextNode: 0x7f825b835800> (Main) t=  0.063: didEnterPreloadState: { MeasureLayout | Preload | Display | Visible }>,
<<ASTextNode: 0x7f825b835800> (Main) t=  0.063: didEnterDisplayState: { MeasureLayout | Preload | Display | Visible }>,
<<ASTextNode: 0x7f825b835800> (Main) t=  0.063: didEnterVisibleState: { MeasureLayout | Preload | Display | Visible }>,
<<ASTextNode: 0x7f825b835800> (Main) t=  0.067: displayWillStart>,
<<ASTextNode: 0x7f825b835800> (Main) t=  0.076: displayDidFinish>,
<<ASTextNode: 0x7f825b835800> (Main) t= 25.383: didExitVisibleState: { MeasureLayout | Preload | Display }>,
<<ASTextNode: 0x7f825b835800> (Main) t= 25.516: didExitDisplayState: { MeasureLayout | Preload }>,
<<ASTextNode: 0x7f825b835800> (Main) t= 25.667: didExitPreloadState: { MeasureLayout }>,
<<ASTextNode: 0x7f825b835800> (Main) t= 28.751: didEnterPreloadState: { MeasureLayout | Preload | Display | Visible }>,
<<ASTextNode: 0x7f825b835800> (Main) t= 28.751: didEnterDisplayState: { MeasureLayout | Preload | Display | Visible }>,
<<ASTextNode: 0x7f825b835800> (Main) t= 28.751: didEnterVisibleState: { MeasureLayout | Preload | Display | Visible }>,
<<ASTextNode: 0x7f825b835800> (Main) t= 28.752: displayWillStart>,
<<ASTextNode: 0x7f825b835800> (Main) t= 28.817: displayDidFinish>
<<ASTextNode: 0x7f825b835800> (Main) t=121.142: calculatedSize: {1282.3920000000001, 160.76999999999998}>,     // <- rotation
<<ASTextNode: 0x7f825b835800> (Main) t=121.143: calculatedSize: {445.24800000000022, 356.49000000000001}>,
<<ASTextNode: 0x7f825b835800> (Main) t=121.164: displayWillStart>,  // <- Display canceled, too bad
<<ASTextNode: 0x7f825b835800> (Main) t=121.179: calculatedSize: {1282.3920000000001, 160.76999999999998}>,
<<ASTextNode: 0x7f825b835800> (Main) t=121.181: calculatedSize: {366, 384.45000000000016}>,
<<ASTextNode: 0x7f825b835800> (Main) t=121.181: displayWillStart>,
<<ASTextNode: 0x7f825b835800> (Main) t=121.185: displayDidFinish>
```

#### `po [myNode.eventLog[5] backtrace]`

```
0   Sample                              0x000000010ce737ff -[ASDisplayNode __didLoad] + 111,
1   Sample                              0x000000010ce57f05 -[ASDisplayNode _loadViewOrLayerIsLayerBacked:] + 677,
2   Sample                              0x000000010ce588cc -[ASDisplayNode view] + 796,
3   Sample                              0x000000010ce6b67c -[ASDisplayNode _addSubnodeSubviewOrSublayer:] + 1020,
4   Sample                              0x000000010ce6bca4 -[ASDisplayNode _addSubnodeViewsAndLayers] + 820,
5   Sample                              0x000000010ce57eec -[ASDisplayNode _loadViewOrLayerIsLayerBacked:] + 652,
6   Sample                              0x000000010ce588cc -[ASDisplayNode view] + 796,
7   Sample                              0x000000010cefbff1 -[ASRangeController configureContentView:forCellNode:] + 1457,
8   Sample                              0x000000010cf29609 -[ASTableView tableView:cellForRowAtIndexPath:] + 329,
9   UIKit                               0x000000010dd344f4 -[UITableView _createPreparedCellForGlobalRow:withIndexPath:willDisplay:] + 766,
10  UIKit                               0x000000010dd3462c -[UITableView _createPreparedCellForGlobalRow:willDisplay:] + 74,
11  UIKit                               0x000000010e034aa5 -[_UITableViewUpdateSupport(Private) _setupAnimationsForNewlyInsertedCells] + 7532,
12  UIKit                               0x000000010e03f702 -[_UITableViewUpdateSupport _setupAnimations] + 118,
13  UIKit                               0x000000010dd0db73 -[UITableView _updateWithItems:updateSupport:] + 3353,
14  UIKit                               0x000000010dd065a0 -[UITableView _endCellAnimationsWithContext:] + 15360,
15  UIKit                               0x000000010dd1ccf0 -[UITableView _updateRowsAtIndexPaths:updateAction:withRowAnimation:] + 303,
16  Sample                              0x000000010cf2e007 __80-[ASTableView rangeController:didInsertNodes:atIndexPaths:withAnimationOptions:]_block_invoke + 135,
17  UIKit                               0x000000010dc86680 +[UIView(Animation) performWithoutAnimation:] + 65,
18  Sample                              0x000000010cf2d929 _ZL30ASPerformBlockWithoutAnimationbU13block_pointerFvvE + 73,
19  Sample                              0x000000010cf2de39 -[ASTableView rangeController:didInsertNodes:atIndexPaths:withAnimationOptions:] + 841,
20  Sample                              0x000000010cefce11 -[ASRangeController dataController:didInsertNodes:atIndexPaths:withAnimationOptions:] + 1089,
21  Sample                              0x000000010ce2a69e __67-[ASDataController _insertNodes:atIndexPaths:withAnimationOptions:]_block_invoke + 606,
22  Sample                              0x000000010ce289e7 __63-[ASDataController insertNodes:ofKind:atIndexPaths:completion:]_block_invoke + 135,
23  Sample                              0x000000010ced3424 __30-[ASMainSerialQueue runBlocks]_block_invoke + 308,
24  libdispatch.dylib                   0x000000011105cd9d _dispatch_call_block_and_release + 12,
25  libdispatch.dylib                   0x000000011107d3eb _dispatch_client_callout + 8,
26  libdispatch.dylib                   0x00000001110651ef _dispatch_main_queue_callback_4CF + 1738,
27  CoreFoundation                      0x000000010fd680f9 __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__ + 9,
28  CoreFoundation                      0x000000010fd29b99 __CFRunLoopRun + 2073,
29  CoreFoundation                      0x000000010fd290f8 CFRunLoopRunSpecific + 488,
30  GraphicsServices                    0x000000011391ead2 GSEventRunModal + 161,
31  UIKit                               0x000000010dbd6f09 UIApplicationMain + 171,
32  Sample                              0x000000010cdbcf9f main + 111,
33  libdyld.dylib                       0x00000001110b192d start + 1,
34  ???                                 0x0000000000000001 0x0 + 1
```

Ready for review @rcancro @appleguy @levi @maicki @hannahmbanana 