### PR TITLE
[Layout] Remove styleClass property from ASLayoutable for now

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -300,7 +300,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   _contentsScaleForDisplay = ASScreenScale();
   _displaySentinel = [[ASSentinel alloc] init];
   
-  _style = [[[[self class] styleClass] alloc] init];
+  _style = [[ASLayoutableStyle alloc] init];
   _preferredFrameSize = CGSizeZero;
   _environmentState = ASEnvironmentStateMakeDefault();
   
@@ -722,11 +722,6 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
 }
 
 #pragma mark - Style
-
-+ (Class)styleClass
-{
-  return [ASLayoutableStyle class];
-}
 
 - (ASLayoutableStyle *)style
 {

--- a/AsyncDisplayKit/Layout/ASLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASLayoutSpec.mm
@@ -59,7 +59,7 @@ typedef std::map<unsigned long, id<ASLayoutable>, std::less<unsigned long>> ASCh
   
   _isMutable = YES;
   _environmentState = ASEnvironmentStateMakeDefault();
-  _style = [[[[self class] styleClass] alloc] init];
+  _style = [[ASLayoutableStyle alloc] init];
   
   return self;
 }
@@ -75,11 +75,6 @@ typedef std::map<unsigned long, id<ASLayoutable>, std::less<unsigned long>> ASCh
 }
 
 #pragma mark - Style
-
-+ (Class)styleClass
-{
-  return [ASLayoutableStyle class];
-}
 
 - (ASLayoutableStyle *)style
 {

--- a/AsyncDisplayKit/Layout/ASLayoutable.h
+++ b/AsyncDisplayKit/Layout/ASLayoutable.h
@@ -69,16 +69,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, assign, readonly) ASLayoutableStyle *style;
 
-/**
-* @discussion This property contains the ASLayoutableStyle class object by default. Subclasses can use this property to
-* return a different size class as needed. For example, if your layoutable would like extend the style object to support
-* more properties you might want to set this property to a custom subclass of ASLayoutableStyle.
-*
-* This property is set only once early in the creation of the layoutable to create the corresponding style object.
-*/
-@property (class, nonatomic, readonly) Class styleClass;
-
-
 #pragma mark - Calculate layout
 
 /**


### PR DESCRIPTION
Currently the styleClass property does not give us any benefits. Let's remove it for now until we found a more though trough way to add extensibility for styles.