### PR TITLE
Add support to image alignment in ASButtonNode

### DIFF
--- a/AsyncDisplayKit/ASButtonNode.h
+++ b/AsyncDisplayKit/ASButtonNode.h
@@ -15,10 +15,10 @@
  Image alignment defines where the image will be placed relative to the text.
  */
 typedef NS_ENUM(NSInteger, ASButtonNodeImageAlignment) {
-  /** Places the image at the left side of the text. */
-  ASButtonNodeImageAlignmentLeft  = 0,
-  /** Places the image at the right side of the text. */
-  ASButtonNodeImageAlignmentRight = 1 << 0
+  /** Places the image before the text. */
+  ASButtonNodeImageAlignmentBeginning  = 0,
+  /** Places the image after the text. */
+  ASButtonNodeImageAlignmentEnd = 1 << 0
 };
 
 @interface ASButtonNode : ASControlNode

--- a/AsyncDisplayKit/ASButtonNode.h
+++ b/AsyncDisplayKit/ASButtonNode.h
@@ -55,7 +55,7 @@ typedef NS_ENUM(NSInteger, ASButtonNodeImageAlignment) {
 @property (nonatomic, assign) UIEdgeInsets contentEdgeInsets;
 
 /**
- * @discusstion Whether the image is left or right aligned. Default is `ASButtonNodeImageAlignmentLeft`.
+ * @discusstion Whether the image should be aligned at the beginning or at the end of node. Default is `ASButtonNodeImageAlignmentBeginning`.
  */
 @property (nonatomic, assign) ASButtonNodeImageAlignment imageAlignment;
 

--- a/AsyncDisplayKit/ASButtonNode.h
+++ b/AsyncDisplayKit/ASButtonNode.h
@@ -11,6 +11,16 @@
 #import <AsyncDisplayKit/ASTextNode.h>
 #import <AsyncDisplayKit/ASImageNode.h>
 
+/**
+ Image alignment defines where the image will be placed relative to the text.
+ */
+typedef NS_ENUM(NSInteger, ASButtonNodeImageAlignment) {
+  /** Places the image at the left side of the text. */
+  ASButtonNodeImageAlignmentLeft  = 0,
+  /** Places the image at the right side of the text. */
+  ASButtonNodeImageAlignmentRight = 1 << 0
+};
+
 @interface ASButtonNode : ASControlNode
 
 @property (nonatomic, readonly) ASTextNode  * _Nonnull titleNode;
@@ -43,6 +53,11 @@
  * @discussion The insets used around the title and image node
  */
 @property (nonatomic, assign) UIEdgeInsets contentEdgeInsets;
+
+/**
+ * @discusstion Whether the image is left or right aligned. Default is `ASButtonNodeImageAlignmentLeft`.
+ */
+@property (nonatomic, assign) ASButtonNodeImageAlignment imageAlignment;
 
 /**
  *  Returns the styled title associated with the specified state.

--- a/AsyncDisplayKit/ASButtonNode.mm
+++ b/AsyncDisplayKit/ASButtonNode.mm
@@ -62,6 +62,7 @@
     _contentHorizontalAlignment = ASHorizontalAlignmentMiddle;
     _contentVerticalAlignment = ASVerticalAlignmentCenter;
     _contentEdgeInsets = UIEdgeInsetsZero;
+    _imageAlignment = ASButtonNodeImageAlignmentLeft;
     self.accessibilityTraits = UIAccessibilityTraitButton;
   }
   return self;
@@ -480,7 +481,11 @@
   }
   
   if (_titleNode.attributedText.length > 0) {
-    [children addObject:_titleNode];
+    if (_imageAlignment == ASButtonNodeImageAlignmentLeft) {
+      [children addObject:_titleNode];
+    } else {
+      [children insertObject:_titleNode atIndex:0];
+    }
   }
   
   stack.children = children;

--- a/AsyncDisplayKit/ASButtonNode.mm
+++ b/AsyncDisplayKit/ASButtonNode.mm
@@ -62,7 +62,7 @@
     _contentHorizontalAlignment = ASHorizontalAlignmentMiddle;
     _contentVerticalAlignment = ASVerticalAlignmentCenter;
     _contentEdgeInsets = UIEdgeInsetsZero;
-    _imageAlignment = ASButtonNodeImageAlignmentLeft;
+    _imageAlignment = ASButtonNodeImageAlignmentBeginning;
     self.accessibilityTraits = UIAccessibilityTraitButton;
   }
   return self;
@@ -481,7 +481,7 @@
   }
   
   if (_titleNode.attributedText.length > 0) {
-    if (_imageAlignment == ASButtonNodeImageAlignmentLeft) {
+    if (_imageAlignment == ASButtonNodeImageAlignmentBeginning) {
       [children addObject:_titleNode];
     } else {
       [children insertObject:_titleNode atIndex:0];


### PR DESCRIPTION
Currently `ASButtonNode`, when both image and text co-exist, the only possible placement combination is image at the left and text at the right. This is because in the `layoutSpecThatFits:` implementation in `ASButtonNode`, an horizontal `ASStackLayoutSpec` is used and no customization is possible.

Subclassing `ASButtonNode` to solve this is not trivial as well given the fact that the stack spec might be a child of another spec.