### PR TITLE
[ASTableView] Don't beginUpdates/endUpdates on Cell Relayout If No Data Source

### DIFF
--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -1164,7 +1164,7 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
 - (void)didLayoutSubviewsOfTableViewCell:(_ASTableViewCell *)tableViewCell
 {
   ASCellNode *node = tableViewCell.node;
-  if (node == nil) {
+  if (node == nil || _asyncDataSource == nil) {
     return;
   }
   


### PR DESCRIPTION
If this happens, it can cause invalid update exceptions because the data source count unexpectedly dropped from e.g. 32 to 0. A more correct fix for this is #2182 but it's causing other problems, and this is sufficient.