### PR TITLE
[ASTableView / ASCollectionView] Improve assertion messages if necessary data source methods are not implemented

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -355,8 +355,8 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
     _asyncDataSourceFlags.asyncDataSourceNodeBlockForItemAtIndexPath = [_asyncDataSource respondsToSelector:@selector(collectionView:nodeBlockForItemAtIndexPath:)];
     _asyncDataSourceFlags.asyncDataSourceNumberOfSectionsInCollectionView = [_asyncDataSource respondsToSelector:@selector(numberOfSectionsInCollectionView:)];
 
-    // Data-source must implement collectionView:nodeForItemAtIndexPath: or collectionView:nodeBlockForItemAtIndexPath:
-    ASDisplayNodeAssertTrue(_asyncDataSourceFlags.asyncDataSourceNodeBlockForItemAtIndexPath || _asyncDataSourceFlags.asyncDataSourceNodeForItemAtIndexPath);
+    ASDisplayNodeAssert(_asyncDataSourceFlags.asyncDataSourceNodeBlockForItemAtIndexPath
+                        || _asyncDataSourceFlags.asyncDataSourceNodeForItemAtIndexPath, @"Data source must implement collectionView:nodeForItemAtIndexPath: or collectionView:nodeBlockForItemAtIndexPath:");
   }
   
   super.dataSource = (id<UICollectionViewDataSource>)_proxyDataSource;

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -306,8 +306,8 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     _asyncDataSourceFlags.asyncDataSourceTableViewCanMoveRowAtIndexPath = [_asyncDataSource respondsToSelector:@selector(tableView:canMoveRowAtIndexPath:)];
     _asyncDataSourceFlags.asyncDataSourceTableViewMoveRowAtIndexPath = [_asyncDataSource respondsToSelector:@selector(tableView:moveRowAtIndexPath:toIndexPath:)];
     
-    // Data source must implement tableView:nodeBlockForRowAtIndexPath: or tableView:nodeForRowAtIndexPath:
-    ASDisplayNodeAssertTrue(_asyncDataSourceFlags.asyncDataSourceTableViewNodeBlockForRowAtIndexPath || _asyncDataSourceFlags.asyncDataSourceTableViewNodeForRowAtIndexPath);
+    ASDisplayNodeAssert(_asyncDataSourceFlags.asyncDataSourceTableViewNodeBlockForRowAtIndexPath
+                        || _asyncDataSourceFlags.asyncDataSourceTableViewNodeForRowAtIndexPath, @"Data source must implement tableView:nodeBlockForRowAtIndexPath: or tableView:nodeForRowAtIndexPath:");
   }
   
   super.dataSource = (id<UITableViewDataSource>)_proxyDataSource;

--- a/AsyncDisplayKitTests/ASCollectionViewTests.mm
+++ b/AsyncDisplayKitTests/ASCollectionViewTests.mm
@@ -120,6 +120,18 @@
 
 @implementation ASCollectionViewTests
 
+- (void)testDataSourceImplementsNecessaryMethods
+{
+  UICollectionViewFlowLayout *layout = [[UICollectionViewFlowLayout alloc] init];
+  ASCollectionView *collectionView = [[ASCollectionView alloc] initWithFrame:CGRectZero collectionViewLayout:layout];
+  
+  id dataSource = [NSObject new];
+  XCTAssertThrows((collectionView.asyncDataSource = dataSource));
+  
+  dataSource = [OCMockObject niceMockForProtocol:@protocol(ASCollectionDataSource)];
+  XCTAssertNoThrow((collectionView.asyncDataSource = dataSource));
+}
+
 - (void)testThatItSetsALayoutInspectorForFlowLayouts
 {
   UICollectionViewFlowLayout *layout = [[UICollectionViewFlowLayout alloc] init];

--- a/AsyncDisplayKitTests/ASTableViewTests.m
+++ b/AsyncDisplayKitTests/ASTableViewTests.m
@@ -159,6 +159,20 @@
 
 @implementation ASTableViewTests
 
+- (void)testDataSourceImplementsNecessaryMethods
+{
+  ASTestTableView *tableView = [[ASTestTableView alloc] __initWithFrame:CGRectMake(0, 0, 100, 400)
+                                                                  style:UITableViewStylePlain];
+  
+  
+  
+  ASTableViewFilledDataSource *dataSource = (ASTableViewFilledDataSource *)[NSObject new];
+  XCTAssertThrows((tableView.asyncDataSource = dataSource));
+  
+  dataSource = [ASTableViewFilledDataSource new];
+  XCTAssertNoThrow((tableView.asyncDataSource = dataSource));
+}
+
 - (void)testConstrainedSizeForRowAtIndexPath
 {
   // Initial width of the table view is non-zero and all nodes are measured with this size.


### PR DESCRIPTION
Improves assertion message if `tableView:nodeBlockForRowAtIndexPath:` / `tableView:nodeForRowAtIndexPath:` or `collectionView:nodeForItemAtIndexPath:` / `collectionView:nodeBlockForItemAtIndexPath:` is not implemented