### PR TITLE
[Layout] Set default value of `flexShrink` to `NO`

### DIFF
--- a/AsyncDisplayKit/Details/ASEnvironment.mm
+++ b/AsyncDisplayKit/Details/ASEnvironment.mm
@@ -16,7 +16,6 @@ ASEnvironmentLayoutOptionsState ASEnvironmentLayoutOptionsStateMakeDefault()
 {
   return (ASEnvironmentLayoutOptionsState) {
     // Default values can be defined in here
-    .flexShrink = YES
   };
 }
 

--- a/AsyncDisplayKitTests/ASStackLayoutSpecSnapshotTests.mm
+++ b/AsyncDisplayKitTests/ASStackLayoutSpecSnapshotTests.mm
@@ -52,7 +52,7 @@ static void setCGSizeToNode(CGSize size, ASDisplayNode *node)
 {
   ASDisplayNode *displayNode = [[ASDisplayNode alloc] init];
   
-  XCTAssertEqual(displayNode.flexShrink, YES);
+  XCTAssertEqual(displayNode.flexShrink, NO);
   XCTAssertEqual(displayNode.flexGrow, NO);
   
   const ASDimension unconstrainedDimension = ASDimensionAuto;


### PR DESCRIPTION
After learning about the number and art of changes we had to do for bringing the recent change for `flexShrink = YES` to Pinterest,  I did further research on the default for `flexShrink = YES` and found other libraries default it to `NO` — even though CSS on the web is `YES`. We've made a final decision that `flexShrink` should remain its current default of `NO`