### PR TITLE
Remove Unneeded Thread Affinity Assertions

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -3059,14 +3059,12 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
 
 - (void)setHitTestSlop:(UIEdgeInsets)hitTestSlop
 {
-  ASDisplayNodeAssertThreadAffinity(self);
   ASDN::MutexLocker l(__instanceLock__);
   _hitTestSlop = hitTestSlop;
 }
 
 - (UIEdgeInsets)hitTestSlop
 {
-  ASDisplayNodeAssertThreadAffinity(self);
   ASDN::MutexLocker l(__instanceLock__);
   return _hitTestSlop;
 }
@@ -3170,7 +3168,6 @@ static void _recursivelySetDisplaySuspended(ASDisplayNode *node, CALayer *layer,
 
 - (BOOL)displaySuspended
 {
-  ASDisplayNodeAssertThreadAffinity(self);
   ASDN::MutexLocker l(__instanceLock__);
   return _flags.displaySuspended;
 }
@@ -3206,14 +3203,12 @@ static void _recursivelySetDisplaySuspended(ASDisplayNode *node, CALayer *layer,
 
 - (BOOL)shouldAnimateSizeChanges
 {
-  ASDisplayNodeAssertThreadAffinity(self);
   ASDN::MutexLocker l(__instanceLock__);
   return _flags.shouldAnimateSizeChanges;
 }
 
 - (void)setShouldAnimateSizeChanges:(BOOL)shouldAnimateSizeChanges
 {
-  ASDisplayNodeAssertThreadAffinity(self);
   ASDN::MutexLocker l(__instanceLock__);
   _flags.shouldAnimateSizeChanges = shouldAnimateSizeChanges;
 }
@@ -3245,16 +3240,12 @@ static const char *ASDisplayNodeDrawingPriorityKey = "ASDrawingPriority";
 
 - (BOOL)isInHierarchy
 {
-  ASDisplayNodeAssertThreadAffinity(self);
-
   ASDN::MutexLocker l(__instanceLock__);
   return _flags.isInHierarchy;
 }
 
 - (void)setInHierarchy:(BOOL)inHierarchy
 {
-  ASDisplayNodeAssertThreadAffinity(self);
-
   ASDN::MutexLocker l(__instanceLock__);
   _flags.isInHierarchy = inHierarchy;
 }


### PR DESCRIPTION
While debugging today, I was trying to `po someLoadedNode` (calls -debugDescription) from a background thread and ran into the `inHierarchy` thread affinity assertion. We don't need it, so let's get rid of it.