### PR TITLE
[Layout] Add assertions for creating an invalid ASDimension from type ASDimensionUnitAuto and ASDimensionUnitFraction

### DIFF
--- a/AsyncDisplayKit/Layout/ASDimension.h
+++ b/AsyncDisplayKit/Layout/ASDimension.h
@@ -89,11 +89,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 ASOVERLOADABLE ASDISPLAYNODE_INLINE ASDimension ASDimensionMake(ASDimensionUnit unit, CGFloat value)
 {
-  if (unit == ASDimensionUnitPoints) {
+  if (unit == ASDimensionUnitAuto ) {
+    ASDisplayNodeCAssert(value == 0, @"ASDimension auto value must be 0.");
+  } else if (unit == ASDimensionUnitPoints) {
     ASDisplayNodeCAssertPositiveReal(@"Points", value);
   } else if (unit == ASDimensionUnitFraction) {
-    // TODO: Enable this assertion for 2.0.  Check that there is no use case for using a larger value, e.g. to layout for a clipsToBounds = NO element.
-    // ASDisplayNodeCAssert( 0 <= value && value <= 1.0, @"ASDimension fraction value (%f) must be between 0 and 1.", value);
+    ASDisplayNodeCAssert( 0 <= value && value <= 1.0, @"ASDimension fraction value (%f) must be between 0 and 1.", value);
   }
   ASDimension dimension;
   dimension.unit = unit;

--- a/AsyncDisplayKitTests/ASDimensionTests.mm
+++ b/AsyncDisplayKitTests/ASDimensionTests.mm
@@ -18,6 +18,18 @@
 
 @implementation ASDimensionTests
 
+- (void)testCreatingDimensionUnitAutos
+{
+  XCTAssertNoThrow(ASDimensionMake(ASDimensionUnitAuto, 0));
+  XCTAssertThrows(ASDimensionMake(ASDimensionUnitAuto, 100));
+}
+
+- (void)testCreatingDimensionUnitFraction
+{
+  XCTAssertNoThrow(ASDimensionMake(ASDimensionUnitFraction, 0.5));
+  XCTAssertThrows(ASDimensionMake(ASDimensionUnitAuto, 100));
+}
+
 - (void)testIntersectingOverlappingSizeRangesReturnsTheirIntersection
 {
   //  range: |---------|


### PR DESCRIPTION
- Enabling assertions for creating auto dimensions via `ASDimensionMake` and providing a value != 0. There is also a constant that actually makes creating auto dimensions called: `ASDimensionAuto`
- Enabling assertions for creating fraction dimensions within the range of 0.0 and 1.0