### PR TITLE
Revise performance measurement naming and structure

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode+Beta.h
+++ b/AsyncDisplayKit/ASDisplayNode+Beta.h
@@ -38,16 +38,16 @@ ASDISPLAYNODE_EXTERN_C_END
  */
 typedef NS_OPTIONS(NSUInteger, ASDisplayNodePerformanceMeasurementOptions) {
   ASDisplayNodePerformanceMeasurementOptionLayoutSpec = 1 << 0,
-  ASDisplayNodePerformanceMeasurementOptionLayoutGeneration = 1 << 1
+  ASDisplayNodePerformanceMeasurementOptionLayoutComputation = 1 << 1
 };
 
-/**
- * Keys to retrieve performance entries from the performance dictionary.
- */
-extern NSString *const ASDisplayNodeLayoutSpecTotalTimeKey;
-extern NSString *const ASDisplayNodeLayoutSpecNumberOfPassesKey;
-extern NSString *const ASDisplayNodeLayoutGenerationTotalTimeKey;
-extern NSString *const ASDisplayNodeLayoutGenerationNumberOfPassesKey;
+struct ASDisplayNodePerformanceMeasurements
+{
+  CFTimeInterval layoutSpecTotalTime;
+  NSInteger layoutSpecNumberOfPasses;
+  CFTimeInterval layoutComputationTotalTime;
+  NSInteger layoutComputationNumberOfPasses;
+};
 
 @interface ASDisplayNode (Beta)
 
@@ -94,10 +94,9 @@ extern NSString *const ASDisplayNodeLayoutGenerationNumberOfPassesKey;
 @property (nonatomic, assign) ASDisplayNodePerformanceMeasurementOptions measurementOptions;
 
 /**
- * @abstract A dictionary representing performance measurements collected.
- * @note see the constants above to retrieve relevant performance measurements
+ * @abstract A simple struct representing performance measurements collected.
  */
-@property (nonatomic, strong, readonly) NSDictionary *performanceMeasurements;
+@property (nonatomic, assign, readonly) struct ASDisplayNodePerformanceMeasurements performanceMeasurements;
 
 /** @name Layout Transitioning */
 

--- a/AsyncDisplayKit/ASDisplayNode+Beta.h
+++ b/AsyncDisplayKit/ASDisplayNode+Beta.h
@@ -41,13 +41,12 @@ typedef NS_OPTIONS(NSUInteger, ASDisplayNodePerformanceMeasurementOptions) {
   ASDisplayNodePerformanceMeasurementOptionLayoutComputation = 1 << 1
 };
 
-struct ASDisplayNodePerformanceMeasurements
-{
+typedef struct {
   CFTimeInterval layoutSpecTotalTime;
   NSInteger layoutSpecNumberOfPasses;
   CFTimeInterval layoutComputationTotalTime;
   NSInteger layoutComputationNumberOfPasses;
-};
+} ASDisplayNodePerformanceMeasurements;
 
 @interface ASDisplayNode (Beta)
 
@@ -96,7 +95,7 @@ struct ASDisplayNodePerformanceMeasurements
 /**
  * @abstract A simple struct representing performance measurements collected.
  */
-@property (nonatomic, assign, readonly) struct ASDisplayNodePerformanceMeasurements performanceMeasurements;
+@property (nonatomic, assign, readonly) ASDisplayNodePerformanceMeasurements performanceMeasurements;
 
 /** @name Layout Transitioning */
 

--- a/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
+++ b/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
@@ -171,9 +171,9 @@ FOUNDATION_EXPORT NSString * const ASRenderingEngineDidDisplayNodesScheduledBefo
   // performance measurement
   ASDisplayNodePerformanceMeasurementOptions _measurementOptions;
   NSTimeInterval _layoutSpecTotalTime;
-  NSUInteger _layoutSpecNumberOfPasses;
-  NSTimeInterval _layoutGenerationTotalTime;
-  NSUInteger _layoutGenerationNumberOfPasses;
+  NSInteger _layoutSpecNumberOfPasses;
+  NSTimeInterval _layoutComputationTotalTime;
+  NSInteger _layoutComputationNumberOfPasses;
 
 #if TIME_DISPLAYNODE_OPS
 @public

--- a/AsyncDisplayKit/Private/_ASScopeTimer.h
+++ b/AsyncDisplayKit/Private/_ASScopeTimer.h
@@ -42,11 +42,16 @@ namespace ASDN {
   struct SumScopeTimer {
     NSTimeInterval begin;
     NSTimeInterval &outT;
-    SumScopeTimer(NSTimeInterval &outRef) : outT(outRef) {
-      begin = CACurrentMediaTime();
+    BOOL enable;
+    SumScopeTimer(NSTimeInterval &outRef, BOOL enable = YES) : outT(outRef), enable(enable) {
+      if (enable) {
+        begin = CACurrentMediaTime();
+      }
     }
     ~SumScopeTimer() {
-      outT += CACurrentMediaTime() - begin;
+      if (enable) {
+        outT += CACurrentMediaTime() - begin;
+      }
     }
   };
 }


### PR DESCRIPTION
Revises performance measurement naming and structure based on Scott's feedback.
- Revises naming from LayoutSpecGeneration to LayoutSpecComputation
- Adds a struct instead of an NSDictionary to retrieve performance metrics
- Includes ASEnvironmentStatePropagateDown in LayoutSpecComputation measurements