### PR TITLE
[Layout] Further deprecation steps for `preferredFrameSize`

### DIFF
--- a/AsyncDisplayKit/ASButtonNode.mm
+++ b/AsyncDisplayKit/ASButtonNode.mm
@@ -510,19 +510,7 @@
   if (UIEdgeInsetsEqualToEdgeInsets(UIEdgeInsetsZero, contentEdgeInsets) == NO) {
     spec = [ASInsetLayoutSpec insetLayoutSpecWithInsets:contentEdgeInsets child:spec];
   }
-  
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  if (CGSizeEqualToSize(self.preferredFrameSize, CGSizeZero) == NO) {
-#if DEBUG
-    NSLog(@"Using -[ASDisplayNde preferredFrameSize] is deprecated.");
-#endif
-    stack.style.width = ASDimensionMake(ASDimensionUnitPoints, self.preferredFrameSize.width);
-    stack.style.height = ASDimensionMake(ASDimensionUnitPoints, self.preferredFrameSize.height);
-    spec = [ASStaticLayoutSpec staticLayoutSpecWithChildren:@[stack]];
-  }
-#pragma clang diagnostic pop
-  
+
   if (_backgroundImageNode.image) {
     spec = [ASBackgroundLayoutSpec backgroundLayoutSpecWithChild:spec background:_backgroundImageNode];
   }

--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -827,7 +827,7 @@ NS_ASSUME_NONNULL_BEGIN
  * size. For example, this property could be set on an ASImageNode to display at a size different from the underlying
  * image size.
  *
- * @return Try to create a CGSize for preferredFrameSize of this node from the width and height property of this node. It will throw if the dimension unit of width or height is of type ASDimensionUnitFraction.
+ * @return Try to create a CGSize for preferredFrameSize of this node from the width and height property of this node. It will return CGSizeZero if widht and height dimensions are not of type ASDimensionUnitPoints.
  *
  * @deprecated Deprecated in version 2.0: Just calls through to set the height and width property of the node. Convert to use sizing properties instead: height, minHeight, maxHeight, width, minWidth, maxWidth.
  */

--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -827,9 +827,9 @@ NS_ASSUME_NONNULL_BEGIN
  * size. For example, this property could be set on an ASImageNode to display at a size different from the underlying
  * image size.
  *
- * @return The preferred frame size of this node
+ * @return Try to create a CGSize for preferredFrameSize of this node from the width and height property of this node. It will throw if the dimension unit of width or height is of type ASDimensionUnitFraction.
  *
- * @deprecated Deprecated in version 2.0: Use sizing properties instead: height, minHeight, maxHeight, width, minWidth, maxWidth
+ * @deprecated Deprecated in version 2.0: Just calls through to set the height and width property of the node. Convert to use sizing properties instead: height, minHeight, maxHeight, width, minWidth, maxWidth.
  */
 @property (nonatomic, assign, readwrite) CGSize preferredFrameSize ASDISPLAYNODE_DEPRECATED;
 

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -3488,11 +3488,11 @@ ASEnvironmentLayoutExtensibilityForwarding
 {
   ASDN::MutexLocker l(__instanceLock__);
   
-  // We don't support fractions in preferredFrameSize
-  ASDisplayNodeAssert(_style.width.unit != ASDimensionUnitFraction, @"preferredFrameSize.width cannot be of unit type ASDimensionUnitFraction");
-  ASDisplayNodeAssert(_style.height.unit != ASDimensionUnitFraction, @"preferredFrameSize.height cannot be of unit type ASDimensionUnitFraction");
+  if (_style.width.unit == ASDimensionUnitPoints && _style.height.unit == ASDimensionUnitPoints) {
+    return CGSizeMake(_style.width.value, _style.height.value);
+  }
 
-  return CGSizeMake(_style.width.value, _style.height.value);
+  return CGSizeZero;
 }
 
 @end

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -2465,8 +2465,7 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
 - (CGSize)calculateSizeThatFits:(CGSize)constrainedSize
 {
   __ASDisplayNodeCheckForLayoutMethodOverrides;
-    
-  ASDN::MutexLocker l(__instanceLock__);
+
   return CGSizeZero;
 }
 

