### PR TITLE
[ASDisplayNode] Use Weak Proxy to Avoid Dangling CALayer.delegate

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -553,8 +553,12 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
     _layer = [self _layerToLoad];
     static int ASLayerDelegateAssociationKey;
 
-    // We cannot make self the layer's delegate directly, because the delegate is
-    // actually `assign` though the docs say weak.
+    /**
+     * CALayer's .delegate property is documented to be weak, but the implementation is actually assign.
+     * Because our layer may survive longer than the node (e.g. if someone else retains it, or if the node
+     * begins deallocation on a background thread and it waiting for the -dealloc call to reach main), the only
+     * way to avoid a dangling pointer is to use a weak proxy.
+     */
     ASWeakProxy *instance = [ASWeakProxy weakProxyWithTarget:self];
     _layer.delegate = (id<CALayerDelegate>)instance;
     objc_setAssociatedObject(_layer, &ASLayerDelegateAssociationKey, instance, OBJC_ASSOCIATION_RETAIN_NONATOMIC);

--- a/AsyncDisplayKit/Details/ASWeakProxy.m
+++ b/AsyncDisplayKit/Details/ASWeakProxy.m
@@ -11,6 +11,8 @@
 //
 
 #import "ASWeakProxy.h"
+#import "ASObjectDescriptionHelpers.h"
+#import "ASAssert.h"
 
 @implementation ASWeakProxy
 
@@ -32,24 +34,37 @@
   return _target;
 }
 
-- (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector
+- (BOOL)respondsToSelector:(SEL)aSelector
 {
-  // Check for a compiled definition for the selector
-  NSMethodSignature *methodSignature = [[_target class] instanceMethodSignatureForSelector:aSelector];
-  
+  return [_target respondsToSelector:aSelector];
+}
+
+/// Strangely, this method doesn't get forwarded by ObjC.
+- (BOOL)isKindOfClass:(Class)aClass
+{
+  return [_target isKindOfClass:aClass];
+}
+
+- (NSString *)description
+{
+  return ASObjectDescriptionMake(self, @[@{ @"target": _target ?: (id)kCFNull }]);
+}
+
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)sel
+{
+  ASDisplayNodeAssertNil(_target, @"ASWeakProxy got %@ when its target is still alive, which is unexpected.", NSStringFromSelector(_cmd));
   // Unfortunately, in order to get this object to work properly, the use of a method which creates an NSMethodSignature
   // from a C string. -methodSignatureForSelector is called when a compiled definition for the selector cannot be found.
   // This is the place where we have to create our own dud NSMethodSignature. This is necessary because if this method
   // returns nil, a selector not found exception is raised. The string argument to -signatureWithObjCTypes: outlines
   // the return type and arguments to the message. To return a dud NSMethodSignature, pretty much any signature will
-  // suffice. Since the -forwardInvocation call will do nothing if the delegate does not respond to the selector,
+  // suffice. Since the -forwardInvocation call will do nothing if the target does not respond to the selector,
   // the dud NSMethodSignature simply gets us around the exception.
-  return methodSignature ?: [NSMethodSignature signatureWithObjCTypes:"@^v^c"];
+  return [NSMethodSignature signatureWithObjCTypes:"@^v^c"];
 }
-
 - (void)forwardInvocation:(NSInvocation *)invocation
 {
-  // If we are down here this means _target where nil. Just don't do anything to prevent a crash
+  ASDisplayNodeAssertNil(_target, @"ASWeakProxy got %@ when its target is still alive, which is unexpected.", NSStringFromSelector(_cmd));
 }
 
 @end

--- a/AsyncDisplayKit/Details/Transactions/_ASAsyncTransactionContainer.h
+++ b/AsyncDisplayKit/Details/Transactions/_ASAsyncTransactionContainer.h
@@ -46,12 +46,6 @@ typedef NS_ENUM(NSUInteger, ASAsyncTransactionContainerState) {
  */
 - (void)asyncdisplaykit_cancelAsyncTransactions;
 
-/**
- @summary Invoked when the asyncdisplaykit_asyncTransactionContainerState property changes.
- @desc You may want to override this in a CALayer or UIView subclass to take appropriate action (such as hiding content while it renders).
- */
-- (void)asyncdisplaykit_asyncTransactionContainerStateDidChange;
-
 @end
 
 @interface CALayer (ASDisplayNodeAsyncTransactionContainer) <ASDisplayNodeAsyncTransactionContainer>

--- a/AsyncDisplayKit/Details/Transactions/_ASAsyncTransactionContainer.m
+++ b/AsyncDisplayKit/Details/Transactions/_ASAsyncTransactionContainer.m
@@ -14,10 +14,6 @@
 #import "_ASAsyncTransactionGroup.h"
 #import <objc/runtime.h>
 
-#ifndef ASASYNCTRANSACTIONCONTAINER_FORWARD_STATE_CHANGE
-#define ASASYNCTRANSACTIONCONTAINER_FORWARD_STATE_CHANGE 1
-#endif
-
 static const char *ASDisplayNodeAssociatedTransactionsKey = "ASAssociatedTransactions";
 static const char *ASDisplayNodeAssociatedCurrentTransactionKey = "ASAssociatedCurrentTransaction";
 
@@ -85,12 +81,10 @@ static const char *ASAsyncTransactionIsContainerKey = "ASTransactionIsContainer"
 
 - (void)asyncdisplaykit_asyncTransactionContainerStateDidChange
 {
-#if ASASYNCTRANSACTIONCONTAINER_FORWARD_STATE_CHANGE
   id delegate = self.delegate;
   if ([delegate respondsToSelector:@selector(asyncdisplaykit_asyncTransactionContainerStateDidChange)]) {
     [delegate asyncdisplaykit_asyncTransactionContainerStateDidChange];
   }
-#endif
 }
 
 - (_ASAsyncTransaction *)asyncdisplaykit_asyncTransaction

--- a/AsyncDisplayKit/Details/_ASDisplayView.mm
+++ b/AsyncDisplayKit/Details/_ASDisplayView.mm
@@ -332,12 +332,6 @@
 }
 #endif
 
