### PR TITLE
Set .flexShrink to YES by default

### DIFF
--- a/AsyncDisplayKit/Details/ASEnvironment.h
+++ b/AsyncDisplayKit/Details/ASEnvironment.h
@@ -38,7 +38,7 @@ typedef struct ASEnvironmentLayoutOptionsState {
   CGFloat spacingBefore;// = 0;
   CGFloat spacingAfter;// = 0;
   BOOL flexGrow;// = NO;
-  BOOL flexShrink;// = NO;
+  BOOL flexShrink;// = NO; Default value is YES if created via ASEnvironmentLayoutOptionsStateMakeDefault
   ASDimension flexBasis;// = ASRelativeDimensionAuto;
   ASStackLayoutAlignSelf alignSelf;// = ASStackLayoutAlignSelfAuto;
   CGFloat ascender;// = 0;
@@ -48,6 +48,7 @@ typedef struct ASEnvironmentLayoutOptionsState {
   
   struct ASEnvironmentStateExtensions _extensions;
 } ASEnvironmentLayoutOptionsState;
+/// Should be used to create an ASEnvironmentLayoutOptionsState
 extern ASEnvironmentLayoutOptionsState ASEnvironmentLayoutOptionsStateMakeDefault();
 
 

--- a/AsyncDisplayKit/Details/ASEnvironment.mm
+++ b/AsyncDisplayKit/Details/ASEnvironment.mm
@@ -15,6 +15,7 @@ ASEnvironmentLayoutOptionsState ASEnvironmentLayoutOptionsStateMakeDefault()
 {
   return (ASEnvironmentLayoutOptionsState) {
     // Default values can be defined in here
+    .flexShrink = YES
   };
 }
 

--- a/AsyncDisplayKit/Private/ASEnvironmentInternal.mm
+++ b/AsyncDisplayKit/Private/ASEnvironmentInternal.mm
@@ -127,7 +127,7 @@ ASEnvironmentState ASEnvironmentMergeObjectAndState(ASEnvironmentState environme
   if (propagation == ASEnvironmentStatePropagation::UP) {
 
    // Object is the parent and the state is the state of the child
-    const ASEnvironmentLayoutOptionsState defaultState = ASEnvironmentDefaultLayoutOptionsState;
+    const ASEnvironmentLayoutOptionsState defaultState = ASEnvironmentLayoutOptionsStateMakeDefault();
     ASEnvironmentLayoutOptionsState parentLayoutOptionsState = environmentState.layoutOptionsState;
     
     // For every field check if the parent value is equal to the default and if so propegate up the value of the passed

--- a/AsyncDisplayKitTests/ASStackLayoutSpecSnapshotTests.mm
+++ b/AsyncDisplayKitTests/ASStackLayoutSpecSnapshotTests.mm
@@ -48,6 +48,19 @@ static void setCGSizeToNode(CGSize size, ASDisplayNode *node)
   node.height = ASDimensionMakeWithPoints(size.height);
 }
 
+- (void)testDefaultStackLayoutableFlexProperties
+{
+  ASDisplayNode *displayNode = [[ASDisplayNode alloc] init];
+  
+  XCTAssertEqual(displayNode.flexShrink, YES);
+  XCTAssertEqual(displayNode.flexGrow, NO);
+  
+  const ASDimension unconstrainedDimension = ASDimensionUnconstrained;
+  const ASDimension flexBasis = displayNode.flexBasis;
+  XCTAssertEqual(flexBasis.type, unconstrainedDimension.type);
+  XCTAssertEqual(flexBasis.value, unconstrainedDimension.value);
+}
+
 - (void)testStackLayoutSpecWithJustify:(ASStackLayoutJustifyContent)justify
                                   flex:(BOOL)flex
                              sizeRange:(ASSizeRange)sizeRange


### PR DESCRIPTION
This is a freshly-rebased variant of #2071 for merging.

To align with the CSS flex-shrink spec, set the default value of flexShrink to YES: http://www.w3.org/TR/css-flexbox-1/#propdef-flex-shrink