--- a/AsyncDisplayKit/ASImageNode.mm
+++ b/AsyncDisplayKit/ASImageNode.mm
@@ -188,20 +188,9 @@ struct ASImageNodeDrawParameters {
 - (CGSize)calculateSizeThatFits:(CGSize)constrainedSize
 {
   ASDN::MutexLocker l(__instanceLock__);
-  
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  // If a preferredFrameSize is set, call the superclass to return that instead of using the image size.
-  if (CGSizeEqualToSize(self.preferredFrameSize, CGSizeZero) == NO) {
-#if DEBUG
-    NSLog(@"Using -[ASDisplayNode preferredFrameSize] is deprecated.");
-#endif
-    return self.preferredFrameSize;
-  }
-#pragma clang diagnostic pop
-  
+
   if (_image == nil) {
-      return constrainedSize;
+    return constrainedSize;
   }
 
   return _image.size;

--- a/AsyncDisplayKit/ASVideoNode.mm
+++ b/AsyncDisplayKit/ASVideoNode.mm
@@ -243,17 +243,6 @@ static NSString * const kRate = @"rate";
   ASDN::MutexLocker l(__instanceLock__);
   CGSize calculatedSize = constrainedSize;
   
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  // if a preferredFrameSize is set, call the superclass to return that instead of using the image size.
-  if (CGSizeEqualToSize(self.preferredFrameSize, CGSizeZero) == NO) {
-#if DEBUG
-    NSLog(@"Using -[ASDisplayNde preferredFrameSize] is deprecated.");
-#endif
-    calculatedSize = self.preferredFrameSize;
-  }
-#pragma clang diagnostic pop
-  
   // Prevent crashes through if infinite width or height
   if (isinf(calculatedSize.width) || isinf(calculatedSize.height)) {
     ASDisplayNodeAssert(NO, @"Infinite width or height in ASVideoNode");

--- a/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
+++ b/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
@@ -107,7 +107,7 @@ FOUNDATION_EXPORT NSString * const ASRenderingEngineDidDisplayNodesScheduledBefo
   ASDisplayNode * __weak _supernode;
   
   ASLayoutableStyle *_style;
-  CGSize _preferredFrameSize;
+  ASLayoutableSize _size;
 
   ASSentinel *_displaySentinel;
 

--- a/AsyncDisplayKitTests/ASDisplayNodeTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeTests.m
@@ -2063,9 +2063,9 @@ static bool stringContainsPointer(NSString *description, id p) {
   node.preferredFrameSize = CGSizeMake(100, 100);
   ASXCTAssertEqualSizes(node.preferredFrameSize, CGSizeMake(100, 100));
   
-  // Throw if requesting a preferred size if widht or height is of unit type fraction
+  // CGSizeZero should be returned if width or height is not of unit type points
   node.style.width = ASDimensionMakeWithFraction(0.5);
-  XCTAssertThrows(node.preferredFrameSize);
+  ASXCTAssertEqualSizes(node.preferredFrameSize, CGSizeZero);
   
 #pragma clang diagnostic pop
 }

--- a/AsyncDisplayKitTests/ASDisplayNodeTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeTests.m
@@ -10,6 +10,7 @@
 
 #import <QuartzCore/QuartzCore.h>
 
+#import "ASXCTExtensions.h"
 #import <XCTest/XCTest.h>
 
 #import "_ASDisplayLayer.h"
@@ -2060,7 +2061,7 @@ static bool stringContainsPointer(NSString *description, id p) {
   
   // Set a specific preferredFrameSize
   node.preferredFrameSize = CGSizeMake(100, 100);
-  XCTAssert(CGSizeEqualToSize(node.preferredFrameSize, CGSizeMake(100, 100)));
+  ASXCTAssertEqualSizes(node.preferredFrameSize, CGSizeMake(100, 100));
   
   // Throw if requesting a preferred size if widht or height is of unit type fraction
   node.style.width = ASDimensionMakeWithFraction(0.5);

--- a/AsyncDisplayKitTests/ASDisplayNodeTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeTests.m
@@ -2048,4 +2048,25 @@ static bool stringContainsPointer(NSString *description, id p) {
   XCTAssertEqualObjects(calls, expected);
 }
 
+- (void)testPreferredFrameSizeDeprecated
+{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
+  ASDisplayNode *node = [ASDisplayNode new];
+  
+  // Default auto preferred frame size will be CGSizeZero
+  XCTAssert(CGSizeEqualToSize(node.preferredFrameSize, CGSizeZero));
+  
+  // Set a specific preferredFrameSize
+  node.preferredFrameSize = CGSizeMake(100, 100);
+  XCTAssert(CGSizeEqualToSize(node.preferredFrameSize, CGSizeMake(100, 100)));
+  
+  // Throw if requesting a preferred size if widht or height is of unit type fraction
+  node.style.width = ASDimensionMakeWithFraction(0.5);
+  XCTAssertThrows(node.preferredFrameSize);
+  
+#pragma clang diagnostic pop
+}
+
 @end


### PR DESCRIPTION
- Remove all support for preferredFrameSize in ASDK
- preferredFrameSize setter calls through and sets the width and height of the node
- preferredFrameSize getter tries to return a CGSize based on the width and height properties otherwise if this is not possible it throws