-- (void)asyncdisplaykit_asyncTransactionContainerStateDidChange
-{
-  ASDisplayNode *node = _asyncdisplaykit_node; // Create strong reference to weak ivar.
-  [node asyncdisplaykit_asyncTransactionContainerStateDidChange];
-}
-
 - (void)tintColorDidChange
 {
     ASDisplayNode *node = _asyncdisplaykit_node; // Create strong reference to weak ivar.

--- a/AsyncDisplayKit/Private/ASDisplayNode+UIViewBridge.mm
+++ b/AsyncDisplayKit/Private/ASDisplayNode+UIViewBridge.mm
@@ -962,8 +962,4 @@ nodeProperty = nodeValueExpr; _setToViewOnly(viewAndPendingViewStateProperty, vi
   [_layer asyncdisplaykit_cancelAsyncTransactions];
 }
 
-- (void)asyncdisplaykit_asyncTransactionContainerStateDidChange
-{
-}
-
 @end

--- a/AsyncDisplayKitTests/ASDisplayNodeTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeTests.m
@@ -1964,6 +1964,23 @@ static bool stringContainsPointer(NSString *description, id p) {
   XCTAssertNoThrow([nodeView removeFromSuperview]);
 }
 
+/**
+ * CALayer.delegate is actually `assign` not weak. This test demonstrates how the layer.delegate
+ * pointer dangling can cause crashes.
+ */
+- (void)testThatLayerDelegateDoesntDangleAndCauseCrash
+{
+  NS_VALID_UNTIL_END_OF_SCOPE UIView *host = [[UIView alloc] init];
+
+  __block NS_VALID_UNTIL_END_OF_SCOPE ASDisplayNode *node = [[ASDisplayNode alloc] init];
+  node.layerBacked = YES;
+
+  [host addSubnode:node];
+  [self executeOffThread:^{
+    node = nil;
+  }];
+  host = nil; // <- Will crash here
+}
 
 - (void)testThatSubnodeGetsInterfaceStateSetIfRasterized
 {

--- a/AsyncDisplayKitTests/ASDisplayNodeTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeTests.m
@@ -1979,7 +1979,7 @@ static bool stringContainsPointer(NSString *description, id p) {
   [self executeOffThread:^{
     node = nil;
   }];
-  host = nil; // <- Will crash here
+  host = nil; // <- Would crash here, when UIView accesses its sublayers' delegates in -dealloc.
 }
 
 - (void)testThatSubnodeGetsInterfaceStateSetIfRasterized

--- a/AsyncDisplayKitTests/ASDisplayNodeTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeTests.m
@@ -1964,10 +1964,12 @@ static bool stringContainsPointer(NSString *description, id p) {
   XCTAssertNoThrow([nodeView removeFromSuperview]);
 }
 
-/**
- * CALayer.delegate is actually `assign` not weak. This test demonstrates how the layer.delegate
- * pointer dangling can cause crashes.
- */
+// Running on main thread
+// Cause retain count of node to fall to zero synchronously on a background thread (pausing main thread)
+// ASDealloc2MainObject queues actual call to -dealloc to occur on the main thread
+// Continue execution on main, before the dealloc can run, to dealloc the host view
+// Node is in an invalid state (about to dealloc, not valid to retain) but accesses to sublayer delegates
+// causes attempted retain — unless weak variable works correctly
 - (void)testThatLayerDelegateDoesntDangleAndCauseCrash
 {
   NS_VALID_UNTIL_END_OF_SCOPE UIView *host = [[UIView alloc] init];


### PR DESCRIPTION
CALayer's delegate property is declared `weak` but implemented `assign`.

If the node is marked for deallocation on a background thread, and the layer tries to access its delegate before the node runs `dealloc` (deferred by ASDealloc2MainObject) then you get a crash for trying to retain an object after it's marked for deallocation.

This diff uses a proxy object between the layer and the node. The layer retains the proxy.