### PR TITLE
Add More Nullability Annotations to Public Headers

### DIFF
--- a/AsyncDisplayKit/ASButtonNode.h
+++ b/AsyncDisplayKit/ASButtonNode.h
@@ -11,6 +11,8 @@
 #import <AsyncDisplayKit/ASTextNode.h>
 #import <AsyncDisplayKit/ASImageNode.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  Image alignment defines where the image will be placed relative to the text.
  */
@@ -23,9 +25,9 @@ typedef NS_ENUM(NSInteger, ASButtonNodeImageAlignment) {
 
 @interface ASButtonNode : ASControlNode
 
-@property (nonatomic, readonly) ASTextNode  * _Nonnull titleNode;
-@property (nonatomic, readonly) ASImageNode * _Nonnull imageNode;
-@property (nonatomic, readonly) ASImageNode * _Nonnull backgroundImageNode;
+@property (nonatomic, readonly) ASTextNode  * titleNode;
+@property (nonatomic, readonly) ASImageNode * imageNode;
+@property (nonatomic, readonly) ASImageNode * backgroundImageNode;
 
 /**
  Spacing between image and title. Defaults to 8.0.
@@ -85,7 +87,7 @@ typedef NS_ENUM(NSInteger, ASButtonNodeImageAlignment) {
  *  @param color The color to use for the title.
  *  @param state The state that uses the specified title. The possible values are described in ASControlState.
  */
-- (void)setTitle:(nonnull NSString *)title withFont:(nullable UIFont *)font withColor:(nullable UIColor *)color forState:(ASControlState)state;
+- (void)setTitle:(NSString *)title withFont:(nullable UIFont *)font withColor:(nullable UIColor *)color forState:(ASControlState)state;
 #endif
 /**
  *  Returns the image used for a button state.
@@ -94,7 +96,7 @@ typedef NS_ENUM(NSInteger, ASButtonNodeImageAlignment) {
  *
  *  @return The image used for the specified state.
  */
-- (UIImage * _Nullable)imageForState:(ASControlState)state;
+- (nullable UIImage *)imageForState:(ASControlState)state;
 
 /**
  *  Sets the image to use for the specified state.
@@ -120,6 +122,8 @@ typedef NS_ENUM(NSInteger, ASButtonNodeImageAlignment) {
  *
  *  @return The background image used for the specified state.
  */
-- (UIImage * _Nullable)backgroundImageForState:(ASControlState)state;
+- (nullable UIImage *)backgroundImageForState:(ASControlState)state;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -18,6 +18,8 @@
 #import <AsyncDisplayKit/ASLayoutable.h>
 #import <AsyncDisplayKit/ASContextTransitioning.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 #define ASDisplayNodeLoggingEnabled 0
 
 @class ASDisplayNode;
@@ -40,12 +42,12 @@ typedef CALayer * _Nonnull(^ASDisplayNodeLayerBlock)();
 /**
  * ASDisplayNode loaded callback block. This block is called BEFORE the -didLoad method and is always called on the main thread.
  */
-typedef void (^ASDisplayNodeDidLoadBlock)(__kindof ASDisplayNode * _Nonnull node);
+typedef void (^ASDisplayNodeDidLoadBlock)(__kindof ASDisplayNode * node);
 
 /**
  * ASDisplayNode will / did render node content in context.
  */
-typedef void (^ASDisplayNodeContextModifier)(_Nonnull CGContextRef context);
+typedef void (^ASDisplayNodeContextModifier)(CGContextRef context);
 
 /**
  * ASDisplayNode layout spec block. This block can be used instead of implementing layoutSpecThatFits: in subclass
@@ -102,7 +104,6 @@ extern NSInteger const ASDefaultDrawingPriority;
  *
  */
 
-NS_ASSUME_NONNULL_BEGIN
 @interface ASDisplayNode : ASDealloc2MainObject <ASLayoutable>
 
 

--- a/AsyncDisplayKit/ASImageNode.h
+++ b/AsyncDisplayKit/ASImageNode.h
@@ -11,6 +11,7 @@
 #import <AsyncDisplayKit/ASControlNode.h>
 
 #import "ASImageProtocols.h"
+#import "ASBaseDefines.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -120,7 +121,7 @@ typedef UIImage * _Nullable (^asimagenode_modification_block_t)(UIImage *image);
  * `displaySuspended` is YES, `displayCompletionBlock` is will be
  * performed immediately and `YES` will be passed for `canceled`.
  */
-- (void)setNeedsDisplayWithCompletion:(void (^ _Nullable)(BOOL canceled))displayCompletionBlock;
+- (void)setNeedsDisplayWithCompletion:(nullable void (^)(BOOL canceled))displayCompletionBlock;
 
 #if TARGET_OS_TV
 /** 
@@ -164,9 +165,9 @@ typedef UIImage * _Nullable (^asimagenode_modification_block_t)(UIImage *image);
 
 @interface ASImageNode (Unavailable)
 
-- (instancetype)initWithLayerBlock:(ASDisplayNodeLayerBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock __unavailable;
+- (instancetype)initWithLayerBlock:(ASDisplayNodeLayerBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock AS_UNAVAILABLE();
 
-- (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock __unavailable;
+- (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock AS_UNAVAILABLE();
 
 @end
 

--- a/AsyncDisplayKit/ASNavigationController.h
+++ b/AsyncDisplayKit/ASNavigationController.h
@@ -14,6 +14,10 @@
 
 #import "ASVisibilityProtocols.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface ASNavigationController : UINavigationController <ASManagesChildVisibilityDepth>
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/AsyncDisplayKit/ASPagerFlowLayout.h
+++ b/AsyncDisplayKit/ASPagerFlowLayout.h
@@ -12,6 +12,10 @@
 
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface ASPagerFlowLayout : UICollectionViewFlowLayout
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/AsyncDisplayKit/ASTabBarController.h
+++ b/AsyncDisplayKit/ASTabBarController.h
@@ -14,6 +14,10 @@
 
 #import "ASVisibilityProtocols.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface ASTabBarController : UITabBarController <ASManagesChildVisibilityDepth>
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/AsyncDisplayKit/ASTableNode.h
+++ b/AsyncDisplayKit/ASTableNode.h
@@ -14,6 +14,8 @@
 #import <AsyncDisplayKit/ASDisplayNode.h>
 #import <AsyncDisplayKit/ASRangeControllerUpdateRangeProtocol+Beta.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @protocol ASTableDataSource;
 @protocol ASTableDelegate;
 @class ASTableView;
@@ -34,3 +36,5 @@
 @property (weak, nonatomic) id <ASTableDataSource> dataSource;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/AsyncDisplayKit/ASTextNode+Beta.h
+++ b/AsyncDisplayKit/ASTextNode+Beta.h
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
  @abstract An array of descending scale factors that will be applied to this text node to try to make it fit within its constrained size
  @default nil (no scaling)
  */
-@property (nullable, nonatomic, copy) NSArray *pointSizeScaleFactors;
+@property (nullable, nonatomic, copy) NSArray<NSNumber *> *pointSizeScaleFactors;
 
 /**
  @abstract Text margins for text laid out in the text node.

--- a/AsyncDisplayKit/ASVisibilityProtocols.h
+++ b/AsyncDisplayKit/ASVisibilityProtocols.h
@@ -14,6 +14,8 @@
 
 #import "ASBaseDefines.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class UIViewController;
 
 ASDISPLAYNODE_EXTERN_C_BEGIN
@@ -106,3 +108,5 @@ ASDISPLAYNODE_EXTERN_C_END
   _parentManagesVisibilityDepth = NO; \
   [self visibilityDepthDidChange]; \
 }
+
+NS_ASSUME_NONNULL_END

--- a/AsyncDisplayKit/AsyncDisplayKit+Debug.h
+++ b/AsyncDisplayKit/AsyncDisplayKit+Debug.h
@@ -14,6 +14,8 @@
 #import "ASImageNode.h"
 #import "ASRangeController.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface ASImageNode (Debugging)
 
 /**
@@ -67,3 +69,4 @@
 
 @end
 
+NS_ASSUME_NONNULL_END

--- a/AsyncDisplayKit/Details/ASCollectionInternal.h
+++ b/AsyncDisplayKit/Details/ASCollectionInternal.h
@@ -12,15 +12,19 @@
 
 #import <AsyncDisplayKit/ASCollectionView.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @protocol ASCollectionViewLayoutFacilitatorProtocol;
 @class ASCollectionNode;
 @class ASDataController;
 @class ASRangeController;
 
 @interface ASCollectionView ()
-- (instancetype)_initWithFrame:(CGRect)frame collectionViewLayout:(UICollectionViewLayout *)layout layoutFacilitator:(id<ASCollectionViewLayoutFacilitatorProtocol>)layoutFacilitator ownedByNode:(BOOL)ownedByNode;
+- (instancetype)_initWithFrame:(CGRect)frame collectionViewLayout:(UICollectionViewLayout *)layout layoutFacilitator:(nullable id<ASCollectionViewLayoutFacilitatorProtocol>)layoutFacilitator ownedByNode:(BOOL)ownedByNode;
 
 @property (nonatomic, weak, readwrite) ASCollectionNode *collectionNode;
 @property (nonatomic, strong, readonly) ASDataController *dataController;
 @property (nonatomic, strong, readonly) ASRangeController *rangeController;
 @end
+
+NS_ASSUME_NONNULL_END

--- a/AsyncDisplayKit/UIImage+ASConvenience.h
+++ b/AsyncDisplayKit/UIImage+ASConvenience.h
@@ -13,9 +13,11 @@
 #import <UIKit/UIImage.h>
 #import <UIKit/UIBezierPath.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 // High-performance flat-colored, rounded-corner resizable images
 //
-// For "Baked-in Opaque" corners, set cornerColor equal to the color behind the rounded image object, e.g. the background color.
+// For "Baked-in Opaque" corners, set cornerColor equal to the color behind the rounded image object, i.e. the background color.
 // For "Baked-in Alpha" corners, set cornerColor = [UIColor clearColor]
 //
 // See http://asyncdisplaykit.org/docs/corner-rounding.html for an explanation.
@@ -45,7 +47,7 @@
 + (UIImage *)as_resizableRoundedImageWithCornerRadius:(CGFloat)cornerRadius
                                           cornerColor:(UIColor *)cornerColor
                                             fillColor:(UIColor *)fillColor
-                                          borderColor:(UIColor *)borderColor
+                                          borderColor:(nullable UIColor *)borderColor
                                           borderWidth:(CGFloat)borderWidth;
 
 /**
@@ -62,10 +64,11 @@
 + (UIImage *)as_resizableRoundedImageWithCornerRadius:(CGFloat)cornerRadius
                                           cornerColor:(UIColor *)cornerColor
                                             fillColor:(UIColor *)fillColor
-                                          borderColor:(UIColor *)borderColor
+                                          borderColor:(nullable UIColor *)borderColor
                                           borderWidth:(CGFloat)borderWidth
                                        roundedCorners:(UIRectCorner)roundedCorners
                                                 scale:(CGFloat)scale;
 
 @end
 
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
I was poking around in the Swift example this morning and I found some missing nullability specifiers. These make for an extremely unpleasant Swift experience.

After this diff, all of our public headers (the ones in the root folder anyway) have full nullability specifications.