### PR TITLE
[ASTextKitFontSizeAdjuster] Use the constrainedSize’s height to adjust font scaling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,9 @@ before_install:
 install: echo "<3"
 env:
   - MODE=tests
-# Examples disabled until updated for new layout
-#  - MODE=examples-pt1
-#  - MODE=examples-pt2
-#  - MODE=examples-pt3
+  - MODE=examples-pt1
+  - MODE=examples-pt2
+  - MODE=examples-pt3
   - MODE=life-without-cocoapods
   - MODE=framework
 script: ./build.sh $MODE

--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -1,12527 +1,2923 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>archiveVersion</key>
-	<string>1</string>
-	<key>classes</key>
-	<dict/>
-	<key>objectVersion</key>
-	<string>46</string>
-	<key>objects</key>
-	<dict>
-		<key>044284FD1BAA365100D16268</key>
-		<dict>
-			<key>fileRef</key>
-			<string>205F0E0E1B371875007741D0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>044284FE1BAA387800D16268</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED461B17847A00DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>044284FF1BAA3BD600D16268</key>
-		<dict>
-			<key>fileRef</key>
-			<string>205F0E0D1B371875007741D0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>044285011BAA3CC700D16268</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.module-map</string>
-			<key>path</key>
-			<string>module.modulemap</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>044285051BAA63FE00D16268</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASBatchFetching.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>044285061BAA63FE00D16268</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASBatchFetching.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>044285081BAA63FE00D16268</key>
-		<dict>
-			<key>fileRef</key>
-			<string>044285051BAA63FE00D16268</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>044285091BAA63FE00D16268</key>
-		<dict>
-			<key>fileRef</key>
-			<string>044285061BAA63FE00D16268</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>0442850A1BAA63FE00D16268</key>
-		<dict>
-			<key>fileRef</key>
-			<string>044285061BAA63FE00D16268</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>0442850B1BAA64EC00D16268</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASMultidimensionalArrayUtils.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>0442850C1BAA64EC00D16268</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ASMultidimensionalArrayUtils.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>0442850E1BAA64EC00D16268</key>
-		<dict>
-			<key>fileRef</key>
-			<string>0442850B1BAA64EC00D16268</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>0442850F1BAA64EC00D16268</key>
-		<dict>
-			<key>fileRef</key>
-			<string>0442850C1BAA64EC00D16268</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>044285101BAA64EC00D16268</key>
-		<dict>
-			<key>fileRef</key>
-			<string>0442850C1BAA64EC00D16268</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>0515EA211A15769900BA8B9A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>051943141A1575670030A7D0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Weak</string>
-				</array>
-			</dict>
-		</dict>
-		<key>0515EA221A1576A100BA8B9A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>051943121A1575630030A7D0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>0516FA3A1A15563400B4EBED</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASAvailability.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>0516FA3B1A15563400B4EBED</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASLog.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>0516FA3E1A1563D200B4EBED</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASMultiplexImageNode.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>0516FA3F1A1563D200B4EBED</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ASMultiplexImageNode.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>0516FA411A1563D200B4EBED</key>
-		<dict>
-			<key>fileRef</key>
-			<string>0516FA3F1A1563D200B4EBED</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>051943121A1575630030A7D0</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>AssetsLibrary.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/AssetsLibrary.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>051943131A1575630030A7D0</key>
-		<dict>
-			<key>fileRef</key>
-			<string>051943121A1575630030A7D0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>051943141A1575670030A7D0</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>Photos.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/Photos.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>051943151A1575670030A7D0</key>
-		<dict>
-			<key>fileRef</key>
-			<string>051943141A1575670030A7D0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Weak</string>
-				</array>
-			</dict>
-		</dict>
-		<key>052EE0651A159FEF002C6279</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASMultiplexImageNodeTests.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>052EE0661A159FEF002C6279</key>
-		<dict>
-			<key>fileRef</key>
-			<string>052EE0651A159FEF002C6279</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>052EE06A1A15A0D8002C6279</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>folder</string>
-			<key>path</key>
-			<string>TestResources</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>052EE06B1A15A0D8002C6279</key>
-		<dict>
-			<key>fileRef</key>
-			<string>052EE06A1A15A0D8002C6279</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>054963471A1EA066000F8E56</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASBasicImageDownloader.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>054963481A1EA066000F8E56</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ASBasicImageDownloader.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>0549634A1A1EA066000F8E56</key>
-		<dict>
-			<key>fileRef</key>
-			<string>054963481A1EA066000F8E56</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>055B9FA61A1C154B00035D6D</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASNetworkImageNode.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>055B9FA71A1C154B00035D6D</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ASNetworkImageNode.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>055B9FA91A1C154B00035D6D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>055B9FA71A1C154B00035D6D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>055F1A3219ABD3E3004DAFF1</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>lineEnding</key>
-			<string>0</string>
-			<key>path</key>
-			<string>ASTableView.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>055F1A3319ABD3E3004DAFF1</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>lineEnding</key>
-			<string>0</string>
-			<key>path</key>
-			<string>ASTableView.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>055F1A3519ABD3E3004DAFF1</key>
-		<dict>
-			<key>fileRef</key>
-			<string>055F1A3319ABD3E3004DAFF1</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>055F1A3619ABD413004DAFF1</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASRangeController.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>055F1A3719ABD413004DAFF1</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ASRangeController.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>055F1A3919ABD413004DAFF1</key>
-		<dict>
-			<key>fileRef</key>
-			<string>055F1A3719ABD413004DAFF1</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>055F1A3A19ABD43F004DAFF1</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASCellNode.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>056D21501ABCEDA1001107EF</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASSnapshotTestCase.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>056D21541ABCEF50001107EF</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASImageNodeSnapshotTests.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>056D21551ABCEF50001107EF</key>
-		<dict>
-			<key>fileRef</key>
-			<string>056D21541ABCEF50001107EF</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>0574D5E119C110610097DC25</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASTableViewProtocols.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>057D02BB1AC0A66700C7AC3C</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>057D02C71AC0A66700C7AC3C</string>
-				<string>057D02C41AC0A66700C7AC3C</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>057D02BC1AC0A66700C7AC3C</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>DE0702FC1C3671E900D7DE62</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>057D02BD1AC0A66700C7AC3C</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>204C979E1B362CB3002B1083</string>
-			</array>
-			<key>isa</key>
-			<string>PBXResourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>057D02BE1AC0A66700C7AC3C</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>057D02E31AC0A66800C7AC3C</string>
-			<key>buildPhases</key>
-			<array>
-				<string>057D02BB1AC0A66700C7AC3C</string>
-				<string>057D02BC1AC0A66700C7AC3C</string>
-				<string>057D02BD1AC0A66700C7AC3C</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array>
-				<string>DEACA2B21C425DC400FA9DDF</string>
-			</array>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>AsyncDisplayKitTestHost</string>
-			<key>productName</key>
-			<string>AsyncDisplayKitTestHost</string>
-			<key>productReference</key>
-			<string>057D02BF1AC0A66700C7AC3C</string>
-			<key>productType</key>
-			<string>com.apple.product-type.application</string>
-		</dict>
-		<key>057D02BF1AC0A66700C7AC3C</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.application</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>AsyncDisplayKitTestHost.app</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>057D02C01AC0A66700C7AC3C</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>204C979D1B362CB3002B1083</string>
-				<string>057D02C51AC0A66700C7AC3C</string>
-				<string>057D02C61AC0A66700C7AC3C</string>
-				<string>057D02C11AC0A66700C7AC3C</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>AsyncDisplayKitTestHost</string>
-			<key>path</key>
-			<string>../AsyncDisplayKitTestHost</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>057D02C11AC0A66700C7AC3C</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>057D02C21AC0A66700C7AC3C</string>
-				<string>057D02C31AC0A66700C7AC3C</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Supporting Files</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>057D02C21AC0A66700C7AC3C</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>057D02C31AC0A66700C7AC3C</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>main.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>057D02C41AC0A66700C7AC3C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>057D02C31AC0A66700C7AC3C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>057D02C51AC0A66700C7AC3C</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>AppDelegate.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>057D02C61AC0A66700C7AC3C</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>AppDelegate.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>057D02C71AC0A66700C7AC3C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>057D02C61AC0A66700C7AC3C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>057D02DF1AC0A66800C7AC3C</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ASSETCATALOG_COMPILER_APPICON_NAME</key>
-				<string>AppIcon</string>
-				<key>CLANG_WARN_UNREACHABLE_CODE</key>
-				<string>YES</string>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>GCC_INSTRUMENT_PROGRAM_FLOW_ARCS</key>
-				<string>NO</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>INFOPLIST_FILE</key>
-				<string>AsyncDisplayKitTestHost/Info.plist</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.1</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<string>$(inherited) @executable_path/Frameworks</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>YES</string>
-				<key>PRODUCT_BUNDLE_IDENTIFIER</key>
-				<string>com.facebook.$(PRODUCT_NAME:rfc1034identifier)</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>057D02E01AC0A66800C7AC3C</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ASSETCATALOG_COMPILER_APPICON_NAME</key>
-				<string>AppIcon</string>
-				<key>CLANG_WARN_UNREACHABLE_CODE</key>
-				<string>YES</string>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>GCC_INSTRUMENT_PROGRAM_FLOW_ARCS</key>
-				<string>NO</string>
-				<key>INFOPLIST_FILE</key>
-				<string>AsyncDisplayKitTestHost/Info.plist</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.1</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<string>$(inherited) @executable_path/Frameworks</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>NO</string>
-				<key>PRODUCT_BUNDLE_IDENTIFIER</key>
-				<string>com.facebook.$(PRODUCT_NAME:rfc1034identifier)</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>057D02E31AC0A66800C7AC3C</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>057D02DF1AC0A66800C7AC3C</string>
-				<string>057D02E01AC0A66800C7AC3C</string>
-				<string>DB1020831CBCA2AD00FA6FE1</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>057D02E51AC0A67000C7AC3C</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>058D09A4195D04C000B7D73C</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>057D02BE1AC0A66700C7AC3C</string>
-			<key>remoteInfo</key>
-			<string>AsyncDisplayKitTestHost</string>
-		</dict>
-		<key>057D02E61AC0A67000C7AC3C</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>target</key>
-			<string>057D02BE1AC0A66700C7AC3C</string>
-			<key>targetProxy</key>
-			<string>057D02E51AC0A67000C7AC3C</string>
-		</dict>
-		<key>0587F9BB1A7309ED00AFF0BA</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASEditableTextNode.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>0587F9BC1A7309ED00AFF0BA</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>lineEnding</key>
-			<string>0</string>
-			<key>path</key>
-			<string>ASEditableTextNode.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>0587F9BE1A7309ED00AFF0BA</key>
-		<dict>
-			<key>fileRef</key>
-			<string>0587F9BC1A7309ED00AFF0BA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>058D09A3195D04C000B7D73C</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>058D09B1195D04C000B7D73C</string>
-				<string>058D09C5195D04C000B7D73C</string>
-				<string>B35061DB1B010EDF0018CF92</string>
-				<string>058D09AE195D04C000B7D73C</string>
-				<string>058D09AD195D04C000B7D73C</string>
-				<string>FD40E2760492F0CAAEAD552D</string>
-			</array>
-			<key>indentWidth</key>
-			<string>2</string>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-			<key>tabWidth</key>
-			<string>2</string>
-			<key>usesTabs</key>
-			<string>0</string>
-		</dict>
-		<key>058D09A4195D04C000B7D73C</key>
-		<dict>
-			<key>attributes</key>
-			<dict>
-				<key>CLASSPREFIX</key>
-				<string>AS</string>
-				<key>LastUpgradeCheck</key>
-				<string>0720</string>
-				<key>ORGANIZATIONNAME</key>
-				<string>Facebook</string>
-				<key>TargetAttributes</key>
-				<dict>
-					<key>057D02BE1AC0A66700C7AC3C</key>
-					<dict>
-						<key>CreatedOnToolsVersion</key>
-						<string>6.2</string>
-					</dict>
-					<key>058D09BB195D04C000B7D73C</key>
-					<dict>
-						<key>TestTargetID</key>
-						<string>057D02BE1AC0A66700C7AC3C</string>
-					</dict>
-					<key>B35061D91B010EDF0018CF92</key>
-					<dict>
-						<key>CreatedOnToolsVersion</key>
-						<string>6.3.1</string>
-					</dict>
-				</dict>
-			</dict>
-			<key>buildConfigurationList</key>
-			<string>058D09A7195D04C000B7D73C</string>
-			<key>compatibilityVersion</key>
-			<string>Xcode 3.2</string>
-			<key>developmentRegion</key>
-			<string>English</string>
-			<key>hasScannedForEncodings</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXProject</string>
-			<key>knownRegions</key>
-			<array>
-				<string>en</string>
-				<string>Base</string>
-			</array>
-			<key>mainGroup</key>
-			<string>058D09A3195D04C000B7D73C</string>
-			<key>productRefGroup</key>
-			<string>058D09AD195D04C000B7D73C</string>
-			<key>projectDirPath</key>
-			<string></string>
-			<key>projectReferences</key>
-			<array/>
-			<key>projectRoot</key>
-			<string></string>
-			<key>targets</key>
-			<array>
-				<string>058D09AB195D04C000B7D73C</string>
-				<string>058D09BB195D04C000B7D73C</string>
-				<string>057D02BE1AC0A66700C7AC3C</string>
-				<string>B35061D91B010EDF0018CF92</string>
-			</array>
-		</dict>
-		<key>058D09A7195D04C000B7D73C</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>058D09CD195D04C000B7D73C</string>
-				<string>058D09CE195D04C000B7D73C</string>
-				<string>DB1020801CBCA2AD00FA6FE1</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>058D09A8195D04C000B7D73C</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>058D0A22195D050800B7D73C</string>
-				<string>8B0768B41CE752EC002E1453</string>
-				<string>E55D86321CA8A14000A0C26F</string>
-				<string>68FC85E41CE29B7E00EDD713</string>
-				<string>058D0A23195D050800B7D73C</string>
-				<string>058D0A24195D050800B7D73C</string>
-				<string>68355B3A1CB57A5A001D4E68</string>
-				<string>DBDB83961C6E879900D0098C</string>
-				<string>058D0A26195D050800B7D73C</string>
-				<string>257754B41BEE44CD00737CA5</string>
-				<string>68B8A4E31CBDB958007E4543</string>
-				<string>69E1006F1CA89CB600D88C1B</string>
-				<string>AC026B711BD57DBF00BBC17E</string>
-				<string>257754BF1BEE458E00737CA5</string>
-				<string>058D0A18195D050800B7D73C</string>
-				<string>68355B3C1CB57A5A001D4E68</string>
-				<string>68EE0DBF1C1B4ED300BA1B99</string>
-				<string>058D0A19195D050800B7D73C</string>
-				<string>9C55866A1BD549CB00B50E3A</string>
-				<string>69708BA71D76386D005C3CF9</string>
-				<string>058D0A27195D050800B7D73C</string>
-				<string>205F0E1A1B37339C007741D0</string>
-				<string>ACF6ED1B1B17843500DA7C62</string>
-				<string>0549634A1A1EA066000F8E56</string>
-				<string>299DA1AA1A828D2900162D41</string>
-				<string>AC6456091B0A335000CF11B8</string>
-				<string>DE8BEAC31C2DF3FC00D57C12</string>
-				<string>ACF6ED1D1B17843500DA7C62</string>
-				<string>18C2ED801B9B7DE800F627B3</string>
-				<string>92DD2FE41BF4B97E0074C9DD</string>
-				<string>DBC452DC1C5BF64600B16017</string>
-				<string>AC3C4A521A1139C100143C57</string>
-				<string>9CFFC6C21CCAC768006A6476</string>
-				<string>205F0E1E1B373A2C007741D0</string>
-				<string>68FC85EB1CE29C7D00EDD713</string>
-				<string>058D0A13195D050800B7D73C</string>
-				<string>464052211A3F83C40061C0BA</string>
-				<string>B30BF6531C5964B0004FCD53</string>
-				<string>05A6D05B19D0EB64002DD95E</string>
-				<string>ACF6ED211B17843500DA7C62</string>
-				<string>8021EC1E1D2B00B100799119</string>
-				<string>058D0A28195D050800B7D73C</string>
-				<string>058D0A29195D050800B7D73C</string>
-				<string>764D83D61C8EA515009B4FB8</string>
-				<string>058D0A2A195D050800B7D73C</string>
-				<string>25E327581C16819500A2170C</string>
-				<string>058D0A14195D050800B7D73C</string>
-				<string>DEC146B81C37A16A004A0EE7</string>
-				<string>058D0A15195D050800B7D73C</string>
-				<string>AEEC47E21C20C2DD00EC1693</string>
-				<string>0587F9BE1A7309ED00AFF0BA</string>
-				<string>464052231A3F83C40061C0BA</string>
-				<string>257754C41BEE458E00737CA5</string>
-				<string>058D0A1A195D050800B7D73C</string>
-				<string>058D0A2B195D050800B7D73C</string>
-				<string>CC3B208B1C3F7A5400798563</string>
-				<string>058D0A16195D050800B7D73C</string>
-				<string>430E7C911B4C23F100697A4C</string>
-				<string>ACF6ED231B17843500DA7C62</string>
-				<string>ACF6ED4C1B17847A00DA7C62</string>
-				<string>68FC85DF1CE29AB700EDD713</string>
-				<string>ACF6ED251B17843500DA7C62</string>
-				<string>CC4981BD1D1C7F65004E13CC</string>
-				<string>DB55C2631C6408D6004EDCF5</string>
-				<string>92074A631CC8BA1900918F75</string>
-				<string>CC446A301D80AAE00071FD03</string>
-				<string>251B8EFA1BBB3D690087C538</string>
-				<string>ACF6ED271B17843500DA7C62</string>
-				<string>257754B01BEE44CD00737CA5</string>
-				<string>0516FA411A1563D200B4EBED</string>
-				<string>DECBD6E91BE56E1900CF4905</string>
-				<string>058D0A1B195D050800B7D73C</string>
-				<string>055B9FA91A1C154B00035D6D</string>
-				<string>AEB7B01B1C5962EA00662EF4</string>
-				<string>CC3B20851C3F76D600798563</string>
-				<string>ACF6ED2C1B17843500DA7C62</string>
-				<string>0442850F1BAA64EC00D16268</string>
-				<string>7A06A73A1C35F08800FE8DAA</string>
-				<string>E52405B31C8FEF03004DC8E7</string>
-				<string>69CB62AD1CB8165900024920</string>
-				<string>257754AB1BEE44CD00737CA5</string>
-				<string>055F1A3919ABD413004DAFF1</string>
-				<string>044285091BAA63FE00D16268</string>
-				<string>257754AE1BEE44CD00737CA5</string>
-				<string>ACF6ED2E1B17843500DA7C62</string>
-				<string>AC47D9461B3BB41900AAEE9D</string>
-				<string>CC4C2A781D88E3BF0039ACAB</string>
-				<string>205F0E121B371BD7007741D0</string>
-				<string>9C8898BB1C738B9800D6B02E</string>
-				<string>D785F6631A74327E00291744</string>
-				<string>E5711A2E1C840C96009619D4</string>
-				<string>058D0A2C195D050800B7D73C</string>
-				<string>9C8221971BA237B80037F19A</string>
-				<string>251B8EF81BBB3D690087C538</string>
-				<string>ACF6ED301B17843500DA7C62</string>
-				<string>257754BE1BEE458E00737CA5</string>
-				<string>257754A91BEE44CD00737CA5</string>
-				<string>697C0DE51CF38F28001DE0D4</string>
-				<string>ACF6ED501B17847A00DA7C62</string>
-				<string>ACF6ED521B17847A00DA7C62</string>
-				<string>83A7D95A1D44542100BF333E</string>
-				<string>257754A61BEE44CD00737CA5</string>
-				<string>81EE38501C8E94F000456208</string>
-				<string>9C70F2041CDA4EFA007D6C76</string>
-				<string>92074A691CC8BADA00918F75</string>
-				<string>ACF6ED321B17843500DA7C62</string>
-				<string>AC026B6B1BD57D6F00BBC17E</string>
-				<string>68355B311CB5799E001D4E68</string>
-				<string>9CFFC6C01CCAC73C006A6476</string>
-				<string>055F1A3519ABD3E3004DAFF1</string>
-				<string>6959433E1D70815300B0EE1F</string>
-				<string>058D0A17195D050800B7D73C</string>
-				<string>257754AC1BEE44CD00737CA5</string>
-				<string>8BDA5FC61CDBDDE1007D13B2</string>
-				<string>205F0E221B376416007741D0</string>
-				<string>257754B21BEE44CD00737CA5</string>
-				<string>9CFFC6BE1CCAC52B006A6476</string>
-				<string>058D0A21195D050800B7D73C</string>
-				<string>205F0E101B371875007741D0</string>
-				<string>CC7FD9DF1BB5E962005CCB2B</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>058D09A9195D04C000B7D73C</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>92DD2FE91BF4D4870074C9DD</string>
-				<string>051943151A1575670030A7D0</string>
-				<string>051943131A1575630030A7D0</string>
-				<string>058D09B0195D04C000B7D73C</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>058D09AA195D04C000B7D73C</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>dstPath</key>
-			<string>include/$(PRODUCT_NAME)</string>
-			<key>dstSubfolderSpec</key>
-			<string>16</string>
-			<key>files</key>
-			<array>
-				<string>CC4C2A7A1D8902350039ACAB</string>
-				<string>CC88F7AE1D80AF5E000D6D4E</string>
-				<string>F7CE6C981D2CDB5800BE4C15</string>
-				<string>F7CE6CB71D2CE2D000BE4C15</string>
-				<string>F7CE6C131D2CDB3E00BE4C15</string>
-				<string>F7CE6C141D2CDB3E00BE4C15</string>
-				<string>F7CE6C151D2CDB3E00BE4C15</string>
-				<string>F7CE6C161D2CDB3E00BE4C15</string>
-				<string>F7CE6C171D2CDB3E00BE4C15</string>
-				<string>F7CE6C181D2CDB3E00BE4C15</string>
-				<string>F7CE6C191D2CDB3E00BE4C15</string>
-				<string>F7CE6C1A1D2CDB3E00BE4C15</string>
-				<string>F7CE6C1B1D2CDB3E00BE4C15</string>
-				<string>F7CE6C1C1D2CDB3E00BE4C15</string>
-				<string>F7CE6C1D1D2CDB3E00BE4C15</string>
-				<string>F7CE6C1E1D2CDB3E00BE4C15</string>
-				<string>F7CE6C1F1D2CDB3E00BE4C15</string>
-				<string>F7CE6C201D2CDB3E00BE4C15</string>
-				<string>F7CE6C211D2CDB3E00BE4C15</string>
-				<string>F7CE6C221D2CDB3E00BE4C15</string>
-				<string>F7CE6C231D2CDB3E00BE4C15</string>
-				<string>F7CE6C241D2CDB3E00BE4C15</string>
-				<string>F7CE6C251D2CDB3E00BE4C15</string>
-				<string>F7CE6C261D2CDB3E00BE4C15</string>
-				<string>F7CE6C271D2CDB3E00BE4C15</string>
-				<string>F7CE6C281D2CDB3E00BE4C15</string>
-				<string>F7CE6C291D2CDB3E00BE4C15</string>
-				<string>F7CE6C2A1D2CDB3E00BE4C15</string>
-				<string>F7CE6C2B1D2CDB3E00BE4C15</string>
-				<string>F7CE6C2C1D2CDB3E00BE4C15</string>
-				<string>F7CE6C2D1D2CDB3E00BE4C15</string>
-				<string>F7CE6C2E1D2CDB3E00BE4C15</string>
-				<string>F7CE6C2F1D2CDB3E00BE4C15</string>
-				<string>F7CE6C301D2CDB3E00BE4C15</string>
-				<string>F7CE6C311D2CDB3E00BE4C15</string>
-				<string>F7CE6C321D2CDB3E00BE4C15</string>
-				<string>F7CE6C331D2CDB3E00BE4C15</string>
-				<string>F7CE6C341D2CDB3E00BE4C15</string>
-				<string>F7CE6C351D2CDB3E00BE4C15</string>
-				<string>F7CE6C361D2CDB3E00BE4C15</string>
-				<string>F7CE6C371D2CDB3E00BE4C15</string>
-				<string>F7CE6C381D2CDB3E00BE4C15</string>
-				<string>F7CE6C391D2CDB3E00BE4C15</string>
-				<string>F7CE6C3A1D2CDB3E00BE4C15</string>
-				<string>F7CE6C3B1D2CDB3E00BE4C15</string>
-				<string>F7CE6C3D1D2CDB3E00BE4C15</string>
-				<string>F7CE6C3E1D2CDB3E00BE4C15</string>
-				<string>F7CE6C3F1D2CDB3E00BE4C15</string>
-				<string>F7CE6C401D2CDB3E00BE4C15</string>
-				<string>F7CE6C411D2CDB3E00BE4C15</string>
-				<string>F7CE6C421D2CDB3E00BE4C15</string>
-				<string>F7CE6C431D2CDB3E00BE4C15</string>
-				<string>F7CE6C441D2CDB3E00BE4C15</string>
-				<string>F7CE6C461D2CDB3E00BE4C15</string>
-				<string>F7CE6C471D2CDB3E00BE4C15</string>
-				<string>F7CE6C481D2CDB3E00BE4C15</string>
-				<string>F7CE6C491D2CDB3E00BE4C15</string>
-				<string>F7CE6C4A1D2CDB3E00BE4C15</string>
-				<string>F7CE6C4B1D2CDB3E00BE4C15</string>
-				<string>F7CE6C4C1D2CDB3E00BE4C15</string>
-				<string>F7CE6C4D1D2CDB3E00BE4C15</string>
-				<string>F7CE6C4E1D2CDB3E00BE4C15</string>
-				<string>F7CE6C4F1D2CDB3E00BE4C15</string>
-				<string>F7CE6C501D2CDB3E00BE4C15</string>
-				<string>F7CE6C511D2CDB3E00BE4C15</string>
-				<string>F7CE6C521D2CDB3E00BE4C15</string>
-				<string>F7CE6C531D2CDB3E00BE4C15</string>
-				<string>F7CE6C541D2CDB3E00BE4C15</string>
-				<string>F7CE6C551D2CDB3E00BE4C15</string>
-				<string>F7CE6C561D2CDB3E00BE4C15</string>
-				<string>F7CE6C571D2CDB3E00BE4C15</string>
-				<string>F7CE6C581D2CDB3E00BE4C15</string>
-				<string>F7CE6C5B1D2CDB3E00BE4C15</string>
-				<string>F7CE6C5C1D2CDB3E00BE4C15</string>
-				<string>F7CE6C5D1D2CDB3E00BE4C15</string>
-				<string>F7CE6C5E1D2CDB3E00BE4C15</string>
-				<string>F7CE6C5F1D2CDB3E00BE4C15</string>
-				<string>F7CE6C601D2CDB3E00BE4C15</string>
-				<string>F7CE6C611D2CDB3E00BE4C15</string>
-				<string>F7CE6C621D2CDB3E00BE4C15</string>
-				<string>F7CE6C631D2CDB3E00BE4C15</string>
-				<string>F7CE6C641D2CDB3E00BE4C15</string>
-				<string>F7CE6C651D2CDB3E00BE4C15</string>
-				<string>F7CE6C661D2CDB3E00BE4C15</string>
-				<string>F7CE6C671D2CDB3E00BE4C15</string>
-				<string>F7CE6C681D2CDB3E00BE4C15</string>
-				<string>F7CE6C691D2CDB3E00BE4C15</string>
-				<string>F7CE6C6A1D2CDB3E00BE4C15</string>
-				<string>F7CE6C6B1D2CDB3E00BE4C15</string>
-				<string>F7CE6C6C1D2CDB3E00BE4C15</string>
-				<string>F7CE6C6D1D2CDB3E00BE4C15</string>
-				<string>F7CE6C6E1D2CDB3E00BE4C15</string>
-				<string>F7CE6C6F1D2CDB3E00BE4C15</string>
-				<string>F7CE6C701D2CDB3E00BE4C15</string>
-				<string>F7CE6C711D2CDB3F00BE4C15</string>
-				<string>F7CE6C721D2CDB3F00BE4C15</string>
-				<string>F7CE6C731D2CDB3F00BE4C15</string>
-				<string>F7CE6C741D2CDB3F00BE4C15</string>
-				<string>F7CE6C751D2CDB3F00BE4C15</string>
-				<string>F7CE6C761D2CDB3F00BE4C15</string>
-				<string>F7CE6C771D2CDB3F00BE4C15</string>
-				<string>F7CE6C781D2CDB3F00BE4C15</string>
-				<string>F7CE6C791D2CDB3F00BE4C15</string>
-				<string>F7CE6C7B1D2CDB3F00BE4C15</string>
-				<string>F7CE6C7C1D2CDB3F00BE4C15</string>
-				<string>F7CE6C7D1D2CDB3F00BE4C15</string>
-				<string>F7CE6C7E1D2CDB3F00BE4C15</string>
-				<string>F7CE6C7F1D2CDB3F00BE4C15</string>
-				<string>F7CE6C801D2CDB5800BE4C15</string>
-				<string>F7CE6C811D2CDB5800BE4C15</string>
-				<string>F7CE6C821D2CDB5800BE4C15</string>
-				<string>F7CE6C831D2CDB5800BE4C15</string>
-				<string>F7CE6C841D2CDB5800BE4C15</string>
-				<string>F7CE6C851D2CDB5800BE4C15</string>
-				<string>F7CE6C861D2CDB5800BE4C15</string>
-				<string>F7CE6C871D2CDB5800BE4C15</string>
-				<string>F7CE6C451D2CDB3E00BE4C15</string>
-				<string>F7CE6C8B1D2CDB5800BE4C15</string>
-				<string>F7CE6C591D2CDB3E00BE4C15</string>
-				<string>F7CE6C5A1D2CDB3E00BE4C15</string>
-				<string>F7CE6C8C1D2CDB5800BE4C15</string>
-				<string>F7CE6C8D1D2CDB5800BE4C15</string>
-				<string>F7CE6C8F1D2CDB5800BE4C15</string>
-				<string>F7CE6C901D2CDB5800BE4C15</string>
-				<string>F7CE6C941D2CDB5800BE4C15</string>
-				<string>F7CE6C951D2CDB5800BE4C15</string>
-				<string>F7CE6C961D2CDB5800BE4C15</string>
-				<string>F7CE6C971D2CDB5800BE4C15</string>
-				<string>F7CE6C991D2CDB5800BE4C15</string>
-				<string>F7CE6C9A1D2CDB5800BE4C15</string>
-				<string>F7CE6C9B1D2CDB5800BE4C15</string>
-				<string>F7CE6C9C1D2CDB5800BE4C15</string>
-				<string>F7CE6C9D1D2CDB5800BE4C15</string>
-				<string>F7CE6C9E1D2CDB5800BE4C15</string>
-				<string>F7CE6C9F1D2CDB5800BE4C15</string>
-				<string>F7CE6CA01D2CDB5800BE4C15</string>
-				<string>F7CE6CA11D2CDB5800BE4C15</string>
-				<string>F7CE6CA21D2CDB5800BE4C15</string>
-				<string>F7CE6CA31D2CDB5800BE4C15</string>
-				<string>F7CE6CA41D2CDB5800BE4C15</string>
-			</array>
-			<key>isa</key>
-			<string>PBXCopyFilesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>058D09AB195D04C000B7D73C</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>058D09CF195D04C000B7D73C</string>
-			<key>buildPhases</key>
-			<array>
-				<string>058D09A8195D04C000B7D73C</string>
-				<string>058D09A9195D04C000B7D73C</string>
-				<string>058D09AA195D04C000B7D73C</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>AsyncDisplayKit</string>
-			<key>productName</key>
-			<string>AsyncDisplayKit</string>
-			<key>productReference</key>
-			<string>058D09AC195D04C000B7D73C</string>
-			<key>productType</key>
-			<string>com.apple.product-type.library.static</string>
-		</dict>
-		<key>058D09AC195D04C000B7D73C</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>libAsyncDisplayKit.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>058D09AD195D04C000B7D73C</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>058D09AC195D04C000B7D73C</string>
-				<string>058D09BC195D04C000B7D73C</string>
-				<string>057D02BF1AC0A66700C7AC3C</string>
-				<string>B35061DA1B010EDF0018CF92</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Products</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D09AE195D04C000B7D73C</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>92DD2FE51BF4D05E0074C9DD</string>
-				<string>051943141A1575670030A7D0</string>
-				<string>051943121A1575630030A7D0</string>
-				<string>058D09AF195D04C000B7D73C</string>
-				<string>058D09BD195D04C000B7D73C</string>
-				<string>058D09C0195D04C000B7D73C</string>
-				<string>EFA731F0396842FF8AB635EE</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Frameworks</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D09AF195D04C000B7D73C</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>Foundation.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/Foundation.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>058D09B0195D04C000B7D73C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09AF195D04C000B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>058D09B1195D04C000B7D73C</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>DBDB83921C6E879900D0098C</string>
-				<string>DBDB83931C6E879900D0098C</string>
-				<string>92DD2FE11BF4B97E0074C9DD</string>
-				<string>92DD2FE21BF4B97E0074C9DD</string>
-				<string>AEEC47DF1C20C2DD00EC1693</string>
-				<string>AEEC47E01C20C2DD00EC1693</string>
-				<string>8BDA5FC31CDBDDE1007D13B2</string>
-				<string>8BDA5FC41CDBDDE1007D13B2</string>
-				<string>055F1A3A19ABD43F004DAFF1</string>
-				<string>AC6456071B0A335000CF11B8</string>
-				<string>18C2ED7C1B9B7DE800F627B3</string>
-				<string>18C2ED7D1B9B7DE800F627B3</string>
-				<string>B13CA0FF1C52004900E031AB</string>
-				<string>AC3C4A4F1A1139C100143C57</string>
-				<string>AC3C4A501A1139C100143C57</string>
-				<string>AC3C4A531A113EEC00143C57</string>
-				<string>B13CA0F61C519E9400E031AB</string>
-				<string>DEC146B41C37A16A004A0EE7</string>
-				<string>DEC146B51C37A16A004A0EE7</string>
-				<string>058D09D5195D050800B7D73C</string>
-				<string>058D09D6195D050800B7D73C</string>
-				<string>DECBD6E51BE56E1900CF4905</string>
-				<string>DECBD6E61BE56E1900CF4905</string>
-				<string>058D09D7195D050800B7D73C</string>
-				<string>058D09D8195D050800B7D73C</string>
-				<string>058D09D9195D050800B7D73C</string>
-				<string>68B027791C1A79CC0041016B</string>
-				<string>683489271D70DE3400327501</string>
-				<string>058D09DA195D050800B7D73C</string>
-				<string>058D09DB195D050800B7D73C</string>
-				<string>058D09DC195D050800B7D73C</string>
-				<string>0587F9BB1A7309ED00AFF0BA</string>
-				<string>0587F9BC1A7309ED00AFF0BA</string>
-				<string>058D09DD195D050800B7D73C</string>
-				<string>058D09DE195D050800B7D73C</string>
-				<string>68355B2E1CB5799E001D4E68</string>
-				<string>8021EC1A1D2B00B100799119</string>
-				<string>8021EC1B1D2B00B100799119</string>
-				<string>0516FA3E1A1563D200B4EBED</string>
-				<string>0516FA3F1A1563D200B4EBED</string>
-				<string>68FC85DC1CE29AB700EDD713</string>
-				<string>68FC85DD1CE29AB700EDD713</string>
-				<string>055B9FA61A1C154B00035D6D</string>
-				<string>055B9FA71A1C154B00035D6D</string>
-				<string>25E327541C16819500A2170C</string>
-				<string>25E327551C16819500A2170C</string>
-				<string>A2763D771CBDD57D00A9ADBD</string>
-				<string>A2763D781CBDD57D00A9ADBD</string>
-				<string>D785F6601A74327E00291744</string>
-				<string>D785F6611A74327E00291744</string>
-				<string>68FC85E01CE29B7E00EDD713</string>
-				<string>68FC85E11CE29B7E00EDD713</string>
-				<string>B0F880581BEAEC7500D17647</string>
-				<string>9CFFC6C11CCAC768006A6476</string>
-				<string>055F1A3219ABD3E3004DAFF1</string>
-				<string>055F1A3319ABD3E3004DAFF1</string>
-				<string>AC7A2C161BDE11DF0093FE1A</string>
-				<string>0574D5E119C110610097DC25</string>
-				<string>058D09DF195D050800B7D73C</string>
-				<string>A373200E1C571B050011FC94</string>
-				<string>058D09E0195D050800B7D73C</string>
-				<string>ACC945A81BA9E7A0005E1FB8</string>
-				<string>9CFFC6BF1CCAC73C006A6476</string>
-				<string>6BDC61F51978FEA400E50D21</string>
-				<string>764D83D21C8EA515009B4FB8</string>
-				<string>764D83D31C8EA515009B4FB8</string>
-				<string>DB55C2651C641AE4004EDCF5</string>
-				<string>68FC85E71CE29C7D00EDD713</string>
-				<string>68FC85E81CE29C7D00EDD713</string>
-				<string>92074A5E1CC8B9DD00918F75</string>
-				<string>058D09E1195D050800B7D73C</string>
-				<string>058D0A01195D050800B7D73C</string>
-				<string>AC6456051B0A333200CF11B8</string>
-				<string>257754661BED245B00737CA5</string>
-				<string>058D09B2195D04C000B7D73C</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>AsyncDisplayKit</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D09B2195D04C000B7D73C</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>058D0A42195D058D00B7D73C</string>
-				<string>058D09B3195D04C000B7D73C</string>
-				<string>044285011BAA3CC700D16268</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Supporting Files</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D09B3195D04C000B7D73C</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>AsyncDisplayKit-Prefix.pch</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D09B8195D04C000B7D73C</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>29CDC2E21AAE70D000833CA4</string>
-				<string>CC051F1F1D7A286A006434CB</string>
-				<string>242995D31B29743C00090100</string>
-				<string>296A0A351A951ABF005ACEAA</string>
-				<string>ACF6ED5C1B178DC700DA7C62</string>
-				<string>9F06E5CD1B4CAF4200F015D8</string>
-				<string>2911485C1A77147A005D0878</string>
-				<string>CC3B208E1C3F7D0A00798563</string>
-				<string>F711994E1D20C21100568860</string>
-				<string>ACF6ED5D1B178DC700DA7C62</string>
-				<string>CCA221D31D6FA7EF00AF6A0F</string>
-				<string>058D0A38195D057000B7D73C</string>
-				<string>2538B6F31BC5D2A2003CA0B4</string>
-				<string>058D0A39195D057000B7D73C</string>
-				<string>CCB2F34D1D63CCC6004E6DE9</string>
-				<string>058D0A3A195D057000B7D73C</string>
-				<string>696FCB311D6E46050093471E</string>
-				<string>CC4981B31D1A02BE004E13CC</string>
-				<string>CC54A81E1D7008B300296A24</string>
-				<string>058D0A3B195D057000B7D73C</string>
-				<string>83A7D95E1D446A6E00BF333E</string>
-				<string>056D21551ABCEF50001107EF</string>
-				<string>AC026B581BD3F61800BBC17E</string>
-				<string>ACF6ED5E1B178DC700DA7C62</string>
-				<string>ACF6ED601B178DC700DA7C62</string>
-				<string>CC7FD9E11BB5F750005CCB2B</string>
-				<string>052EE0661A159FEF002C6279</string>
-				<string>058D0A3C195D057000B7D73C</string>
-				<string>CC8B05D81D73979700F54286</string>
-				<string>697B315A1CFE4B410049936F</string>
-				<string>ACF6ED611B178DC700DA7C62</string>
-				<string>CC8B05D61D73836400F54286</string>
-				<string>CC0AEEA41D66316E005D1C78</string>
-				<string>69B225671D72535E00B25B22</string>
-				<string>ACF6ED621B178DC700DA7C62</string>
-				<string>7AB338691C55B97B0055FDE8</string>
-				<string>254C6B541BF8FF2A003EC431</string>
-				<string>05EA6FE71AC0966E00E35788</string>
-				<string>ACF6ED631B178DC700DA7C62</string>
-				<string>81E95C141D62639600336598</string>
-				<string>3C9C128519E616EF00E942A0</string>
-				<string>AEEC47E41C21D3D200EC1693</string>
-				<string>254C6B521BF8FE6D003EC431</string>
-				<string>058D0A3D195D057000B7D73C</string>
-				<string>CC3B20901C3F892D00798563</string>
-				<string>058D0A40195D057000B7D73C</string>
-				<string>DBC453221C5FD97200B16017</string>
-				<string>058D0A41195D057000B7D73C</string>
-				<string>DBC452DE1C5C6A6A00B16017</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>058D09B9195D04C000B7D73C</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>92DD2FEA1BF4D49B0074C9DD</string>
-				<string>0515EA221A1576A100BA8B9A</string>
-				<string>0515EA211A15769900BA8B9A</string>
-				<string>058D09BE195D04C000B7D73C</string>
-				<string>058D09C1195D04C000B7D73C</string>
-				<string>058D09C4195D04C000B7D73C</string>
-				<string>058D09BF195D04C000B7D73C</string>
-				<string>DB7121BCD50849C498C886FB</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>058D09BA195D04C000B7D73C</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>052EE06B1A15A0D8002C6279</string>
-				<string>058D09CA195D04C000B7D73C</string>
-			</array>
-			<key>isa</key>
-			<string>PBXResourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>058D09BB195D04C000B7D73C</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>058D09D2195D04C000B7D73C</string>
-			<key>buildPhases</key>
-			<array>
-				<string>6FC88520799A02B99A34AE39</string>
-				<string>2E61B6A0DB0F436A9DDBE86F</string>
-				<string>058D09B8195D04C000B7D73C</string>
-				<string>058D09B9195D04C000B7D73C</string>
-				<string>058D09BA195D04C000B7D73C</string>
-				<string>3B9D88CDF51B429C8409E4B6</string>
-				<string>B130AB1AC0A1E5162E211C19</string>
-				<string>8263A58A38B225EFD5108DAB</string>
-				<string>7095785F8A59BE64AD3E4C7E</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array>
-				<string>058D09C3195D04C000B7D73C</string>
-				<string>057D02E61AC0A67000C7AC3C</string>
-			</array>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>AsyncDisplayKitTests</string>
-			<key>productName</key>
-			<string>AsyncDisplayKitTests</string>
-			<key>productReference</key>
-			<string>058D09BC195D04C000B7D73C</string>
-			<key>productType</key>
-			<string>com.apple.product-type.bundle.unit-test</string>
-		</dict>
-		<key>058D09BC195D04C000B7D73C</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.cfbundle</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>AsyncDisplayKitTests.xctest</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>058D09BD195D04C000B7D73C</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>XCTest.framework</string>
-			<key>path</key>
-			<string>Library/Frameworks/XCTest.framework</string>
-			<key>sourceTree</key>
-			<string>DEVELOPER_DIR</string>
-		</dict>
-		<key>058D09BE195D04C000B7D73C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09BD195D04C000B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>058D09BF195D04C000B7D73C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09AF195D04C000B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>058D09C0195D04C000B7D73C</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>UIKit.framework</string>
-			<key>path</key>
-			<string>Library/Frameworks/UIKit.framework</string>
-			<key>sourceTree</key>
-			<string>DEVELOPER_DIR</string>
-		</dict>
-		<key>058D09C1195D04C000B7D73C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09C0195D04C000B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>058D09C2195D04C000B7D73C</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>058D09A4195D04C000B7D73C</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>058D09AB195D04C000B7D73C</string>
-			<key>remoteInfo</key>
-			<string>AsyncDisplayKit</string>
-		</dict>
-		<key>058D09C3195D04C000B7D73C</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>target</key>
-			<string>058D09AB195D04C000B7D73C</string>
-			<key>targetProxy</key>
-			<string>058D09C2195D04C000B7D73C</string>
-		</dict>
-		<key>058D09C4195D04C000B7D73C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09AC195D04C000B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>058D09C5195D04C000B7D73C</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>CC051F1E1D7A286A006434CB</string>
-				<string>CC8B05D71D73979700F54286</string>
-				<string>CC8B05D41D73836400F54286</string>
-				<string>CC8B05D51D73836400F54286</string>
-				<string>69B225681D7265DA00B25B22</string>
-				<string>CC54A81D1D7008B300296A24</string>
-				<string>CCA221D21D6FA7EF00AF6A0F</string>
-				<string>CC0AEEA31D66316E005D1C78</string>
-				<string>CCB2F34C1D63CCC6004E6DE9</string>
-				<string>83A7D95D1D446A6E00BF333E</string>
-				<string>DBC453211C5FD97200B16017</string>
-				<string>DBC452DD1C5C6A6A00B16017</string>
-				<string>CC3B208F1C3F892D00798563</string>
-				<string>CC3B208D1C3F7D0A00798563</string>
-				<string>057D02C01AC0A66700C7AC3C</string>
-				<string>056D21501ABCEDA1001107EF</string>
-				<string>05EA6FE61AC0966E00E35788</string>
-				<string>056D21541ABCEF50001107EF</string>
-				<string>ACF6ED531B178DC700DA7C62</string>
-				<string>7AB338681C55B97B0055FDE8</string>
-				<string>ACF6ED551B178DC700DA7C62</string>
-				<string>ACF6ED591B178DC700DA7C62</string>
-				<string>696FCB301D6E46050093471E</string>
-				<string>ACF6ED5A1B178DC700DA7C62</string>
-				<string>ACF6ED5B1B178DC700DA7C62</string>
-				<string>AC026B571BD3F61800BBC17E</string>
-				<string>81E95C131D62639600336598</string>
-				<string>ACF6ED571B178DC700DA7C62</string>
-				<string>ACF6ED581B178DC700DA7C62</string>
-				<string>242995D21B29743C00090100</string>
-				<string>29CDC2E11AAE70D000833CA4</string>
-				<string>CC7FD9E01BB5F750005CCB2B</string>
-				<string>296A0A341A951ABF005ACEAA</string>
-				<string>9F06E5CC1B4CAF4200F015D8</string>
-				<string>2911485B1A77147A005D0878</string>
-				<string>ACF6ED541B178DC700DA7C62</string>
-				<string>058D0A2D195D057000B7D73C</string>
-				<string>058D0A2E195D057000B7D73C</string>
-				<string>058D0A2F195D057000B7D73C</string>
-				<string>69B225661D72535E00B25B22</string>
-				<string>058D0A30195D057000B7D73C</string>
-				<string>058D0A31195D057000B7D73C</string>
-				<string>697B31591CFE4B410049936F</string>
-				<string>052EE0651A159FEF002C6279</string>
-				<string>058D0A32195D057000B7D73C</string>
-				<string>3C9C128419E616EF00E942A0</string>
-				<string>CC4981B21D1A02BE004E13CC</string>
-				<string>058D0A33195D057000B7D73C</string>
-				<string>254C6B511BF8FE6D003EC431</string>
-				<string>254C6B531BF8FF2A003EC431</string>
-				<string>058D0A36195D057000B7D73C</string>
-				<string>058D0A37195D057000B7D73C</string>
-				<string>AEEC47E31C21D3D200EC1693</string>
-				<string>F711994D1D20C21100568860</string>
-				<string>058D09C6195D04C000B7D73C</string>
-				<string>052EE06A1A15A0D8002C6279</string>
-				<string>2538B6F21BC5D2A2003CA0B4</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>AsyncDisplayKitTests</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D09C6195D04C000B7D73C</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>058D09C7195D04C000B7D73C</string>
-				<string>058D09C8195D04C000B7D73C</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Supporting Files</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D09C7195D04C000B7D73C</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>AsyncDisplayKitTests-Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D09C8195D04C000B7D73C</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>058D09C9195D04C000B7D73C</string>
-			</array>
-			<key>isa</key>
-			<string>PBXVariantGroup</string>
-			<key>name</key>
-			<string>InfoPlist.strings</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D09C9195D04C000B7D73C</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.strings</string>
-			<key>name</key>
-			<string>en</string>
-			<key>path</key>
-			<string>en.lproj/InfoPlist.strings</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D09CA195D04C000B7D73C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09C8195D04C000B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>058D09CD195D04C000B7D73C</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>c++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_CODE_COVERAGE</key>
-				<string>NO</string>
-				<key>CLANG_ENABLE_MODULES</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
-				<string>YES</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>ENABLE_TESTABILITY</key>
-				<string>YES</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_DYNAMIC_NO_PIC</key>
-				<string>NO</string>
-				<key>GCC_GENERATE_TEST_COVERAGE_FILES</key>
-				<string>YES</string>
-				<key>GCC_INSTRUMENT_PROGRAM_FLOW_ARCS</key>
-				<string>YES</string>
-				<key>GCC_OPTIMIZATION_LEVEL</key>
-				<string>0</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
-				<string>NO</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES_ERROR</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES_AGGRESSIVE</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.1</string>
-				<key>ONLY_ACTIVE_ARCH</key>
-				<string>YES</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>058D09CE195D04C000B7D73C</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>c++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_CODE_COVERAGE</key>
-				<string>NO</string>
-				<key>CLANG_ENABLE_MODULES</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
-				<string>YES</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>ENABLE_NS_ASSERTIONS</key>
-				<string>NO</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_GENERATE_TEST_COVERAGE_FILES</key>
-				<string>YES</string>
-				<key>GCC_INSTRUMENT_PROGRAM_FLOW_ARCS</key>
-				<string>YES</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES_ERROR</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES_AGGRESSIVE</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.1</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>VALIDATE_PRODUCT</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>058D09CF195D04C000B7D73C</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>058D09D0195D04C000B7D73C</string>
-				<string>058D09D1195D04C000B7D73C</string>
-				<string>DB1020811CBCA2AD00FA6FE1</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>058D09D0195D04C000B7D73C</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>APPLICATION_EXTENSION_API_ONLY</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_CODE_COVERAGE</key>
-				<string>YES</string>
-				<key>DSTROOT</key>
-				<string>/tmp/AsyncDisplayKit.dst</string>
-				<key>GCC_INPUT_FILETYPE</key>
-				<string>automatic</string>
-				<key>GCC_INSTRUMENT_PROGRAM_FLOW_ARCS</key>
-				<string>NO</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>AsyncDisplayKit/AsyncDisplayKit-Prefix.pch</string>
-				<key>GCC_TREAT_WARNINGS_AS_ERRORS</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_MISSING_NEWLINE</key>
-				<string>YES</string>
-				<key>GCC_WARN_INITIALIZER_NOT_FULLY_BRACKETED</key>
-				<string>YES</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.1</string>
-				<key>OTHER_CFLAGS</key>
-				<string>-Wall</string>
-				<key>OTHER_LDFLAGS</key>
-				<string>-ObjC</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>include/$(TARGET_NAME)</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>058D09D1195D04C000B7D73C</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>APPLICATION_EXTENSION_API_ONLY</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_CODE_COVERAGE</key>
-				<string>YES</string>
-				<key>DSTROOT</key>
-				<string>/tmp/AsyncDisplayKit.dst</string>
-				<key>GCC_INPUT_FILETYPE</key>
-				<string>automatic</string>
-				<key>GCC_INSTRUMENT_PROGRAM_FLOW_ARCS</key>
-				<string>NO</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>AsyncDisplayKit/AsyncDisplayKit-Prefix.pch</string>
-				<key>GCC_TREAT_WARNINGS_AS_ERRORS</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_MISSING_NEWLINE</key>
-				<string>YES</string>
-				<key>GCC_WARN_INITIALIZER_NOT_FULLY_BRACKETED</key>
-				<string>YES</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.1</string>
-				<key>OTHER_CFLAGS</key>
-				<string>-Wall</string>
-				<key>OTHER_LDFLAGS</key>
-				<string>-ObjC</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>include/$(TARGET_NAME)</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>058D09D2195D04C000B7D73C</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>058D09D3195D04C000B7D73C</string>
-				<string>058D09D4195D04C000B7D73C</string>
-				<string>DB1020821CBCA2AD00FA6FE1</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>058D09D3195D04C000B7D73C</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>FB07EABBCF28656C6297BC2D</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>BUNDLE_LOADER</key>
-				<string>$(TEST_HOST)</string>
-				<key>CLANG_ENABLE_CODE_COVERAGE</key>
-				<string>YES</string>
-				<key>FRAMEWORK_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>$(DEVELOPER_FRAMEWORKS_DIR)</string>
-				</array>
-				<key>GCC_INSTRUMENT_PROGRAM_FLOW_ARCS</key>
-				<string>NO</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>AsyncDisplayKit/AsyncDisplayKit-Prefix.pch</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-					<string>COCOAPODS=1</string>
-					<string>FB_REFERENCE_IMAGE_DIR="\"$(SOURCE_ROOT)/$(PROJECT_NAME)Tests/ReferenceImages\""</string>
-				</array>
-				<key>GCC_TREAT_WARNINGS_AS_ERRORS</key>
-				<string>YES</string>
-				<key>GCC_WARN_INITIALIZER_NOT_FULLY_BRACKETED</key>
-				<string>YES</string>
-				<key>INFOPLIST_FILE</key>
-				<string>AsyncDisplayKitTests/AsyncDisplayKitTests-Info.plist</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.1</string>
-				<key>PRODUCT_BUNDLE_IDENTIFIER</key>
-				<string>com.facebook.${PRODUCT_NAME:rfc1034identifier}</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>TEST_HOST</key>
-				<string>$(BUILT_PRODUCTS_DIR)/AsyncDisplayKitTestHost.app/AsyncDisplayKitTestHost</string>
-				<key>WRAPPER_EXTENSION</key>
-				<string>xctest</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>058D09D4195D04C000B7D73C</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>D3779BCFF841AD3EB56537ED</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>BUNDLE_LOADER</key>
-				<string>$(TEST_HOST)</string>
-				<key>CLANG_ENABLE_CODE_COVERAGE</key>
-				<string>YES</string>
-				<key>FRAMEWORK_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>$(DEVELOPER_FRAMEWORKS_DIR)</string>
-				</array>
-				<key>GCC_INSTRUMENT_PROGRAM_FLOW_ARCS</key>
-				<string>NO</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>AsyncDisplayKit/AsyncDisplayKit-Prefix.pch</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>COCOAPODS=1</string>
-					<string>FB_REFERENCE_IMAGE_DIR="\"$(SOURCE_ROOT)/$(PROJECT_NAME)Tests/ReferenceImages\""</string>
-				</array>
-				<key>GCC_TREAT_WARNINGS_AS_ERRORS</key>
-				<string>YES</string>
-				<key>GCC_WARN_INITIALIZER_NOT_FULLY_BRACKETED</key>
-				<string>YES</string>
-				<key>INFOPLIST_FILE</key>
-				<string>AsyncDisplayKitTests/AsyncDisplayKitTests-Info.plist</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.1</string>
-				<key>PRODUCT_BUNDLE_IDENTIFIER</key>
-				<string>com.facebook.${PRODUCT_NAME:rfc1034identifier}</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>TEST_HOST</key>
-				<string>$(BUILT_PRODUCTS_DIR)/AsyncDisplayKitTestHost.app/AsyncDisplayKitTestHost</string>
-				<key>WRAPPER_EXTENSION</key>
-				<string>xctest</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>058D09D5195D050800B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASControlNode.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D09D6195D050800B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ASControlNode.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D09D7195D050800B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASControlNode+Subclasses.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D09D8195D050800B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>lineEnding</key>
-			<string>0</string>
-			<key>path</key>
-			<string>ASDisplayNode.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D09D9195D050800B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>lineEnding</key>
-			<string>0</string>
-			<key>path</key>
-			<string>ASDisplayNode.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D09DA195D050800B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>lineEnding</key>
-			<string>0</string>
-			<key>path</key>
-			<string>ASDisplayNode+Subclasses.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D09DB195D050800B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASDisplayNodeExtras.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D09DC195D050800B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ASDisplayNodeExtras.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D09DD195D050800B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASImageNode.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D09DE195D050800B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>lineEnding</key>
-			<string>0</string>
-			<key>path</key>
-			<string>ASImageNode.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D09DF195D050800B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASTextNode.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D09E0195D050800B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>lineEnding</key>
-			<string>0</string>
-			<key>path</key>
-			<string>ASTextNode.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D09E1195D050800B7D73C</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>CC4C2A751D88E3BF0039ACAB</string>
-				<string>CC4C2A761D88E3BF0039ACAB</string>
-				<string>058D09E2195D050800B7D73C</string>
-				<string>058D09E3195D050800B7D73C</string>
-				<string>058D09E4195D050800B7D73C</string>
-				<string>058D09E5195D050800B7D73C</string>
-				<string>69CB62A91CB8165900024920</string>
-				<string>69CB62AA1CB8165900024920</string>
-				<string>205F0E171B37339C007741D0</string>
-				<string>205F0E181B37339C007741D0</string>
-				<string>054963471A1EA066000F8E56</string>
-				<string>054963481A1EA066000F8E56</string>
-				<string>299DA1A71A828D2900162D41</string>
-				<string>299DA1A81A828D2900162D41</string>
-				<string>251B8EF41BBB3D690087C538</string>
-				<string>251B8EF51BBB3D690087C538</string>
-				<string>205F0E1B1B373A2C007741D0</string>
-				<string>205F0E1C1B373A2C007741D0</string>
-				<string>05A6D05819D0EB64002DD95E</string>
-				<string>05A6D05919D0EB64002DD95E</string>
-				<string>698548611CA9E025008A345F</string>
-				<string>9CFFC6BD1CCAC52B006A6476</string>
-				<string>4640521B1A3F83C40061C0BA</string>
-				<string>4640521C1A3F83C40061C0BA</string>
-				<string>058D09E6195D050800B7D73C</string>
-				<string>058D09E7195D050800B7D73C</string>
-				<string>68355B371CB57A5A001D4E68</string>
-				<string>68355B381CB57A5A001D4E68</string>
-				<string>05F20AA31A15733C00DCA68A</string>
-				<string>430E7C8D1B4C23F100697A4C</string>
-				<string>430E7C8E1B4C23F100697A4C</string>
-				<string>4640521D1A3F83C40061C0BA</string>
-				<string>292C59991A956527007E5DD6</string>
-				<string>68EE0DBB1C1B4ED300BA1B99</string>
-				<string>68EE0DBC1C1B4ED300BA1B99</string>
-				<string>058D09E8195D050800B7D73C</string>
-				<string>058D09E9195D050800B7D73C</string>
-				<string>CC7FD9DC1BB5E962005CCB2B</string>
-				<string>CC7FD9DD1BB5E962005CCB2B</string>
-				<string>68355B391CB57A5A001D4E68</string>
-				<string>68355B361CB57A5A001D4E68</string>
-				<string>055F1A3619ABD413004DAFF1</string>
-				<string>055F1A3719ABD413004DAFF1</string>
-				<string>69F10C851C84C35D0026140C</string>
-				<string>81EE384D1C8E94F000456208</string>
-				<string>81EE384E1C8E94F000456208</string>
-				<string>296A0A311A951715005ACEAA</string>
-				<string>205F0E111B371BD7007741D0</string>
-				<string>058D0A12195D050800B7D73C</string>
-				<string>9C70F2011CDA4EFA007D6C76</string>
-				<string>9C70F2021CDA4EFA007D6C76</string>
-				<string>68B8A4DF1CBDB958007E4543</string>
-				<string>68B8A4E01CBDB958007E4543</string>
-				<string>205F0E1F1B376416007741D0</string>
-				<string>205F0E201B376416007741D0</string>
-				<string>25B171EA1C12242700508A7A</string>
-				<string>CC4981BA1D1C7F65004E13CC</string>
-				<string>CC4981BB1D1C7F65004E13CC</string>
-				<string>058D09F5195D050800B7D73C</string>
-				<string>058D09F6195D050800B7D73C</string>
-				<string>058D09F7195D050800B7D73C</string>
-				<string>205F0E0D1B371875007741D0</string>
-				<string>205F0E0E1B371875007741D0</string>
-				<string>058D09FF195D050800B7D73C</string>
-				<string>CC3B20871C3F7A5400798563</string>
-				<string>CC3B20881C3F7A5400798563</string>
-				<string>DBC452D91C5BF64600B16017</string>
-				<string>DBC452DA1C5BF64600B16017</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>Details</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D09E2195D050800B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>_ASDisplayLayer.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D09E3195D050800B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>_ASDisplayLayer.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D09E4195D050800B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>_ASDisplayView.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D09E5195D050800B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>_ASDisplayView.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D09E6195D050800B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASHighlightOverlayLayer.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D09E7195D050800B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ASHighlightOverlayLayer.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D09E8195D050800B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASMutableAttributedStringBuilder.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D09E9195D050800B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASMutableAttributedStringBuilder.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D09F5195D050800B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>NSMutableAttributedString+TextKitAdditions.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D09F6195D050800B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>NSMutableAttributedString+TextKitAdditions.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D09F7195D050800B7D73C</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>058D09F8195D050800B7D73C</string>
-				<string>058D09F9195D050800B7D73C</string>
-				<string>058D09FA195D050800B7D73C</string>
-				<string>058D09FB195D050800B7D73C</string>
-				<string>058D09FC195D050800B7D73C</string>
-				<string>058D09FD195D050800B7D73C</string>
-				<string>058D09FE195D050800B7D73C</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>Transactions</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D09F8195D050800B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>_ASAsyncTransaction.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D09F9195D050800B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>_ASAsyncTransaction.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D09FA195D050800B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>_ASAsyncTransactionContainer+Private.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D09FB195D050800B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>_ASAsyncTransactionContainer.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D09FC195D050800B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>_ASAsyncTransactionContainer.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D09FD195D050800B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>_ASAsyncTransactionGroup.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D09FE195D050800B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>_ASAsyncTransactionGroup.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D09FF195D050800B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>UIView+ASConvenience.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D0A01195D050800B7D73C</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>CC446A2D1D80AAE00071FD03</string>
-				<string>CC446A2E1D80AAE00071FD03</string>
-				<string>CC54A81B1D70077A00296A24</string>
-				<string>058D0A02195D050800B7D73C</string>
-				<string>058D0A03195D050800B7D73C</string>
-				<string>058D0A04195D050800B7D73C</string>
-				<string>AC026B6D1BD57DBF00BBC17E</string>
-				<string>AC026B6E1BD57DBF00BBC17E</string>
-				<string>058D0A05195D050800B7D73C</string>
-				<string>058D0A06195D050800B7D73C</string>
-				<string>058D0A07195D050800B7D73C</string>
-				<string>DB55C25F1C6408D6004EDCF5</string>
-				<string>DB55C2601C6408D6004EDCF5</string>
-				<string>2967F9E11AB0A4CF0072E4AB</string>
-				<string>044285051BAA63FE00D16268</string>
-				<string>044285061BAA63FE00D16268</string>
-				<string>251B8EF61BBB3D690087C538</string>
-				<string>8B0768B11CE752EC002E1453</string>
-				<string>8B0768B21CE752EC002E1453</string>
-				<string>AEB7B0181C5962EA00662EF4</string>
-				<string>AEB7B0191C5962EA00662EF4</string>
-				<string>058D0A08195D050800B7D73C</string>
-				<string>058D0A09195D050800B7D73C</string>
-				<string>058D0A0A195D050800B7D73C</string>
-				<string>DE6EA3211C14000600183B10</string>
-				<string>058D0A0B195D050800B7D73C</string>
-				<string>058D0A0C195D050800B7D73C</string>
-				<string>6959433D1D70815300B0EE1F</string>
-				<string>6959433C1D70815300B0EE1F</string>
-				<string>69E100691CA89CB600D88C1B</string>
-				<string>69E1006A1CA89CB600D88C1B</string>
-				<string>68B8A4DB1CBD911D007E4543</string>
-				<string>058D0A0D195D050800B7D73C</string>
-				<string>058D0A0E195D050800B7D73C</string>
-				<string>ACF6ED431B17847A00DA7C62</string>
-				<string>ACF6ED441B17847A00DA7C62</string>
-				<string>ACF6ED451B17847A00DA7C62</string>
-				<string>E52405B41C8FEF16004DC8E7</string>
-				<string>E52405B21C8FEF03004DC8E7</string>
-				<string>0442850B1BAA64EC00D16268</string>
-				<string>0442850C1BAA64EC00D16268</string>
-				<string>CC3B20811C3F76D600798563</string>
-				<string>CC3B20821C3F76D600798563</string>
-				<string>058D0A10195D050800B7D73C</string>
-				<string>058D0A11195D050800B7D73C</string>
-				<string>9C8221931BA237B80037F19A</string>
-				<string>9C8221941BA237B80037F19A</string>
-				<string>ACF6ED461B17847A00DA7C62</string>
-				<string>ACF6ED471B17847A00DA7C62</string>
-				<string>ACF6ED481B17847A00DA7C62</string>
-				<string>ACF6ED491B17847A00DA7C62</string>
-				<string>ACF6ED4A1B17847A00DA7C62</string>
-				<string>83A7D9581D44542100BF333E</string>
-				<string>83A7D9591D44542100BF333E</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>Private</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D0A02195D050800B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>_AS-objc-internal.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D0A03195D050800B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>_ASCoreAnimationExtras.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D0A04195D050800B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>_ASCoreAnimationExtras.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D0A05195D050800B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>_ASPendingState.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D0A06195D050800B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>_ASPendingState.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D0A07195D050800B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>_ASScopeTimer.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D0A08195D050800B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ASDisplayNode+AsyncDisplay.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D0A09195D050800B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASDisplayNode+DebugTiming.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D0A0A195D050800B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ASDisplayNode+DebugTiming.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D0A0B195D050800B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ASDisplayNode+UIViewBridge.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D0A0C195D050800B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASDisplayNodeInternal.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D0A0D195D050800B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASImageNode+CGExtras.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D0A0E195D050800B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASImageNode+CGExtras.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D0A10195D050800B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASSentinel.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D0A11195D050800B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASSentinel.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D0A12195D050800B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASThread.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D0A13195D050800B7D73C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09D6195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>058D0A14195D050800B7D73C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09D9195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>058D0A15195D050800B7D73C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09DC195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>058D0A16195D050800B7D73C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09DE195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>058D0A17195D050800B7D73C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09E0195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>058D0A18195D050800B7D73C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09E3195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>058D0A19195D050800B7D73C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09E5195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>058D0A1A195D050800B7D73C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09E7195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>058D0A1B195D050800B7D73C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09E9195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>058D0A21195D050800B7D73C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09F6195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>058D0A22195D050800B7D73C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09F9195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>058D0A23195D050800B7D73C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09FC195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>058D0A24195D050800B7D73C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09FE195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>058D0A26195D050800B7D73C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D0A04195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>058D0A27195D050800B7D73C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D0A06195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>058D0A28195D050800B7D73C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D0A08195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>058D0A29195D050800B7D73C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D0A0A195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>058D0A2A195D050800B7D73C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D0A0B195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>058D0A2B195D050800B7D73C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D0A0E195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>058D0A2C195D050800B7D73C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D0A11195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>058D0A2D195D057000B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASDisplayLayerTests.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D0A2E195D057000B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASDisplayNodeAppearanceTests.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D0A2F195D057000B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASDisplayNodeTests.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D0A30195D057000B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASDisplayNodeTestsHelper.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D0A31195D057000B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASDisplayNodeTestsHelper.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D0A32195D057000B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASMutableAttributedStringBuilderTests.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D0A33195D057000B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASTextKitCoreTextAdditionsTests.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D0A36195D057000B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASTextNodeTests.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D0A37195D057000B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ASTextNodeWordKernerTests.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D0A38195D057000B7D73C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D0A2D195D057000B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>058D0A39195D057000B7D73C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D0A2E195D057000B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>058D0A3A195D057000B7D73C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D0A2F195D057000B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>058D0A3B195D057000B7D73C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D0A31195D057000B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>058D0A3C195D057000B7D73C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D0A32195D057000B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>058D0A3D195D057000B7D73C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D0A33195D057000B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>058D0A40195D057000B7D73C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D0A36195D057000B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>058D0A41195D057000B7D73C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D0A37195D057000B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>058D0A42195D058D00B7D73C</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>058D0A43195D058D00B7D73C</string>
-				<string>0516FA3A1A15563400B4EBED</string>
-				<string>058D0A44195D058D00B7D73C</string>
-				<string>1950C4481A3BB5C1005C8279</string>
-				<string>0516FA3B1A15563400B4EBED</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>Base</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-		</dict>
-		<key>058D0A43195D058D00B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASAssert.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>058D0A44195D058D00B7D73C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASBaseDefines.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>05A6D05819D0EB64002DD95E</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>ASDealloc2MainObject.h</string>
-			<key>path</key>
-			<string>../Details/ASDealloc2MainObject.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>05A6D05919D0EB64002DD95E</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>ASDealloc2MainObject.m</string>
-			<key>path</key>
-			<string>../Details/ASDealloc2MainObject.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>05A6D05B19D0EB64002DD95E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>05A6D05919D0EB64002DD95E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>05EA6FE61AC0966E00E35788</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASSnapshotTestCase.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>05EA6FE71AC0966E00E35788</key>
-		<dict>
-			<key>fileRef</key>
-			<string>05EA6FE61AC0966E00E35788</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>05F20AA31A15733C00DCA68A</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASImageProtocols.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>18C2ED7C1B9B7DE800F627B3</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASCollectionNode.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>18C2ED7D1B9B7DE800F627B3</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ASCollectionNode.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>18C2ED7F1B9B7DE800F627B3</key>
-		<dict>
-			<key>fileRef</key>
-			<string>18C2ED7C1B9B7DE800F627B3</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>18C2ED801B9B7DE800F627B3</key>
-		<dict>
-			<key>fileRef</key>
-			<string>18C2ED7D1B9B7DE800F627B3</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>18C2ED831B9B7DE800F627B3</key>
-		<dict>
-			<key>fileRef</key>
-			<string>18C2ED7D1B9B7DE800F627B3</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>1950C4481A3BB5C1005C8279</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASEqualityHelpers.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>204C979D1B362CB3002B1083</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>image.png</string>
-			<key>name</key>
-			<string>Default-568h@2x.png</string>
-			<key>path</key>
-			<string>../Default-568h@2x.png</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>204C979E1B362CB3002B1083</key>
-		<dict>
-			<key>fileRef</key>
-			<string>204C979D1B362CB3002B1083</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>205F0E0D1B371875007741D0</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>UICollectionViewLayout+ASConvenience.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>205F0E0E1B371875007741D0</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>UICollectionViewLayout+ASConvenience.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>205F0E101B371875007741D0</key>
-		<dict>
-			<key>fileRef</key>
-			<string>205F0E0E1B371875007741D0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>205F0E111B371BD7007741D0</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASScrollDirection.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>205F0E121B371BD7007741D0</key>
-		<dict>
-			<key>fileRef</key>
-			<string>205F0E111B371BD7007741D0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>205F0E171B37339C007741D0</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASAbstractLayoutController.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>205F0E181B37339C007741D0</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ASAbstractLayoutController.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>205F0E1A1B37339C007741D0</key>
-		<dict>
-			<key>fileRef</key>
-			<string>205F0E181B37339C007741D0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>205F0E1B1B373A2C007741D0</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASCollectionViewLayoutController.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>205F0E1C1B373A2C007741D0</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ASCollectionViewLayoutController.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>205F0E1E1B373A2C007741D0</key>
-		<dict>
-			<key>fileRef</key>
-			<string>205F0E1C1B373A2C007741D0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>205F0E1F1B376416007741D0</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>CGRect+ASConvenience.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>205F0E201B376416007741D0</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>CGRect+ASConvenience.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>205F0E221B376416007741D0</key>
-		<dict>
-			<key>fileRef</key>
-			<string>205F0E201B376416007741D0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>242995D21B29743C00090100</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASBasicImageDownloaderTests.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>242995D31B29743C00090100</key>
-		<dict>
-			<key>fileRef</key>
-			<string>242995D21B29743C00090100</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251B8EF21BBB3D690087C538</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>lineEnding</key>
-			<string>0</string>
-			<key>path</key>
-			<string>ASCollectionDataController.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>251B8EF31BBB3D690087C538</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>lineEnding</key>
-			<string>0</string>
-			<key>path</key>
-			<string>ASCollectionDataController.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>251B8EF41BBB3D690087C538</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASCollectionViewFlowLayoutInspector.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>251B8EF51BBB3D690087C538</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASCollectionViewFlowLayoutInspector.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>251B8EF61BBB3D690087C538</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASDataController+Subclasses.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>251B8EF81BBB3D690087C538</key>
-		<dict>
-			<key>fileRef</key>
-			<string>251B8EF31BBB3D690087C538</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251B8EFA1BBB3D690087C538</key>
-		<dict>
-			<key>fileRef</key>
-			<string>251B8EF51BBB3D690087C538</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2538B6F21BC5D2A2003CA0B4</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>lineEnding</key>
-			<string>0</string>
-			<key>path</key>
-			<string>ASCollectionViewFlowLayoutInspectorTests.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-			<key>xcLanguageSpecificationIdentifier</key>
-			<string>xcode.lang.objc</string>
-		</dict>
-		<key>2538B6F31BC5D2A2003CA0B4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2538B6F21BC5D2A2003CA0B4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>254C6B511BF8FE6D003EC431</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ASTextKitTruncationTests.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>254C6B521BF8FE6D003EC431</key>
-		<dict>
-			<key>fileRef</key>
-			<string>254C6B511BF8FE6D003EC431</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>254C6B531BF8FF2A003EC431</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ASTextKitTests.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>254C6B541BF8FF2A003EC431</key>
-		<dict>
-			<key>fileRef</key>
-			<string>254C6B531BF8FF2A003EC431</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>254C6B731BF94DF4003EC431</key>
-		<dict>
-			<key>fileRef</key>
-			<string>257754BB1BEE458E00737CA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>254C6B741BF94DF4003EC431</key>
-		<dict>
-			<key>fileRef</key>
-			<string>257754B91BEE458E00737CA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>254C6B751BF94DF4003EC431</key>
-		<dict>
-			<key>fileRef</key>
-			<string>257754BA1BEE458E00737CA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>254C6B761BF94DF4003EC431</key>
-		<dict>
-			<key>fileRef</key>
-			<string>257754BC1BEE458E00737CA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>254C6B771BF94DF4003EC431</key>
-		<dict>
-			<key>fileRef</key>
-			<string>257754951BEE44CD00737CA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>254C6B781BF94DF4003EC431</key>
-		<dict>
-			<key>fileRef</key>
-			<string>257754961BEE44CD00737CA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>254C6B791BF94DF4003EC431</key>
-		<dict>
-			<key>fileRef</key>
-			<string>257754981BEE44CD00737CA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>254C6B7A1BF94DF4003EC431</key>
-		<dict>
-			<key>fileRef</key>
-			<string>257754931BEE44CD00737CA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>254C6B7B1BF94DF4003EC431</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2577549B1BEE44CD00737CA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>254C6B7C1BF94DF4003EC431</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2577549D1BEE44CD00737CA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>254C6B7D1BF94DF4003EC431</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2577549F1BEE44CD00737CA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>254C6B7E1BF94DF4003EC431</key>
-		<dict>
-			<key>fileRef</key>
-			<string>257754A11BEE44CD00737CA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>254C6B7F1BF94DF4003EC431</key>
-		<dict>
-			<key>fileRef</key>
-			<string>257754A31BEE44CD00737CA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>254C6B821BF94F8A003EC431</key>
-		<dict>
-			<key>fileRef</key>
-			<string>257754B71BEE458D00737CA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>254C6B831BF94F8A003EC431</key>
-		<dict>
-			<key>fileRef</key>
-			<string>257754B81BEE458E00737CA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>254C6B841BF94F8A003EC431</key>
-		<dict>
-			<key>fileRef</key>
-			<string>257754BD1BEE458E00737CA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>254C6B851BF94F8A003EC431</key>
-		<dict>
-			<key>fileRef</key>
-			<string>257754941BEE44CD00737CA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>254C6B861BF94F8A003EC431</key>
-		<dict>
-			<key>fileRef</key>
-			<string>257754971BEE44CD00737CA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>254C6B871BF94F8A003EC431</key>
-		<dict>
-			<key>fileRef</key>
-			<string>257754991BEE44CD00737CA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>254C6B881BF94F8A003EC431</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2577549A1BEE44CD00737CA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>254C6B891BF94F8A003EC431</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2577549C1BEE44CD00737CA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>254C6B8A1BF94F8A003EC431</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2577549E1BEE44CD00737CA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>254C6B8B1BF94F8A003EC431</key>
-		<dict>
-			<key>fileRef</key>
-			<string>257754A01BEE44CD00737CA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>254C6B8C1BF94F8A003EC431</key>
-		<dict>
-			<key>fileRef</key>
-			<string>257754A21BEE44CD00737CA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>257754661BED245B00737CA5</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>69708BA41D76386D005C3CF9</string>
-				<string>69708BA51D76386D005C3CF9</string>
-				<string>B30BF6501C5964B0004FCD53</string>
-				<string>B30BF6511C5964B0004FCD53</string>
-				<string>257754BA1BEE458E00737CA5</string>
-				<string>257754B71BEE458D00737CA5</string>
-				<string>257754BB1BEE458E00737CA5</string>
-				<string>257754B81BEE458E00737CA5</string>
-				<string>257754B91BEE458E00737CA5</string>
-				<string>257754BC1BEE458E00737CA5</string>
-				<string>257754BD1BEE458E00737CA5</string>
-				<string>257754941BEE44CD00737CA5</string>
-				<string>257754951BEE44CD00737CA5</string>
-				<string>257754961BEE44CD00737CA5</string>
-				<string>257754971BEE44CD00737CA5</string>
-				<string>257754981BEE44CD00737CA5</string>
-				<string>257754991BEE44CD00737CA5</string>
-				<string>257754931BEE44CD00737CA5</string>
-				<string>2577549A1BEE44CD00737CA5</string>
-				<string>2577549B1BEE44CD00737CA5</string>
-				<string>2577549C1BEE44CD00737CA5</string>
-				<string>2577549D1BEE44CD00737CA5</string>
-				<string>2577549E1BEE44CD00737CA5</string>
-				<string>2577549F1BEE44CD00737CA5</string>
-				<string>257754A01BEE44CD00737CA5</string>
-				<string>257754A11BEE44CD00737CA5</string>
-				<string>257754A21BEE44CD00737CA5</string>
-				<string>A32FEDD31C501B6A004F642A</string>
-				<string>9C8898BA1C738B9800D6B02E</string>
-				<string>257754A31BEE44CD00737CA5</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>TextKit</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>257754931BEE44CD00737CA5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>ASTextKitRenderer.h</string>
-			<key>path</key>
-			<string>TextKit/ASTextKitRenderer.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>257754941BEE44CD00737CA5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>name</key>
-			<string>ASTextKitAttributes.mm</string>
-			<key>path</key>
-			<string>TextKit/ASTextKitAttributes.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>257754951BEE44CD00737CA5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>ASTextKitAttributes.h</string>
-			<key>path</key>
-			<string>TextKit/ASTextKitAttributes.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>257754961BEE44CD00737CA5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>ASTextKitContext.h</string>
-			<key>path</key>
-			<string>TextKit/ASTextKitContext.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>257754971BEE44CD00737CA5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>name</key>
-			<string>ASTextKitContext.mm</string>
-			<key>path</key>
-			<string>TextKit/ASTextKitContext.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>257754981BEE44CD00737CA5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>ASTextKitEntityAttribute.h</string>
-			<key>path</key>
-			<string>TextKit/ASTextKitEntityAttribute.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>257754991BEE44CD00737CA5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>ASTextKitEntityAttribute.m</string>
-			<key>path</key>
-			<string>TextKit/ASTextKitEntityAttribute.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2577549A1BEE44CD00737CA5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>name</key>
-			<string>ASTextKitRenderer.mm</string>
-			<key>path</key>
-			<string>TextKit/ASTextKitRenderer.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2577549B1BEE44CD00737CA5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>ASTextKitRenderer+Positioning.h</string>
-			<key>path</key>
-			<string>TextKit/ASTextKitRenderer+Positioning.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2577549C1BEE44CD00737CA5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>name</key>
-			<string>ASTextKitRenderer+Positioning.mm</string>
-			<key>path</key>
-			<string>TextKit/ASTextKitRenderer+Positioning.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2577549D1BEE44CD00737CA5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>ASTextKitRenderer+TextChecking.h</string>
-			<key>path</key>
-			<string>TextKit/ASTextKitRenderer+TextChecking.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2577549E1BEE44CD00737CA5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>name</key>
-			<string>ASTextKitRenderer+TextChecking.mm</string>
-			<key>path</key>
-			<string>TextKit/ASTextKitRenderer+TextChecking.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2577549F1BEE44CD00737CA5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>ASTextKitShadower.h</string>
-			<key>path</key>
-			<string>TextKit/ASTextKitShadower.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>257754A01BEE44CD00737CA5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>name</key>
-			<string>ASTextKitShadower.mm</string>
-			<key>path</key>
-			<string>TextKit/ASTextKitShadower.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>257754A11BEE44CD00737CA5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>ASTextKitTailTruncater.h</string>
-			<key>path</key>
-			<string>TextKit/ASTextKitTailTruncater.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>257754A21BEE44CD00737CA5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>name</key>
-			<string>ASTextKitTailTruncater.mm</string>
-			<key>path</key>
-			<string>TextKit/ASTextKitTailTruncater.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>257754A31BEE44CD00737CA5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>ASTextKitTruncating.h</string>
-			<key>path</key>
-			<string>TextKit/ASTextKitTruncating.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>257754A61BEE44CD00737CA5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>257754941BEE44CD00737CA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>257754A91BEE44CD00737CA5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>257754971BEE44CD00737CA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>257754AB1BEE44CD00737CA5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>257754991BEE44CD00737CA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>257754AC1BEE44CD00737CA5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2577549A1BEE44CD00737CA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>257754AE1BEE44CD00737CA5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2577549C1BEE44CD00737CA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>257754B01BEE44CD00737CA5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2577549E1BEE44CD00737CA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>257754B21BEE44CD00737CA5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>257754A01BEE44CD00737CA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>257754B41BEE44CD00737CA5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>257754A21BEE44CD00737CA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>257754B71BEE458D00737CA5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>ASTextKitComponents.m</string>
-			<key>path</key>
-			<string>TextKit/ASTextKitComponents.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>257754B81BEE458E00737CA5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>ASTextKitCoreTextAdditions.m</string>
-			<key>path</key>
-			<string>TextKit/ASTextKitCoreTextAdditions.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>257754B91BEE458E00737CA5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>ASTextNodeWordKerner.h</string>
-			<key>path</key>
-			<string>TextKit/ASTextNodeWordKerner.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>257754BA1BEE458E00737CA5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>ASTextKitComponents.h</string>
-			<key>path</key>
-			<string>TextKit/ASTextKitComponents.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>257754BB1BEE458E00737CA5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>ASTextKitCoreTextAdditions.h</string>
-			<key>path</key>
-			<string>TextKit/ASTextKitCoreTextAdditions.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>257754BC1BEE458E00737CA5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>ASTextNodeTypes.h</string>
-			<key>path</key>
-			<string>TextKit/ASTextNodeTypes.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>257754BD1BEE458E00737CA5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>ASTextNodeWordKerner.m</string>
-			<key>path</key>
-			<string>TextKit/ASTextNodeWordKerner.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>257754BE1BEE458E00737CA5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>257754B71BEE458D00737CA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>257754BF1BEE458E00737CA5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>257754B81BEE458E00737CA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>257754C41BEE458E00737CA5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>257754BD1BEE458E00737CA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25B171EA1C12242700508A7A</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>DE8BEABF1C2DF3FC00D57C12</string>
-				<string>DE8BEAC01C2DF3FC00D57C12</string>
-				<string>251B8EF21BBB3D690087C538</string>
-				<string>251B8EF31BBB3D690087C538</string>
-				<string>464052191A3F83C40061C0BA</string>
-				<string>4640521A1A3F83C40061C0BA</string>
-				<string>AC026B671BD57D6F00BBC17E</string>
-				<string>AC026B681BD57D6F00BBC17E</string>
-				<string>E5711A2A1C840C81009619D4</string>
-				<string>E5711A2D1C840C96009619D4</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Data Controller</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25E327541C16819500A2170C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>lineEnding</key>
-			<string>0</string>
-			<key>path</key>
-			<string>ASPagerNode.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25E327551C16819500A2170C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>lineEnding</key>
-			<string>0</string>
-			<key>path</key>
-			<string>ASPagerNode.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-			<key>xcLanguageSpecificationIdentifier</key>
-			<string>xcode.lang.objc</string>
-		</dict>
-		<key>25E327571C16819500A2170C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25E327541C16819500A2170C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25E327581C16819500A2170C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25E327551C16819500A2170C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25E327591C16819500A2170C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25E327551C16819500A2170C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2767E9411BB19BD600EA9B77</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACC945A81BA9E7A0005E1FB8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>2911485B1A77147A005D0878</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASControlNodeTests.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2911485C1A77147A005D0878</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2911485B1A77147A005D0878</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>292C59991A956527007E5DD6</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASLayoutRangeType.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2967F9E11AB0A4CF0072E4AB</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASBasicImageDownloaderInternal.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>296A0A311A951715005ACEAA</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>ASScrollDirection.h</string>
-			<key>path</key>
-			<string>AsyncDisplayKit/Details/ASScrollDirection.h</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-		</dict>
-		<key>296A0A341A951ABF005ACEAA</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASBatchFetchingTests.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>296A0A351A951ABF005ACEAA</key>
-		<dict>
-			<key>fileRef</key>
-			<string>296A0A341A951ABF005ACEAA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>299DA1A71A828D2900162D41</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASBatchContext.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>299DA1A81A828D2900162D41</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ASBatchContext.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>299DA1AA1A828D2900162D41</key>
-		<dict>
-			<key>fileRef</key>
-			<string>299DA1A81A828D2900162D41</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>29CDC2E11AAE70D000833CA4</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASBasicImageDownloaderContextTests.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>29CDC2E21AAE70D000833CA4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>29CDC2E11AAE70D000833CA4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2C107F5B1BA9F54500F13DE5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>6BDC61F51978FEA400E50D21</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>2E61B6A0DB0F436A9DDBE86F</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>[CP] Check Pods Manifest.lock</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>diff "${PODS_ROOT}/../Podfile.lock" "${PODS_ROOT}/Manifest.lock" &gt; /dev/null
-if [[ $? != 0 ]] ; then
-    cat &lt;&lt; EOM
-error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.
-EOM
-    exit 1
-fi
-</string>
-			<key>showEnvVarsInLog</key>
-			<string>0</string>
-		</dict>
-		<key>34566CB31BC1213700715E6B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CC7FD9DD1BB5E962005CCB2B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>34EFC75B1B701BAF00AD841F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED071B17843500DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>34EFC75C1B701BD200AD841F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED081B17843500DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>34EFC75D1B701BE900AD841F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED431B17847A00DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>34EFC75E1B701BF000AD841F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED441B17847A00DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>34EFC75F1B701C8600AD841F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED091B17843500DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>34EFC7601B701C8B00AD841F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED0A1B17843500DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>34EFC7611B701C9C00AD841F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED011B17843500DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>34EFC7621B701CA400AD841F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED021B17843500DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>34EFC7631B701CBF00AD841F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED031B17843500DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>34EFC7641B701CC600AD841F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED041B17843500DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>34EFC7651B701CCC00AD841F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AC47D9431B3BB41900AAEE9D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>34EFC7661B701CD200AD841F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AC47D9441B3BB41900AAEE9D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>34EFC7671B701CD900AD841F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED0B1B17843500DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>34EFC7681B701CDE00AD841F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED0C1B17843500DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>34EFC7691B701CE100AD841F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED111B17843500DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>34EFC76A1B701CE600AD841F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED0D1B17843500DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>34EFC76B1B701CEB00AD841F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED0E1B17843500DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>34EFC76C1B701CED00AD841F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED121B17843500DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>34EFC76D1B701CF100AD841F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED131B17843500DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>34EFC76E1B701CF400AD841F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED141B17843500DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>34EFC76F1B701CF700AD841F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED151B17843500DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>34EFC7701B701CFA00AD841F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AC21EC0F1B3D0BF600C8B19A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>34EFC7711B701CFF00AD841F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED161B17843500DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>34EFC7721B701D0300AD841F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED171B17843500DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>34EFC7731B701D0700AD841F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED181B17843500DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>34EFC7741B701D0A00AD841F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED191B17843500DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>34EFC7751B701D2400AD841F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED471B17847A00DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>34EFC7761B701D2A00AD841F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED481B17847A00DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>34EFC7771B701D2D00AD841F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED491B17847A00DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>34EFC7781B701D3100AD841F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED4A1B17847A00DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>34EFC7791B701D3600AD841F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED451B17847A00DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>3B9D88CDF51B429C8409E4B6</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>[CP] Copy Pods Resources</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>"${SRCROOT}/Pods/Target Support Files/Pods-AsyncDisplayKitTests/Pods-AsyncDisplayKitTests-resources.sh"
-</string>
-			<key>showEnvVarsInLog</key>
-			<string>0</string>
-		</dict>
-		<key>3C9C128419E616EF00E942A0</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>lineEnding</key>
-			<string>0</string>
-			<key>path</key>
-			<string>ASTableViewTests.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-			<key>xcLanguageSpecificationIdentifier</key>
-			<string>xcode.lang.objc</string>
-		</dict>
-		<key>3C9C128519E616EF00E942A0</key>
-		<dict>
-			<key>fileRef</key>
-			<string>3C9C128419E616EF00E942A0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>430E7C8D1B4C23F100697A4C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASIndexPath.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>430E7C8E1B4C23F100697A4C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASIndexPath.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>430E7C901B4C23F100697A4C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>430E7C8D1B4C23F100697A4C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>430E7C911B4C23F100697A4C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>430E7C8E1B4C23F100697A4C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>430E7C921B4C23F100697A4C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>430E7C8E1B4C23F100697A4C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>464052191A3F83C40061C0BA</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>lineEnding</key>
-			<string>0</string>
-			<key>path</key>
-			<string>ASDataController.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4640521A1A3F83C40061C0BA</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>lineEnding</key>
-			<string>0</string>
-			<key>path</key>
-			<string>ASDataController.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4640521B1A3F83C40061C0BA</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASFlowLayoutController.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4640521C1A3F83C40061C0BA</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ASFlowLayoutController.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4640521D1A3F83C40061C0BA</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASLayoutController.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>464052211A3F83C40061C0BA</key>
-		<dict>
-			<key>fileRef</key>
-			<string>4640521A1A3F83C40061C0BA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>464052231A3F83C40061C0BA</key>
-		<dict>
-			<key>fileRef</key>
-			<string>4640521C1A3F83C40061C0BA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>509E68601B3AED8E009B9150</key>
-		<dict>
-			<key>fileRef</key>
-			<string>205F0E111B371BD7007741D0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>509E68611B3AEDA0009B9150</key>
-		<dict>
-			<key>fileRef</key>
-			<string>205F0E171B37339C007741D0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>509E68621B3AEDA5009B9150</key>
-		<dict>
-			<key>fileRef</key>
-			<string>205F0E181B37339C007741D0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>509E68631B3AEDB4009B9150</key>
-		<dict>
-			<key>fileRef</key>
-			<string>205F0E1B1B373A2C007741D0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>509E68641B3AEDB7009B9150</key>
-		<dict>
-			<key>fileRef</key>
-			<string>205F0E1C1B373A2C007741D0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>509E68651B3AEDC5009B9150</key>
-		<dict>
-			<key>fileRef</key>
-			<string>205F0E1F1B376416007741D0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>509E68661B3AEDD7009B9150</key>
-		<dict>
-			<key>fileRef</key>
-			<string>205F0E201B376416007741D0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>636EA1A41C7FF4EC00EE152F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>DBC452DA1C5BF64600B16017</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>636EA1A51C7FF4EF00EE152F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AEB7B0191C5962EA00662EF4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>680346941CE4052A0009FEB4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>68FC85DC1CE29AB700EDD713</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>683489271D70DE3400327501</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASDisplayNode+Deprecated.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>683489281D70DE3400327501</key>
-		<dict>
-			<key>fileRef</key>
-			<string>683489271D70DE3400327501</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>68355B2E1CB5799E001D4E68</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ASImageNode+AnimatedImage.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>68355B311CB5799E001D4E68</key>
-		<dict>
-			<key>fileRef</key>
-			<string>68355B2E1CB5799E001D4E68</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>68355B341CB579B9001D4E68</key>
-		<dict>
-			<key>fileRef</key>
-			<string>68355B2E1CB5799E001D4E68</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>68355B361CB57A5A001D4E68</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASPINRemoteImageDownloader.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>68355B371CB57A5A001D4E68</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASImageContainerProtocolCategories.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>68355B381CB57A5A001D4E68</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASImageContainerProtocolCategories.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>68355B391CB57A5A001D4E68</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASPINRemoteImageDownloader.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>68355B3A1CB57A5A001D4E68</key>
-		<dict>
-			<key>fileRef</key>
-			<string>68355B361CB57A5A001D4E68</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>68355B3C1CB57A5A001D4E68</key>
-		<dict>
-			<key>fileRef</key>
-			<string>68355B381CB57A5A001D4E68</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>68355B3E1CB57A60001D4E68</key>
-		<dict>
-			<key>fileRef</key>
-			<string>68355B361CB57A5A001D4E68</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>68355B3F1CB57A64001D4E68</key>
-		<dict>
-			<key>fileRef</key>
-			<string>68355B391CB57A5A001D4E68</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>68355B401CB57A69001D4E68</key>
-		<dict>
-			<key>fileRef</key>
-			<string>68355B381CB57A5A001D4E68</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>68355B411CB57A6C001D4E68</key>
-		<dict>
-			<key>fileRef</key>
-			<string>68355B371CB57A5A001D4E68</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>68AF37DB1CBEF4D80077BF76</key>
-		<dict>
-			<key>fileRef</key>
-			<string>68B8A4DB1CBD911D007E4543</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>68B027791C1A79CC0041016B</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASDisplayNode+Beta.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>68B0277B1C1A79D60041016B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>68B027791C1A79CC0041016B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>68B8A4DB1CBD911D007E4543</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASImageNode+AnimatedImagePrivate.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>68B8A4DF1CBDB958007E4543</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASWeakProxy.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>68B8A4E01CBDB958007E4543</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASWeakProxy.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>68B8A4E21CBDB958007E4543</key>
-		<dict>
-			<key>fileRef</key>
-			<string>68B8A4DF1CBDB958007E4543</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>68B8A4E31CBDB958007E4543</key>
-		<dict>
-			<key>fileRef</key>
-			<string>68B8A4E01CBDB958007E4543</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>68B8A4E41CBDB958007E4543</key>
-		<dict>
-			<key>fileRef</key>
-			<string>68B8A4E01CBDB958007E4543</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>68EE0DBB1C1B4ED300BA1B99</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASMainSerialQueue.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>68EE0DBC1C1B4ED300BA1B99</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ASMainSerialQueue.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>68EE0DBE1C1B4ED300BA1B99</key>
-		<dict>
-			<key>fileRef</key>
-			<string>68EE0DBB1C1B4ED300BA1B99</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>68EE0DBF1C1B4ED300BA1B99</key>
-		<dict>
-			<key>fileRef</key>
-			<string>68EE0DBC1C1B4ED300BA1B99</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>68EE0DC01C1B4ED300BA1B99</key>
-		<dict>
-			<key>fileRef</key>
-			<string>68EE0DBC1C1B4ED300BA1B99</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>68FC85DC1CE29AB700EDD713</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASNavigationController.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>68FC85DD1CE29AB700EDD713</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASNavigationController.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>68FC85DF1CE29AB700EDD713</key>
-		<dict>
-			<key>fileRef</key>
-			<string>68FC85DD1CE29AB700EDD713</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>68FC85E01CE29B7E00EDD713</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASTabBarController.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>68FC85E11CE29B7E00EDD713</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASTabBarController.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>68FC85E31CE29B7E00EDD713</key>
-		<dict>
-			<key>fileRef</key>
-			<string>68FC85E01CE29B7E00EDD713</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>68FC85E41CE29B7E00EDD713</key>
-		<dict>
-			<key>fileRef</key>
-			<string>68FC85E11CE29B7E00EDD713</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>68FC85E51CE29B7E00EDD713</key>
-		<dict>
-			<key>fileRef</key>
-			<string>68FC85E11CE29B7E00EDD713</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>68FC85E61CE29B9400EDD713</key>
-		<dict>
-			<key>fileRef</key>
-			<string>68FC85DD1CE29AB700EDD713</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>68FC85E71CE29C7D00EDD713</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASVisibilityProtocols.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>68FC85E81CE29C7D00EDD713</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASVisibilityProtocols.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>68FC85EA1CE29C7D00EDD713</key>
-		<dict>
-			<key>fileRef</key>
-			<string>68FC85E71CE29C7D00EDD713</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>68FC85EB1CE29C7D00EDD713</key>
-		<dict>
-			<key>fileRef</key>
-			<string>68FC85E81CE29C7D00EDD713</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>68FC85EC1CE29C7D00EDD713</key>
-		<dict>
-			<key>fileRef</key>
-			<string>68FC85E81CE29C7D00EDD713</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>6959433C1D70815300B0EE1F</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ASDisplayNodeLayout.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>6959433D1D70815300B0EE1F</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASDisplayNodeLayout.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>6959433E1D70815300B0EE1F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>6959433C1D70815300B0EE1F</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>6959433F1D70815300B0EE1F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>6959433C1D70815300B0EE1F</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>695943401D70815300B0EE1F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>6959433D1D70815300B0EE1F</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>696FCB301D6E46050093471E</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ASBackgroundLayoutSpecSnapshotTests.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>696FCB311D6E46050093471E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>696FCB301D6E46050093471E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>69708BA41D76386D005C3CF9</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>ASEqualityHashHelpers.h</string>
-			<key>path</key>
-			<string>TextKit/ASEqualityHashHelpers.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>69708BA51D76386D005C3CF9</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>name</key>
-			<string>ASEqualityHashHelpers.mm</string>
-			<key>path</key>
-			<string>TextKit/ASEqualityHashHelpers.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>69708BA61D76386D005C3CF9</key>
-		<dict>
-			<key>fileRef</key>
-			<string>69708BA41D76386D005C3CF9</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>69708BA71D76386D005C3CF9</key>
-		<dict>
-			<key>fileRef</key>
-			<string>69708BA51D76386D005C3CF9</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>69708BA81D76386D005C3CF9</key>
-		<dict>
-			<key>fileRef</key>
-			<string>69708BA51D76386D005C3CF9</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>697B31591CFE4B410049936F</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASEditableTextNodeTests.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>697B315A1CFE4B410049936F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>697B31591CFE4B410049936F</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>697C0DE11CF38F28001DE0D4</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>ASLayoutValidation.h</string>
-			<key>path</key>
-			<string>AsyncDisplayKit/Layout/ASLayoutValidation.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>697C0DE21CF38F28001DE0D4</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>name</key>
-			<string>ASLayoutValidation.mm</string>
-			<key>path</key>
-			<string>AsyncDisplayKit/Layout/ASLayoutValidation.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>697C0DE41CF38F28001DE0D4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>697C0DE11CF38F28001DE0D4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>697C0DE51CF38F28001DE0D4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>697C0DE21CF38F28001DE0D4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>697C0DE61CF38F28001DE0D4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>697C0DE21CF38F28001DE0D4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>698548611CA9E025008A345F</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASEnvironment.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>698548641CA9E025008A345F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>698548611CA9E025008A345F</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>698C8B601CAB49FC0052DC3F</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>ASLayoutableExtensibility.h</string>
-			<key>path</key>
-			<string>AsyncDisplayKit/Layout/ASLayoutableExtensibility.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>698C8B621CAB49FC0052DC3F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>698C8B601CAB49FC0052DC3F</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>69B225661D72535E00B25B22</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ASDisplayNodeLayoutTests.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>69B225671D72535E00B25B22</key>
-		<dict>
-			<key>fileRef</key>
-			<string>69B225661D72535E00B25B22</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>69B225681D7265DA00B25B22</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASXCTExtensions.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>69CB62A91CB8165900024920</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>_ASDisplayViewAccessiblity.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>69CB62AA1CB8165900024920</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>_ASDisplayViewAccessiblity.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>69CB62AC1CB8165900024920</key>
-		<dict>
-			<key>fileRef</key>
-			<string>69CB62A91CB8165900024920</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>69CB62AD1CB8165900024920</key>
-		<dict>
-			<key>fileRef</key>
-			<string>69CB62AA1CB8165900024920</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>69CB62AE1CB8165900024920</key>
-		<dict>
-			<key>fileRef</key>
-			<string>69CB62AA1CB8165900024920</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>69E0E8A71D356C9400627613</key>
-		<dict>
-			<key>fileRef</key>
-			<string>1950C4481A3BB5C1005C8279</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>69E100691CA89CB600D88C1B</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASEnvironmentInternal.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>69E1006A1CA89CB600D88C1B</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ASEnvironmentInternal.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>69E1006E1CA89CB600D88C1B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>69E100691CA89CB600D88C1B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>69E1006F1CA89CB600D88C1B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>69E1006A1CA89CB600D88C1B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>69E100701CA89CB600D88C1B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>69E1006A1CA89CB600D88C1B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>69F10C851C84C35D0026140C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASRangeControllerUpdateRangeProtocol+Beta.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>69F10C871C84C35D0026140C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>69F10C851C84C35D0026140C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>6BDC61F51978FEA400E50D21</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>AsyncDisplayKit.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>6FC88520799A02B99A34AE39</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>&#128230; Check Pods Manifest.lock</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>diff "${PODS_ROOT}/../Podfile.lock" "${PODS_ROOT}/Manifest.lock" &gt; /dev/null
-if [[ $? != 0 ]] ; then
-    cat &lt;&lt; EOM
-error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.
-EOM
-    exit 1
-fi
-</string>
-			<key>showEnvVarsInLog</key>
-			<string>0</string>
-		</dict>
-		<key>7095785F8A59BE64AD3E4C7E</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>&#128230; Copy Pods Resources</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>"${SRCROOT}/Pods/Target Support Files/Pods-AsyncDisplayKitTests/Pods-AsyncDisplayKitTests-resources.sh"
-</string>
-			<key>showEnvVarsInLog</key>
-			<string>0</string>
-		</dict>
-		<key>7630FFA81C9E267E007A7C0E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AEEC47DF1C20C2DD00EC1693</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>764D83D21C8EA515009B4FB8</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>AsyncDisplayKit+Debug.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>764D83D31C8EA515009B4FB8</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>AsyncDisplayKit+Debug.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>764D83D51C8EA515009B4FB8</key>
-		<dict>
-			<key>fileRef</key>
-			<string>764D83D21C8EA515009B4FB8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>764D83D61C8EA515009B4FB8</key>
-		<dict>
-			<key>fileRef</key>
-			<string>764D83D31C8EA515009B4FB8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>767E7F8E1C90191D0066C000</key>
-		<dict>
-			<key>fileRef</key>
-			<string>764D83D31C8EA515009B4FB8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>7A06A7381C35F08800FE8DAA</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>name</key>
-			<string>ASRelativeLayoutSpec.mm</string>
-			<key>path</key>
-			<string>AsyncDisplayKit/Layout/ASRelativeLayoutSpec.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>7A06A7391C35F08800FE8DAA</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>ASRelativeLayoutSpec.h</string>
-			<key>path</key>
-			<string>AsyncDisplayKit/Layout/ASRelativeLayoutSpec.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>7A06A73A1C35F08800FE8DAA</key>
-		<dict>
-			<key>fileRef</key>
-			<string>7A06A7381C35F08800FE8DAA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>7AB338661C55B3420055FDE8</key>
-		<dict>
-			<key>fileRef</key>
-			<string>7A06A7381C35F08800FE8DAA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>7AB338671C55B3460055FDE8</key>
-		<dict>
-			<key>fileRef</key>
-			<string>7A06A7391C35F08800FE8DAA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>7AB338681C55B97B0055FDE8</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ASRelativeLayoutSpecSnapshotTests.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>7AB338691C55B97B0055FDE8</key>
-		<dict>
-			<key>fileRef</key>
-			<string>7AB338681C55B97B0055FDE8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>8021EC1A1D2B00B100799119</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>UIImage+ASConvenience.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8021EC1B1D2B00B100799119</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>UIImage+ASConvenience.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8021EC1D1D2B00B100799119</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8021EC1A1D2B00B100799119</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>8021EC1E1D2B00B100799119</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8021EC1B1D2B00B100799119</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>8021EC1F1D2B00B100799119</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8021EC1B1D2B00B100799119</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>81E95C131D62639600336598</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASTextNodeSnapshotTests.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>81E95C141D62639600336598</key>
-		<dict>
-			<key>fileRef</key>
-			<string>81E95C131D62639600336598</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>81EE384D1C8E94F000456208</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>ASRunLoopQueue.h</string>
-			<key>path</key>
-			<string>../ASRunLoopQueue.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>81EE384E1C8E94F000456208</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>name</key>
-			<string>ASRunLoopQueue.mm</string>
-			<key>path</key>
-			<string>../ASRunLoopQueue.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>81EE38501C8E94F000456208</key>
-		<dict>
-			<key>fileRef</key>
-			<string>81EE384E1C8E94F000456208</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>8263A58A38B225EFD5108DAB</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>&#128230; Embed Pods Frameworks</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>"${SRCROOT}/Pods/Target Support Files/Pods-AsyncDisplayKitTests/Pods-AsyncDisplayKitTests-frameworks.sh"
-</string>
-			<key>showEnvVarsInLog</key>
-			<string>0</string>
-		</dict>
-		<key>83A7D9581D44542100BF333E</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASWeakMap.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>83A7D9591D44542100BF333E</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASWeakMap.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>83A7D95A1D44542100BF333E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>83A7D9591D44542100BF333E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>83A7D95B1D44547700BF333E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>83A7D9591D44542100BF333E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>83A7D95C1D44548100BF333E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>83A7D9581D44542100BF333E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>83A7D95D1D446A6E00BF333E</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASWeakMapTests.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>83A7D95E1D446A6E00BF333E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>83A7D95D1D446A6E00BF333E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>8B0768B11CE752EC002E1453</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASDefaultPlaybackButton.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8B0768B21CE752EC002E1453</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASDefaultPlaybackButton.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8B0768B41CE752EC002E1453</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8B0768B21CE752EC002E1453</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>8BBBAB8C1CEBAF1700107FC6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8B0768B11CE752EC002E1453</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>8BBBAB8D1CEBAF1E00107FC6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8B0768B21CE752EC002E1453</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>8BDA5FC31CDBDDE1007D13B2</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASVideoPlayerNode.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8BDA5FC41CDBDDE1007D13B2</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ASVideoPlayerNode.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8BDA5FC61CDBDDE1007D13B2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8BDA5FC41CDBDDE1007D13B2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>8BDA5FC71CDBDF91007D13B2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8BDA5FC31CDBDDE1007D13B2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>8BDA5FC81CDBDF95007D13B2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8BDA5FC41CDBDDE1007D13B2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>92074A5E1CC8B9DD00918F75</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>92074A5F1CC8BA1900918F75</string>
-				<string>92074A601CC8BA1900918F75</string>
-				<string>92074A651CC8BADA00918F75</string>
-				<string>92074A661CC8BADA00918F75</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>tvOS</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>92074A5F1CC8BA1900918F75</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASImageNode+tvOS.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>92074A601CC8BA1900918F75</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASImageNode+tvOS.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>92074A621CC8BA1900918F75</key>
-		<dict>
-			<key>fileRef</key>
-			<string>92074A5F1CC8BA1900918F75</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>92074A631CC8BA1900918F75</key>
-		<dict>
-			<key>fileRef</key>
-			<string>92074A601CC8BA1900918F75</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>92074A641CC8BA1900918F75</key>
-		<dict>
-			<key>fileRef</key>
-			<string>92074A601CC8BA1900918F75</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>92074A651CC8BADA00918F75</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASControlNode+tvOS.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>92074A661CC8BADA00918F75</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASControlNode+tvOS.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>92074A681CC8BADA00918F75</key>
-		<dict>
-			<key>fileRef</key>
-			<string>92074A651CC8BADA00918F75</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>92074A691CC8BADA00918F75</key>
-		<dict>
-			<key>fileRef</key>
-			<string>92074A661CC8BADA00918F75</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>92074A6A1CC8BADA00918F75</key>
-		<dict>
-			<key>fileRef</key>
-			<string>92074A661CC8BADA00918F75</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>92DD2FE11BF4B97E0074C9DD</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASMapNode.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>92DD2FE21BF4B97E0074C9DD</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ASMapNode.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>92DD2FE41BF4B97E0074C9DD</key>
-		<dict>
-			<key>fileRef</key>
-			<string>92DD2FE21BF4B97E0074C9DD</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>92DD2FE51BF4D05E0074C9DD</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>MapKit.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/MapKit.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>92DD2FE61BF4D05E0074C9DD</key>
-		<dict>
-			<key>fileRef</key>
-			<string>92DD2FE51BF4D05E0074C9DD</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>92DD2FE71BF4D0850074C9DD</key>
-		<dict>
-			<key>fileRef</key>
-			<string>92DD2FE21BF4B97E0074C9DD</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>92DD2FE81BF4D0A80074C9DD</key>
-		<dict>
-			<key>fileRef</key>
-			<string>92DD2FE11BF4B97E0074C9DD</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>92DD2FE91BF4D4870074C9DD</key>
-		<dict>
-			<key>fileRef</key>
-			<string>92DD2FE51BF4D05E0074C9DD</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Weak</string>
-				</array>
-			</dict>
-		</dict>
-		<key>92DD2FEA1BF4D49B0074C9DD</key>
-		<dict>
-			<key>fileRef</key>
-			<string>92DD2FE51BF4D05E0074C9DD</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9B92C8851BC2EB6E00EE46B2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>251B8EF31BBB3D690087C538</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9B92C8861BC2EB7600EE46B2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>251B8EF51BBB3D690087C538</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9C49C36E1B853957000B0DD5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>ASStackLayoutable.h</string>
-			<key>path</key>
-			<string>AsyncDisplayKit/Layout/ASStackLayoutable.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9C49C3701B853961000B0DD5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9C49C36E1B853957000B0DD5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>9C5586671BD549CB00B50E3A</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>ASAsciiArtBoxCreator.h</string>
-			<key>path</key>
-			<string>AsyncDisplayKit/Layout/ASAsciiArtBoxCreator.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9C5586681BD549CB00B50E3A</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>ASAsciiArtBoxCreator.m</string>
-			<key>path</key>
-			<string>AsyncDisplayKit/Layout/ASAsciiArtBoxCreator.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9C55866A1BD549CB00B50E3A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9C5586681BD549CB00B50E3A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9C55866B1BD54A1900B50E3A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9C5586681BD549CB00B50E3A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9C55866C1BD54A3000B50E3A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9C5586671BD549CB00B50E3A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>9C6BB3B01B8CC9C200F13F52</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>ASStaticLayoutable.h</string>
-			<key>path</key>
-			<string>AsyncDisplayKit/Layout/ASStaticLayoutable.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9C6BB3B31B8CC9C200F13F52</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9C6BB3B01B8CC9C200F13F52</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>9C70F2011CDA4EFA007D6C76</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASTraitCollection.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9C70F2021CDA4EFA007D6C76</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASTraitCollection.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9C70F2041CDA4EFA007D6C76</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9C70F2021CDA4EFA007D6C76</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9C70F2051CDA4F06007D6C76</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9C70F2021CDA4EFA007D6C76</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9C70F2061CDA4F0C007D6C76</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9C70F2011CDA4EFA007D6C76</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>9C70F2081CDAA3C6007D6C76</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9CFFC6BD1CCAC52B006A6476</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9C70F2091CDABA36007D6C76</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9CFFC6BF1CCAC73C006A6476</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9C70F20A1CDBE949007D6C76</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9CFFC6C11CCAC768006A6476</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9C70F20B1CDBE9A4007D6C76</key>
-		<dict>
-			<key>fileRef</key>
-			<string>251B8EF61BBB3D690087C538</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9C70F20C1CDBE9B6007D6C76</key>
-		<dict>
-			<key>fileRef</key>
-			<string>251B8EF21BBB3D690087C538</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9C70F20D1CDBE9CB007D6C76</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AEB7B0181C5962EA00662EF4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9C70F20E1CDBE9E5007D6C76</key>
-		<dict>
-			<key>fileRef</key>
-			<string>DBC452D91C5BF64600B16017</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>9C70F20F1CDBE9FF007D6C76</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B30BF6501C5964B0004FCD53</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9C8221931BA237B80037F19A</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASStackBaselinePositionedLayout.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9C8221941BA237B80037F19A</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ASStackBaselinePositionedLayout.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9C8221961BA237B80037F19A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9C8221931BA237B80037F19A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9C8221971BA237B80037F19A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9C8221941BA237B80037F19A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9C8221981BA237B80037F19A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9C8221941BA237B80037F19A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9C8898BA1C738B9800D6B02E</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>name</key>
-			<string>ASTextKitFontSizeAdjuster.mm</string>
-			<key>path</key>
-			<string>TextKit/ASTextKitFontSizeAdjuster.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9C8898BB1C738B9800D6B02E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9C8898BA1C738B9800D6B02E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9C8898BC1C738BA800D6B02E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9C8898BA1C738B9800D6B02E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9C8898BD1C738BB800D6B02E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>A32FEDD31C501B6A004F642A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9CC606651D24DF9E006581A0</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CC4981BB1D1C7F65004E13CC</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9CDC18CB1B910E12004965E2</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>ASLayoutablePrivate.h</string>
-			<key>path</key>
-			<string>AsyncDisplayKit/Layout/ASLayoutablePrivate.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9CDC18CD1B910E12004965E2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9CDC18CB1B910E12004965E2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>9CFFC6BD1CCAC52B006A6476</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ASEnvironment.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9CFFC6BE1CCAC52B006A6476</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9CFFC6BD1CCAC52B006A6476</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9CFFC6BF1CCAC73C006A6476</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ASViewController.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9CFFC6C01CCAC73C006A6476</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9CFFC6BF1CCAC73C006A6476</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9CFFC6C11CCAC768006A6476</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ASTableNode.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9CFFC6C21CCAC768006A6476</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9CFFC6C11CCAC768006A6476</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9F06E5CC1B4CAF4200F015D8</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>lineEnding</key>
-			<string>0</string>
-			<key>path</key>
-			<string>ASCollectionViewTests.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-			<key>xcLanguageSpecificationIdentifier</key>
-			<string>xcode.lang.objc</string>
-		</dict>
-		<key>9F06E5CD1B4CAF4200F015D8</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9F06E5CC1B4CAF4200F015D8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>A2763D771CBDD57D00A9ADBD</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>ASPINRemoteImageDownloader.h</string>
-			<key>path</key>
-			<string>Details/ASPINRemoteImageDownloader.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>A2763D781CBDD57D00A9ADBD</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>ASPINRemoteImageDownloader.m</string>
-			<key>path</key>
-			<string>Details/ASPINRemoteImageDownloader.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>A2763D7A1CBDD57D00A9ADBD</key>
-		<dict>
-			<key>fileRef</key>
-			<string>A2763D771CBDD57D00A9ADBD</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>A32FEDD31C501B6A004F642A</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>ASTextKitFontSizeAdjuster.h</string>
-			<key>path</key>
-			<string>TextKit/ASTextKitFontSizeAdjuster.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>A373200E1C571B050011FC94</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASTextNode+Beta.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>A37320101C571B740011FC94</key>
-		<dict>
-			<key>fileRef</key>
-			<string>A373200E1C571B050011FC94</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>AC026B571BD3F61800BBC17E</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASStaticLayoutSpecSnapshotTests.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AC026B581BD3F61800BBC17E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AC026B571BD3F61800BBC17E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>AC026B671BD57D6F00BBC17E</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASChangeSetDataController.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AC026B681BD57D6F00BBC17E</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ASChangeSetDataController.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AC026B6A1BD57D6F00BBC17E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AC026B671BD57D6F00BBC17E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>AC026B6B1BD57D6F00BBC17E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AC026B681BD57D6F00BBC17E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>AC026B6C1BD57D6F00BBC17E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AC026B681BD57D6F00BBC17E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>AC026B6D1BD57DBF00BBC17E</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>_ASHierarchyChangeSet.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AC026B6E1BD57DBF00BBC17E</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>_ASHierarchyChangeSet.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AC026B701BD57DBF00BBC17E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AC026B6D1BD57DBF00BBC17E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>AC026B711BD57DBF00BBC17E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AC026B6E1BD57DBF00BBC17E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>AC026B721BD57DBF00BBC17E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AC026B6E1BD57DBF00BBC17E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>AC21EC0F1B3D0BF600C8B19A</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>ASStackLayoutDefines.h</string>
-			<key>path</key>
-			<string>AsyncDisplayKit/Layout/ASStackLayoutDefines.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AC3C4A4F1A1139C100143C57</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>lineEnding</key>
-			<string>0</string>
-			<key>path</key>
-			<string>ASCollectionView.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AC3C4A501A1139C100143C57</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>lineEnding</key>
-			<string>0</string>
-			<key>path</key>
-			<string>ASCollectionView.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AC3C4A521A1139C100143C57</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AC3C4A501A1139C100143C57</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>AC3C4A531A113EEC00143C57</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASCollectionViewProtocols.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AC47D9421B3B891B00AAEE9D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AC6456071B0A335000CF11B8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>AC47D9431B3BB41900AAEE9D</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>ASRelativeSize.h</string>
-			<key>path</key>
-			<string>AsyncDisplayKit/Layout/ASRelativeSize.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AC47D9441B3BB41900AAEE9D</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>name</key>
-			<string>ASRelativeSize.mm</string>
-			<key>path</key>
-			<string>AsyncDisplayKit/Layout/ASRelativeSize.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AC47D9461B3BB41900AAEE9D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AC47D9441B3BB41900AAEE9D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>AC6456051B0A333200CF11B8</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>9C5586671BD549CB00B50E3A</string>
-				<string>9C5586681BD549CB00B50E3A</string>
-				<string>ACF6ED011B17843500DA7C62</string>
-				<string>ACF6ED021B17843500DA7C62</string>
-				<string>ACF6ED031B17843500DA7C62</string>
-				<string>ACF6ED041B17843500DA7C62</string>
-				<string>ACF6ED071B17843500DA7C62</string>
-				<string>ACF6ED081B17843500DA7C62</string>
-				<string>ACF6ED091B17843500DA7C62</string>
-				<string>ACF6ED0A1B17843500DA7C62</string>
-				<string>ACF6ED0B1B17843500DA7C62</string>
-				<string>ACF6ED0C1B17843500DA7C62</string>
-				<string>ACF6ED111B17843500DA7C62</string>
-				<string>E55D86311CA8A14000A0C26F</string>
-				<string>698C8B601CAB49FC0052DC3F</string>
-				<string>9CDC18CB1B910E12004965E2</string>
-				<string>ACF6ED0D1B17843500DA7C62</string>
-				<string>ACF6ED0E1B17843500DA7C62</string>
-				<string>697C0DE11CF38F28001DE0D4</string>
-				<string>697C0DE21CF38F28001DE0D4</string>
-				<string>ACF6ED121B17843500DA7C62</string>
-				<string>ACF6ED131B17843500DA7C62</string>
-				<string>ACF6ED141B17843500DA7C62</string>
-				<string>ACF6ED151B17843500DA7C62</string>
-				<string>7A06A7391C35F08800FE8DAA</string>
-				<string>7A06A7381C35F08800FE8DAA</string>
-				<string>AC47D9431B3BB41900AAEE9D</string>
-				<string>AC47D9441B3BB41900AAEE9D</string>
-				<string>9C49C36E1B853957000B0DD5</string>
-				<string>AC21EC0F1B3D0BF600C8B19A</string>
-				<string>ACF6ED161B17843500DA7C62</string>
-				<string>ACF6ED171B17843500DA7C62</string>
-				<string>9C6BB3B01B8CC9C200F13F52</string>
-				<string>ACF6ED181B17843500DA7C62</string>
-				<string>ACF6ED191B17843500DA7C62</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Layout</string>
-			<key>path</key>
-			<string>..</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AC6456071B0A335000CF11B8</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ASCellNode.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AC6456091B0A335000CF11B8</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AC6456071B0A335000CF11B8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>AC7A2C161BDE11DF0093FE1A</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASTableViewInternal.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AC7A2C181BDE11DF0093FE1A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AC7A2C161BDE11DF0093FE1A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>ACC945A81BA9E7A0005E1FB8</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASViewController.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ACF6ED011B17843500DA7C62</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>ASBackgroundLayoutSpec.h</string>
-			<key>path</key>
-			<string>AsyncDisplayKit/Layout/ASBackgroundLayoutSpec.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ACF6ED021B17843500DA7C62</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>lineEnding</key>
-			<string>0</string>
-			<key>name</key>
-			<string>ASBackgroundLayoutSpec.mm</string>
-			<key>path</key>
-			<string>AsyncDisplayKit/Layout/ASBackgroundLayoutSpec.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ACF6ED031B17843500DA7C62</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>ASCenterLayoutSpec.h</string>
-			<key>path</key>
-			<string>AsyncDisplayKit/Layout/ASCenterLayoutSpec.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ACF6ED041B17843500DA7C62</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>lineEnding</key>
-			<string>0</string>
-			<key>name</key>
-			<string>ASCenterLayoutSpec.mm</string>
-			<key>path</key>
-			<string>AsyncDisplayKit/Layout/ASCenterLayoutSpec.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ACF6ED071B17843500DA7C62</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>ASDimension.h</string>
-			<key>path</key>
-			<string>AsyncDisplayKit/Layout/ASDimension.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ACF6ED081B17843500DA7C62</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>name</key>
-			<string>ASDimension.mm</string>
-			<key>path</key>
-			<string>AsyncDisplayKit/Layout/ASDimension.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ACF6ED091B17843500DA7C62</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>ASInsetLayoutSpec.h</string>
-			<key>path</key>
-			<string>AsyncDisplayKit/Layout/ASInsetLayoutSpec.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ACF6ED0A1B17843500DA7C62</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>lineEnding</key>
-			<string>0</string>
-			<key>name</key>
-			<string>ASInsetLayoutSpec.mm</string>
-			<key>path</key>
-			<string>AsyncDisplayKit/Layout/ASInsetLayoutSpec.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ACF6ED0B1B17843500DA7C62</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>ASLayout.h</string>
-			<key>path</key>
-			<string>AsyncDisplayKit/Layout/ASLayout.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ACF6ED0C1B17843500DA7C62</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>name</key>
-			<string>ASLayout.mm</string>
-			<key>path</key>
-			<string>AsyncDisplayKit/Layout/ASLayout.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ACF6ED0D1B17843500DA7C62</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>ASLayoutSpec.h</string>
-			<key>path</key>
-			<string>AsyncDisplayKit/Layout/ASLayoutSpec.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ACF6ED0E1B17843500DA7C62</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>lineEnding</key>
-			<string>0</string>
-			<key>name</key>
-			<string>ASLayoutSpec.mm</string>
-			<key>path</key>
-			<string>AsyncDisplayKit/Layout/ASLayoutSpec.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ACF6ED111B17843500DA7C62</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>ASLayoutable.h</string>
-			<key>path</key>
-			<string>AsyncDisplayKit/Layout/ASLayoutable.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ACF6ED121B17843500DA7C62</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>ASOverlayLayoutSpec.h</string>
-			<key>path</key>
-			<string>AsyncDisplayKit/Layout/ASOverlayLayoutSpec.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ACF6ED131B17843500DA7C62</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>lineEnding</key>
-			<string>0</string>
-			<key>name</key>
-			<string>ASOverlayLayoutSpec.mm</string>
-			<key>path</key>
-			<string>AsyncDisplayKit/Layout/ASOverlayLayoutSpec.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ACF6ED141B17843500DA7C62</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>ASRatioLayoutSpec.h</string>
-			<key>path</key>
-			<string>AsyncDisplayKit/Layout/ASRatioLayoutSpec.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ACF6ED151B17843500DA7C62</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>lineEnding</key>
-			<string>0</string>
-			<key>name</key>
-			<string>ASRatioLayoutSpec.mm</string>
-			<key>path</key>
-			<string>AsyncDisplayKit/Layout/ASRatioLayoutSpec.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ACF6ED161B17843500DA7C62</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>ASStackLayoutSpec.h</string>
-			<key>path</key>
-			<string>AsyncDisplayKit/Layout/ASStackLayoutSpec.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ACF6ED171B17843500DA7C62</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>name</key>
-			<string>ASStackLayoutSpec.mm</string>
-			<key>path</key>
-			<string>AsyncDisplayKit/Layout/ASStackLayoutSpec.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ACF6ED181B17843500DA7C62</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>ASStaticLayoutSpec.h</string>
-			<key>path</key>
-			<string>AsyncDisplayKit/Layout/ASStaticLayoutSpec.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ACF6ED191B17843500DA7C62</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>lineEnding</key>
-			<string>0</string>
-			<key>name</key>
-			<string>ASStaticLayoutSpec.mm</string>
-			<key>path</key>
-			<string>AsyncDisplayKit/Layout/ASStaticLayoutSpec.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ACF6ED1B1B17843500DA7C62</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED021B17843500DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>ACF6ED1D1B17843500DA7C62</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED041B17843500DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>ACF6ED211B17843500DA7C62</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED081B17843500DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>ACF6ED231B17843500DA7C62</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED0A1B17843500DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>ACF6ED251B17843500DA7C62</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED0C1B17843500DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>ACF6ED271B17843500DA7C62</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED0E1B17843500DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>ACF6ED2C1B17843500DA7C62</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED131B17843500DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>ACF6ED2E1B17843500DA7C62</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED151B17843500DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>ACF6ED301B17843500DA7C62</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED171B17843500DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>ACF6ED321B17843500DA7C62</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED191B17843500DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>ACF6ED431B17847A00DA7C62</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASInternalHelpers.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ACF6ED441B17847A00DA7C62</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASInternalHelpers.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ACF6ED451B17847A00DA7C62</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASLayoutSpecUtilities.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ACF6ED461B17847A00DA7C62</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASStackLayoutSpecUtilities.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ACF6ED471B17847A00DA7C62</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASStackPositionedLayout.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ACF6ED481B17847A00DA7C62</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ASStackPositionedLayout.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ACF6ED491B17847A00DA7C62</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASStackUnpositionedLayout.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ACF6ED4A1B17847A00DA7C62</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>lineEnding</key>
-			<string>0</string>
-			<key>path</key>
-			<string>ASStackUnpositionedLayout.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ACF6ED4C1B17847A00DA7C62</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED441B17847A00DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>ACF6ED501B17847A00DA7C62</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED481B17847A00DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>ACF6ED521B17847A00DA7C62</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED4A1B17847A00DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>ACF6ED531B178DC700DA7C62</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ASCenterLayoutSpecSnapshotTests.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ACF6ED541B178DC700DA7C62</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ASDimensionTests.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ACF6ED551B178DC700DA7C62</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ASInsetLayoutSpecSnapshotTests.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ACF6ED571B178DC700DA7C62</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASLayoutSpecSnapshotTestsHelper.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ACF6ED581B178DC700DA7C62</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>lineEnding</key>
-			<string>0</string>
-			<key>path</key>
-			<string>ASLayoutSpecSnapshotTestsHelper.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-			<key>xcLanguageSpecificationIdentifier</key>
-			<string>xcode.lang.objc</string>
-		</dict>
-		<key>ACF6ED591B178DC700DA7C62</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ASOverlayLayoutSpecSnapshotTests.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ACF6ED5A1B178DC700DA7C62</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ASRatioLayoutSpecSnapshotTests.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ACF6ED5B1B178DC700DA7C62</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ASStackLayoutSpecSnapshotTests.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>ACF6ED5C1B178DC700DA7C62</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED531B178DC700DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>ACF6ED5D1B178DC700DA7C62</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED541B178DC700DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>ACF6ED5E1B178DC700DA7C62</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED551B178DC700DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>ACF6ED601B178DC700DA7C62</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED581B178DC700DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>ACF6ED611B178DC700DA7C62</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED591B178DC700DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>ACF6ED621B178DC700DA7C62</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED5A1B178DC700DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>ACF6ED631B178DC700DA7C62</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED5B1B178DC700DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>AEB7B0181C5962EA00662EF4</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASDefaultPlayButton.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AEB7B0191C5962EA00662EF4</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASDefaultPlayButton.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AEB7B01B1C5962EA00662EF4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AEB7B0191C5962EA00662EF4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>AEEC47DF1C20C2DD00EC1693</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASVideoNode.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AEEC47E01C20C2DD00EC1693</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ASVideoNode.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AEEC47E21C20C2DD00EC1693</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AEEC47E01C20C2DD00EC1693</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>AEEC47E31C21D3D200EC1693</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASVideoNodeTests.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AEEC47E41C21D3D200EC1693</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AEEC47E31C21D3D200EC1693</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B0F880581BEAEC7500D17647</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASTableNode.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B130AB1AC0A1E5162E211C19</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>[CP] Embed Pods Frameworks</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>"${SRCROOT}/Pods/Target Support Files/Pods-AsyncDisplayKitTests/Pods-AsyncDisplayKitTests-frameworks.sh"
-</string>
-			<key>showEnvVarsInLog</key>
-			<string>0</string>
-		</dict>
-		<key>B13CA0F61C519E9400E031AB</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASCollectionViewLayoutFacilitatorProtocol.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B13CA0F81C519EBA00E031AB</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B13CA0F61C519E9400E031AB</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>B13CA0FF1C52004900E031AB</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASCollectionNode+Beta.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B13CA1011C52004900E031AB</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B13CA0FF1C52004900E031AB</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>B30BF6501C5964B0004FCD53</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>ASLayoutManager.h</string>
-			<key>path</key>
-			<string>TextKit/ASLayoutManager.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B30BF6511C5964B0004FCD53</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>ASLayoutManager.m</string>
-			<key>path</key>
-			<string>TextKit/ASLayoutManager.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B30BF6531C5964B0004FCD53</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B30BF6511C5964B0004FCD53</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B30BF6541C59D889004FCD53</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B30BF6511C5964B0004FCD53</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B35061D51B010EDF0018CF92</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>9C70F2091CDABA36007D6C76</string>
-				<string>8BBBAB8D1CEBAF1E00107FC6</string>
-				<string>DE4843DB1C93EAB100A1F33B</string>
-				<string>B30BF6541C59D889004FCD53</string>
-				<string>92DD2FE71BF4D0850074C9DD</string>
-				<string>636EA1A51C7FF4EF00EE152F</string>
-				<string>9B92C8861BC2EB7600EE46B2</string>
-				<string>9B92C8851BC2EB6E00EE46B2</string>
-				<string>B350623D1B010EFD0018CF92</string>
-				<string>B35062401B010EFD0018CF92</string>
-				<string>AC026B721BD57DBF00BBC17E</string>
-				<string>B35062421B010EFD0018CF92</string>
-				<string>B350624A1B010EFD0018CF92</string>
-				<string>68EE0DC01C1B4ED300BA1B99</string>
-				<string>B35062101B010EFD0018CF92</string>
-				<string>9C55866B1BD54A1900B50E3A</string>
-				<string>B35062121B010EFD0018CF92</string>
-				<string>DEFAD8131CC48914000527C4</string>
-				<string>B350624C1B010EFD0018CF92</string>
-				<string>69708BA81D76386D005C3CF9</string>
-				<string>509E68621B3AEDA5009B9150</string>
-				<string>254C6B861BF94F8A003EC431</string>
-				<string>DBDB83971C6E879900D0098C</string>
-				<string>9C8898BC1C738BA800D6B02E</string>
-				<string>34EFC7621B701CA400AD841F</string>
-				<string>DE8BEAC41C2DF3FC00D57C12</string>
-				<string>9C70F2081CDAA3C6007D6C76</string>
-				<string>B35062141B010EFD0018CF92</string>
-				<string>B35062161B010EFD0018CF92</string>
-				<string>AC47D9421B3B891B00AAEE9D</string>
-				<string>34EFC7641B701CC600AD841F</string>
-				<string>18C2ED831B9B7DE800F627B3</string>
-				<string>E55D86331CA8A14000A0C26F</string>
-				<string>68FC85EC1CE29C7D00EDD713</string>
-				<string>68B8A4E41CBDB958007E4543</string>
-				<string>9C70F20A1CDBE949007D6C76</string>
-				<string>69CB62AE1CB8165900024920</string>
-				<string>B35061F61B010EFD0018CF92</string>
-				<string>509E68641B3AEDB7009B9150</string>
-				<string>B35061F91B010EFD0018CF92</string>
-				<string>8021EC1F1D2B00B100799119</string>
-				<string>B35062181B010EFD0018CF92</string>
-				<string>B350621A1B010EFD0018CF92</string>
-				<string>767E7F8E1C90191D0066C000</string>
-				<string>34EFC75C1B701BD200AD841F</string>
-				<string>B350624E1B010EFD0018CF92</string>
-				<string>25E327591C16819500A2170C</string>
-				<string>636EA1A41C7FF4EC00EE152F</string>
-				<string>B35062501B010EFD0018CF92</string>
-				<string>DEC146B91C37A16A004A0EE7</string>
-				<string>69E100701CA89CB600D88C1B</string>
-				<string>254C6B891BF94F8A003EC431</string>
-				<string>68355B341CB579B9001D4E68</string>
-				<string>E5711A301C840C96009619D4</string>
-				<string>B35062511B010EFD0018CF92</string>
-				<string>B35061FC1B010EFD0018CF92</string>
-				<string>B35061FF1B010EFD0018CF92</string>
-				<string>B35062011B010EFD0018CF92</string>
-				<string>254C6B881BF94F8A003EC431</string>
-				<string>CC3B208C1C3F7A5400798563</string>
-				<string>B350621C1B010EFD0018CF92</string>
-				<string>B350621E1B010EFD0018CF92</string>
-				<string>9CC606651D24DF9E006581A0</string>
-				<string>92074A641CC8BA1900918F75</string>
-				<string>B35062541B010EFD0018CF92</string>
-				<string>CC446A311D80AAE00071FD03</string>
-				<string>68355B401CB57A69001D4E68</string>
-				<string>B35062031B010EFD0018CF92</string>
-				<string>254C6B821BF94F8A003EC431</string>
-				<string>430E7C921B4C23F100697A4C</string>
-				<string>34EFC7601B701C8B00AD841F</string>
-				<string>34EFC75E1B701BF000AD841F</string>
-				<string>34EFC7681B701CDE00AD841F</string>
-				<string>DECBD6EA1BE56E1900CF4905</string>
-				<string>254C6B841BF94F8A003EC431</string>
-				<string>34EFC76B1B701CEB00AD841F</string>
-				<string>CC3B20861C3F76D600798563</string>
-				<string>254C6B8C1BF94F8A003EC431</string>
-				<string>B35062051B010EFD0018CF92</string>
-				<string>B35062251B010EFD0018CF92</string>
-				<string>B35062071B010EFD0018CF92</string>
-				<string>34EFC76D1B701CF100AD841F</string>
-				<string>044285101BAA64EC00D16268</string>
-				<string>B35062271B010EFD0018CF92</string>
-				<string>0442850A1BAA63FE00D16268</string>
-				<string>68FC85E61CE29B9400EDD713</string>
-				<string>CC4C2A791D88E3BF0039ACAB</string>
-				<string>34EFC76F1B701CF700AD841F</string>
-				<string>254C6B8B1BF94F8A003EC431</string>
-				<string>34EFC7661B701CD200AD841F</string>
-				<string>254C6B851BF94F8A003EC431</string>
-				<string>509E68601B3AED8E009B9150</string>
-				<string>B35062091B010EFD0018CF92</string>
-				<string>B35062561B010EFD0018CF92</string>
-				<string>9C8221981BA237B80037F19A</string>
-				<string>8BDA5FC81CDBDF95007D13B2</string>
-				<string>34EFC7721B701D0300AD841F</string>
-				<string>34EFC7761B701D2A00AD841F</string>
-				<string>7AB338661C55B3420055FDE8</string>
-				<string>697C0DE61CF38F28001DE0D4</string>
-				<string>9C70F2051CDA4F06007D6C76</string>
-				<string>83A7D95B1D44547700BF333E</string>
-				<string>34EFC7781B701D3100AD841F</string>
-				<string>DE84918E1C8FFF9F003D89E9</string>
-				<string>68FC85E51CE29B7E00EDD713</string>
-				<string>AC026B6C1BD57D6F00BBC17E</string>
-				<string>34EFC7741B701D0A00AD841F</string>
-				<string>92074A6A1CC8BADA00918F75</string>
-				<string>DB78412E1C6BCE1600A9E2B4</string>
-				<string>B350620B1B010EFD0018CF92</string>
-				<string>B350620E1B010EFD0018CF92</string>
-				<string>6959433F1D70815300B0EE1F</string>
-				<string>68355B3E1CB57A60001D4E68</string>
-				<string>509E68661B3AEDD7009B9150</string>
-				<string>254C6B871BF94F8A003EC431</string>
-				<string>34566CB31BC1213700715E6B</string>
-				<string>254C6B831BF94F8A003EC431</string>
-				<string>B350623B1B010EFD0018CF92</string>
-				<string>044284FD1BAA365100D16268</string>
-				<string>254C6B8A1BF94F8A003EC431</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>B35061D61B010EDF0018CF92</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>92DD2FE61BF4D05E0074C9DD</string>
-				<string>B350625F1B0111800018CF92</string>
-				<string>B350625E1B0111780018CF92</string>
-				<string>B350625D1B0111740018CF92</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>B35061D71B010EDF0018CF92</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>69E0E8A71D356C9400627613</string>
-				<string>698C8B621CAB49FC0052DC3F</string>
-				<string>698548641CA9E025008A345F</string>
-				<string>AC026B6A1BD57D6F00BBC17E</string>
-				<string>B35062481B010EFD0018CF92</string>
-				<string>69F10C871C84C35D0026140C</string>
-				<string>B350623C1B010EFD0018CF92</string>
-				<string>9C70F20D1CDBE9CB007D6C76</string>
-				<string>68355B411CB57A6C001D4E68</string>
-				<string>7630FFA81C9E267E007A7C0E</string>
-				<string>B350623F1B010EFD0018CF92</string>
-				<string>B13CA1011C52004900E031AB</string>
-				<string>254C6B7E1BF94DF4003EC431</string>
-				<string>B35062411B010EFD0018CF92</string>
-				<string>B35062491B010EFD0018CF92</string>
-				<string>B350620F1B010EFD0018CF92</string>
-				<string>B35062111B010EFD0018CF92</string>
-				<string>68EE0DBE1C1B4ED300BA1B99</string>
-				<string>B350624B1B010EFD0018CF92</string>
-				<string>CC54A81C1D70079800296A24</string>
-				<string>9C55866C1BD54A3000B50E3A</string>
-				<string>B350624D1B010EFD0018CF92</string>
-				<string>254C6B771BF94DF4003EC431</string>
-				<string>509E68611B3AEDA0009B9150</string>
-				<string>B35062571B010F070018CF92</string>
-				<string>254C6B7D1BF94DF4003EC431</string>
-				<string>B35062581B010F070018CF92</string>
-				<string>DE84918D1C8FFF2B003D89E9</string>
-				<string>254C6B731BF94DF4003EC431</string>
-				<string>A2763D7A1CBDD57D00A9ADBD</string>
-				<string>254C6B7A1BF94DF4003EC431</string>
-				<string>69CB62AC1CB8165900024920</string>
-				<string>68355B3F1CB57A64001D4E68</string>
-				<string>254C6B7C1BF94DF4003EC431</string>
-				<string>34EFC7611B701C9C00AD841F</string>
-				<string>68AF37DB1CBEF4D80077BF76</string>
-				<string>B35062591B010F070018CF92</string>
-				<string>B35062131B010EFD0018CF92</string>
-				<string>B35062461B010EFD0018CF92</string>
-				<string>B35062151B010EFD0018CF92</string>
-				<string>92074A681CC8BADA00918F75</string>
-				<string>044285081BAA63FE00D16268</string>
-				<string>AC026B701BD57DBF00BBC17E</string>
-				<string>B35061F31B010EFD0018CF92</string>
-				<string>34EFC7631B701CBF00AD841F</string>
-				<string>9C70F20C1CDBE9B6007D6C76</string>
-				<string>18C2ED7F1B9B7DE800F627B3</string>
-				<string>9C8898BD1C738BB800D6B02E</string>
-				<string>B35061F51B010EFD0018CF92</string>
-				<string>254C6B791BF94DF4003EC431</string>
-				<string>509E68631B3AEDB4009B9150</string>
-				<string>CC3B20841C3F76D600798563</string>
-				<string>92074A621CC8BA1900918F75</string>
-				<string>B35061F71B010EFD0018CF92</string>
-				<string>68FC85E31CE29B7E00EDD713</string>
-				<string>DE6EA3231C14000600183B10</string>
-				<string>9C70F20F1CDBE9FF007D6C76</string>
-				<string>B35061FA1B010EFD0018CF92</string>
-				<string>B35061F81B010EFD0018CF92</string>
-				<string>B35062171B010EFD0018CF92</string>
-				<string>B35062191B010EFD0018CF92</string>
-				<string>34EFC75B1B701BAF00AD841F</string>
-				<string>68FC85EA1CE29C7D00EDD713</string>
-				<string>A37320101C571B740011FC94</string>
-				<string>DBABFAFC1C6A8D2F0039EA4A</string>
-				<string>9C70F2061CDA4F0C007D6C76</string>
-				<string>8021EC1D1D2B00B100799119</string>
-				<string>B350624F1B010EFD0018CF92</string>
-				<string>B35061FD1B010EFD0018CF92</string>
-				<string>B35061FB1B010EFD0018CF92</string>
-				<string>B35061FE1B010EFD0018CF92</string>
-				<string>B35062521B010EFD0018CF92</string>
-				<string>B35062001B010EFD0018CF92</string>
-				<string>680346941CE4052A0009FEB4</string>
-				<string>B350621B1B010EFD0018CF92</string>
-				<string>B350621D1B010EFD0018CF92</string>
-				<string>C78F7E2B1BF7809800CDEAFC</string>
-				<string>AC7A2C181BDE11DF0093FE1A</string>
-				<string>B35062531B010EFD0018CF92</string>
-				<string>254C6B7F1BF94DF4003EC431</string>
-				<string>7AB338671C55B3460055FDE8</string>
-				<string>B35062021B010EFD0018CF92</string>
-				<string>B350621F1B010EFD0018CF92</string>
-				<string>430E7C901B4C23F100697A4C</string>
-				<string>9C70F20B1CDBE9A4007D6C76</string>
-				<string>34EFC75F1B701C8600AD841F</string>
-				<string>34EFC75D1B701BE900AD841F</string>
-				<string>34EFC7671B701CD900AD841F</string>
-				<string>DEC146B71C37A16A004A0EE7</string>
-				<string>DBDB83951C6E879900D0098C</string>
-				<string>34EFC7691B701CE100AD841F</string>
-				<string>9CDC18CD1B910E12004965E2</string>
-				<string>68B8A4E21CBDB958007E4543</string>
-				<string>B35062201B010EFD0018CF92</string>
-				<string>697C0DE41CF38F28001DE0D4</string>
-				<string>B35062211B010EFD0018CF92</string>
-				<string>34EFC76A1B701CE600AD841F</string>
-				<string>695943401D70815300B0EE1F</string>
-				<string>34EFC7791B701D3600AD841F</string>
-				<string>B350625C1B010F070018CF92</string>
-				<string>0442850E1BAA64EC00D16268</string>
-				<string>CC3B208A1C3F7A5400798563</string>
-				<string>DE8BEAC21C2DF3FC00D57C12</string>
-				<string>B35062041B010EFD0018CF92</string>
-				<string>B350623E1B010EFD0018CF92</string>
-				<string>DECBD6E81BE56E1900CF4905</string>
-				<string>B35062241B010EFD0018CF92</string>
-				<string>B13CA0F81C519EBA00E031AB</string>
-				<string>8BBBAB8C1CEBAF1700107FC6</string>
-				<string>B35062061B010EFD0018CF92</string>
-				<string>34EFC76C1B701CED00AD841F</string>
-				<string>B35062261B010EFD0018CF92</string>
-				<string>34EFC76E1B701CF400AD841F</string>
-				<string>34EFC7651B701CCC00AD841F</string>
-				<string>254C6B741BF94DF4003EC431</string>
-				<string>DB55C2671C641AE4004EDCF5</string>
-				<string>68B0277B1C1A79D60041016B</string>
-				<string>CCF18FF41D2575E300DF5895</string>
-				<string>83A7D95C1D44548100BF333E</string>
-				<string>69708BA61D76386D005C3CF9</string>
-				<string>B350622D1B010EFD0018CF92</string>
-				<string>254C6B751BF94DF4003EC431</string>
-				<string>683489281D70DE3400327501</string>
-				<string>B35062081B010EFD0018CF92</string>
-				<string>25E327571C16819500A2170C</string>
-				<string>B35062551B010EFD0018CF92</string>
-				<string>9C8221961BA237B80037F19A</string>
-				<string>9C70F20E1CDBE9E5007D6C76</string>
-				<string>9C49C3701B853961000B0DD5</string>
-				<string>DE040EF91C2B40AC004692FF</string>
-				<string>34EFC7701B701CFA00AD841F</string>
-				<string>764D83D51C8EA515009B4FB8</string>
-				<string>E5711A2C1C840C81009619D4</string>
-				<string>CC4C2A771D88E3BF0039ACAB</string>
-				<string>254C6B7B1BF94DF4003EC431</string>
-				<string>CC7FD9E21BB603FF005CCB2B</string>
-				<string>DE4843DC1C93EAC100A1F33B</string>
-				<string>254C6B761BF94DF4003EC431</string>
-				<string>34EFC7711B701CFF00AD841F</string>
-				<string>2767E9411BB19BD600EA9B77</string>
-				<string>92DD2FE81BF4D0A80074C9DD</string>
-				<string>044284FE1BAA387800D16268</string>
-				<string>34EFC7751B701D2400AD841F</string>
-				<string>69E1006E1CA89CB600D88C1B</string>
-				<string>34EFC7771B701D2D00AD841F</string>
-				<string>9C6BB3B31B8CC9C200F13F52</string>
-				<string>34EFC7731B701D0700AD841F</string>
-				<string>CC446A2F1D80AAE00071FD03</string>
-				<string>254C6B781BF94DF4003EC431</string>
-				<string>B350620A1B010EFD0018CF92</string>
-				<string>B350620C1B010EFD0018CF92</string>
-				<string>B350620D1B010EFD0018CF92</string>
-				<string>B35062391B010EFD0018CF92</string>
-				<string>2C107F5B1BA9F54500F13DE5</string>
-				<string>509E68651B3AEDC5009B9150</string>
-				<string>B350623A1B010EFD0018CF92</string>
-				<string>044284FF1BAA3BD600D16268</string>
-				<string>B35062431B010EFD0018CF92</string>
-				<string>8BDA5FC71CDBDF91007D13B2</string>
-			</array>
-			<key>isa</key>
-			<string>PBXHeadersBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>B35061D81B010EDF0018CF92</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXResourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>B35061D91B010EDF0018CF92</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>B35061ED1B010EDF0018CF92</string>
-			<key>buildPhases</key>
-			<array>
-				<string>B35061D51B010EDF0018CF92</string>
-				<string>B35061D61B010EDF0018CF92</string>
-				<string>B35061D71B010EDF0018CF92</string>
-				<string>B35061D81B010EDF0018CF92</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>AsyncDisplayKit-iOS</string>
-			<key>productName</key>
-			<string>AsyncDisplayKit</string>
-			<key>productReference</key>
-			<string>B35061DA1B010EDF0018CF92</string>
-			<key>productType</key>
-			<string>com.apple.product-type.framework</string>
-		</dict>
-		<key>B35061DA1B010EDF0018CF92</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.framework</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>AsyncDisplayKit.framework</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>B35061DB1B010EDF0018CF92</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>B35061DC1B010EDF0018CF92</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>AsyncDisplayKit-iOS</string>
-			<key>path</key>
-			<string>AsyncDisplayKit</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B35061DC1B010EDF0018CF92</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>B35061DD1B010EDF0018CF92</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Supporting Files</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B35061DD1B010EDF0018CF92</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>name</key>
-			<string>Info.plist</string>
-			<key>path</key>
-			<string>../AsyncDisplayKit-iOS/Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>B35061ED1B010EDF0018CF92</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>B35061EE1B010EDF0018CF92</string>
-				<string>B35061EF1B010EDF0018CF92</string>
-				<string>DB1020841CBCA2AD00FA6FE1</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>B35061EE1B010EDF0018CF92</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>CLANG_ENABLE_CODE_COVERAGE</key>
-				<string>YES</string>
-				<key>CLANG_WARN_UNREACHABLE_CODE</key>
-				<string>YES</string>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEBUG_INFORMATION_FORMAT</key>
-				<string>dwarf-with-dsym</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>GCC_INSTRUMENT_PROGRAM_FLOW_ARCS</key>
-				<string>YES</string>
-				<key>GCC_NO_COMMON_BLOCKS</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>AsyncDisplayKit/AsyncDisplayKit-Prefix.pch</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>INFOPLIST_FILE</key>
-				<string>$(SRCROOT)/AsyncDisplayKit-iOS/Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<string>$(inherited) @executable_path/Frameworks @loader_path/Frameworks</string>
-				<key>MODULEMAP_FILE</key>
-				<string>AsyncDisplayKit/module.modulemap</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>YES</string>
-				<key>PRODUCT_BUNDLE_IDENTIFIER</key>
-				<string>com.facebook.$(PRODUCT_NAME:rfc1034identifier)</string>
-				<key>PRODUCT_NAME</key>
-				<string>AsyncDisplayKit</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>B35061EF1B010EDF0018CF92</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>CLANG_ENABLE_CODE_COVERAGE</key>
-				<string>YES</string>
-				<key>CLANG_WARN_UNREACHABLE_CODE</key>
-				<string>YES</string>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEBUG_INFORMATION_FORMAT</key>
-				<string>dwarf-with-dsym</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>GCC_INSTRUMENT_PROGRAM_FLOW_ARCS</key>
-				<string>NO</string>
-				<key>GCC_NO_COMMON_BLOCKS</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>AsyncDisplayKit/AsyncDisplayKit-Prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>$(SRCROOT)/AsyncDisplayKit-iOS/Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<string>$(inherited) @executable_path/Frameworks @loader_path/Frameworks</string>
-				<key>MODULEMAP_FILE</key>
-				<string>AsyncDisplayKit/module.modulemap</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>NO</string>
-				<key>PRODUCT_BUNDLE_IDENTIFIER</key>
-				<string>com.facebook.$(PRODUCT_NAME:rfc1034identifier)</string>
-				<key>PRODUCT_NAME</key>
-				<string>AsyncDisplayKit</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>B35061F31B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>055F1A3A19ABD43F004DAFF1</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>B35061F51B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AC3C4A4F1A1139C100143C57</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>B35061F61B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AC3C4A501A1139C100143C57</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B35061F71B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AC3C4A531A113EEC00143C57</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>B35061F81B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09D5195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>B35061F91B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09D6195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B35061FA1B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09D7195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>B35061FB1B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09D8195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>B35061FC1B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09D9195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B35061FD1B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09DA195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>B35061FE1B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09DB195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>B35061FF1B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09DC195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B35062001B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>0587F9BB1A7309ED00AFF0BA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>B35062011B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>0587F9BC1A7309ED00AFF0BA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B35062021B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09DD195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>B35062031B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09DE195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B35062041B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>0516FA3E1A1563D200B4EBED</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>B35062051B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>0516FA3F1A1563D200B4EBED</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B35062061B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>055B9FA61A1C154B00035D6D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>B35062071B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>055B9FA71A1C154B00035D6D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B35062081B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>D785F6601A74327E00291744</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>B35062091B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>D785F6611A74327E00291744</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B350620A1B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>055F1A3219ABD3E3004DAFF1</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>B350620B1B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>055F1A3319ABD3E3004DAFF1</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B350620C1B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>0574D5E119C110610097DC25</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>B350620D1B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09DF195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>B350620E1B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09E0195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B350620F1B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09E2195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>B35062101B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09E3195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B35062111B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09E4195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>B35062121B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09E5195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B35062131B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>054963471A1EA066000F8E56</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>B35062141B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>054963481A1EA066000F8E56</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B35062151B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>299DA1A71A828D2900162D41</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>B35062161B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>299DA1A81A828D2900162D41</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B35062171B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>464052191A3F83C40061C0BA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>B35062181B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>4640521A1A3F83C40061C0BA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B35062191B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>05A6D05819D0EB64002DD95E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>B350621A1B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>05A6D05919D0EB64002DD95E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>B350621B1B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>4640521B1A3F83C40061C0BA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>B350621C1B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>4640521C1A3F83C40061C0BA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B350621D1B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09E6195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>B350621E1B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09E7195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B350621F1B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>05F20AA31A15733C00DCA68A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>B35062201B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>4640521D1A3F83C40061C0BA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>B35062211B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>292C59991A956527007E5DD6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>B35062241B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09E8195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>B35062251B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09E9195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B35062261B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>055F1A3619ABD413004DAFF1</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>B35062271B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>055F1A3719ABD413004DAFF1</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B350622D1B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>296A0A311A951715005ACEAA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>B35062391B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D0A12195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>B350623A1B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09F5195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>B350623B1B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09F6195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B350623C1B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09F8195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>B350623D1B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09F9195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B350623E1B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09FA195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B350623F1B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09FB195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>B35062401B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09FC195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B35062411B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09FD195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>B35062421B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09FE195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B35062431B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09FF195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>B35062461B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2967F9E11AB0A4CF0072E4AB</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B35062481B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D0A02195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B35062491B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D0A03195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B350624A1B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D0A04195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B350624B1B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D0A05195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B350624C1B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D0A06195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B350624D1B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D0A07195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B350624E1B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D0A08195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B350624F1B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D0A09195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B35062501B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D0A0A195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B35062511B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D0A0B195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B35062521B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D0A0C195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B35062531B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D0A0D195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B35062541B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D0A0E195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B35062551B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D0A10195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B35062561B010EFD0018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D0A11195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B35062571B010F070018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D0A43195D058D00B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>B35062581B010F070018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>0516FA3A1A15563400B4EBED</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>B35062591B010F070018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D0A44195D058D00B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>B350625C1B010F070018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>0516FA3B1A15563400B4EBED</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>B350625D1B0111740018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>051943141A1575670030A7D0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B350625E1B0111780018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>051943121A1575630030A7D0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>B350625F1B0111800018CF92</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09AF195D04C000B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>BDC2D162BD55A807C1475DA5</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-AsyncDisplayKitTests.profile.xcconfig</string>
-			<key>path</key>
-			<string>Pods/Target Support Files/Pods-AsyncDisplayKitTests/Pods-AsyncDisplayKitTests.profile.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>C78F7E2B1BF7809800CDEAFC</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B0F880581BEAEC7500D17647</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>CC051F1E1D7A286A006434CB</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASCALayerTests.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>CC051F1F1D7A286A006434CB</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CC051F1E1D7A286A006434CB</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>CC0AEEA31D66316E005D1C78</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASUICollectionViewTests.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>CC0AEEA41D66316E005D1C78</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CC0AEEA31D66316E005D1C78</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>CC3B20811C3F76D600798563</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASPendingStateController.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>CC3B20821C3F76D600798563</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ASPendingStateController.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>CC3B20841C3F76D600798563</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CC3B20811C3F76D600798563</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>CC3B20851C3F76D600798563</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CC3B20821C3F76D600798563</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>CC3B20861C3F76D600798563</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CC3B20821C3F76D600798563</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>CC3B20871C3F7A5400798563</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASWeakSet.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>CC3B20881C3F7A5400798563</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASWeakSet.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>CC3B208A1C3F7A5400798563</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CC3B20871C3F7A5400798563</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>CC3B208B1C3F7A5400798563</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CC3B20881C3F7A5400798563</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>CC3B208C1C3F7A5400798563</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CC3B20881C3F7A5400798563</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>CC3B208D1C3F7D0A00798563</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASWeakSetTests.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>CC3B208E1C3F7D0A00798563</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CC3B208D1C3F7D0A00798563</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>CC3B208F1C3F892D00798563</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ASBridgedPropertiesTests.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>CC3B20901C3F892D00798563</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CC3B208F1C3F892D00798563</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>CC446A2D1D80AAE00071FD03</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASObjectDescriptionHelpers.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>CC446A2E1D80AAE00071FD03</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASObjectDescriptionHelpers.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>CC446A2F1D80AAE00071FD03</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CC446A2D1D80AAE00071FD03</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>CC446A301D80AAE00071FD03</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CC446A2E1D80AAE00071FD03</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>CC446A311D80AAE00071FD03</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CC446A2E1D80AAE00071FD03</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>CC4981B21D1A02BE004E13CC</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASTableViewThrashTests.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>CC4981B31D1A02BE004E13CC</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CC4981B21D1A02BE004E13CC</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>CC4981BA1D1C7F65004E13CC</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>NSIndexSet+ASHelpers.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>CC4981BB1D1C7F65004E13CC</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>NSIndexSet+ASHelpers.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>CC4981BD1D1C7F65004E13CC</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CC4981BB1D1C7F65004E13CC</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>CC4C2A751D88E3BF0039ACAB</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASTraceEvent.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>CC4C2A761D88E3BF0039ACAB</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASTraceEvent.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>CC4C2A771D88E3BF0039ACAB</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CC4C2A751D88E3BF0039ACAB</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>CC4C2A781D88E3BF0039ACAB</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CC4C2A761D88E3BF0039ACAB</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>CC4C2A791D88E3BF0039ACAB</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CC4C2A761D88E3BF0039ACAB</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>CC4C2A7A1D8902350039ACAB</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CC4C2A751D88E3BF0039ACAB</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>CC54A81B1D70077A00296A24</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASDispatch.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>CC54A81C1D70079800296A24</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CC54A81B1D70077A00296A24</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>CC54A81D1D7008B300296A24</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASDispatchTests.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>CC54A81E1D7008B300296A24</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CC54A81D1D7008B300296A24</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>CC7FD9DC1BB5E962005CCB2B</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASPhotosFrameworkImageRequest.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>CC7FD9DD1BB5E962005CCB2B</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASPhotosFrameworkImageRequest.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>CC7FD9DF1BB5E962005CCB2B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CC7FD9DD1BB5E962005CCB2B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>CC7FD9E01BB5F750005CCB2B</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASPhotosFrameworkImageRequestTests.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>CC7FD9E11BB5F750005CCB2B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CC7FD9E01BB5F750005CCB2B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>CC7FD9E21BB603FF005CCB2B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CC7FD9DC1BB5E962005CCB2B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>CC88F7AE1D80AF5E000D6D4E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CC446A2D1D80AAE00071FD03</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>CC8B05D41D73836400F54286</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASPerformanceTestContext.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>CC8B05D51D73836400F54286</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASPerformanceTestContext.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>CC8B05D61D73836400F54286</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CC8B05D51D73836400F54286</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>CC8B05D71D73979700F54286</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASTextNodePerformanceTests.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>CC8B05D81D73979700F54286</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CC8B05D71D73979700F54286</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>CCA221D21D6FA7EF00AF6A0F</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASViewControllerTests.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>CCA221D31D6FA7EF00AF6A0F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CCA221D21D6FA7EF00AF6A0F</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>CCB2F34C1D63CCC6004E6DE9</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASDisplayNodeSnapshotTests.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>CCB2F34D1D63CCC6004E6DE9</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CCB2F34C1D63CCC6004E6DE9</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>CCF18FF41D2575E300DF5895</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CC4981BA1D1C7F65004E13CC</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>D3779BCFF841AD3EB56537ED</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-AsyncDisplayKitTests.release.xcconfig</string>
-			<key>path</key>
-			<string>Pods/Target Support Files/Pods-AsyncDisplayKitTests/Pods-AsyncDisplayKitTests.release.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>D785F6601A74327E00291744</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASScrollNode.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>D785F6611A74327E00291744</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASScrollNode.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>D785F6631A74327E00291744</key>
-		<dict>
-			<key>fileRef</key>
-			<string>D785F6611A74327E00291744</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>DB1020801CBCA2AD00FA6FE1</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>c++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_CODE_COVERAGE</key>
-				<string>NO</string>
-				<key>CLANG_ENABLE_MODULES</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
-				<string>YES</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>ENABLE_NS_ASSERTIONS</key>
-				<string>NO</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_GENERATE_TEST_COVERAGE_FILES</key>
-				<string>YES</string>
-				<key>GCC_INSTRUMENT_PROGRAM_FLOW_ARCS</key>
-				<string>YES</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES_ERROR</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES_AGGRESSIVE</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.1</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>VALIDATE_PRODUCT</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Profile</string>
-		</dict>
-		<key>DB1020811CBCA2AD00FA6FE1</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>APPLICATION_EXTENSION_API_ONLY</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_CODE_COVERAGE</key>
-				<string>YES</string>
-				<key>DSTROOT</key>
-				<string>/tmp/AsyncDisplayKit.dst</string>
-				<key>GCC_INPUT_FILETYPE</key>
-				<string>automatic</string>
-				<key>GCC_INSTRUMENT_PROGRAM_FLOW_ARCS</key>
-				<string>NO</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>AsyncDisplayKit/AsyncDisplayKit-Prefix.pch</string>
-				<key>GCC_TREAT_WARNINGS_AS_ERRORS</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_MISSING_NEWLINE</key>
-				<string>YES</string>
-				<key>GCC_WARN_INITIALIZER_NOT_FULLY_BRACKETED</key>
-				<string>YES</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.1</string>
-				<key>OTHER_CFLAGS</key>
-				<string>-Wall</string>
-				<key>OTHER_LDFLAGS</key>
-				<string>-ObjC</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>include/$(TARGET_NAME)</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Profile</string>
-		</dict>
-		<key>DB1020821CBCA2AD00FA6FE1</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>BDC2D162BD55A807C1475DA5</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>BUNDLE_LOADER</key>
-				<string>$(TEST_HOST)</string>
-				<key>CLANG_ENABLE_CODE_COVERAGE</key>
-				<string>YES</string>
-				<key>FRAMEWORK_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>$(DEVELOPER_FRAMEWORKS_DIR)</string>
-				</array>
-				<key>GCC_INSTRUMENT_PROGRAM_FLOW_ARCS</key>
-				<string>NO</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>AsyncDisplayKit/AsyncDisplayKit-Prefix.pch</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>COCOAPODS=1</string>
-					<string>FB_REFERENCE_IMAGE_DIR="\"$(SOURCE_ROOT)/$(PROJECT_NAME)Tests/ReferenceImages\""</string>
-				</array>
-				<key>GCC_TREAT_WARNINGS_AS_ERRORS</key>
-				<string>YES</string>
-				<key>GCC_WARN_INITIALIZER_NOT_FULLY_BRACKETED</key>
-				<string>YES</string>
-				<key>INFOPLIST_FILE</key>
-				<string>AsyncDisplayKitTests/AsyncDisplayKitTests-Info.plist</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.1</string>
-				<key>PRODUCT_BUNDLE_IDENTIFIER</key>
-				<string>com.facebook.${PRODUCT_NAME:rfc1034identifier}</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>TEST_HOST</key>
-				<string>$(BUILT_PRODUCTS_DIR)/AsyncDisplayKitTestHost.app/AsyncDisplayKitTestHost</string>
-				<key>WRAPPER_EXTENSION</key>
-				<string>xctest</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Profile</string>
-		</dict>
-		<key>DB1020831CBCA2AD00FA6FE1</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ASSETCATALOG_COMPILER_APPICON_NAME</key>
-				<string>AppIcon</string>
-				<key>CLANG_WARN_UNREACHABLE_CODE</key>
-				<string>YES</string>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>GCC_INSTRUMENT_PROGRAM_FLOW_ARCS</key>
-				<string>NO</string>
-				<key>INFOPLIST_FILE</key>
-				<string>AsyncDisplayKitTestHost/Info.plist</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.1</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<string>$(inherited) @executable_path/Frameworks</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>NO</string>
-				<key>PRODUCT_BUNDLE_IDENTIFIER</key>
-				<string>com.facebook.$(PRODUCT_NAME:rfc1034identifier)</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Profile</string>
-		</dict>
-		<key>DB1020841CBCA2AD00FA6FE1</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>CLANG_ENABLE_CODE_COVERAGE</key>
-				<string>YES</string>
-				<key>CLANG_WARN_UNREACHABLE_CODE</key>
-				<string>YES</string>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>CURRENT_PROJECT_VERSION</key>
-				<string>1</string>
-				<key>DEBUG_INFORMATION_FORMAT</key>
-				<string>dwarf-with-dsym</string>
-				<key>DEFINES_MODULE</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_INSTALL_NAME_BASE</key>
-				<string>@rpath</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>GCC_INSTRUMENT_PROGRAM_FLOW_ARCS</key>
-				<string>NO</string>
-				<key>GCC_NO_COMMON_BLOCKS</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>AsyncDisplayKit/AsyncDisplayKit-Prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>$(SRCROOT)/AsyncDisplayKit-iOS/Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<string>$(inherited) @executable_path/Frameworks @loader_path/Frameworks</string>
-				<key>MODULEMAP_FILE</key>
-				<string>AsyncDisplayKit/module.modulemap</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>NO</string>
-				<key>PRODUCT_BUNDLE_IDENTIFIER</key>
-				<string>com.facebook.$(PRODUCT_NAME:rfc1034identifier)</string>
-				<key>PRODUCT_NAME</key>
-				<string>AsyncDisplayKit</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-				<key>VERSIONING_SYSTEM</key>
-				<string>apple-generic</string>
-				<key>VERSION_INFO_PREFIX</key>
-				<string></string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Profile</string>
-		</dict>
-		<key>DB55C25F1C6408D6004EDCF5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>_ASTransitionContext.h</string>
-			<key>path</key>
-			<string>../_ASTransitionContext.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>DB55C2601C6408D6004EDCF5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>_ASTransitionContext.m</string>
-			<key>path</key>
-			<string>../_ASTransitionContext.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>DB55C2631C6408D6004EDCF5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>DB55C2601C6408D6004EDCF5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>DB55C2651C641AE4004EDCF5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASContextTransitioning.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>DB55C2671C641AE4004EDCF5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>DB55C2651C641AE4004EDCF5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>DB7121BCD50849C498C886FB</key>
-		<dict>
-			<key>fileRef</key>
-			<string>EFA731F0396842FF8AB635EE</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>DB78412E1C6BCE1600A9E2B4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>DB55C2601C6408D6004EDCF5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>DBABFAFC1C6A8D2F0039EA4A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>DB55C25F1C6408D6004EDCF5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>DBC452D91C5BF64600B16017</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>NSArray+Diffing.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>DBC452DA1C5BF64600B16017</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>NSArray+Diffing.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>DBC452DC1C5BF64600B16017</key>
-		<dict>
-			<key>fileRef</key>
-			<string>DBC452DA1C5BF64600B16017</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>DBC452DD1C5C6A6A00B16017</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ArrayDiffingTests.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>DBC452DE1C5C6A6A00B16017</key>
-		<dict>
-			<key>fileRef</key>
-			<string>DBC452DD1C5C6A6A00B16017</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>DBC453211C5FD97200B16017</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASDisplayNodeImplicitHierarchyTests.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>DBC453221C5FD97200B16017</key>
-		<dict>
-			<key>fileRef</key>
-			<string>DBC453211C5FD97200B16017</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>DBDB83921C6E879900D0098C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASPagerFlowLayout.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>DBDB83931C6E879900D0098C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASPagerFlowLayout.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>DBDB83951C6E879900D0098C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>DBDB83921C6E879900D0098C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>DBDB83961C6E879900D0098C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>DBDB83931C6E879900D0098C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>DBDB83971C6E879900D0098C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>DBDB83931C6E879900D0098C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>DE040EF91C2B40AC004692FF</key>
-		<dict>
-			<key>fileRef</key>
-			<string>251B8EF41BBB3D690087C538</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>DE0702FC1C3671E900D7DE62</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09AC195D04C000B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>DE4843DB1C93EAB100A1F33B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E52405B21C8FEF03004DC8E7</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>DE4843DC1C93EAC100A1F33B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E52405B41C8FEF16004DC8E7</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>DE6EA3211C14000600183B10</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASDisplayNode+FrameworkPrivate.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>DE6EA3231C14000600183B10</key>
-		<dict>
-			<key>fileRef</key>
-			<string>DE6EA3211C14000600183B10</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>DE84918D1C8FFF2B003D89E9</key>
-		<dict>
-			<key>fileRef</key>
-			<string>81EE384D1C8E94F000456208</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>DE84918E1C8FFF9F003D89E9</key>
-		<dict>
-			<key>fileRef</key>
-			<string>81EE384E1C8E94F000456208</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>DE8BEABF1C2DF3FC00D57C12</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASDelegateProxy.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>DE8BEAC01C2DF3FC00D57C12</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASDelegateProxy.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>DE8BEAC21C2DF3FC00D57C12</key>
-		<dict>
-			<key>fileRef</key>
-			<string>DE8BEABF1C2DF3FC00D57C12</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>DE8BEAC31C2DF3FC00D57C12</key>
-		<dict>
-			<key>fileRef</key>
-			<string>DE8BEAC01C2DF3FC00D57C12</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>DE8BEAC41C2DF3FC00D57C12</key>
-		<dict>
-			<key>fileRef</key>
-			<string>DE8BEAC01C2DF3FC00D57C12</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>DEACA2B11C425DC400FA9DDF</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>058D09A4195D04C000B7D73C</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>058D09AB195D04C000B7D73C</string>
-			<key>remoteInfo</key>
-			<string>AsyncDisplayKit</string>
-		</dict>
-		<key>DEACA2B21C425DC400FA9DDF</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>target</key>
-			<string>058D09AB195D04C000B7D73C</string>
-			<key>targetProxy</key>
-			<string>DEACA2B11C425DC400FA9DDF</string>
-		</dict>
-		<key>DEC146B41C37A16A004A0EE7</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>ASCollectionInternal.h</string>
-			<key>path</key>
-			<string>Details/ASCollectionInternal.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>DEC146B51C37A16A004A0EE7</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>ASCollectionInternal.m</string>
-			<key>path</key>
-			<string>Details/ASCollectionInternal.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>DEC146B71C37A16A004A0EE7</key>
-		<dict>
-			<key>fileRef</key>
-			<string>DEC146B41C37A16A004A0EE7</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>DEC146B81C37A16A004A0EE7</key>
-		<dict>
-			<key>fileRef</key>
-			<string>DEC146B51C37A16A004A0EE7</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>DEC146B91C37A16A004A0EE7</key>
-		<dict>
-			<key>fileRef</key>
-			<string>DEC146B51C37A16A004A0EE7</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>DECBD6E51BE56E1900CF4905</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASButtonNode.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>DECBD6E61BE56E1900CF4905</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ASButtonNode.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>DECBD6E81BE56E1900CF4905</key>
-		<dict>
-			<key>fileRef</key>
-			<string>DECBD6E51BE56E1900CF4905</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>DECBD6E91BE56E1900CF4905</key>
-		<dict>
-			<key>fileRef</key>
-			<string>DECBD6E61BE56E1900CF4905</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>DECBD6EA1BE56E1900CF4905</key>
-		<dict>
-			<key>fileRef</key>
-			<string>DECBD6E61BE56E1900CF4905</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>DEFAD8131CC48914000527C4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AEEC47E01C20C2DD00EC1693</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E52405B21C8FEF03004DC8E7</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ASLayoutTransition.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E52405B31C8FEF03004DC8E7</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E52405B21C8FEF03004DC8E7</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E52405B41C8FEF16004DC8E7</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASLayoutTransition.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E55D86311CA8A14000A0C26F</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>name</key>
-			<string>ASLayoutable.mm</string>
-			<key>path</key>
-			<string>AsyncDisplayKit/Layout/ASLayoutable.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E55D86321CA8A14000A0C26F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E55D86311CA8A14000A0C26F</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E55D86331CA8A14000A0C26F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E55D86311CA8A14000A0C26F</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E5711A2A1C840C81009619D4</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ASIndexedNodeContext.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E5711A2C1C840C81009619D4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E5711A2A1C840C81009619D4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E5711A2D1C840C96009619D4</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ASIndexedNodeContext.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E5711A2E1C840C96009619D4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E5711A2D1C840C96009619D4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E5711A301C840C96009619D4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E5711A2D1C840C96009619D4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EFA731F0396842FF8AB635EE</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>libPods-AsyncDisplayKitTests.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>F711994D1D20C21100568860</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ASDisplayNodeExtrasTests.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F711994E1D20C21100568860</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F711994D1D20C21100568860</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C131D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>DBDB83921C6E879900D0098C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C141D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>92DD2FE11BF4B97E0074C9DD</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C151D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AEEC47DF1C20C2DD00EC1693</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C161D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>055F1A3A19ABD43F004DAFF1</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C171D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>18C2ED7C1B9B7DE800F627B3</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C181D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B13CA0FF1C52004900E031AB</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C191D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AC3C4A4F1A1139C100143C57</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C1A1D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AC3C4A531A113EEC00143C57</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C1B1D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B13CA0F61C519E9400E031AB</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C1C1D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09D5195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C1D1D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>DECBD6E51BE56E1900CF4905</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C1E1D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09D7195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C1F1D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09D8195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C201D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>68B027791C1A79CC0041016B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C211D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09DA195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C221D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09DB195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C231D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>0587F9BB1A7309ED00AFF0BA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C241D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09DD195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C251D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8021EC1A1D2B00B100799119</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C261D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>0516FA3E1A1563D200B4EBED</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C271D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>68FC85DC1CE29AB700EDD713</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C281D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>055B9FA61A1C154B00035D6D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C291D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25E327541C16819500A2170C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C2A1D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>D785F6601A74327E00291744</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C2B1D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>68FC85E01CE29B7E00EDD713</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C2C1D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B0F880581BEAEC7500D17647</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C2D1D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>055F1A3219ABD3E3004DAFF1</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C2E1D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>0574D5E119C110610097DC25</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C2F1D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09DF195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C301D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>A373200E1C571B050011FC94</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C311D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACC945A81BA9E7A0005E1FB8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C321D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>6BDC61F51978FEA400E50D21</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C331D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>764D83D21C8EA515009B4FB8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C341D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>DB55C2651C641AE4004EDCF5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C351D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>68FC85E71CE29C7D00EDD713</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C361D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09E2195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C371D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09E4195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C381D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>205F0E171B37339C007741D0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C391D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>054963471A1EA066000F8E56</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C3A1D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>299DA1A71A828D2900162D41</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C3B1D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>251B8EF41BBB3D690087C538</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C3D1D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>205F0E1B1B373A2C007741D0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C3E1D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>05A6D05819D0EB64002DD95E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C3F1D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>698548611CA9E025008A345F</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C401D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>4640521B1A3F83C40061C0BA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C411D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09E6195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C421D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>430E7C8D1B4C23F100697A4C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C431D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>05F20AA31A15733C00DCA68A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C441D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>68355B371CB57A5A001D4E68</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C451D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>68355B391CB57A5A001D4E68</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C461D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>4640521D1A3F83C40061C0BA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C471D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>292C59991A956527007E5DD6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C481D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09E8195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C491D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CC7FD9DC1BB5E962005CCB2B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C4A1D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>055F1A3619ABD413004DAFF1</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C4B1D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>69F10C851C84C35D0026140C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C4C1D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>81EE384D1C8E94F000456208</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C4D1D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>296A0A311A951715005ACEAA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C4E1D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D0A12195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C4F1D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>205F0E1F1B376416007741D0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C501D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>464052191A3F83C40061C0BA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C511D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AC026B671BD57D6F00BBC17E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C521D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E5711A2A1C840C81009619D4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C531D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09F5195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C541D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09F8195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C551D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09FA195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C561D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09FB195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C571D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09FD195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C581D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>205F0E0D1B371875007741D0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C591D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D09FF195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C5A1D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9C70F2011CDA4EFA007D6C76</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C5B1D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9C5586671BD549CB00B50E3A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C5C1D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED011B17843500DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C5D1D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED031B17843500DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C5E1D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED071B17843500DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C5F1D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED091B17843500DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C601D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED0B1B17843500DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C611D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED111B17843500DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C621D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9CDC18CB1B910E12004965E2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C631D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED0D1B17843500DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C641D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED121B17843500DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C651D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED141B17843500DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C661D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>7A06A7391C35F08800FE8DAA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C671D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AC47D9431B3BB41900AAEE9D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C681D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9C49C36E1B853957000B0DD5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C691D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AC21EC0F1B3D0BF600C8B19A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C6A1D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED161B17843500DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C6B1D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9C6BB3B01B8CC9C200F13F52</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C6C1D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED181B17843500DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C6D1D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>257754BA1BEE458E00737CA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C6E1D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>257754B91BEE458E00737CA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C6F1D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>257754BC1BEE458E00737CA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C701D2CDB3E00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>257754951BEE44CD00737CA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C711D2CDB3F00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>257754961BEE44CD00737CA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C721D2CDB3F00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>257754981BEE44CD00737CA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C731D2CDB3F00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>257754931BEE44CD00737CA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C741D2CDB3F00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2577549B1BEE44CD00737CA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C751D2CDB3F00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2577549D1BEE44CD00737CA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C761D2CDB3F00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2577549F1BEE44CD00737CA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C771D2CDB3F00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>257754A11BEE44CD00737CA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C781D2CDB3F00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>A32FEDD31C501B6A004F642A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C791D2CDB3F00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>257754A31BEE44CD00737CA5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C7B1D2CDB3F00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D0A43195D058D00B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C7C1D2CDB3F00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>0516FA3A1A15563400B4EBED</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C7D1D2CDB3F00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D0A44195D058D00B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C7E1D2CDB3F00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>1950C4481A3BB5C1005C8279</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C7F1D2CDB3F00BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>0516FA3B1A15563400B4EBED</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C801D2CDB5800BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8BDA5FC31CDBDDE1007D13B2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C811D2CDB5800BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>DEC146B41C37A16A004A0EE7</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C821D2CDB5800BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AC7A2C161BDE11DF0093FE1A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C831D2CDB5800BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>92074A5F1CC8BA1900918F75</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C841D2CDB5800BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>92074A651CC8BADA00918F75</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C851D2CDB5800BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CC4981BA1D1C7F65004E13CC</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C861D2CDB5800BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>69CB62A91CB8165900024920</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C871D2CDB5800BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>251B8EF61BBB3D690087C538</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C8B1D2CDB5800BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>251B8EF21BBB3D690087C538</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C8C1D2CDB5800BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D0A03195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C8D1D2CDB5800BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AC026B6D1BD57DBF00BBC17E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C8F1D2CDB5800BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D0A07195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C901D2CDB5800BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>DB55C25F1C6408D6004EDCF5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C941D2CDB5800BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D0A0C195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C951D2CDB5800BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E52405B41C8FEF16004DC8E7</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C961D2CDB5800BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>69E100691CA89CB600D88C1B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C971D2CDB5800BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D0A0D195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C981D2CDB5800BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED431B17847A00DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C991D2CDB5800BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED451B17847A00DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C9A1D2CDB5800BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>0442850B1BAA64EC00D16268</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C9B1D2CDB5800BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CC3B20811C3F76D600798563</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C9C1D2CDB5800BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>058D0A10195D050800B7D73C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C9D1D2CDB5800BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9C8221931BA237B80037F19A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C9E1D2CDB5800BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED461B17847A00DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6C9F1D2CDB5800BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED471B17847A00DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6CA01D2CDB5800BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>ACF6ED491B17847A00DA7C62</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6CA11D2CDB5800BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CC3B20871C3F7A5400798563</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6CA21D2CDB5800BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8B0768B11CE752EC002E1453</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6CA31D2CDB5800BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>697C0DE11CF38F28001DE0D4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6CA41D2CDB5800BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>B30BF6501C5964B0004FCD53</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F7CE6CB71D2CE2D000BE4C15</key>
-		<dict>
-			<key>fileRef</key>
-			<string>698C8B601CAB49FC0052DC3F</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>FB07EABBCF28656C6297BC2D</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-AsyncDisplayKitTests.debug.xcconfig</string>
-			<key>path</key>
-			<string>Pods/Target Support Files/Pods-AsyncDisplayKitTests/Pods-AsyncDisplayKitTests.debug.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>FD40E2760492F0CAAEAD552D</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>FB07EABBCF28656C6297BC2D</string>
-				<string>D3779BCFF841AD3EB56537ED</string>
-				<string>BDC2D162BD55A807C1475DA5</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Pods</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-	</dict>
-	<key>rootObject</key>
-	<string>058D09A4195D04C000B7D73C</string>
-</dict>
-</plist>
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		044284FD1BAA365100D16268 /* UICollectionViewLayout+ASConvenience.m in Sources */ = {isa = PBXBuildFile; fileRef = 205F0E0E1B371875007741D0 /* UICollectionViewLayout+ASConvenience.m */; };
+		044284FE1BAA387800D16268 /* ASStackLayoutSpecUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = ACF6ED461B17847A00DA7C62 /* ASStackLayoutSpecUtilities.h */; };
+		044284FF1BAA3BD600D16268 /* UICollectionViewLayout+ASConvenience.h in Headers */ = {isa = PBXBuildFile; fileRef = 205F0E0D1B371875007741D0 /* UICollectionViewLayout+ASConvenience.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		044285081BAA63FE00D16268 /* ASBatchFetching.h in Headers */ = {isa = PBXBuildFile; fileRef = 044285051BAA63FE00D16268 /* ASBatchFetching.h */; };
+		044285091BAA63FE00D16268 /* ASBatchFetching.m in Sources */ = {isa = PBXBuildFile; fileRef = 044285061BAA63FE00D16268 /* ASBatchFetching.m */; };
+		0442850A1BAA63FE00D16268 /* ASBatchFetching.m in Sources */ = {isa = PBXBuildFile; fileRef = 044285061BAA63FE00D16268 /* ASBatchFetching.m */; };
+		0442850E1BAA64EC00D16268 /* ASMultidimensionalArrayUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 0442850B1BAA64EC00D16268 /* ASMultidimensionalArrayUtils.h */; };
+		0442850F1BAA64EC00D16268 /* ASMultidimensionalArrayUtils.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0442850C1BAA64EC00D16268 /* ASMultidimensionalArrayUtils.mm */; };
+		044285101BAA64EC00D16268 /* ASMultidimensionalArrayUtils.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0442850C1BAA64EC00D16268 /* ASMultidimensionalArrayUtils.mm */; };
+		0515EA211A15769900BA8B9A /* Photos.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 051943141A1575670030A7D0 /* Photos.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		0515EA221A1576A100BA8B9A /* AssetsLibrary.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 051943121A1575630030A7D0 /* AssetsLibrary.framework */; };
+		0516FA411A1563D200B4EBED /* ASMultiplexImageNode.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0516FA3F1A1563D200B4EBED /* ASMultiplexImageNode.mm */; };
+		051943131A1575630030A7D0 /* AssetsLibrary.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 051943121A1575630030A7D0 /* AssetsLibrary.framework */; };
+		051943151A1575670030A7D0 /* Photos.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 051943141A1575670030A7D0 /* Photos.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		052EE0661A159FEF002C6279 /* ASMultiplexImageNodeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 052EE0651A159FEF002C6279 /* ASMultiplexImageNodeTests.m */; };
+		052EE06B1A15A0D8002C6279 /* TestResources in Resources */ = {isa = PBXBuildFile; fileRef = 052EE06A1A15A0D8002C6279 /* TestResources */; };
+		0549634A1A1EA066000F8E56 /* ASBasicImageDownloader.mm in Sources */ = {isa = PBXBuildFile; fileRef = 054963481A1EA066000F8E56 /* ASBasicImageDownloader.mm */; };
+		055B9FA91A1C154B00035D6D /* ASNetworkImageNode.mm in Sources */ = {isa = PBXBuildFile; fileRef = 055B9FA71A1C154B00035D6D /* ASNetworkImageNode.mm */; };
+		055F1A3519ABD3E3004DAFF1 /* ASTableView.mm in Sources */ = {isa = PBXBuildFile; fileRef = 055F1A3319ABD3E3004DAFF1 /* ASTableView.mm */; };
+		055F1A3919ABD413004DAFF1 /* ASRangeController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 055F1A3719ABD413004DAFF1 /* ASRangeController.mm */; };
+		056D21551ABCEF50001107EF /* ASImageNodeSnapshotTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 056D21541ABCEF50001107EF /* ASImageNodeSnapshotTests.m */; };
+		057D02C41AC0A66700C7AC3C /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 057D02C31AC0A66700C7AC3C /* main.m */; };
+		057D02C71AC0A66700C7AC3C /* AppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 057D02C61AC0A66700C7AC3C /* AppDelegate.mm */; };
+		0587F9BE1A7309ED00AFF0BA /* ASEditableTextNode.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0587F9BC1A7309ED00AFF0BA /* ASEditableTextNode.mm */; };
+		058D09B0195D04C000B7D73C /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 058D09AF195D04C000B7D73C /* Foundation.framework */; };
+		058D09BE195D04C000B7D73C /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 058D09BD195D04C000B7D73C /* XCTest.framework */; };
+		058D09BF195D04C000B7D73C /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 058D09AF195D04C000B7D73C /* Foundation.framework */; };
+		058D09C1195D04C000B7D73C /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 058D09C0195D04C000B7D73C /* UIKit.framework */; };
+		058D09C4195D04C000B7D73C /* libAsyncDisplayKit.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 058D09AC195D04C000B7D73C /* libAsyncDisplayKit.a */; };
+		058D09CA195D04C000B7D73C /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 058D09C8195D04C000B7D73C /* InfoPlist.strings */; };
+		058D0A13195D050800B7D73C /* ASControlNode.mm in Sources */ = {isa = PBXBuildFile; fileRef = 058D09D6195D050800B7D73C /* ASControlNode.mm */; };
+		058D0A14195D050800B7D73C /* ASDisplayNode.mm in Sources */ = {isa = PBXBuildFile; fileRef = 058D09D9195D050800B7D73C /* ASDisplayNode.mm */; };
+		058D0A15195D050800B7D73C /* ASDisplayNodeExtras.mm in Sources */ = {isa = PBXBuildFile; fileRef = 058D09DC195D050800B7D73C /* ASDisplayNodeExtras.mm */; };
+		058D0A16195D050800B7D73C /* ASImageNode.mm in Sources */ = {isa = PBXBuildFile; fileRef = 058D09DE195D050800B7D73C /* ASImageNode.mm */; };
+		058D0A17195D050800B7D73C /* ASTextNode.mm in Sources */ = {isa = PBXBuildFile; fileRef = 058D09E0195D050800B7D73C /* ASTextNode.mm */; };
+		058D0A18195D050800B7D73C /* _ASDisplayLayer.mm in Sources */ = {isa = PBXBuildFile; fileRef = 058D09E3195D050800B7D73C /* _ASDisplayLayer.mm */; };
+		058D0A19195D050800B7D73C /* _ASDisplayView.mm in Sources */ = {isa = PBXBuildFile; fileRef = 058D09E5195D050800B7D73C /* _ASDisplayView.mm */; };
+		058D0A1A195D050800B7D73C /* ASHighlightOverlayLayer.mm in Sources */ = {isa = PBXBuildFile; fileRef = 058D09E7195D050800B7D73C /* ASHighlightOverlayLayer.mm */; };
+		058D0A1B195D050800B7D73C /* ASMutableAttributedStringBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 058D09E9195D050800B7D73C /* ASMutableAttributedStringBuilder.m */; };
+		058D0A21195D050800B7D73C /* NSMutableAttributedString+TextKitAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 058D09F6195D050800B7D73C /* NSMutableAttributedString+TextKitAdditions.m */; };
+		058D0A22195D050800B7D73C /* _ASAsyncTransaction.mm in Sources */ = {isa = PBXBuildFile; fileRef = 058D09F9195D050800B7D73C /* _ASAsyncTransaction.mm */; };
+		058D0A23195D050800B7D73C /* _ASAsyncTransactionContainer.m in Sources */ = {isa = PBXBuildFile; fileRef = 058D09FC195D050800B7D73C /* _ASAsyncTransactionContainer.m */; };
+		058D0A24195D050800B7D73C /* _ASAsyncTransactionGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = 058D09FE195D050800B7D73C /* _ASAsyncTransactionGroup.m */; };
+		058D0A26195D050800B7D73C /* _ASCoreAnimationExtras.mm in Sources */ = {isa = PBXBuildFile; fileRef = 058D0A04195D050800B7D73C /* _ASCoreAnimationExtras.mm */; };
+		058D0A27195D050800B7D73C /* _ASPendingState.mm in Sources */ = {isa = PBXBuildFile; fileRef = 058D0A06195D050800B7D73C /* _ASPendingState.mm */; };
+		058D0A28195D050800B7D73C /* ASDisplayNode+AsyncDisplay.mm in Sources */ = {isa = PBXBuildFile; fileRef = 058D0A08195D050800B7D73C /* ASDisplayNode+AsyncDisplay.mm */; };
+		058D0A29195D050800B7D73C /* ASDisplayNode+DebugTiming.mm in Sources */ = {isa = PBXBuildFile; fileRef = 058D0A0A195D050800B7D73C /* ASDisplayNode+DebugTiming.mm */; };
+		058D0A2A195D050800B7D73C /* ASDisplayNode+UIViewBridge.mm in Sources */ = {isa = PBXBuildFile; fileRef = 058D0A0B195D050800B7D73C /* ASDisplayNode+UIViewBridge.mm */; };
+		058D0A2B195D050800B7D73C /* ASImageNode+CGExtras.m in Sources */ = {isa = PBXBuildFile; fileRef = 058D0A0E195D050800B7D73C /* ASImageNode+CGExtras.m */; };
+		058D0A2C195D050800B7D73C /* ASSentinel.m in Sources */ = {isa = PBXBuildFile; fileRef = 058D0A11195D050800B7D73C /* ASSentinel.m */; };
+		058D0A38195D057000B7D73C /* ASDisplayLayerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 058D0A2D195D057000B7D73C /* ASDisplayLayerTests.m */; };
+		058D0A39195D057000B7D73C /* ASDisplayNodeAppearanceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 058D0A2E195D057000B7D73C /* ASDisplayNodeAppearanceTests.m */; };
+		058D0A3A195D057000B7D73C /* ASDisplayNodeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 058D0A2F195D057000B7D73C /* ASDisplayNodeTests.m */; };
+		058D0A3B195D057000B7D73C /* ASDisplayNodeTestsHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 058D0A31195D057000B7D73C /* ASDisplayNodeTestsHelper.m */; };
+		058D0A3C195D057000B7D73C /* ASMutableAttributedStringBuilderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 058D0A32195D057000B7D73C /* ASMutableAttributedStringBuilderTests.m */; };
+		058D0A3D195D057000B7D73C /* ASTextKitCoreTextAdditionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 058D0A33195D057000B7D73C /* ASTextKitCoreTextAdditionsTests.m */; };
+		058D0A40195D057000B7D73C /* ASTextNodeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 058D0A36195D057000B7D73C /* ASTextNodeTests.m */; };
+		058D0A41195D057000B7D73C /* ASTextNodeWordKernerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 058D0A37195D057000B7D73C /* ASTextNodeWordKernerTests.mm */; };
+		05A6D05B19D0EB64002DD95E /* ASDealloc2MainObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 05A6D05919D0EB64002DD95E /* ASDealloc2MainObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		05EA6FE71AC0966E00E35788 /* ASSnapshotTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 05EA6FE61AC0966E00E35788 /* ASSnapshotTestCase.m */; };
+		18C2ED7F1B9B7DE800F627B3 /* ASCollectionNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 18C2ED7C1B9B7DE800F627B3 /* ASCollectionNode.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		18C2ED801B9B7DE800F627B3 /* ASCollectionNode.mm in Sources */ = {isa = PBXBuildFile; fileRef = 18C2ED7D1B9B7DE800F627B3 /* ASCollectionNode.mm */; };
+		18C2ED831B9B7DE800F627B3 /* ASCollectionNode.mm in Sources */ = {isa = PBXBuildFile; fileRef = 18C2ED7D1B9B7DE800F627B3 /* ASCollectionNode.mm */; };
+		204C979E1B362CB3002B1083 /* Default-568h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 204C979D1B362CB3002B1083 /* Default-568h@2x.png */; };
+		205F0E101B371875007741D0 /* UICollectionViewLayout+ASConvenience.m in Sources */ = {isa = PBXBuildFile; fileRef = 205F0E0E1B371875007741D0 /* UICollectionViewLayout+ASConvenience.m */; };
+		205F0E121B371BD7007741D0 /* ASScrollDirection.m in Sources */ = {isa = PBXBuildFile; fileRef = 205F0E111B371BD7007741D0 /* ASScrollDirection.m */; };
+		205F0E1A1B37339C007741D0 /* ASAbstractLayoutController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 205F0E181B37339C007741D0 /* ASAbstractLayoutController.mm */; };
+		205F0E1E1B373A2C007741D0 /* ASCollectionViewLayoutController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 205F0E1C1B373A2C007741D0 /* ASCollectionViewLayoutController.mm */; };
+		205F0E221B376416007741D0 /* CGRect+ASConvenience.m in Sources */ = {isa = PBXBuildFile; fileRef = 205F0E201B376416007741D0 /* CGRect+ASConvenience.m */; };
+		242995D31B29743C00090100 /* ASBasicImageDownloaderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 242995D21B29743C00090100 /* ASBasicImageDownloaderTests.m */; };
+		251B8EF81BBB3D690087C538 /* ASCollectionDataController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 251B8EF31BBB3D690087C538 /* ASCollectionDataController.mm */; };
+		251B8EFA1BBB3D690087C538 /* ASCollectionViewFlowLayoutInspector.m in Sources */ = {isa = PBXBuildFile; fileRef = 251B8EF51BBB3D690087C538 /* ASCollectionViewFlowLayoutInspector.m */; };
+		2538B6F31BC5D2A2003CA0B4 /* ASCollectionViewFlowLayoutInspectorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2538B6F21BC5D2A2003CA0B4 /* ASCollectionViewFlowLayoutInspectorTests.m */; };
+		254C6B521BF8FE6D003EC431 /* ASTextKitTruncationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 254C6B511BF8FE6D003EC431 /* ASTextKitTruncationTests.mm */; };
+		254C6B541BF8FF2A003EC431 /* ASTextKitTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 254C6B531BF8FF2A003EC431 /* ASTextKitTests.mm */; };
+		254C6B731BF94DF4003EC431 /* ASTextKitCoreTextAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 257754BB1BEE458E00737CA5 /* ASTextKitCoreTextAdditions.h */; };
+		254C6B741BF94DF4003EC431 /* ASTextNodeWordKerner.h in Headers */ = {isa = PBXBuildFile; fileRef = 257754B91BEE458E00737CA5 /* ASTextNodeWordKerner.h */; };
+		254C6B751BF94DF4003EC431 /* ASTextKitComponents.h in Headers */ = {isa = PBXBuildFile; fileRef = 257754BA1BEE458E00737CA5 /* ASTextKitComponents.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		254C6B761BF94DF4003EC431 /* ASTextNodeTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 257754BC1BEE458E00737CA5 /* ASTextNodeTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		254C6B771BF94DF4003EC431 /* ASTextKitAttributes.h in Headers */ = {isa = PBXBuildFile; fileRef = 257754951BEE44CD00737CA5 /* ASTextKitAttributes.h */; };
+		254C6B781BF94DF4003EC431 /* ASTextKitContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 257754961BEE44CD00737CA5 /* ASTextKitContext.h */; };
+		254C6B791BF94DF4003EC431 /* ASTextKitEntityAttribute.h in Headers */ = {isa = PBXBuildFile; fileRef = 257754981BEE44CD00737CA5 /* ASTextKitEntityAttribute.h */; };
+		254C6B7A1BF94DF4003EC431 /* ASTextKitRenderer.h in Headers */ = {isa = PBXBuildFile; fileRef = 257754931BEE44CD00737CA5 /* ASTextKitRenderer.h */; };
+		254C6B7B1BF94DF4003EC431 /* ASTextKitRenderer+Positioning.h in Headers */ = {isa = PBXBuildFile; fileRef = 2577549B1BEE44CD00737CA5 /* ASTextKitRenderer+Positioning.h */; };
+		254C6B7C1BF94DF4003EC431 /* ASTextKitRenderer+TextChecking.h in Headers */ = {isa = PBXBuildFile; fileRef = 2577549D1BEE44CD00737CA5 /* ASTextKitRenderer+TextChecking.h */; };
+		254C6B7D1BF94DF4003EC431 /* ASTextKitShadower.h in Headers */ = {isa = PBXBuildFile; fileRef = 2577549F1BEE44CD00737CA5 /* ASTextKitShadower.h */; };
+		254C6B7E1BF94DF4003EC431 /* ASTextKitTailTruncater.h in Headers */ = {isa = PBXBuildFile; fileRef = 257754A11BEE44CD00737CA5 /* ASTextKitTailTruncater.h */; };
+		254C6B7F1BF94DF4003EC431 /* ASTextKitTruncating.h in Headers */ = {isa = PBXBuildFile; fileRef = 257754A31BEE44CD00737CA5 /* ASTextKitTruncating.h */; };
+		254C6B821BF94F8A003EC431 /* ASTextKitComponents.m in Sources */ = {isa = PBXBuildFile; fileRef = 257754B71BEE458D00737CA5 /* ASTextKitComponents.m */; };
+		254C6B831BF94F8A003EC431 /* ASTextKitCoreTextAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 257754B81BEE458E00737CA5 /* ASTextKitCoreTextAdditions.m */; };
+		254C6B841BF94F8A003EC431 /* ASTextNodeWordKerner.m in Sources */ = {isa = PBXBuildFile; fileRef = 257754BD1BEE458E00737CA5 /* ASTextNodeWordKerner.m */; };
+		254C6B851BF94F8A003EC431 /* ASTextKitAttributes.mm in Sources */ = {isa = PBXBuildFile; fileRef = 257754941BEE44CD00737CA5 /* ASTextKitAttributes.mm */; };
+		254C6B861BF94F8A003EC431 /* ASTextKitContext.mm in Sources */ = {isa = PBXBuildFile; fileRef = 257754971BEE44CD00737CA5 /* ASTextKitContext.mm */; };
+		254C6B871BF94F8A003EC431 /* ASTextKitEntityAttribute.m in Sources */ = {isa = PBXBuildFile; fileRef = 257754991BEE44CD00737CA5 /* ASTextKitEntityAttribute.m */; };
+		254C6B881BF94F8A003EC431 /* ASTextKitRenderer.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2577549A1BEE44CD00737CA5 /* ASTextKitRenderer.mm */; };
+		254C6B891BF94F8A003EC431 /* ASTextKitRenderer+Positioning.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2577549C1BEE44CD00737CA5 /* ASTextKitRenderer+Positioning.mm */; };
+		254C6B8A1BF94F8A003EC431 /* ASTextKitRenderer+TextChecking.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2577549E1BEE44CD00737CA5 /* ASTextKitRenderer+TextChecking.mm */; };
+		254C6B8B1BF94F8A003EC431 /* ASTextKitShadower.mm in Sources */ = {isa = PBXBuildFile; fileRef = 257754A01BEE44CD00737CA5 /* ASTextKitShadower.mm */; };
+		254C6B8C1BF94F8A003EC431 /* ASTextKitTailTruncater.mm in Sources */ = {isa = PBXBuildFile; fileRef = 257754A21BEE44CD00737CA5 /* ASTextKitTailTruncater.mm */; };
+		257754A61BEE44CD00737CA5 /* ASTextKitAttributes.mm in Sources */ = {isa = PBXBuildFile; fileRef = 257754941BEE44CD00737CA5 /* ASTextKitAttributes.mm */; };
+		257754A91BEE44CD00737CA5 /* ASTextKitContext.mm in Sources */ = {isa = PBXBuildFile; fileRef = 257754971BEE44CD00737CA5 /* ASTextKitContext.mm */; };
+		257754AB1BEE44CD00737CA5 /* ASTextKitEntityAttribute.m in Sources */ = {isa = PBXBuildFile; fileRef = 257754991BEE44CD00737CA5 /* ASTextKitEntityAttribute.m */; };
+		257754AC1BEE44CD00737CA5 /* ASTextKitRenderer.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2577549A1BEE44CD00737CA5 /* ASTextKitRenderer.mm */; };
+		257754AE1BEE44CD00737CA5 /* ASTextKitRenderer+Positioning.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2577549C1BEE44CD00737CA5 /* ASTextKitRenderer+Positioning.mm */; };
+		257754B01BEE44CD00737CA5 /* ASTextKitRenderer+TextChecking.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2577549E1BEE44CD00737CA5 /* ASTextKitRenderer+TextChecking.mm */; };
+		257754B21BEE44CD00737CA5 /* ASTextKitShadower.mm in Sources */ = {isa = PBXBuildFile; fileRef = 257754A01BEE44CD00737CA5 /* ASTextKitShadower.mm */; };
+		257754B41BEE44CD00737CA5 /* ASTextKitTailTruncater.mm in Sources */ = {isa = PBXBuildFile; fileRef = 257754A21BEE44CD00737CA5 /* ASTextKitTailTruncater.mm */; };
+		257754BE1BEE458E00737CA5 /* ASTextKitComponents.m in Sources */ = {isa = PBXBuildFile; fileRef = 257754B71BEE458D00737CA5 /* ASTextKitComponents.m */; };
+		257754BF1BEE458E00737CA5 /* ASTextKitCoreTextAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 257754B81BEE458E00737CA5 /* ASTextKitCoreTextAdditions.m */; };
+		257754C41BEE458E00737CA5 /* ASTextNodeWordKerner.m in Sources */ = {isa = PBXBuildFile; fileRef = 257754BD1BEE458E00737CA5 /* ASTextNodeWordKerner.m */; };
+		25E327571C16819500A2170C /* ASPagerNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 25E327541C16819500A2170C /* ASPagerNode.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25E327581C16819500A2170C /* ASPagerNode.m in Sources */ = {isa = PBXBuildFile; fileRef = 25E327551C16819500A2170C /* ASPagerNode.m */; };
+		25E327591C16819500A2170C /* ASPagerNode.m in Sources */ = {isa = PBXBuildFile; fileRef = 25E327551C16819500A2170C /* ASPagerNode.m */; };
+		2767E9411BB19BD600EA9B77 /* ASViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = ACC945A81BA9E7A0005E1FB8 /* ASViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2911485C1A77147A005D0878 /* ASControlNodeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2911485B1A77147A005D0878 /* ASControlNodeTests.m */; };
+		296A0A351A951ABF005ACEAA /* ASBatchFetchingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 296A0A341A951ABF005ACEAA /* ASBatchFetchingTests.m */; };
+		299DA1AA1A828D2900162D41 /* ASBatchContext.mm in Sources */ = {isa = PBXBuildFile; fileRef = 299DA1A81A828D2900162D41 /* ASBatchContext.mm */; };
+		29CDC2E21AAE70D000833CA4 /* ASBasicImageDownloaderContextTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 29CDC2E11AAE70D000833CA4 /* ASBasicImageDownloaderContextTests.m */; };
+		2C107F5B1BA9F54500F13DE5 /* AsyncDisplayKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BDC61F51978FEA400E50D21 /* AsyncDisplayKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		34566CB31BC1213700715E6B /* ASPhotosFrameworkImageRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = CC7FD9DD1BB5E962005CCB2B /* ASPhotosFrameworkImageRequest.m */; };
+		34EFC75B1B701BAF00AD841F /* ASDimension.h in Headers */ = {isa = PBXBuildFile; fileRef = ACF6ED071B17843500DA7C62 /* ASDimension.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		34EFC75C1B701BD200AD841F /* ASDimension.mm in Sources */ = {isa = PBXBuildFile; fileRef = ACF6ED081B17843500DA7C62 /* ASDimension.mm */; };
+		34EFC75D1B701BE900AD841F /* ASInternalHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = ACF6ED431B17847A00DA7C62 /* ASInternalHelpers.h */; };
+		34EFC75E1B701BF000AD841F /* ASInternalHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = ACF6ED441B17847A00DA7C62 /* ASInternalHelpers.m */; };
+		34EFC75F1B701C8600AD841F /* ASInsetLayoutSpec.h in Headers */ = {isa = PBXBuildFile; fileRef = ACF6ED091B17843500DA7C62 /* ASInsetLayoutSpec.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		34EFC7601B701C8B00AD841F /* ASInsetLayoutSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = ACF6ED0A1B17843500DA7C62 /* ASInsetLayoutSpec.mm */; };
+		34EFC7611B701C9C00AD841F /* ASBackgroundLayoutSpec.h in Headers */ = {isa = PBXBuildFile; fileRef = ACF6ED011B17843500DA7C62 /* ASBackgroundLayoutSpec.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		34EFC7621B701CA400AD841F /* ASBackgroundLayoutSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = ACF6ED021B17843500DA7C62 /* ASBackgroundLayoutSpec.mm */; };
+		34EFC7631B701CBF00AD841F /* ASCenterLayoutSpec.h in Headers */ = {isa = PBXBuildFile; fileRef = ACF6ED031B17843500DA7C62 /* ASCenterLayoutSpec.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		34EFC7641B701CC600AD841F /* ASCenterLayoutSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = ACF6ED041B17843500DA7C62 /* ASCenterLayoutSpec.mm */; };
+		34EFC7651B701CCC00AD841F /* ASRelativeSize.h in Headers */ = {isa = PBXBuildFile; fileRef = AC47D9431B3BB41900AAEE9D /* ASRelativeSize.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		34EFC7661B701CD200AD841F /* ASRelativeSize.mm in Sources */ = {isa = PBXBuildFile; fileRef = AC47D9441B3BB41900AAEE9D /* ASRelativeSize.mm */; };
+		34EFC7671B701CD900AD841F /* ASLayout.h in Headers */ = {isa = PBXBuildFile; fileRef = ACF6ED0B1B17843500DA7C62 /* ASLayout.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		34EFC7681B701CDE00AD841F /* ASLayout.mm in Sources */ = {isa = PBXBuildFile; fileRef = ACF6ED0C1B17843500DA7C62 /* ASLayout.mm */; };
+		34EFC7691B701CE100AD841F /* ASLayoutable.h in Headers */ = {isa = PBXBuildFile; fileRef = ACF6ED111B17843500DA7C62 /* ASLayoutable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		34EFC76A1B701CE600AD841F /* ASLayoutSpec.h in Headers */ = {isa = PBXBuildFile; fileRef = ACF6ED0D1B17843500DA7C62 /* ASLayoutSpec.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		34EFC76B1B701CEB00AD841F /* ASLayoutSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = ACF6ED0E1B17843500DA7C62 /* ASLayoutSpec.mm */; };
+		34EFC76C1B701CED00AD841F /* ASOverlayLayoutSpec.h in Headers */ = {isa = PBXBuildFile; fileRef = ACF6ED121B17843500DA7C62 /* ASOverlayLayoutSpec.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		34EFC76D1B701CF100AD841F /* ASOverlayLayoutSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = ACF6ED131B17843500DA7C62 /* ASOverlayLayoutSpec.mm */; };
+		34EFC76E1B701CF400AD841F /* ASRatioLayoutSpec.h in Headers */ = {isa = PBXBuildFile; fileRef = ACF6ED141B17843500DA7C62 /* ASRatioLayoutSpec.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		34EFC76F1B701CF700AD841F /* ASRatioLayoutSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = ACF6ED151B17843500DA7C62 /* ASRatioLayoutSpec.mm */; };
+		34EFC7701B701CFA00AD841F /* ASStackLayoutDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = AC21EC0F1B3D0BF600C8B19A /* ASStackLayoutDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		34EFC7711B701CFF00AD841F /* ASStackLayoutSpec.h in Headers */ = {isa = PBXBuildFile; fileRef = ACF6ED161B17843500DA7C62 /* ASStackLayoutSpec.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		34EFC7721B701D0300AD841F /* ASStackLayoutSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = ACF6ED171B17843500DA7C62 /* ASStackLayoutSpec.mm */; };
+		34EFC7731B701D0700AD841F /* ASStaticLayoutSpec.h in Headers */ = {isa = PBXBuildFile; fileRef = ACF6ED181B17843500DA7C62 /* ASStaticLayoutSpec.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		34EFC7741B701D0A00AD841F /* ASStaticLayoutSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = ACF6ED191B17843500DA7C62 /* ASStaticLayoutSpec.mm */; };
+		34EFC7751B701D2400AD841F /* ASStackPositionedLayout.h in Headers */ = {isa = PBXBuildFile; fileRef = ACF6ED471B17847A00DA7C62 /* ASStackPositionedLayout.h */; };
+		34EFC7761B701D2A00AD841F /* ASStackPositionedLayout.mm in Sources */ = {isa = PBXBuildFile; fileRef = ACF6ED481B17847A00DA7C62 /* ASStackPositionedLayout.mm */; };
+		34EFC7771B701D2D00AD841F /* ASStackUnpositionedLayout.h in Headers */ = {isa = PBXBuildFile; fileRef = ACF6ED491B17847A00DA7C62 /* ASStackUnpositionedLayout.h */; };
+		34EFC7781B701D3100AD841F /* ASStackUnpositionedLayout.mm in Sources */ = {isa = PBXBuildFile; fileRef = ACF6ED4A1B17847A00DA7C62 /* ASStackUnpositionedLayout.mm */; };
+		34EFC7791B701D3600AD841F /* ASLayoutSpecUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = ACF6ED451B17847A00DA7C62 /* ASLayoutSpecUtilities.h */; };
+		3C9C128519E616EF00E942A0 /* ASTableViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C9C128419E616EF00E942A0 /* ASTableViewTests.m */; };
+		430E7C901B4C23F100697A4C /* ASIndexPath.h in Headers */ = {isa = PBXBuildFile; fileRef = 430E7C8D1B4C23F100697A4C /* ASIndexPath.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		430E7C911B4C23F100697A4C /* ASIndexPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 430E7C8E1B4C23F100697A4C /* ASIndexPath.m */; };
+		430E7C921B4C23F100697A4C /* ASIndexPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 430E7C8E1B4C23F100697A4C /* ASIndexPath.m */; };
+		464052211A3F83C40061C0BA /* ASDataController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4640521A1A3F83C40061C0BA /* ASDataController.mm */; };
+		464052231A3F83C40061C0BA /* ASFlowLayoutController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4640521C1A3F83C40061C0BA /* ASFlowLayoutController.mm */; };
+		509E68601B3AED8E009B9150 /* ASScrollDirection.m in Sources */ = {isa = PBXBuildFile; fileRef = 205F0E111B371BD7007741D0 /* ASScrollDirection.m */; };
+		509E68611B3AEDA0009B9150 /* ASAbstractLayoutController.h in Headers */ = {isa = PBXBuildFile; fileRef = 205F0E171B37339C007741D0 /* ASAbstractLayoutController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		509E68621B3AEDA5009B9150 /* ASAbstractLayoutController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 205F0E181B37339C007741D0 /* ASAbstractLayoutController.mm */; };
+		509E68631B3AEDB4009B9150 /* ASCollectionViewLayoutController.h in Headers */ = {isa = PBXBuildFile; fileRef = 205F0E1B1B373A2C007741D0 /* ASCollectionViewLayoutController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		509E68641B3AEDB7009B9150 /* ASCollectionViewLayoutController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 205F0E1C1B373A2C007741D0 /* ASCollectionViewLayoutController.mm */; };
+		509E68651B3AEDC5009B9150 /* CGRect+ASConvenience.h in Headers */ = {isa = PBXBuildFile; fileRef = 205F0E1F1B376416007741D0 /* CGRect+ASConvenience.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		509E68661B3AEDD7009B9150 /* CGRect+ASConvenience.m in Sources */ = {isa = PBXBuildFile; fileRef = 205F0E201B376416007741D0 /* CGRect+ASConvenience.m */; };
+		636EA1A41C7FF4EC00EE152F /* NSArray+Diffing.m in Sources */ = {isa = PBXBuildFile; fileRef = DBC452DA1C5BF64600B16017 /* NSArray+Diffing.m */; };
+		636EA1A51C7FF4EF00EE152F /* ASDefaultPlayButton.m in Sources */ = {isa = PBXBuildFile; fileRef = AEB7B0191C5962EA00662EF4 /* ASDefaultPlayButton.m */; };
+		680346941CE4052A0009FEB4 /* ASNavigationController.h in Headers */ = {isa = PBXBuildFile; fileRef = 68FC85DC1CE29AB700EDD713 /* ASNavigationController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		683489281D70DE3400327501 /* ASDisplayNode+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 683489271D70DE3400327501 /* ASDisplayNode+Deprecated.h */; };
+		68355B311CB5799E001D4E68 /* ASImageNode+AnimatedImage.mm in Sources */ = {isa = PBXBuildFile; fileRef = 68355B2E1CB5799E001D4E68 /* ASImageNode+AnimatedImage.mm */; };
+		68355B341CB579B9001D4E68 /* ASImageNode+AnimatedImage.mm in Sources */ = {isa = PBXBuildFile; fileRef = 68355B2E1CB5799E001D4E68 /* ASImageNode+AnimatedImage.mm */; };
+		68355B3A1CB57A5A001D4E68 /* ASPINRemoteImageDownloader.m in Sources */ = {isa = PBXBuildFile; fileRef = 68355B361CB57A5A001D4E68 /* ASPINRemoteImageDownloader.m */; };
+		68355B3C1CB57A5A001D4E68 /* ASImageContainerProtocolCategories.m in Sources */ = {isa = PBXBuildFile; fileRef = 68355B381CB57A5A001D4E68 /* ASImageContainerProtocolCategories.m */; };
+		68355B3E1CB57A60001D4E68 /* ASPINRemoteImageDownloader.m in Sources */ = {isa = PBXBuildFile; fileRef = 68355B361CB57A5A001D4E68 /* ASPINRemoteImageDownloader.m */; };
+		68355B3F1CB57A64001D4E68 /* ASPINRemoteImageDownloader.h in Headers */ = {isa = PBXBuildFile; fileRef = 68355B391CB57A5A001D4E68 /* ASPINRemoteImageDownloader.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		68355B401CB57A69001D4E68 /* ASImageContainerProtocolCategories.m in Sources */ = {isa = PBXBuildFile; fileRef = 68355B381CB57A5A001D4E68 /* ASImageContainerProtocolCategories.m */; };
+		68355B411CB57A6C001D4E68 /* ASImageContainerProtocolCategories.h in Headers */ = {isa = PBXBuildFile; fileRef = 68355B371CB57A5A001D4E68 /* ASImageContainerProtocolCategories.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		68AF37DB1CBEF4D80077BF76 /* ASImageNode+AnimatedImagePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 68B8A4DB1CBD911D007E4543 /* ASImageNode+AnimatedImagePrivate.h */; };
+		68B0277B1C1A79D60041016B /* ASDisplayNode+Beta.h in Headers */ = {isa = PBXBuildFile; fileRef = 68B027791C1A79CC0041016B /* ASDisplayNode+Beta.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		68B8A4E21CBDB958007E4543 /* ASWeakProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 68B8A4DF1CBDB958007E4543 /* ASWeakProxy.h */; };
+		68B8A4E31CBDB958007E4543 /* ASWeakProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 68B8A4E01CBDB958007E4543 /* ASWeakProxy.m */; };
+		68B8A4E41CBDB958007E4543 /* ASWeakProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 68B8A4E01CBDB958007E4543 /* ASWeakProxy.m */; };
+		68EE0DBE1C1B4ED300BA1B99 /* ASMainSerialQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = 68EE0DBB1C1B4ED300BA1B99 /* ASMainSerialQueue.h */; };
+		68EE0DBF1C1B4ED300BA1B99 /* ASMainSerialQueue.mm in Sources */ = {isa = PBXBuildFile; fileRef = 68EE0DBC1C1B4ED300BA1B99 /* ASMainSerialQueue.mm */; };
+		68EE0DC01C1B4ED300BA1B99 /* ASMainSerialQueue.mm in Sources */ = {isa = PBXBuildFile; fileRef = 68EE0DBC1C1B4ED300BA1B99 /* ASMainSerialQueue.mm */; };
+		68FC85DF1CE29AB700EDD713 /* ASNavigationController.m in Sources */ = {isa = PBXBuildFile; fileRef = 68FC85DD1CE29AB700EDD713 /* ASNavigationController.m */; };
+		68FC85E31CE29B7E00EDD713 /* ASTabBarController.h in Headers */ = {isa = PBXBuildFile; fileRef = 68FC85E01CE29B7E00EDD713 /* ASTabBarController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		68FC85E41CE29B7E00EDD713 /* ASTabBarController.m in Sources */ = {isa = PBXBuildFile; fileRef = 68FC85E11CE29B7E00EDD713 /* ASTabBarController.m */; };
+		68FC85E51CE29B7E00EDD713 /* ASTabBarController.m in Sources */ = {isa = PBXBuildFile; fileRef = 68FC85E11CE29B7E00EDD713 /* ASTabBarController.m */; };
+		68FC85E61CE29B9400EDD713 /* ASNavigationController.m in Sources */ = {isa = PBXBuildFile; fileRef = 68FC85DD1CE29AB700EDD713 /* ASNavigationController.m */; };
+		68FC85EA1CE29C7D00EDD713 /* ASVisibilityProtocols.h in Headers */ = {isa = PBXBuildFile; fileRef = 68FC85E71CE29C7D00EDD713 /* ASVisibilityProtocols.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		68FC85EB1CE29C7D00EDD713 /* ASVisibilityProtocols.m in Sources */ = {isa = PBXBuildFile; fileRef = 68FC85E81CE29C7D00EDD713 /* ASVisibilityProtocols.m */; };
+		68FC85EC1CE29C7D00EDD713 /* ASVisibilityProtocols.m in Sources */ = {isa = PBXBuildFile; fileRef = 68FC85E81CE29C7D00EDD713 /* ASVisibilityProtocols.m */; };
+		6959433E1D70815300B0EE1F /* ASDisplayNodeLayout.mm in Sources */ = {isa = PBXBuildFile; fileRef = 6959433C1D70815300B0EE1F /* ASDisplayNodeLayout.mm */; };
+		6959433F1D70815300B0EE1F /* ASDisplayNodeLayout.mm in Sources */ = {isa = PBXBuildFile; fileRef = 6959433C1D70815300B0EE1F /* ASDisplayNodeLayout.mm */; };
+		695943401D70815300B0EE1F /* ASDisplayNodeLayout.h in Headers */ = {isa = PBXBuildFile; fileRef = 6959433D1D70815300B0EE1F /* ASDisplayNodeLayout.h */; };
+		696FCB311D6E46050093471E /* ASBackgroundLayoutSpecSnapshotTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 696FCB301D6E46050093471E /* ASBackgroundLayoutSpecSnapshotTests.mm */; };
+		69708BA61D76386D005C3CF9 /* ASEqualityHashHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 69708BA41D76386D005C3CF9 /* ASEqualityHashHelpers.h */; };
+		69708BA71D76386D005C3CF9 /* ASEqualityHashHelpers.mm in Sources */ = {isa = PBXBuildFile; fileRef = 69708BA51D76386D005C3CF9 /* ASEqualityHashHelpers.mm */; };
+		69708BA81D76386D005C3CF9 /* ASEqualityHashHelpers.mm in Sources */ = {isa = PBXBuildFile; fileRef = 69708BA51D76386D005C3CF9 /* ASEqualityHashHelpers.mm */; };
+		697B315A1CFE4B410049936F /* ASEditableTextNodeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 697B31591CFE4B410049936F /* ASEditableTextNodeTests.m */; };
+		697C0DE41CF38F28001DE0D4 /* ASLayoutValidation.h in Headers */ = {isa = PBXBuildFile; fileRef = 697C0DE11CF38F28001DE0D4 /* ASLayoutValidation.h */; };
+		697C0DE51CF38F28001DE0D4 /* ASLayoutValidation.mm in Sources */ = {isa = PBXBuildFile; fileRef = 697C0DE21CF38F28001DE0D4 /* ASLayoutValidation.mm */; };
+		697C0DE61CF38F28001DE0D4 /* ASLayoutValidation.mm in Sources */ = {isa = PBXBuildFile; fileRef = 697C0DE21CF38F28001DE0D4 /* ASLayoutValidation.mm */; };
+		698548641CA9E025008A345F /* ASEnvironment.h in Headers */ = {isa = PBXBuildFile; fileRef = 698548611CA9E025008A345F /* ASEnvironment.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		698C8B621CAB49FC0052DC3F /* ASLayoutableExtensibility.h in Headers */ = {isa = PBXBuildFile; fileRef = 698C8B601CAB49FC0052DC3F /* ASLayoutableExtensibility.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		69B225671D72535E00B25B22 /* ASDisplayNodeLayoutTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 69B225661D72535E00B25B22 /* ASDisplayNodeLayoutTests.mm */; };
+		69CB62AC1CB8165900024920 /* _ASDisplayViewAccessiblity.h in Headers */ = {isa = PBXBuildFile; fileRef = 69CB62A91CB8165900024920 /* _ASDisplayViewAccessiblity.h */; };
+		69CB62AD1CB8165900024920 /* _ASDisplayViewAccessiblity.mm in Sources */ = {isa = PBXBuildFile; fileRef = 69CB62AA1CB8165900024920 /* _ASDisplayViewAccessiblity.mm */; };
+		69CB62AE1CB8165900024920 /* _ASDisplayViewAccessiblity.mm in Sources */ = {isa = PBXBuildFile; fileRef = 69CB62AA1CB8165900024920 /* _ASDisplayViewAccessiblity.mm */; };
+		69E0E8A71D356C9400627613 /* ASEqualityHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 1950C4481A3BB5C1005C8279 /* ASEqualityHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		69E1006E1CA89CB600D88C1B /* ASEnvironmentInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 69E100691CA89CB600D88C1B /* ASEnvironmentInternal.h */; };
+		69E1006F1CA89CB600D88C1B /* ASEnvironmentInternal.mm in Sources */ = {isa = PBXBuildFile; fileRef = 69E1006A1CA89CB600D88C1B /* ASEnvironmentInternal.mm */; };
+		69E100701CA89CB600D88C1B /* ASEnvironmentInternal.mm in Sources */ = {isa = PBXBuildFile; fileRef = 69E1006A1CA89CB600D88C1B /* ASEnvironmentInternal.mm */; };
+		69F10C871C84C35D0026140C /* ASRangeControllerUpdateRangeProtocol+Beta.h in Headers */ = {isa = PBXBuildFile; fileRef = 69F10C851C84C35D0026140C /* ASRangeControllerUpdateRangeProtocol+Beta.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7630FFA81C9E267E007A7C0E /* ASVideoNode.h in Headers */ = {isa = PBXBuildFile; fileRef = AEEC47DF1C20C2DD00EC1693 /* ASVideoNode.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		764D83D51C8EA515009B4FB8 /* AsyncDisplayKit+Debug.h in Headers */ = {isa = PBXBuildFile; fileRef = 764D83D21C8EA515009B4FB8 /* AsyncDisplayKit+Debug.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		764D83D61C8EA515009B4FB8 /* AsyncDisplayKit+Debug.m in Sources */ = {isa = PBXBuildFile; fileRef = 764D83D31C8EA515009B4FB8 /* AsyncDisplayKit+Debug.m */; };
+		767E7F8E1C90191D0066C000 /* AsyncDisplayKit+Debug.m in Sources */ = {isa = PBXBuildFile; fileRef = 764D83D31C8EA515009B4FB8 /* AsyncDisplayKit+Debug.m */; };
+		7A06A73A1C35F08800FE8DAA /* ASRelativeLayoutSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7A06A7381C35F08800FE8DAA /* ASRelativeLayoutSpec.mm */; };
+		7AB338661C55B3420055FDE8 /* ASRelativeLayoutSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7A06A7381C35F08800FE8DAA /* ASRelativeLayoutSpec.mm */; };
+		7AB338671C55B3460055FDE8 /* ASRelativeLayoutSpec.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A06A7391C35F08800FE8DAA /* ASRelativeLayoutSpec.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7AB338691C55B97B0055FDE8 /* ASRelativeLayoutSpecSnapshotTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7AB338681C55B97B0055FDE8 /* ASRelativeLayoutSpecSnapshotTests.mm */; };
+		8021EC1D1D2B00B100799119 /* UIImage+ASConvenience.h in Headers */ = {isa = PBXBuildFile; fileRef = 8021EC1A1D2B00B100799119 /* UIImage+ASConvenience.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8021EC1E1D2B00B100799119 /* UIImage+ASConvenience.m in Sources */ = {isa = PBXBuildFile; fileRef = 8021EC1B1D2B00B100799119 /* UIImage+ASConvenience.m */; };
+		8021EC1F1D2B00B100799119 /* UIImage+ASConvenience.m in Sources */ = {isa = PBXBuildFile; fileRef = 8021EC1B1D2B00B100799119 /* UIImage+ASConvenience.m */; };
+		81E95C141D62639600336598 /* ASTextNodeSnapshotTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 81E95C131D62639600336598 /* ASTextNodeSnapshotTests.m */; };
+		81EE38501C8E94F000456208 /* ASRunLoopQueue.mm in Sources */ = {isa = PBXBuildFile; fileRef = 81EE384E1C8E94F000456208 /* ASRunLoopQueue.mm */; };
+		83A7D95A1D44542100BF333E /* ASWeakMap.m in Sources */ = {isa = PBXBuildFile; fileRef = 83A7D9591D44542100BF333E /* ASWeakMap.m */; };
+		83A7D95B1D44547700BF333E /* ASWeakMap.m in Sources */ = {isa = PBXBuildFile; fileRef = 83A7D9591D44542100BF333E /* ASWeakMap.m */; };
+		83A7D95C1D44548100BF333E /* ASWeakMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 83A7D9581D44542100BF333E /* ASWeakMap.h */; };
+		83A7D95E1D446A6E00BF333E /* ASWeakMapTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 83A7D95D1D446A6E00BF333E /* ASWeakMapTests.m */; };
+		8B0768B41CE752EC002E1453 /* ASDefaultPlaybackButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B0768B21CE752EC002E1453 /* ASDefaultPlaybackButton.m */; };
+		8BBBAB8C1CEBAF1700107FC6 /* ASDefaultPlaybackButton.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B0768B11CE752EC002E1453 /* ASDefaultPlaybackButton.h */; };
+		8BBBAB8D1CEBAF1E00107FC6 /* ASDefaultPlaybackButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B0768B21CE752EC002E1453 /* ASDefaultPlaybackButton.m */; };
+		8BDA5FC61CDBDDE1007D13B2 /* ASVideoPlayerNode.mm in Sources */ = {isa = PBXBuildFile; fileRef = 8BDA5FC41CDBDDE1007D13B2 /* ASVideoPlayerNode.mm */; };
+		8BDA5FC71CDBDF91007D13B2 /* ASVideoPlayerNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BDA5FC31CDBDDE1007D13B2 /* ASVideoPlayerNode.h */; };
+		8BDA5FC81CDBDF95007D13B2 /* ASVideoPlayerNode.mm in Sources */ = {isa = PBXBuildFile; fileRef = 8BDA5FC41CDBDDE1007D13B2 /* ASVideoPlayerNode.mm */; };
+		92074A621CC8BA1900918F75 /* ASImageNode+tvOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 92074A5F1CC8BA1900918F75 /* ASImageNode+tvOS.h */; };
+		92074A631CC8BA1900918F75 /* ASImageNode+tvOS.m in Sources */ = {isa = PBXBuildFile; fileRef = 92074A601CC8BA1900918F75 /* ASImageNode+tvOS.m */; };
+		92074A641CC8BA1900918F75 /* ASImageNode+tvOS.m in Sources */ = {isa = PBXBuildFile; fileRef = 92074A601CC8BA1900918F75 /* ASImageNode+tvOS.m */; };
+		92074A681CC8BADA00918F75 /* ASControlNode+tvOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 92074A651CC8BADA00918F75 /* ASControlNode+tvOS.h */; };
+		92074A691CC8BADA00918F75 /* ASControlNode+tvOS.m in Sources */ = {isa = PBXBuildFile; fileRef = 92074A661CC8BADA00918F75 /* ASControlNode+tvOS.m */; };
+		92074A6A1CC8BADA00918F75 /* ASControlNode+tvOS.m in Sources */ = {isa = PBXBuildFile; fileRef = 92074A661CC8BADA00918F75 /* ASControlNode+tvOS.m */; };
+		92DD2FE41BF4B97E0074C9DD /* ASMapNode.mm in Sources */ = {isa = PBXBuildFile; fileRef = 92DD2FE21BF4B97E0074C9DD /* ASMapNode.mm */; };
+		92DD2FE61BF4D05E0074C9DD /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 92DD2FE51BF4D05E0074C9DD /* MapKit.framework */; };
+		92DD2FE71BF4D0850074C9DD /* ASMapNode.mm in Sources */ = {isa = PBXBuildFile; fileRef = 92DD2FE21BF4B97E0074C9DD /* ASMapNode.mm */; };
+		92DD2FE81BF4D0A80074C9DD /* ASMapNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 92DD2FE11BF4B97E0074C9DD /* ASMapNode.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		92DD2FE91BF4D4870074C9DD /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 92DD2FE51BF4D05E0074C9DD /* MapKit.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		92DD2FEA1BF4D49B0074C9DD /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 92DD2FE51BF4D05E0074C9DD /* MapKit.framework */; };
+		9B92C8851BC2EB6E00EE46B2 /* ASCollectionDataController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 251B8EF31BBB3D690087C538 /* ASCollectionDataController.mm */; };
+		9B92C8861BC2EB7600EE46B2 /* ASCollectionViewFlowLayoutInspector.m in Sources */ = {isa = PBXBuildFile; fileRef = 251B8EF51BBB3D690087C538 /* ASCollectionViewFlowLayoutInspector.m */; };
+		9C49C3701B853961000B0DD5 /* ASStackLayoutable.h in Headers */ = {isa = PBXBuildFile; fileRef = 9C49C36E1B853957000B0DD5 /* ASStackLayoutable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9C55866A1BD549CB00B50E3A /* ASAsciiArtBoxCreator.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C5586681BD549CB00B50E3A /* ASAsciiArtBoxCreator.m */; };
+		9C55866B1BD54A1900B50E3A /* ASAsciiArtBoxCreator.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C5586681BD549CB00B50E3A /* ASAsciiArtBoxCreator.m */; };
+		9C55866C1BD54A3000B50E3A /* ASAsciiArtBoxCreator.h in Headers */ = {isa = PBXBuildFile; fileRef = 9C5586671BD549CB00B50E3A /* ASAsciiArtBoxCreator.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9C6BB3B31B8CC9C200F13F52 /* ASStaticLayoutable.h in Headers */ = {isa = PBXBuildFile; fileRef = 9C6BB3B01B8CC9C200F13F52 /* ASStaticLayoutable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9C70F2041CDA4EFA007D6C76 /* ASTraitCollection.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C70F2021CDA4EFA007D6C76 /* ASTraitCollection.m */; };
+		9C70F2051CDA4F06007D6C76 /* ASTraitCollection.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C70F2021CDA4EFA007D6C76 /* ASTraitCollection.m */; };
+		9C70F2061CDA4F0C007D6C76 /* ASTraitCollection.h in Headers */ = {isa = PBXBuildFile; fileRef = 9C70F2011CDA4EFA007D6C76 /* ASTraitCollection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9C70F2081CDAA3C6007D6C76 /* ASEnvironment.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9CFFC6BD1CCAC52B006A6476 /* ASEnvironment.mm */; };
+		9C70F2091CDABA36007D6C76 /* ASViewController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9CFFC6BF1CCAC73C006A6476 /* ASViewController.mm */; };
+		9C70F20A1CDBE949007D6C76 /* ASTableNode.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9CFFC6C11CCAC768006A6476 /* ASTableNode.mm */; };
+		9C70F20B1CDBE9A4007D6C76 /* ASDataController+Subclasses.h in Headers */ = {isa = PBXBuildFile; fileRef = 251B8EF61BBB3D690087C538 /* ASDataController+Subclasses.h */; };
+		9C70F20C1CDBE9B6007D6C76 /* ASCollectionDataController.h in Headers */ = {isa = PBXBuildFile; fileRef = 251B8EF21BBB3D690087C538 /* ASCollectionDataController.h */; };
+		9C70F20D1CDBE9CB007D6C76 /* ASDefaultPlayButton.h in Headers */ = {isa = PBXBuildFile; fileRef = AEB7B0181C5962EA00662EF4 /* ASDefaultPlayButton.h */; };
+		9C70F20E1CDBE9E5007D6C76 /* NSArray+Diffing.h in Headers */ = {isa = PBXBuildFile; fileRef = DBC452D91C5BF64600B16017 /* NSArray+Diffing.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9C70F20F1CDBE9FF007D6C76 /* ASLayoutManager.h in Headers */ = {isa = PBXBuildFile; fileRef = B30BF6501C5964B0004FCD53 /* ASLayoutManager.h */; };
+		9C8221961BA237B80037F19A /* ASStackBaselinePositionedLayout.h in Headers */ = {isa = PBXBuildFile; fileRef = 9C8221931BA237B80037F19A /* ASStackBaselinePositionedLayout.h */; };
+		9C8221971BA237B80037F19A /* ASStackBaselinePositionedLayout.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9C8221941BA237B80037F19A /* ASStackBaselinePositionedLayout.mm */; };
+		9C8221981BA237B80037F19A /* ASStackBaselinePositionedLayout.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9C8221941BA237B80037F19A /* ASStackBaselinePositionedLayout.mm */; };
+		9C8898BB1C738B9800D6B02E /* ASTextKitFontSizeAdjuster.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9C8898BA1C738B9800D6B02E /* ASTextKitFontSizeAdjuster.mm */; };
+		9C8898BC1C738BA800D6B02E /* ASTextKitFontSizeAdjuster.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9C8898BA1C738B9800D6B02E /* ASTextKitFontSizeAdjuster.mm */; };
+		9C8898BD1C738BB800D6B02E /* ASTextKitFontSizeAdjuster.h in Headers */ = {isa = PBXBuildFile; fileRef = A32FEDD31C501B6A004F642A /* ASTextKitFontSizeAdjuster.h */; };
+		9CC606651D24DF9E006581A0 /* NSIndexSet+ASHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = CC4981BB1D1C7F65004E13CC /* NSIndexSet+ASHelpers.m */; };
+		9CDC18CD1B910E12004965E2 /* ASLayoutablePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 9CDC18CB1B910E12004965E2 /* ASLayoutablePrivate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9CFFC6BE1CCAC52B006A6476 /* ASEnvironment.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9CFFC6BD1CCAC52B006A6476 /* ASEnvironment.mm */; };
+		9CFFC6C01CCAC73C006A6476 /* ASViewController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9CFFC6BF1CCAC73C006A6476 /* ASViewController.mm */; };
+		9CFFC6C21CCAC768006A6476 /* ASTableNode.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9CFFC6C11CCAC768006A6476 /* ASTableNode.mm */; };
+		9F06E5CD1B4CAF4200F015D8 /* ASCollectionViewTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9F06E5CC1B4CAF4200F015D8 /* ASCollectionViewTests.mm */; };
+		A2763D7A1CBDD57D00A9ADBD /* ASPINRemoteImageDownloader.h in Headers */ = {isa = PBXBuildFile; fileRef = A2763D771CBDD57D00A9ADBD /* ASPINRemoteImageDownloader.h */; };
+		A37320101C571B740011FC94 /* ASTextNode+Beta.h in Headers */ = {isa = PBXBuildFile; fileRef = A373200E1C571B050011FC94 /* ASTextNode+Beta.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AC026B581BD3F61800BBC17E /* ASStaticLayoutSpecSnapshotTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AC026B571BD3F61800BBC17E /* ASStaticLayoutSpecSnapshotTests.m */; };
+		AC026B6A1BD57D6F00BBC17E /* ASChangeSetDataController.h in Headers */ = {isa = PBXBuildFile; fileRef = AC026B671BD57D6F00BBC17E /* ASChangeSetDataController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AC026B6B1BD57D6F00BBC17E /* ASChangeSetDataController.mm in Sources */ = {isa = PBXBuildFile; fileRef = AC026B681BD57D6F00BBC17E /* ASChangeSetDataController.mm */; };
+		AC026B6C1BD57D6F00BBC17E /* ASChangeSetDataController.mm in Sources */ = {isa = PBXBuildFile; fileRef = AC026B681BD57D6F00BBC17E /* ASChangeSetDataController.mm */; };
+		AC026B701BD57DBF00BBC17E /* _ASHierarchyChangeSet.h in Headers */ = {isa = PBXBuildFile; fileRef = AC026B6D1BD57DBF00BBC17E /* _ASHierarchyChangeSet.h */; };
+		AC026B711BD57DBF00BBC17E /* _ASHierarchyChangeSet.mm in Sources */ = {isa = PBXBuildFile; fileRef = AC026B6E1BD57DBF00BBC17E /* _ASHierarchyChangeSet.mm */; };
+		AC026B721BD57DBF00BBC17E /* _ASHierarchyChangeSet.mm in Sources */ = {isa = PBXBuildFile; fileRef = AC026B6E1BD57DBF00BBC17E /* _ASHierarchyChangeSet.mm */; };
+		AC3C4A521A1139C100143C57 /* ASCollectionView.mm in Sources */ = {isa = PBXBuildFile; fileRef = AC3C4A501A1139C100143C57 /* ASCollectionView.mm */; };
+		AC47D9421B3B891B00AAEE9D /* ASCellNode.mm in Sources */ = {isa = PBXBuildFile; fileRef = AC6456071B0A335000CF11B8 /* ASCellNode.mm */; };
+		AC47D9461B3BB41900AAEE9D /* ASRelativeSize.mm in Sources */ = {isa = PBXBuildFile; fileRef = AC47D9441B3BB41900AAEE9D /* ASRelativeSize.mm */; };
+		AC6456091B0A335000CF11B8 /* ASCellNode.mm in Sources */ = {isa = PBXBuildFile; fileRef = AC6456071B0A335000CF11B8 /* ASCellNode.mm */; };
+		AC7A2C181BDE11DF0093FE1A /* ASTableViewInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = AC7A2C161BDE11DF0093FE1A /* ASTableViewInternal.h */; };
+		ACF6ED1B1B17843500DA7C62 /* ASBackgroundLayoutSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = ACF6ED021B17843500DA7C62 /* ASBackgroundLayoutSpec.mm */; };
+		ACF6ED1D1B17843500DA7C62 /* ASCenterLayoutSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = ACF6ED041B17843500DA7C62 /* ASCenterLayoutSpec.mm */; };
+		ACF6ED211B17843500DA7C62 /* ASDimension.mm in Sources */ = {isa = PBXBuildFile; fileRef = ACF6ED081B17843500DA7C62 /* ASDimension.mm */; };
+		ACF6ED231B17843500DA7C62 /* ASInsetLayoutSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = ACF6ED0A1B17843500DA7C62 /* ASInsetLayoutSpec.mm */; };
+		ACF6ED251B17843500DA7C62 /* ASLayout.mm in Sources */ = {isa = PBXBuildFile; fileRef = ACF6ED0C1B17843500DA7C62 /* ASLayout.mm */; };
+		ACF6ED271B17843500DA7C62 /* ASLayoutSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = ACF6ED0E1B17843500DA7C62 /* ASLayoutSpec.mm */; };
+		ACF6ED2C1B17843500DA7C62 /* ASOverlayLayoutSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = ACF6ED131B17843500DA7C62 /* ASOverlayLayoutSpec.mm */; };
+		ACF6ED2E1B17843500DA7C62 /* ASRatioLayoutSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = ACF6ED151B17843500DA7C62 /* ASRatioLayoutSpec.mm */; };
+		ACF6ED301B17843500DA7C62 /* ASStackLayoutSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = ACF6ED171B17843500DA7C62 /* ASStackLayoutSpec.mm */; };
+		ACF6ED321B17843500DA7C62 /* ASStaticLayoutSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = ACF6ED191B17843500DA7C62 /* ASStaticLayoutSpec.mm */; };
+		ACF6ED4C1B17847A00DA7C62 /* ASInternalHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = ACF6ED441B17847A00DA7C62 /* ASInternalHelpers.m */; };
+		ACF6ED501B17847A00DA7C62 /* ASStackPositionedLayout.mm in Sources */ = {isa = PBXBuildFile; fileRef = ACF6ED481B17847A00DA7C62 /* ASStackPositionedLayout.mm */; };
+		ACF6ED521B17847A00DA7C62 /* ASStackUnpositionedLayout.mm in Sources */ = {isa = PBXBuildFile; fileRef = ACF6ED4A1B17847A00DA7C62 /* ASStackUnpositionedLayout.mm */; };
+		ACF6ED5C1B178DC700DA7C62 /* ASCenterLayoutSpecSnapshotTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = ACF6ED531B178DC700DA7C62 /* ASCenterLayoutSpecSnapshotTests.mm */; };
+		ACF6ED5D1B178DC700DA7C62 /* ASDimensionTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = ACF6ED541B178DC700DA7C62 /* ASDimensionTests.mm */; };
+		ACF6ED5E1B178DC700DA7C62 /* ASInsetLayoutSpecSnapshotTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = ACF6ED551B178DC700DA7C62 /* ASInsetLayoutSpecSnapshotTests.mm */; };
+		ACF6ED601B178DC700DA7C62 /* ASLayoutSpecSnapshotTestsHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = ACF6ED581B178DC700DA7C62 /* ASLayoutSpecSnapshotTestsHelper.m */; };
+		ACF6ED611B178DC700DA7C62 /* ASOverlayLayoutSpecSnapshotTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = ACF6ED591B178DC700DA7C62 /* ASOverlayLayoutSpecSnapshotTests.mm */; };
+		ACF6ED621B178DC700DA7C62 /* ASRatioLayoutSpecSnapshotTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = ACF6ED5A1B178DC700DA7C62 /* ASRatioLayoutSpecSnapshotTests.mm */; };
+		ACF6ED631B178DC700DA7C62 /* ASStackLayoutSpecSnapshotTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = ACF6ED5B1B178DC700DA7C62 /* ASStackLayoutSpecSnapshotTests.mm */; };
+		AEB7B01B1C5962EA00662EF4 /* ASDefaultPlayButton.m in Sources */ = {isa = PBXBuildFile; fileRef = AEB7B0191C5962EA00662EF4 /* ASDefaultPlayButton.m */; };
+		AEEC47E21C20C2DD00EC1693 /* ASVideoNode.mm in Sources */ = {isa = PBXBuildFile; fileRef = AEEC47E01C20C2DD00EC1693 /* ASVideoNode.mm */; };
+		AEEC47E41C21D3D200EC1693 /* ASVideoNodeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AEEC47E31C21D3D200EC1693 /* ASVideoNodeTests.m */; };
+		B13CA0F81C519EBA00E031AB /* ASCollectionViewLayoutFacilitatorProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = B13CA0F61C519E9400E031AB /* ASCollectionViewLayoutFacilitatorProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B13CA1011C52004900E031AB /* ASCollectionNode+Beta.h in Headers */ = {isa = PBXBuildFile; fileRef = B13CA0FF1C52004900E031AB /* ASCollectionNode+Beta.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B30BF6531C5964B0004FCD53 /* ASLayoutManager.m in Sources */ = {isa = PBXBuildFile; fileRef = B30BF6511C5964B0004FCD53 /* ASLayoutManager.m */; };
+		B30BF6541C59D889004FCD53 /* ASLayoutManager.m in Sources */ = {isa = PBXBuildFile; fileRef = B30BF6511C5964B0004FCD53 /* ASLayoutManager.m */; };
+		B35061F31B010EFD0018CF92 /* ASCellNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 055F1A3A19ABD43F004DAFF1 /* ASCellNode.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B35061F51B010EFD0018CF92 /* ASCollectionView.h in Headers */ = {isa = PBXBuildFile; fileRef = AC3C4A4F1A1139C100143C57 /* ASCollectionView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B35061F61B010EFD0018CF92 /* ASCollectionView.mm in Sources */ = {isa = PBXBuildFile; fileRef = AC3C4A501A1139C100143C57 /* ASCollectionView.mm */; };
+		B35061F71B010EFD0018CF92 /* ASCollectionViewProtocols.h in Headers */ = {isa = PBXBuildFile; fileRef = AC3C4A531A113EEC00143C57 /* ASCollectionViewProtocols.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B35061F81B010EFD0018CF92 /* ASControlNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 058D09D5195D050800B7D73C /* ASControlNode.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B35061F91B010EFD0018CF92 /* ASControlNode.mm in Sources */ = {isa = PBXBuildFile; fileRef = 058D09D6195D050800B7D73C /* ASControlNode.mm */; };
+		B35061FA1B010EFD0018CF92 /* ASControlNode+Subclasses.h in Headers */ = {isa = PBXBuildFile; fileRef = 058D09D7195D050800B7D73C /* ASControlNode+Subclasses.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B35061FB1B010EFD0018CF92 /* ASDisplayNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 058D09D8195D050800B7D73C /* ASDisplayNode.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B35061FC1B010EFD0018CF92 /* ASDisplayNode.mm in Sources */ = {isa = PBXBuildFile; fileRef = 058D09D9195D050800B7D73C /* ASDisplayNode.mm */; };
+		B35061FD1B010EFD0018CF92 /* ASDisplayNode+Subclasses.h in Headers */ = {isa = PBXBuildFile; fileRef = 058D09DA195D050800B7D73C /* ASDisplayNode+Subclasses.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B35061FE1B010EFD0018CF92 /* ASDisplayNodeExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = 058D09DB195D050800B7D73C /* ASDisplayNodeExtras.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B35061FF1B010EFD0018CF92 /* ASDisplayNodeExtras.mm in Sources */ = {isa = PBXBuildFile; fileRef = 058D09DC195D050800B7D73C /* ASDisplayNodeExtras.mm */; };
+		B35062001B010EFD0018CF92 /* ASEditableTextNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 0587F9BB1A7309ED00AFF0BA /* ASEditableTextNode.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B35062011B010EFD0018CF92 /* ASEditableTextNode.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0587F9BC1A7309ED00AFF0BA /* ASEditableTextNode.mm */; };
+		B35062021B010EFD0018CF92 /* ASImageNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 058D09DD195D050800B7D73C /* ASImageNode.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B35062031B010EFD0018CF92 /* ASImageNode.mm in Sources */ = {isa = PBXBuildFile; fileRef = 058D09DE195D050800B7D73C /* ASImageNode.mm */; };
+		B35062041B010EFD0018CF92 /* ASMultiplexImageNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 0516FA3E1A1563D200B4EBED /* ASMultiplexImageNode.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B35062051B010EFD0018CF92 /* ASMultiplexImageNode.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0516FA3F1A1563D200B4EBED /* ASMultiplexImageNode.mm */; };
+		B35062061B010EFD0018CF92 /* ASNetworkImageNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 055B9FA61A1C154B00035D6D /* ASNetworkImageNode.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B35062071B010EFD0018CF92 /* ASNetworkImageNode.mm in Sources */ = {isa = PBXBuildFile; fileRef = 055B9FA71A1C154B00035D6D /* ASNetworkImageNode.mm */; };
+		B35062081B010EFD0018CF92 /* ASScrollNode.h in Headers */ = {isa = PBXBuildFile; fileRef = D785F6601A74327E00291744 /* ASScrollNode.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B35062091B010EFD0018CF92 /* ASScrollNode.m in Sources */ = {isa = PBXBuildFile; fileRef = D785F6611A74327E00291744 /* ASScrollNode.m */; };
+		B350620A1B010EFD0018CF92 /* ASTableView.h in Headers */ = {isa = PBXBuildFile; fileRef = 055F1A3219ABD3E3004DAFF1 /* ASTableView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B350620B1B010EFD0018CF92 /* ASTableView.mm in Sources */ = {isa = PBXBuildFile; fileRef = 055F1A3319ABD3E3004DAFF1 /* ASTableView.mm */; };
+		B350620C1B010EFD0018CF92 /* ASTableViewProtocols.h in Headers */ = {isa = PBXBuildFile; fileRef = 0574D5E119C110610097DC25 /* ASTableViewProtocols.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B350620D1B010EFD0018CF92 /* ASTextNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 058D09DF195D050800B7D73C /* ASTextNode.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B350620E1B010EFD0018CF92 /* ASTextNode.mm in Sources */ = {isa = PBXBuildFile; fileRef = 058D09E0195D050800B7D73C /* ASTextNode.mm */; };
+		B350620F1B010EFD0018CF92 /* _ASDisplayLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 058D09E2195D050800B7D73C /* _ASDisplayLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B35062101B010EFD0018CF92 /* _ASDisplayLayer.mm in Sources */ = {isa = PBXBuildFile; fileRef = 058D09E3195D050800B7D73C /* _ASDisplayLayer.mm */; };
+		B35062111B010EFD0018CF92 /* _ASDisplayView.h in Headers */ = {isa = PBXBuildFile; fileRef = 058D09E4195D050800B7D73C /* _ASDisplayView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B35062121B010EFD0018CF92 /* _ASDisplayView.mm in Sources */ = {isa = PBXBuildFile; fileRef = 058D09E5195D050800B7D73C /* _ASDisplayView.mm */; };
+		B35062131B010EFD0018CF92 /* ASBasicImageDownloader.h in Headers */ = {isa = PBXBuildFile; fileRef = 054963471A1EA066000F8E56 /* ASBasicImageDownloader.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B35062141B010EFD0018CF92 /* ASBasicImageDownloader.mm in Sources */ = {isa = PBXBuildFile; fileRef = 054963481A1EA066000F8E56 /* ASBasicImageDownloader.mm */; };
+		B35062151B010EFD0018CF92 /* ASBatchContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 299DA1A71A828D2900162D41 /* ASBatchContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B35062161B010EFD0018CF92 /* ASBatchContext.mm in Sources */ = {isa = PBXBuildFile; fileRef = 299DA1A81A828D2900162D41 /* ASBatchContext.mm */; };
+		B35062171B010EFD0018CF92 /* ASDataController.h in Headers */ = {isa = PBXBuildFile; fileRef = 464052191A3F83C40061C0BA /* ASDataController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B35062181B010EFD0018CF92 /* ASDataController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4640521A1A3F83C40061C0BA /* ASDataController.mm */; };
+		B35062191B010EFD0018CF92 /* ASDealloc2MainObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 05A6D05819D0EB64002DD95E /* ASDealloc2MainObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B350621A1B010EFD0018CF92 /* ASDealloc2MainObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 05A6D05919D0EB64002DD95E /* ASDealloc2MainObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		B350621B1B010EFD0018CF92 /* ASFlowLayoutController.h in Headers */ = {isa = PBXBuildFile; fileRef = 4640521B1A3F83C40061C0BA /* ASFlowLayoutController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B350621C1B010EFD0018CF92 /* ASFlowLayoutController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4640521C1A3F83C40061C0BA /* ASFlowLayoutController.mm */; };
+		B350621D1B010EFD0018CF92 /* ASHighlightOverlayLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 058D09E6195D050800B7D73C /* ASHighlightOverlayLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B350621E1B010EFD0018CF92 /* ASHighlightOverlayLayer.mm in Sources */ = {isa = PBXBuildFile; fileRef = 058D09E7195D050800B7D73C /* ASHighlightOverlayLayer.mm */; };
+		B350621F1B010EFD0018CF92 /* ASImageProtocols.h in Headers */ = {isa = PBXBuildFile; fileRef = 05F20AA31A15733C00DCA68A /* ASImageProtocols.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B35062201B010EFD0018CF92 /* ASLayoutController.h in Headers */ = {isa = PBXBuildFile; fileRef = 4640521D1A3F83C40061C0BA /* ASLayoutController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B35062211B010EFD0018CF92 /* ASLayoutRangeType.h in Headers */ = {isa = PBXBuildFile; fileRef = 292C59991A956527007E5DD6 /* ASLayoutRangeType.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B35062241B010EFD0018CF92 /* ASMutableAttributedStringBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 058D09E8195D050800B7D73C /* ASMutableAttributedStringBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B35062251B010EFD0018CF92 /* ASMutableAttributedStringBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 058D09E9195D050800B7D73C /* ASMutableAttributedStringBuilder.m */; };
+		B35062261B010EFD0018CF92 /* ASRangeController.h in Headers */ = {isa = PBXBuildFile; fileRef = 055F1A3619ABD413004DAFF1 /* ASRangeController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B35062271B010EFD0018CF92 /* ASRangeController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 055F1A3719ABD413004DAFF1 /* ASRangeController.mm */; };
+		B350622D1B010EFD0018CF92 /* ASScrollDirection.h in Headers */ = {isa = PBXBuildFile; fileRef = 296A0A311A951715005ACEAA /* ASScrollDirection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B35062391B010EFD0018CF92 /* ASThread.h in Headers */ = {isa = PBXBuildFile; fileRef = 058D0A12195D050800B7D73C /* ASThread.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B350623A1B010EFD0018CF92 /* NSMutableAttributedString+TextKitAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 058D09F5195D050800B7D73C /* NSMutableAttributedString+TextKitAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B350623B1B010EFD0018CF92 /* NSMutableAttributedString+TextKitAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 058D09F6195D050800B7D73C /* NSMutableAttributedString+TextKitAdditions.m */; };
+		B350623C1B010EFD0018CF92 /* _ASAsyncTransaction.h in Headers */ = {isa = PBXBuildFile; fileRef = 058D09F8195D050800B7D73C /* _ASAsyncTransaction.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B350623D1B010EFD0018CF92 /* _ASAsyncTransaction.mm in Sources */ = {isa = PBXBuildFile; fileRef = 058D09F9195D050800B7D73C /* _ASAsyncTransaction.mm */; };
+		B350623E1B010EFD0018CF92 /* _ASAsyncTransactionContainer+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 058D09FA195D050800B7D73C /* _ASAsyncTransactionContainer+Private.h */; };
+		B350623F1B010EFD0018CF92 /* _ASAsyncTransactionContainer.h in Headers */ = {isa = PBXBuildFile; fileRef = 058D09FB195D050800B7D73C /* _ASAsyncTransactionContainer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B35062401B010EFD0018CF92 /* _ASAsyncTransactionContainer.m in Sources */ = {isa = PBXBuildFile; fileRef = 058D09FC195D050800B7D73C /* _ASAsyncTransactionContainer.m */; };
+		B35062411B010EFD0018CF92 /* _ASAsyncTransactionGroup.h in Headers */ = {isa = PBXBuildFile; fileRef = 058D09FD195D050800B7D73C /* _ASAsyncTransactionGroup.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B35062421B010EFD0018CF92 /* _ASAsyncTransactionGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = 058D09FE195D050800B7D73C /* _ASAsyncTransactionGroup.m */; };
+		B35062431B010EFD0018CF92 /* UIView+ASConvenience.h in Headers */ = {isa = PBXBuildFile; fileRef = 058D09FF195D050800B7D73C /* UIView+ASConvenience.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B35062461B010EFD0018CF92 /* ASBasicImageDownloaderInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 2967F9E11AB0A4CF0072E4AB /* ASBasicImageDownloaderInternal.h */; };
+		B35062481B010EFD0018CF92 /* _AS-objc-internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 058D0A02195D050800B7D73C /* _AS-objc-internal.h */; };
+		B35062491B010EFD0018CF92 /* _ASCoreAnimationExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = 058D0A03195D050800B7D73C /* _ASCoreAnimationExtras.h */; };
+		B350624A1B010EFD0018CF92 /* _ASCoreAnimationExtras.mm in Sources */ = {isa = PBXBuildFile; fileRef = 058D0A04195D050800B7D73C /* _ASCoreAnimationExtras.mm */; };
+		B350624B1B010EFD0018CF92 /* _ASPendingState.h in Headers */ = {isa = PBXBuildFile; fileRef = 058D0A05195D050800B7D73C /* _ASPendingState.h */; };
+		B350624C1B010EFD0018CF92 /* _ASPendingState.mm in Sources */ = {isa = PBXBuildFile; fileRef = 058D0A06195D050800B7D73C /* _ASPendingState.mm */; };
+		B350624D1B010EFD0018CF92 /* _ASScopeTimer.h in Headers */ = {isa = PBXBuildFile; fileRef = 058D0A07195D050800B7D73C /* _ASScopeTimer.h */; };
+		B350624E1B010EFD0018CF92 /* ASDisplayNode+AsyncDisplay.mm in Sources */ = {isa = PBXBuildFile; fileRef = 058D0A08195D050800B7D73C /* ASDisplayNode+AsyncDisplay.mm */; };
+		B350624F1B010EFD0018CF92 /* ASDisplayNode+DebugTiming.h in Headers */ = {isa = PBXBuildFile; fileRef = 058D0A09195D050800B7D73C /* ASDisplayNode+DebugTiming.h */; };
+		B35062501B010EFD0018CF92 /* ASDisplayNode+DebugTiming.mm in Sources */ = {isa = PBXBuildFile; fileRef = 058D0A0A195D050800B7D73C /* ASDisplayNode+DebugTiming.mm */; };
+		B35062511B010EFD0018CF92 /* ASDisplayNode+UIViewBridge.mm in Sources */ = {isa = PBXBuildFile; fileRef = 058D0A0B195D050800B7D73C /* ASDisplayNode+UIViewBridge.mm */; };
+		B35062521B010EFD0018CF92 /* ASDisplayNodeInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 058D0A0C195D050800B7D73C /* ASDisplayNodeInternal.h */; };
+		B35062531B010EFD0018CF92 /* ASImageNode+CGExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = 058D0A0D195D050800B7D73C /* ASImageNode+CGExtras.h */; };
+		B35062541B010EFD0018CF92 /* ASImageNode+CGExtras.m in Sources */ = {isa = PBXBuildFile; fileRef = 058D0A0E195D050800B7D73C /* ASImageNode+CGExtras.m */; };
+		B35062551B010EFD0018CF92 /* ASSentinel.h in Headers */ = {isa = PBXBuildFile; fileRef = 058D0A10195D050800B7D73C /* ASSentinel.h */; };
+		B35062561B010EFD0018CF92 /* ASSentinel.m in Sources */ = {isa = PBXBuildFile; fileRef = 058D0A11195D050800B7D73C /* ASSentinel.m */; };
+		B35062571B010F070018CF92 /* ASAssert.h in Headers */ = {isa = PBXBuildFile; fileRef = 058D0A43195D058D00B7D73C /* ASAssert.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B35062581B010F070018CF92 /* ASAvailability.h in Headers */ = {isa = PBXBuildFile; fileRef = 0516FA3A1A15563400B4EBED /* ASAvailability.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B35062591B010F070018CF92 /* ASBaseDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 058D0A44195D058D00B7D73C /* ASBaseDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B350625C1B010F070018CF92 /* ASLog.h in Headers */ = {isa = PBXBuildFile; fileRef = 0516FA3B1A15563400B4EBED /* ASLog.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B350625D1B0111740018CF92 /* Photos.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 051943141A1575670030A7D0 /* Photos.framework */; };
+		B350625E1B0111780018CF92 /* AssetsLibrary.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 051943121A1575630030A7D0 /* AssetsLibrary.framework */; };
+		B350625F1B0111800018CF92 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 058D09AF195D04C000B7D73C /* Foundation.framework */; };
+		C78F7E2B1BF7809800CDEAFC /* ASTableNode.h in Headers */ = {isa = PBXBuildFile; fileRef = B0F880581BEAEC7500D17647 /* ASTableNode.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CC051F1F1D7A286A006434CB /* ASCALayerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CC051F1E1D7A286A006434CB /* ASCALayerTests.m */; };
+		CC0AEEA41D66316E005D1C78 /* ASUICollectionViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CC0AEEA31D66316E005D1C78 /* ASUICollectionViewTests.m */; };
+		CC3B20841C3F76D600798563 /* ASPendingStateController.h in Headers */ = {isa = PBXBuildFile; fileRef = CC3B20811C3F76D600798563 /* ASPendingStateController.h */; };
+		CC3B20851C3F76D600798563 /* ASPendingStateController.mm in Sources */ = {isa = PBXBuildFile; fileRef = CC3B20821C3F76D600798563 /* ASPendingStateController.mm */; };
+		CC3B20861C3F76D600798563 /* ASPendingStateController.mm in Sources */ = {isa = PBXBuildFile; fileRef = CC3B20821C3F76D600798563 /* ASPendingStateController.mm */; };
+		CC3B208A1C3F7A5400798563 /* ASWeakSet.h in Headers */ = {isa = PBXBuildFile; fileRef = CC3B20871C3F7A5400798563 /* ASWeakSet.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CC3B208B1C3F7A5400798563 /* ASWeakSet.m in Sources */ = {isa = PBXBuildFile; fileRef = CC3B20881C3F7A5400798563 /* ASWeakSet.m */; };
+		CC3B208C1C3F7A5400798563 /* ASWeakSet.m in Sources */ = {isa = PBXBuildFile; fileRef = CC3B20881C3F7A5400798563 /* ASWeakSet.m */; };
+		CC3B208E1C3F7D0A00798563 /* ASWeakSetTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CC3B208D1C3F7D0A00798563 /* ASWeakSetTests.m */; };
+		CC3B20901C3F892D00798563 /* ASBridgedPropertiesTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = CC3B208F1C3F892D00798563 /* ASBridgedPropertiesTests.mm */; };
+		CC446A2F1D80AAE00071FD03 /* ASObjectDescriptionHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = CC446A2D1D80AAE00071FD03 /* ASObjectDescriptionHelpers.h */; };
+		CC446A301D80AAE00071FD03 /* ASObjectDescriptionHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = CC446A2E1D80AAE00071FD03 /* ASObjectDescriptionHelpers.m */; };
+		CC446A311D80AAE00071FD03 /* ASObjectDescriptionHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = CC446A2E1D80AAE00071FD03 /* ASObjectDescriptionHelpers.m */; };
+		CC4981B31D1A02BE004E13CC /* ASTableViewThrashTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CC4981B21D1A02BE004E13CC /* ASTableViewThrashTests.m */; };
+		CC4981BD1D1C7F65004E13CC /* NSIndexSet+ASHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = CC4981BB1D1C7F65004E13CC /* NSIndexSet+ASHelpers.m */; };
+		CC4C2A771D88E3BF0039ACAB /* ASTraceEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = CC4C2A751D88E3BF0039ACAB /* ASTraceEvent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CC4C2A781D88E3BF0039ACAB /* ASTraceEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = CC4C2A761D88E3BF0039ACAB /* ASTraceEvent.m */; };
+		CC4C2A791D88E3BF0039ACAB /* ASTraceEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = CC4C2A761D88E3BF0039ACAB /* ASTraceEvent.m */; };
+		CC4C2A7A1D8902350039ACAB /* ASTraceEvent.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = CC4C2A751D88E3BF0039ACAB /* ASTraceEvent.h */; };
+		CC54A81C1D70079800296A24 /* ASDispatch.h in Headers */ = {isa = PBXBuildFile; fileRef = CC54A81B1D70077A00296A24 /* ASDispatch.h */; };
+		CC54A81E1D7008B300296A24 /* ASDispatchTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CC54A81D1D7008B300296A24 /* ASDispatchTests.m */; };
+		CC7FD9DF1BB5E962005CCB2B /* ASPhotosFrameworkImageRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = CC7FD9DD1BB5E962005CCB2B /* ASPhotosFrameworkImageRequest.m */; };
+		CC7FD9E11BB5F750005CCB2B /* ASPhotosFrameworkImageRequestTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CC7FD9E01BB5F750005CCB2B /* ASPhotosFrameworkImageRequestTests.m */; };
+		CC7FD9E21BB603FF005CCB2B /* ASPhotosFrameworkImageRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = CC7FD9DC1BB5E962005CCB2B /* ASPhotosFrameworkImageRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CC88F7AE1D80AF5E000D6D4E /* ASObjectDescriptionHelpers.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = CC446A2D1D80AAE00071FD03 /* ASObjectDescriptionHelpers.h */; };
+		CC8B05D61D73836400F54286 /* ASPerformanceTestContext.m in Sources */ = {isa = PBXBuildFile; fileRef = CC8B05D51D73836400F54286 /* ASPerformanceTestContext.m */; };
+		CC8B05D81D73979700F54286 /* ASTextNodePerformanceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CC8B05D71D73979700F54286 /* ASTextNodePerformanceTests.m */; };
+		CCA221D31D6FA7EF00AF6A0F /* ASViewControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CCA221D21D6FA7EF00AF6A0F /* ASViewControllerTests.m */; };
+		CCB2F34D1D63CCC6004E6DE9 /* ASDisplayNodeSnapshotTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CCB2F34C1D63CCC6004E6DE9 /* ASDisplayNodeSnapshotTests.m */; };
+		CCF18FF41D2575E300DF5895 /* NSIndexSet+ASHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = CC4981BA1D1C7F65004E13CC /* NSIndexSet+ASHelpers.h */; };
+		D785F6631A74327E00291744 /* ASScrollNode.m in Sources */ = {isa = PBXBuildFile; fileRef = D785F6611A74327E00291744 /* ASScrollNode.m */; };
+		DB55C2631C6408D6004EDCF5 /* _ASTransitionContext.m in Sources */ = {isa = PBXBuildFile; fileRef = DB55C2601C6408D6004EDCF5 /* _ASTransitionContext.m */; };
+		DB55C2671C641AE4004EDCF5 /* ASContextTransitioning.h in Headers */ = {isa = PBXBuildFile; fileRef = DB55C2651C641AE4004EDCF5 /* ASContextTransitioning.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DB7121BCD50849C498C886FB /* libPods-AsyncDisplayKitTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EFA731F0396842FF8AB635EE /* libPods-AsyncDisplayKitTests.a */; };
+		DB78412E1C6BCE1600A9E2B4 /* _ASTransitionContext.m in Sources */ = {isa = PBXBuildFile; fileRef = DB55C2601C6408D6004EDCF5 /* _ASTransitionContext.m */; };
+		DBABFAFC1C6A8D2F0039EA4A /* _ASTransitionContext.h in Headers */ = {isa = PBXBuildFile; fileRef = DB55C25F1C6408D6004EDCF5 /* _ASTransitionContext.h */; };
+		DBC452DC1C5BF64600B16017 /* NSArray+Diffing.m in Sources */ = {isa = PBXBuildFile; fileRef = DBC452DA1C5BF64600B16017 /* NSArray+Diffing.m */; };
+		DBC452DE1C5C6A6A00B16017 /* ArrayDiffingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DBC452DD1C5C6A6A00B16017 /* ArrayDiffingTests.m */; };
+		DBC453221C5FD97200B16017 /* ASDisplayNodeImplicitHierarchyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DBC453211C5FD97200B16017 /* ASDisplayNodeImplicitHierarchyTests.m */; };
+		DBDB83951C6E879900D0098C /* ASPagerFlowLayout.h in Headers */ = {isa = PBXBuildFile; fileRef = DBDB83921C6E879900D0098C /* ASPagerFlowLayout.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DBDB83961C6E879900D0098C /* ASPagerFlowLayout.m in Sources */ = {isa = PBXBuildFile; fileRef = DBDB83931C6E879900D0098C /* ASPagerFlowLayout.m */; };
+		DBDB83971C6E879900D0098C /* ASPagerFlowLayout.m in Sources */ = {isa = PBXBuildFile; fileRef = DBDB83931C6E879900D0098C /* ASPagerFlowLayout.m */; };
+		DE040EF91C2B40AC004692FF /* ASCollectionViewFlowLayoutInspector.h in Headers */ = {isa = PBXBuildFile; fileRef = 251B8EF41BBB3D690087C538 /* ASCollectionViewFlowLayoutInspector.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DE0702FC1C3671E900D7DE62 /* libAsyncDisplayKit.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 058D09AC195D04C000B7D73C /* libAsyncDisplayKit.a */; };
+		DE4843DB1C93EAB100A1F33B /* ASLayoutTransition.mm in Sources */ = {isa = PBXBuildFile; fileRef = E52405B21C8FEF03004DC8E7 /* ASLayoutTransition.mm */; };
+		DE4843DC1C93EAC100A1F33B /* ASLayoutTransition.h in Headers */ = {isa = PBXBuildFile; fileRef = E52405B41C8FEF16004DC8E7 /* ASLayoutTransition.h */; };
+		DE6EA3231C14000600183B10 /* ASDisplayNode+FrameworkPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = DE6EA3211C14000600183B10 /* ASDisplayNode+FrameworkPrivate.h */; };
+		DE84918D1C8FFF2B003D89E9 /* ASRunLoopQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = 81EE384D1C8E94F000456208 /* ASRunLoopQueue.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DE84918E1C8FFF9F003D89E9 /* ASRunLoopQueue.mm in Sources */ = {isa = PBXBuildFile; fileRef = 81EE384E1C8E94F000456208 /* ASRunLoopQueue.mm */; };
+		DE8BEAC21C2DF3FC00D57C12 /* ASDelegateProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = DE8BEABF1C2DF3FC00D57C12 /* ASDelegateProxy.h */; };
+		DE8BEAC31C2DF3FC00D57C12 /* ASDelegateProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = DE8BEAC01C2DF3FC00D57C12 /* ASDelegateProxy.m */; };
+		DE8BEAC41C2DF3FC00D57C12 /* ASDelegateProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = DE8BEAC01C2DF3FC00D57C12 /* ASDelegateProxy.m */; };
+		DEC146B71C37A16A004A0EE7 /* ASCollectionInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = DEC146B41C37A16A004A0EE7 /* ASCollectionInternal.h */; };
+		DEC146B81C37A16A004A0EE7 /* ASCollectionInternal.m in Sources */ = {isa = PBXBuildFile; fileRef = DEC146B51C37A16A004A0EE7 /* ASCollectionInternal.m */; };
+		DEC146B91C37A16A004A0EE7 /* ASCollectionInternal.m in Sources */ = {isa = PBXBuildFile; fileRef = DEC146B51C37A16A004A0EE7 /* ASCollectionInternal.m */; };
+		DECBD6E81BE56E1900CF4905 /* ASButtonNode.h in Headers */ = {isa = PBXBuildFile; fileRef = DECBD6E51BE56E1900CF4905 /* ASButtonNode.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DECBD6E91BE56E1900CF4905 /* ASButtonNode.mm in Sources */ = {isa = PBXBuildFile; fileRef = DECBD6E61BE56E1900CF4905 /* ASButtonNode.mm */; };
+		DECBD6EA1BE56E1900CF4905 /* ASButtonNode.mm in Sources */ = {isa = PBXBuildFile; fileRef = DECBD6E61BE56E1900CF4905 /* ASButtonNode.mm */; };
+		DEFAD8131CC48914000527C4 /* ASVideoNode.mm in Sources */ = {isa = PBXBuildFile; fileRef = AEEC47E01C20C2DD00EC1693 /* ASVideoNode.mm */; };
+		E52405B31C8FEF03004DC8E7 /* ASLayoutTransition.mm in Sources */ = {isa = PBXBuildFile; fileRef = E52405B21C8FEF03004DC8E7 /* ASLayoutTransition.mm */; };
+		E55D86321CA8A14000A0C26F /* ASLayoutable.mm in Sources */ = {isa = PBXBuildFile; fileRef = E55D86311CA8A14000A0C26F /* ASLayoutable.mm */; };
+		E55D86331CA8A14000A0C26F /* ASLayoutable.mm in Sources */ = {isa = PBXBuildFile; fileRef = E55D86311CA8A14000A0C26F /* ASLayoutable.mm */; };
+		E5711A2C1C840C81009619D4 /* ASIndexedNodeContext.h in Headers */ = {isa = PBXBuildFile; fileRef = E5711A2A1C840C81009619D4 /* ASIndexedNodeContext.h */; };
+		E5711A2E1C840C96009619D4 /* ASIndexedNodeContext.mm in Sources */ = {isa = PBXBuildFile; fileRef = E5711A2D1C840C96009619D4 /* ASIndexedNodeContext.mm */; };
+		E5711A301C840C96009619D4 /* ASIndexedNodeContext.mm in Sources */ = {isa = PBXBuildFile; fileRef = E5711A2D1C840C96009619D4 /* ASIndexedNodeContext.mm */; };
+		F711994E1D20C21100568860 /* ASDisplayNodeExtrasTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F711994D1D20C21100568860 /* ASDisplayNodeExtrasTests.m */; };
+		F7CE6C131D2CDB3E00BE4C15 /* ASPagerFlowLayout.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = DBDB83921C6E879900D0098C /* ASPagerFlowLayout.h */; };
+		F7CE6C141D2CDB3E00BE4C15 /* ASMapNode.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 92DD2FE11BF4B97E0074C9DD /* ASMapNode.h */; };
+		F7CE6C151D2CDB3E00BE4C15 /* ASVideoNode.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = AEEC47DF1C20C2DD00EC1693 /* ASVideoNode.h */; };
+		F7CE6C161D2CDB3E00BE4C15 /* ASCellNode.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 055F1A3A19ABD43F004DAFF1 /* ASCellNode.h */; };
+		F7CE6C171D2CDB3E00BE4C15 /* ASCollectionNode.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 18C2ED7C1B9B7DE800F627B3 /* ASCollectionNode.h */; };
+		F7CE6C181D2CDB3E00BE4C15 /* ASCollectionNode+Beta.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = B13CA0FF1C52004900E031AB /* ASCollectionNode+Beta.h */; };
+		F7CE6C191D2CDB3E00BE4C15 /* ASCollectionView.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = AC3C4A4F1A1139C100143C57 /* ASCollectionView.h */; };
+		F7CE6C1A1D2CDB3E00BE4C15 /* ASCollectionViewProtocols.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = AC3C4A531A113EEC00143C57 /* ASCollectionViewProtocols.h */; };
+		F7CE6C1B1D2CDB3E00BE4C15 /* ASCollectionViewLayoutFacilitatorProtocol.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = B13CA0F61C519E9400E031AB /* ASCollectionViewLayoutFacilitatorProtocol.h */; };
+		F7CE6C1C1D2CDB3E00BE4C15 /* ASControlNode.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 058D09D5195D050800B7D73C /* ASControlNode.h */; };
+		F7CE6C1D1D2CDB3E00BE4C15 /* ASButtonNode.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = DECBD6E51BE56E1900CF4905 /* ASButtonNode.h */; };
+		F7CE6C1E1D2CDB3E00BE4C15 /* ASControlNode+Subclasses.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 058D09D7195D050800B7D73C /* ASControlNode+Subclasses.h */; };
+		F7CE6C1F1D2CDB3E00BE4C15 /* ASDisplayNode.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 058D09D8195D050800B7D73C /* ASDisplayNode.h */; };
+		F7CE6C201D2CDB3E00BE4C15 /* ASDisplayNode+Beta.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 68B027791C1A79CC0041016B /* ASDisplayNode+Beta.h */; };
+		F7CE6C211D2CDB3E00BE4C15 /* ASDisplayNode+Subclasses.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 058D09DA195D050800B7D73C /* ASDisplayNode+Subclasses.h */; };
+		F7CE6C221D2CDB3E00BE4C15 /* ASDisplayNodeExtras.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 058D09DB195D050800B7D73C /* ASDisplayNodeExtras.h */; };
+		F7CE6C231D2CDB3E00BE4C15 /* ASEditableTextNode.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 0587F9BB1A7309ED00AFF0BA /* ASEditableTextNode.h */; };
+		F7CE6C241D2CDB3E00BE4C15 /* ASImageNode.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 058D09DD195D050800B7D73C /* ASImageNode.h */; };
+		F7CE6C251D2CDB3E00BE4C15 /* UIImage+ASConvenience.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 8021EC1A1D2B00B100799119 /* UIImage+ASConvenience.h */; };
+		F7CE6C261D2CDB3E00BE4C15 /* ASMultiplexImageNode.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 0516FA3E1A1563D200B4EBED /* ASMultiplexImageNode.h */; };
+		F7CE6C271D2CDB3E00BE4C15 /* ASNavigationController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 68FC85DC1CE29AB700EDD713 /* ASNavigationController.h */; };
+		F7CE6C281D2CDB3E00BE4C15 /* ASNetworkImageNode.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 055B9FA61A1C154B00035D6D /* ASNetworkImageNode.h */; };
+		F7CE6C291D2CDB3E00BE4C15 /* ASPagerNode.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 25E327541C16819500A2170C /* ASPagerNode.h */; };
+		F7CE6C2A1D2CDB3E00BE4C15 /* ASScrollNode.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = D785F6601A74327E00291744 /* ASScrollNode.h */; };
+		F7CE6C2B1D2CDB3E00BE4C15 /* ASTabBarController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 68FC85E01CE29B7E00EDD713 /* ASTabBarController.h */; };
+		F7CE6C2C1D2CDB3E00BE4C15 /* ASTableNode.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = B0F880581BEAEC7500D17647 /* ASTableNode.h */; };
+		F7CE6C2D1D2CDB3E00BE4C15 /* ASTableView.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 055F1A3219ABD3E3004DAFF1 /* ASTableView.h */; };
+		F7CE6C2E1D2CDB3E00BE4C15 /* ASTableViewProtocols.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 0574D5E119C110610097DC25 /* ASTableViewProtocols.h */; };
+		F7CE6C2F1D2CDB3E00BE4C15 /* ASTextNode.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 058D09DF195D050800B7D73C /* ASTextNode.h */; };
+		F7CE6C301D2CDB3E00BE4C15 /* ASTextNode+Beta.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = A373200E1C571B050011FC94 /* ASTextNode+Beta.h */; };
+		F7CE6C311D2CDB3E00BE4C15 /* ASViewController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = ACC945A81BA9E7A0005E1FB8 /* ASViewController.h */; };
+		F7CE6C321D2CDB3E00BE4C15 /* AsyncDisplayKit.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 6BDC61F51978FEA400E50D21 /* AsyncDisplayKit.h */; };
+		F7CE6C331D2CDB3E00BE4C15 /* AsyncDisplayKit+Debug.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 764D83D21C8EA515009B4FB8 /* AsyncDisplayKit+Debug.h */; };
+		F7CE6C341D2CDB3E00BE4C15 /* ASContextTransitioning.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = DB55C2651C641AE4004EDCF5 /* ASContextTransitioning.h */; };
+		F7CE6C351D2CDB3E00BE4C15 /* ASVisibilityProtocols.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 68FC85E71CE29C7D00EDD713 /* ASVisibilityProtocols.h */; };
+		F7CE6C361D2CDB3E00BE4C15 /* _ASDisplayLayer.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 058D09E2195D050800B7D73C /* _ASDisplayLayer.h */; };
+		F7CE6C371D2CDB3E00BE4C15 /* _ASDisplayView.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 058D09E4195D050800B7D73C /* _ASDisplayView.h */; };
+		F7CE6C381D2CDB3E00BE4C15 /* ASAbstractLayoutController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 205F0E171B37339C007741D0 /* ASAbstractLayoutController.h */; };
+		F7CE6C391D2CDB3E00BE4C15 /* ASBasicImageDownloader.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 054963471A1EA066000F8E56 /* ASBasicImageDownloader.h */; };
+		F7CE6C3A1D2CDB3E00BE4C15 /* ASBatchContext.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 299DA1A71A828D2900162D41 /* ASBatchContext.h */; };
+		F7CE6C3B1D2CDB3E00BE4C15 /* ASCollectionViewFlowLayoutInspector.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 251B8EF41BBB3D690087C538 /* ASCollectionViewFlowLayoutInspector.h */; };
+		F7CE6C3D1D2CDB3E00BE4C15 /* ASCollectionViewLayoutController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 205F0E1B1B373A2C007741D0 /* ASCollectionViewLayoutController.h */; };
+		F7CE6C3E1D2CDB3E00BE4C15 /* ASDealloc2MainObject.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 05A6D05819D0EB64002DD95E /* ASDealloc2MainObject.h */; };
+		F7CE6C3F1D2CDB3E00BE4C15 /* ASEnvironment.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 698548611CA9E025008A345F /* ASEnvironment.h */; };
+		F7CE6C401D2CDB3E00BE4C15 /* ASFlowLayoutController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 4640521B1A3F83C40061C0BA /* ASFlowLayoutController.h */; };
+		F7CE6C411D2CDB3E00BE4C15 /* ASHighlightOverlayLayer.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 058D09E6195D050800B7D73C /* ASHighlightOverlayLayer.h */; };
+		F7CE6C421D2CDB3E00BE4C15 /* ASIndexPath.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 430E7C8D1B4C23F100697A4C /* ASIndexPath.h */; };
+		F7CE6C431D2CDB3E00BE4C15 /* ASImageProtocols.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 05F20AA31A15733C00DCA68A /* ASImageProtocols.h */; };
+		F7CE6C441D2CDB3E00BE4C15 /* ASImageContainerProtocolCategories.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 68355B371CB57A5A001D4E68 /* ASImageContainerProtocolCategories.h */; };
+		F7CE6C451D2CDB3E00BE4C15 /* ASPINRemoteImageDownloader.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 68355B391CB57A5A001D4E68 /* ASPINRemoteImageDownloader.h */; };
+		F7CE6C461D2CDB3E00BE4C15 /* ASLayoutController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 4640521D1A3F83C40061C0BA /* ASLayoutController.h */; };
+		F7CE6C471D2CDB3E00BE4C15 /* ASLayoutRangeType.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 292C59991A956527007E5DD6 /* ASLayoutRangeType.h */; };
+		F7CE6C481D2CDB3E00BE4C15 /* ASMutableAttributedStringBuilder.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 058D09E8195D050800B7D73C /* ASMutableAttributedStringBuilder.h */; };
+		F7CE6C491D2CDB3E00BE4C15 /* ASPhotosFrameworkImageRequest.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = CC7FD9DC1BB5E962005CCB2B /* ASPhotosFrameworkImageRequest.h */; };
+		F7CE6C4A1D2CDB3E00BE4C15 /* ASRangeController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 055F1A3619ABD413004DAFF1 /* ASRangeController.h */; };
+		F7CE6C4B1D2CDB3E00BE4C15 /* ASRangeControllerUpdateRangeProtocol+Beta.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 69F10C851C84C35D0026140C /* ASRangeControllerUpdateRangeProtocol+Beta.h */; };
+		F7CE6C4C1D2CDB3E00BE4C15 /* ASRunLoopQueue.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 81EE384D1C8E94F000456208 /* ASRunLoopQueue.h */; };
+		F7CE6C4D1D2CDB3E00BE4C15 /* ASScrollDirection.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 296A0A311A951715005ACEAA /* ASScrollDirection.h */; };
+		F7CE6C4E1D2CDB3E00BE4C15 /* ASThread.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 058D0A12195D050800B7D73C /* ASThread.h */; };
+		F7CE6C4F1D2CDB3E00BE4C15 /* CGRect+ASConvenience.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 205F0E1F1B376416007741D0 /* CGRect+ASConvenience.h */; };
+		F7CE6C501D2CDB3E00BE4C15 /* ASDataController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 464052191A3F83C40061C0BA /* ASDataController.h */; };
+		F7CE6C511D2CDB3E00BE4C15 /* ASChangeSetDataController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = AC026B671BD57D6F00BBC17E /* ASChangeSetDataController.h */; };
+		F7CE6C521D2CDB3E00BE4C15 /* ASIndexedNodeContext.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E5711A2A1C840C81009619D4 /* ASIndexedNodeContext.h */; };
+		F7CE6C531D2CDB3E00BE4C15 /* NSMutableAttributedString+TextKitAdditions.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 058D09F5195D050800B7D73C /* NSMutableAttributedString+TextKitAdditions.h */; };
+		F7CE6C541D2CDB3E00BE4C15 /* _ASAsyncTransaction.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 058D09F8195D050800B7D73C /* _ASAsyncTransaction.h */; };
+		F7CE6C551D2CDB3E00BE4C15 /* _ASAsyncTransactionContainer+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 058D09FA195D050800B7D73C /* _ASAsyncTransactionContainer+Private.h */; };
+		F7CE6C561D2CDB3E00BE4C15 /* _ASAsyncTransactionContainer.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 058D09FB195D050800B7D73C /* _ASAsyncTransactionContainer.h */; };
+		F7CE6C571D2CDB3E00BE4C15 /* _ASAsyncTransactionGroup.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 058D09FD195D050800B7D73C /* _ASAsyncTransactionGroup.h */; };
+		F7CE6C581D2CDB3E00BE4C15 /* UICollectionViewLayout+ASConvenience.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 205F0E0D1B371875007741D0 /* UICollectionViewLayout+ASConvenience.h */; };
+		F7CE6C591D2CDB3E00BE4C15 /* UIView+ASConvenience.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 058D09FF195D050800B7D73C /* UIView+ASConvenience.h */; };
+		F7CE6C5A1D2CDB3E00BE4C15 /* ASTraitCollection.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9C70F2011CDA4EFA007D6C76 /* ASTraitCollection.h */; };
+		F7CE6C5B1D2CDB3E00BE4C15 /* ASAsciiArtBoxCreator.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9C5586671BD549CB00B50E3A /* ASAsciiArtBoxCreator.h */; };
+		F7CE6C5C1D2CDB3E00BE4C15 /* ASBackgroundLayoutSpec.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = ACF6ED011B17843500DA7C62 /* ASBackgroundLayoutSpec.h */; };
+		F7CE6C5D1D2CDB3E00BE4C15 /* ASCenterLayoutSpec.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = ACF6ED031B17843500DA7C62 /* ASCenterLayoutSpec.h */; };
+		F7CE6C5E1D2CDB3E00BE4C15 /* ASDimension.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = ACF6ED071B17843500DA7C62 /* ASDimension.h */; };
+		F7CE6C5F1D2CDB3E00BE4C15 /* ASInsetLayoutSpec.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = ACF6ED091B17843500DA7C62 /* ASInsetLayoutSpec.h */; };
+		F7CE6C601D2CDB3E00BE4C15 /* ASLayout.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = ACF6ED0B1B17843500DA7C62 /* ASLayout.h */; };
+		F7CE6C611D2CDB3E00BE4C15 /* ASLayoutable.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = ACF6ED111B17843500DA7C62 /* ASLayoutable.h */; };
+		F7CE6C621D2CDB3E00BE4C15 /* ASLayoutablePrivate.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9CDC18CB1B910E12004965E2 /* ASLayoutablePrivate.h */; };
+		F7CE6C631D2CDB3E00BE4C15 /* ASLayoutSpec.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = ACF6ED0D1B17843500DA7C62 /* ASLayoutSpec.h */; };
+		F7CE6C641D2CDB3E00BE4C15 /* ASOverlayLayoutSpec.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = ACF6ED121B17843500DA7C62 /* ASOverlayLayoutSpec.h */; };
+		F7CE6C651D2CDB3E00BE4C15 /* ASRatioLayoutSpec.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = ACF6ED141B17843500DA7C62 /* ASRatioLayoutSpec.h */; };
+		F7CE6C661D2CDB3E00BE4C15 /* ASRelativeLayoutSpec.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 7A06A7391C35F08800FE8DAA /* ASRelativeLayoutSpec.h */; };
+		F7CE6C671D2CDB3E00BE4C15 /* ASRelativeSize.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = AC47D9431B3BB41900AAEE9D /* ASRelativeSize.h */; };
+		F7CE6C681D2CDB3E00BE4C15 /* ASStackLayoutable.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9C49C36E1B853957000B0DD5 /* ASStackLayoutable.h */; };
+		F7CE6C691D2CDB3E00BE4C15 /* ASStackLayoutDefines.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = AC21EC0F1B3D0BF600C8B19A /* ASStackLayoutDefines.h */; };
+		F7CE6C6A1D2CDB3E00BE4C15 /* ASStackLayoutSpec.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = ACF6ED161B17843500DA7C62 /* ASStackLayoutSpec.h */; };
+		F7CE6C6B1D2CDB3E00BE4C15 /* ASStaticLayoutable.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9C6BB3B01B8CC9C200F13F52 /* ASStaticLayoutable.h */; };
+		F7CE6C6C1D2CDB3E00BE4C15 /* ASStaticLayoutSpec.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = ACF6ED181B17843500DA7C62 /* ASStaticLayoutSpec.h */; };
+		F7CE6C6D1D2CDB3E00BE4C15 /* ASTextKitComponents.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 257754BA1BEE458E00737CA5 /* ASTextKitComponents.h */; };
+		F7CE6C6E1D2CDB3E00BE4C15 /* ASTextNodeWordKerner.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 257754B91BEE458E00737CA5 /* ASTextNodeWordKerner.h */; };
+		F7CE6C6F1D2CDB3E00BE4C15 /* ASTextNodeTypes.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 257754BC1BEE458E00737CA5 /* ASTextNodeTypes.h */; };
+		F7CE6C701D2CDB3E00BE4C15 /* ASTextKitAttributes.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 257754951BEE44CD00737CA5 /* ASTextKitAttributes.h */; };
+		F7CE6C711D2CDB3F00BE4C15 /* ASTextKitContext.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 257754961BEE44CD00737CA5 /* ASTextKitContext.h */; };
+		F7CE6C721D2CDB3F00BE4C15 /* ASTextKitEntityAttribute.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 257754981BEE44CD00737CA5 /* ASTextKitEntityAttribute.h */; };
+		F7CE6C731D2CDB3F00BE4C15 /* ASTextKitRenderer.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 257754931BEE44CD00737CA5 /* ASTextKitRenderer.h */; };
+		F7CE6C741D2CDB3F00BE4C15 /* ASTextKitRenderer+Positioning.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 2577549B1BEE44CD00737CA5 /* ASTextKitRenderer+Positioning.h */; };
+		F7CE6C751D2CDB3F00BE4C15 /* ASTextKitRenderer+TextChecking.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 2577549D1BEE44CD00737CA5 /* ASTextKitRenderer+TextChecking.h */; };
+		F7CE6C761D2CDB3F00BE4C15 /* ASTextKitShadower.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 2577549F1BEE44CD00737CA5 /* ASTextKitShadower.h */; };
+		F7CE6C771D2CDB3F00BE4C15 /* ASTextKitTailTruncater.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 257754A11BEE44CD00737CA5 /* ASTextKitTailTruncater.h */; };
+		F7CE6C781D2CDB3F00BE4C15 /* ASTextKitFontSizeAdjuster.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = A32FEDD31C501B6A004F642A /* ASTextKitFontSizeAdjuster.h */; };
+		F7CE6C791D2CDB3F00BE4C15 /* ASTextKitTruncating.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 257754A31BEE44CD00737CA5 /* ASTextKitTruncating.h */; };
+		F7CE6C7B1D2CDB3F00BE4C15 /* ASAssert.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 058D0A43195D058D00B7D73C /* ASAssert.h */; };
+		F7CE6C7C1D2CDB3F00BE4C15 /* ASAvailability.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 0516FA3A1A15563400B4EBED /* ASAvailability.h */; };
+		F7CE6C7D1D2CDB3F00BE4C15 /* ASBaseDefines.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 058D0A44195D058D00B7D73C /* ASBaseDefines.h */; };
+		F7CE6C7E1D2CDB3F00BE4C15 /* ASEqualityHelpers.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 1950C4481A3BB5C1005C8279 /* ASEqualityHelpers.h */; };
+		F7CE6C7F1D2CDB3F00BE4C15 /* ASLog.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 0516FA3B1A15563400B4EBED /* ASLog.h */; };
+		F7CE6C801D2CDB5800BE4C15 /* ASVideoPlayerNode.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 8BDA5FC31CDBDDE1007D13B2 /* ASVideoPlayerNode.h */; };
+		F7CE6C811D2CDB5800BE4C15 /* ASCollectionInternal.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = DEC146B41C37A16A004A0EE7 /* ASCollectionInternal.h */; };
+		F7CE6C821D2CDB5800BE4C15 /* ASTableViewInternal.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = AC7A2C161BDE11DF0093FE1A /* ASTableViewInternal.h */; };
+		F7CE6C831D2CDB5800BE4C15 /* ASImageNode+tvOS.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 92074A5F1CC8BA1900918F75 /* ASImageNode+tvOS.h */; };
+		F7CE6C841D2CDB5800BE4C15 /* ASControlNode+tvOS.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 92074A651CC8BADA00918F75 /* ASControlNode+tvOS.h */; };
+		F7CE6C851D2CDB5800BE4C15 /* NSIndexSet+ASHelpers.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = CC4981BA1D1C7F65004E13CC /* NSIndexSet+ASHelpers.h */; };
+		F7CE6C861D2CDB5800BE4C15 /* _ASDisplayViewAccessiblity.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 69CB62A91CB8165900024920 /* _ASDisplayViewAccessiblity.h */; };
+		F7CE6C871D2CDB5800BE4C15 /* ASDataController+Subclasses.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 251B8EF61BBB3D690087C538 /* ASDataController+Subclasses.h */; };
+		F7CE6C8B1D2CDB5800BE4C15 /* ASCollectionDataController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 251B8EF21BBB3D690087C538 /* ASCollectionDataController.h */; };
+		F7CE6C8C1D2CDB5800BE4C15 /* _ASCoreAnimationExtras.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 058D0A03195D050800B7D73C /* _ASCoreAnimationExtras.h */; };
+		F7CE6C8D1D2CDB5800BE4C15 /* _ASHierarchyChangeSet.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = AC026B6D1BD57DBF00BBC17E /* _ASHierarchyChangeSet.h */; };
+		F7CE6C8F1D2CDB5800BE4C15 /* _ASScopeTimer.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 058D0A07195D050800B7D73C /* _ASScopeTimer.h */; };
+		F7CE6C901D2CDB5800BE4C15 /* _ASTransitionContext.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = DB55C25F1C6408D6004EDCF5 /* _ASTransitionContext.h */; };
+		F7CE6C941D2CDB5800BE4C15 /* ASDisplayNodeInternal.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 058D0A0C195D050800B7D73C /* ASDisplayNodeInternal.h */; };
+		F7CE6C951D2CDB5800BE4C15 /* ASLayoutTransition.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E52405B41C8FEF16004DC8E7 /* ASLayoutTransition.h */; };
+		F7CE6C961D2CDB5800BE4C15 /* ASEnvironmentInternal.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 69E100691CA89CB600D88C1B /* ASEnvironmentInternal.h */; };
+		F7CE6C971D2CDB5800BE4C15 /* ASImageNode+CGExtras.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 058D0A0D195D050800B7D73C /* ASImageNode+CGExtras.h */; };
+		F7CE6C981D2CDB5800BE4C15 /* ASInternalHelpers.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = ACF6ED431B17847A00DA7C62 /* ASInternalHelpers.h */; };
+		F7CE6C991D2CDB5800BE4C15 /* ASLayoutSpecUtilities.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = ACF6ED451B17847A00DA7C62 /* ASLayoutSpecUtilities.h */; };
+		F7CE6C9A1D2CDB5800BE4C15 /* ASMultidimensionalArrayUtils.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 0442850B1BAA64EC00D16268 /* ASMultidimensionalArrayUtils.h */; };
+		F7CE6C9B1D2CDB5800BE4C15 /* ASPendingStateController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = CC3B20811C3F76D600798563 /* ASPendingStateController.h */; };
+		F7CE6C9C1D2CDB5800BE4C15 /* ASSentinel.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 058D0A10195D050800B7D73C /* ASSentinel.h */; };
+		F7CE6C9D1D2CDB5800BE4C15 /* ASStackBaselinePositionedLayout.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9C8221931BA237B80037F19A /* ASStackBaselinePositionedLayout.h */; };
+		F7CE6C9E1D2CDB5800BE4C15 /* ASStackLayoutSpecUtilities.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = ACF6ED461B17847A00DA7C62 /* ASStackLayoutSpecUtilities.h */; };
+		F7CE6C9F1D2CDB5800BE4C15 /* ASStackPositionedLayout.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = ACF6ED471B17847A00DA7C62 /* ASStackPositionedLayout.h */; };
+		F7CE6CA01D2CDB5800BE4C15 /* ASStackUnpositionedLayout.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = ACF6ED491B17847A00DA7C62 /* ASStackUnpositionedLayout.h */; };
+		F7CE6CA11D2CDB5800BE4C15 /* ASWeakSet.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = CC3B20871C3F7A5400798563 /* ASWeakSet.h */; };
+		F7CE6CA21D2CDB5800BE4C15 /* ASDefaultPlaybackButton.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 8B0768B11CE752EC002E1453 /* ASDefaultPlaybackButton.h */; };
+		F7CE6CA31D2CDB5800BE4C15 /* ASLayoutValidation.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 697C0DE11CF38F28001DE0D4 /* ASLayoutValidation.h */; };
+		F7CE6CA41D2CDB5800BE4C15 /* ASLayoutManager.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = B30BF6501C5964B0004FCD53 /* ASLayoutManager.h */; };
+		F7CE6CB71D2CE2D000BE4C15 /* ASLayoutableExtensibility.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 698C8B601CAB49FC0052DC3F /* ASLayoutableExtensibility.h */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		057D02E51AC0A67000C7AC3C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 058D09A4195D04C000B7D73C /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 057D02BE1AC0A66700C7AC3C;
+			remoteInfo = AsyncDisplayKitTestHost;
+		};
+		058D09C2195D04C000B7D73C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 058D09A4195D04C000B7D73C /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 058D09AB195D04C000B7D73C;
+			remoteInfo = AsyncDisplayKit;
+		};
+		DEACA2B11C425DC400FA9DDF /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 058D09A4195D04C000B7D73C /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 058D09AB195D04C000B7D73C;
+			remoteInfo = AsyncDisplayKit;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		058D09AA195D04C000B7D73C /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+				CC4C2A7A1D8902350039ACAB /* ASTraceEvent.h in CopyFiles */,
+				CC88F7AE1D80AF5E000D6D4E /* ASObjectDescriptionHelpers.h in CopyFiles */,
+				F7CE6C981D2CDB5800BE4C15 /* ASInternalHelpers.h in CopyFiles */,
+				F7CE6CB71D2CE2D000BE4C15 /* ASLayoutableExtensibility.h in CopyFiles */,
+				F7CE6C131D2CDB3E00BE4C15 /* ASPagerFlowLayout.h in CopyFiles */,
+				F7CE6C141D2CDB3E00BE4C15 /* ASMapNode.h in CopyFiles */,
+				F7CE6C151D2CDB3E00BE4C15 /* ASVideoNode.h in CopyFiles */,
+				F7CE6C161D2CDB3E00BE4C15 /* ASCellNode.h in CopyFiles */,
+				F7CE6C171D2CDB3E00BE4C15 /* ASCollectionNode.h in CopyFiles */,
+				F7CE6C181D2CDB3E00BE4C15 /* ASCollectionNode+Beta.h in CopyFiles */,
+				F7CE6C191D2CDB3E00BE4C15 /* ASCollectionView.h in CopyFiles */,
+				F7CE6C1A1D2CDB3E00BE4C15 /* ASCollectionViewProtocols.h in CopyFiles */,
+				F7CE6C1B1D2CDB3E00BE4C15 /* ASCollectionViewLayoutFacilitatorProtocol.h in CopyFiles */,
+				F7CE6C1C1D2CDB3E00BE4C15 /* ASControlNode.h in CopyFiles */,
+				F7CE6C1D1D2CDB3E00BE4C15 /* ASButtonNode.h in CopyFiles */,
+				F7CE6C1E1D2CDB3E00BE4C15 /* ASControlNode+Subclasses.h in CopyFiles */,
+				F7CE6C1F1D2CDB3E00BE4C15 /* ASDisplayNode.h in CopyFiles */,
+				F7CE6C201D2CDB3E00BE4C15 /* ASDisplayNode+Beta.h in CopyFiles */,
+				F7CE6C211D2CDB3E00BE4C15 /* ASDisplayNode+Subclasses.h in CopyFiles */,
+				F7CE6C221D2CDB3E00BE4C15 /* ASDisplayNodeExtras.h in CopyFiles */,
+				F7CE6C231D2CDB3E00BE4C15 /* ASEditableTextNode.h in CopyFiles */,
+				F7CE6C241D2CDB3E00BE4C15 /* ASImageNode.h in CopyFiles */,
+				F7CE6C251D2CDB3E00BE4C15 /* UIImage+ASConvenience.h in CopyFiles */,
+				F7CE6C261D2CDB3E00BE4C15 /* ASMultiplexImageNode.h in CopyFiles */,
+				F7CE6C271D2CDB3E00BE4C15 /* ASNavigationController.h in CopyFiles */,
+				F7CE6C281D2CDB3E00BE4C15 /* ASNetworkImageNode.h in CopyFiles */,
+				F7CE6C291D2CDB3E00BE4C15 /* ASPagerNode.h in CopyFiles */,
+				F7CE6C2A1D2CDB3E00BE4C15 /* ASScrollNode.h in CopyFiles */,
+				F7CE6C2B1D2CDB3E00BE4C15 /* ASTabBarController.h in CopyFiles */,
+				F7CE6C2C1D2CDB3E00BE4C15 /* ASTableNode.h in CopyFiles */,
+				F7CE6C2D1D2CDB3E00BE4C15 /* ASTableView.h in CopyFiles */,
+				F7CE6C2E1D2CDB3E00BE4C15 /* ASTableViewProtocols.h in CopyFiles */,
+				F7CE6C2F1D2CDB3E00BE4C15 /* ASTextNode.h in CopyFiles */,
+				F7CE6C301D2CDB3E00BE4C15 /* ASTextNode+Beta.h in CopyFiles */,
+				F7CE6C311D2CDB3E00BE4C15 /* ASViewController.h in CopyFiles */,
+				F7CE6C321D2CDB3E00BE4C15 /* AsyncDisplayKit.h in CopyFiles */,
+				F7CE6C331D2CDB3E00BE4C15 /* AsyncDisplayKit+Debug.h in CopyFiles */,
+				F7CE6C341D2CDB3E00BE4C15 /* ASContextTransitioning.h in CopyFiles */,
+				F7CE6C351D2CDB3E00BE4C15 /* ASVisibilityProtocols.h in CopyFiles */,
+				F7CE6C361D2CDB3E00BE4C15 /* _ASDisplayLayer.h in CopyFiles */,
+				F7CE6C371D2CDB3E00BE4C15 /* _ASDisplayView.h in CopyFiles */,
+				F7CE6C381D2CDB3E00BE4C15 /* ASAbstractLayoutController.h in CopyFiles */,
+				F7CE6C391D2CDB3E00BE4C15 /* ASBasicImageDownloader.h in CopyFiles */,
+				F7CE6C3A1D2CDB3E00BE4C15 /* ASBatchContext.h in CopyFiles */,
+				F7CE6C3B1D2CDB3E00BE4C15 /* ASCollectionViewFlowLayoutInspector.h in CopyFiles */,
+				F7CE6C3D1D2CDB3E00BE4C15 /* ASCollectionViewLayoutController.h in CopyFiles */,
+				F7CE6C3E1D2CDB3E00BE4C15 /* ASDealloc2MainObject.h in CopyFiles */,
+				F7CE6C3F1D2CDB3E00BE4C15 /* ASEnvironment.h in CopyFiles */,
+				F7CE6C401D2CDB3E00BE4C15 /* ASFlowLayoutController.h in CopyFiles */,
+				F7CE6C411D2CDB3E00BE4C15 /* ASHighlightOverlayLayer.h in CopyFiles */,
+				F7CE6C421D2CDB3E00BE4C15 /* ASIndexPath.h in CopyFiles */,
+				F7CE6C431D2CDB3E00BE4C15 /* ASImageProtocols.h in CopyFiles */,
+				F7CE6C441D2CDB3E00BE4C15 /* ASImageContainerProtocolCategories.h in CopyFiles */,
+				F7CE6C461D2CDB3E00BE4C15 /* ASLayoutController.h in CopyFiles */,
+				F7CE6C471D2CDB3E00BE4C15 /* ASLayoutRangeType.h in CopyFiles */,
+				F7CE6C481D2CDB3E00BE4C15 /* ASMutableAttributedStringBuilder.h in CopyFiles */,
+				F7CE6C491D2CDB3E00BE4C15 /* ASPhotosFrameworkImageRequest.h in CopyFiles */,
+				F7CE6C4A1D2CDB3E00BE4C15 /* ASRangeController.h in CopyFiles */,
+				F7CE6C4B1D2CDB3E00BE4C15 /* ASRangeControllerUpdateRangeProtocol+Beta.h in CopyFiles */,
+				F7CE6C4C1D2CDB3E00BE4C15 /* ASRunLoopQueue.h in CopyFiles */,
+				F7CE6C4D1D2CDB3E00BE4C15 /* ASScrollDirection.h in CopyFiles */,
+				F7CE6C4E1D2CDB3E00BE4C15 /* ASThread.h in CopyFiles */,
+				F7CE6C4F1D2CDB3E00BE4C15 /* CGRect+ASConvenience.h in CopyFiles */,
+				F7CE6C501D2CDB3E00BE4C15 /* ASDataController.h in CopyFiles */,
+				F7CE6C511D2CDB3E00BE4C15 /* ASChangeSetDataController.h in CopyFiles */,
+				F7CE6C521D2CDB3E00BE4C15 /* ASIndexedNodeContext.h in CopyFiles */,
+				F7CE6C531D2CDB3E00BE4C15 /* NSMutableAttributedString+TextKitAdditions.h in CopyFiles */,
+				F7CE6C541D2CDB3E00BE4C15 /* _ASAsyncTransaction.h in CopyFiles */,
+				F7CE6C551D2CDB3E00BE4C15 /* _ASAsyncTransactionContainer+Private.h in CopyFiles */,
+				F7CE6C561D2CDB3E00BE4C15 /* _ASAsyncTransactionContainer.h in CopyFiles */,
+				F7CE6C571D2CDB3E00BE4C15 /* _ASAsyncTransactionGroup.h in CopyFiles */,
+				F7CE6C581D2CDB3E00BE4C15 /* UICollectionViewLayout+ASConvenience.h in CopyFiles */,
+				F7CE6C5B1D2CDB3E00BE4C15 /* ASAsciiArtBoxCreator.h in CopyFiles */,
+				F7CE6C5C1D2CDB3E00BE4C15 /* ASBackgroundLayoutSpec.h in CopyFiles */,
+				F7CE6C5D1D2CDB3E00BE4C15 /* ASCenterLayoutSpec.h in CopyFiles */,
+				F7CE6C5E1D2CDB3E00BE4C15 /* ASDimension.h in CopyFiles */,
+				F7CE6C5F1D2CDB3E00BE4C15 /* ASInsetLayoutSpec.h in CopyFiles */,
+				F7CE6C601D2CDB3E00BE4C15 /* ASLayout.h in CopyFiles */,
+				F7CE6C611D2CDB3E00BE4C15 /* ASLayoutable.h in CopyFiles */,
+				F7CE6C621D2CDB3E00BE4C15 /* ASLayoutablePrivate.h in CopyFiles */,
+				F7CE6C631D2CDB3E00BE4C15 /* ASLayoutSpec.h in CopyFiles */,
+				F7CE6C641D2CDB3E00BE4C15 /* ASOverlayLayoutSpec.h in CopyFiles */,
+				F7CE6C651D2CDB3E00BE4C15 /* ASRatioLayoutSpec.h in CopyFiles */,
+				F7CE6C661D2CDB3E00BE4C15 /* ASRelativeLayoutSpec.h in CopyFiles */,
+				F7CE6C671D2CDB3E00BE4C15 /* ASRelativeSize.h in CopyFiles */,
+				F7CE6C681D2CDB3E00BE4C15 /* ASStackLayoutable.h in CopyFiles */,
+				F7CE6C691D2CDB3E00BE4C15 /* ASStackLayoutDefines.h in CopyFiles */,
+				F7CE6C6A1D2CDB3E00BE4C15 /* ASStackLayoutSpec.h in CopyFiles */,
+				F7CE6C6B1D2CDB3E00BE4C15 /* ASStaticLayoutable.h in CopyFiles */,
+				F7CE6C6C1D2CDB3E00BE4C15 /* ASStaticLayoutSpec.h in CopyFiles */,
+				F7CE6C6D1D2CDB3E00BE4C15 /* ASTextKitComponents.h in CopyFiles */,
+				F7CE6C6E1D2CDB3E00BE4C15 /* ASTextNodeWordKerner.h in CopyFiles */,
+				F7CE6C6F1D2CDB3E00BE4C15 /* ASTextNodeTypes.h in CopyFiles */,
+				F7CE6C701D2CDB3E00BE4C15 /* ASTextKitAttributes.h in CopyFiles */,
+				F7CE6C711D2CDB3F00BE4C15 /* ASTextKitContext.h in CopyFiles */,
+				F7CE6C721D2CDB3F00BE4C15 /* ASTextKitEntityAttribute.h in CopyFiles */,
+				F7CE6C731D2CDB3F00BE4C15 /* ASTextKitRenderer.h in CopyFiles */,
+				F7CE6C741D2CDB3F00BE4C15 /* ASTextKitRenderer+Positioning.h in CopyFiles */,
+				F7CE6C751D2CDB3F00BE4C15 /* ASTextKitRenderer+TextChecking.h in CopyFiles */,
+				F7CE6C761D2CDB3F00BE4C15 /* ASTextKitShadower.h in CopyFiles */,
+				F7CE6C771D2CDB3F00BE4C15 /* ASTextKitTailTruncater.h in CopyFiles */,
+				F7CE6C781D2CDB3F00BE4C15 /* ASTextKitFontSizeAdjuster.h in CopyFiles */,
+				F7CE6C791D2CDB3F00BE4C15 /* ASTextKitTruncating.h in CopyFiles */,
+				F7CE6C7B1D2CDB3F00BE4C15 /* ASAssert.h in CopyFiles */,
+				F7CE6C7C1D2CDB3F00BE4C15 /* ASAvailability.h in CopyFiles */,
+				F7CE6C7D1D2CDB3F00BE4C15 /* ASBaseDefines.h in CopyFiles */,
+				F7CE6C7E1D2CDB3F00BE4C15 /* ASEqualityHelpers.h in CopyFiles */,
+				F7CE6C7F1D2CDB3F00BE4C15 /* ASLog.h in CopyFiles */,
+				F7CE6C801D2CDB5800BE4C15 /* ASVideoPlayerNode.h in CopyFiles */,
+				F7CE6C811D2CDB5800BE4C15 /* ASCollectionInternal.h in CopyFiles */,
+				F7CE6C821D2CDB5800BE4C15 /* ASTableViewInternal.h in CopyFiles */,
+				F7CE6C831D2CDB5800BE4C15 /* ASImageNode+tvOS.h in CopyFiles */,
+				F7CE6C841D2CDB5800BE4C15 /* ASControlNode+tvOS.h in CopyFiles */,
+				F7CE6C851D2CDB5800BE4C15 /* NSIndexSet+ASHelpers.h in CopyFiles */,
+				F7CE6C861D2CDB5800BE4C15 /* _ASDisplayViewAccessiblity.h in CopyFiles */,
+				F7CE6C871D2CDB5800BE4C15 /* ASDataController+Subclasses.h in CopyFiles */,
+				F7CE6C451D2CDB3E00BE4C15 /* ASPINRemoteImageDownloader.h in CopyFiles */,
+				F7CE6C8B1D2CDB5800BE4C15 /* ASCollectionDataController.h in CopyFiles */,
+				F7CE6C591D2CDB3E00BE4C15 /* UIView+ASConvenience.h in CopyFiles */,
+				F7CE6C5A1D2CDB3E00BE4C15 /* ASTraitCollection.h in CopyFiles */,
+				F7CE6C8C1D2CDB5800BE4C15 /* _ASCoreAnimationExtras.h in CopyFiles */,
+				F7CE6C8D1D2CDB5800BE4C15 /* _ASHierarchyChangeSet.h in CopyFiles */,
+				F7CE6C8F1D2CDB5800BE4C15 /* _ASScopeTimer.h in CopyFiles */,
+				F7CE6C901D2CDB5800BE4C15 /* _ASTransitionContext.h in CopyFiles */,
+				F7CE6C941D2CDB5800BE4C15 /* ASDisplayNodeInternal.h in CopyFiles */,
+				F7CE6C951D2CDB5800BE4C15 /* ASLayoutTransition.h in CopyFiles */,
+				F7CE6C961D2CDB5800BE4C15 /* ASEnvironmentInternal.h in CopyFiles */,
+				F7CE6C971D2CDB5800BE4C15 /* ASImageNode+CGExtras.h in CopyFiles */,
+				F7CE6C991D2CDB5800BE4C15 /* ASLayoutSpecUtilities.h in CopyFiles */,
+				F7CE6C9A1D2CDB5800BE4C15 /* ASMultidimensionalArrayUtils.h in CopyFiles */,
+				F7CE6C9B1D2CDB5800BE4C15 /* ASPendingStateController.h in CopyFiles */,
+				F7CE6C9C1D2CDB5800BE4C15 /* ASSentinel.h in CopyFiles */,
+				F7CE6C9D1D2CDB5800BE4C15 /* ASStackBaselinePositionedLayout.h in CopyFiles */,
+				F7CE6C9E1D2CDB5800BE4C15 /* ASStackLayoutSpecUtilities.h in CopyFiles */,
+				F7CE6C9F1D2CDB5800BE4C15 /* ASStackPositionedLayout.h in CopyFiles */,
+				F7CE6CA01D2CDB5800BE4C15 /* ASStackUnpositionedLayout.h in CopyFiles */,
+				F7CE6CA11D2CDB5800BE4C15 /* ASWeakSet.h in CopyFiles */,
+				F7CE6CA21D2CDB5800BE4C15 /* ASDefaultPlaybackButton.h in CopyFiles */,
+				F7CE6CA31D2CDB5800BE4C15 /* ASLayoutValidation.h in CopyFiles */,
+				F7CE6CA41D2CDB5800BE4C15 /* ASLayoutManager.h in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		044285011BAA3CC700D16268 /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
+		044285051BAA63FE00D16268 /* ASBatchFetching.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASBatchFetching.h; sourceTree = "<group>"; };
+		044285061BAA63FE00D16268 /* ASBatchFetching.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASBatchFetching.m; sourceTree = "<group>"; };
+		0442850B1BAA64EC00D16268 /* ASMultidimensionalArrayUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASMultidimensionalArrayUtils.h; sourceTree = "<group>"; };
+		0442850C1BAA64EC00D16268 /* ASMultidimensionalArrayUtils.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASMultidimensionalArrayUtils.mm; sourceTree = "<group>"; };
+		0516FA3A1A15563400B4EBED /* ASAvailability.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASAvailability.h; sourceTree = "<group>"; };
+		0516FA3B1A15563400B4EBED /* ASLog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASLog.h; sourceTree = "<group>"; };
+		0516FA3E1A1563D200B4EBED /* ASMultiplexImageNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASMultiplexImageNode.h; sourceTree = "<group>"; };
+		0516FA3F1A1563D200B4EBED /* ASMultiplexImageNode.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASMultiplexImageNode.mm; sourceTree = "<group>"; };
+		051943121A1575630030A7D0 /* AssetsLibrary.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AssetsLibrary.framework; path = System/Library/Frameworks/AssetsLibrary.framework; sourceTree = SDKROOT; };
+		051943141A1575670030A7D0 /* Photos.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Photos.framework; path = System/Library/Frameworks/Photos.framework; sourceTree = SDKROOT; };
+		052EE0651A159FEF002C6279 /* ASMultiplexImageNodeTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASMultiplexImageNodeTests.m; sourceTree = "<group>"; };
+		052EE06A1A15A0D8002C6279 /* TestResources */ = {isa = PBXFileReference; lastKnownFileType = folder; path = TestResources; sourceTree = "<group>"; };
+		054963471A1EA066000F8E56 /* ASBasicImageDownloader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASBasicImageDownloader.h; sourceTree = "<group>"; };
+		054963481A1EA066000F8E56 /* ASBasicImageDownloader.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASBasicImageDownloader.mm; sourceTree = "<group>"; };
+		055B9FA61A1C154B00035D6D /* ASNetworkImageNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASNetworkImageNode.h; sourceTree = "<group>"; };
+		055B9FA71A1C154B00035D6D /* ASNetworkImageNode.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASNetworkImageNode.mm; sourceTree = "<group>"; };
+		055F1A3219ABD3E3004DAFF1 /* ASTableView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = ASTableView.h; sourceTree = "<group>"; };
+		055F1A3319ABD3E3004DAFF1 /* ASTableView.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; lineEnding = 0; path = ASTableView.mm; sourceTree = "<group>"; };
+		055F1A3619ABD413004DAFF1 /* ASRangeController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASRangeController.h; sourceTree = "<group>"; };
+		055F1A3719ABD413004DAFF1 /* ASRangeController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASRangeController.mm; sourceTree = "<group>"; };
+		055F1A3A19ABD43F004DAFF1 /* ASCellNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASCellNode.h; sourceTree = "<group>"; };
+		056D21501ABCEDA1001107EF /* ASSnapshotTestCase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASSnapshotTestCase.h; sourceTree = "<group>"; };
+		056D21541ABCEF50001107EF /* ASImageNodeSnapshotTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASImageNodeSnapshotTests.m; sourceTree = "<group>"; };
+		0574D5E119C110610097DC25 /* ASTableViewProtocols.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ASTableViewProtocols.h; sourceTree = "<group>"; };
+		057D02BF1AC0A66700C7AC3C /* AsyncDisplayKitTestHost.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AsyncDisplayKitTestHost.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		057D02C21AC0A66700C7AC3C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		057D02C31AC0A66700C7AC3C /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		057D02C51AC0A66700C7AC3C /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		057D02C61AC0A66700C7AC3C /* AppDelegate.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = AppDelegate.mm; sourceTree = "<group>"; };
+		0587F9BB1A7309ED00AFF0BA /* ASEditableTextNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASEditableTextNode.h; sourceTree = "<group>"; };
+		0587F9BC1A7309ED00AFF0BA /* ASEditableTextNode.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; lineEnding = 0; path = ASEditableTextNode.mm; sourceTree = "<group>"; };
+		058D09AC195D04C000B7D73C /* libAsyncDisplayKit.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libAsyncDisplayKit.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		058D09AF195D04C000B7D73C /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		058D09B3195D04C000B7D73C /* AsyncDisplayKit-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "AsyncDisplayKit-Prefix.pch"; sourceTree = "<group>"; };
+		058D09BC195D04C000B7D73C /* AsyncDisplayKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AsyncDisplayKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		058D09BD195D04C000B7D73C /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
+		058D09C0195D04C000B7D73C /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
+		058D09C7195D04C000B7D73C /* AsyncDisplayKitTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "AsyncDisplayKitTests-Info.plist"; sourceTree = "<group>"; };
+		058D09C9195D04C000B7D73C /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		058D09D5195D050800B7D73C /* ASControlNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASControlNode.h; sourceTree = "<group>"; };
+		058D09D6195D050800B7D73C /* ASControlNode.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASControlNode.mm; sourceTree = "<group>"; };
+		058D09D7195D050800B7D73C /* ASControlNode+Subclasses.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ASControlNode+Subclasses.h"; sourceTree = "<group>"; };
+		058D09D8195D050800B7D73C /* ASDisplayNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = ASDisplayNode.h; sourceTree = "<group>"; };
+		058D09D9195D050800B7D73C /* ASDisplayNode.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; lineEnding = 0; path = ASDisplayNode.mm; sourceTree = "<group>"; };
+		058D09DA195D050800B7D73C /* ASDisplayNode+Subclasses.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = "ASDisplayNode+Subclasses.h"; sourceTree = "<group>"; };
+		058D09DB195D050800B7D73C /* ASDisplayNodeExtras.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASDisplayNodeExtras.h; sourceTree = "<group>"; };
+		058D09DC195D050800B7D73C /* ASDisplayNodeExtras.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASDisplayNodeExtras.mm; sourceTree = "<group>"; };
+		058D09DD195D050800B7D73C /* ASImageNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASImageNode.h; sourceTree = "<group>"; };
+		058D09DE195D050800B7D73C /* ASImageNode.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; lineEnding = 0; path = ASImageNode.mm; sourceTree = "<group>"; };
+		058D09DF195D050800B7D73C /* ASTextNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTextNode.h; sourceTree = "<group>"; };
+		058D09E0195D050800B7D73C /* ASTextNode.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; lineEnding = 0; path = ASTextNode.mm; sourceTree = "<group>"; };
+		058D09E2195D050800B7D73C /* _ASDisplayLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _ASDisplayLayer.h; sourceTree = "<group>"; };
+		058D09E3195D050800B7D73C /* _ASDisplayLayer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _ASDisplayLayer.mm; sourceTree = "<group>"; };
+		058D09E4195D050800B7D73C /* _ASDisplayView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _ASDisplayView.h; sourceTree = "<group>"; };
+		058D09E5195D050800B7D73C /* _ASDisplayView.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _ASDisplayView.mm; sourceTree = "<group>"; };
+		058D09E6195D050800B7D73C /* ASHighlightOverlayLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASHighlightOverlayLayer.h; sourceTree = "<group>"; };
+		058D09E7195D050800B7D73C /* ASHighlightOverlayLayer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASHighlightOverlayLayer.mm; sourceTree = "<group>"; };
+		058D09E8195D050800B7D73C /* ASMutableAttributedStringBuilder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASMutableAttributedStringBuilder.h; sourceTree = "<group>"; };
+		058D09E9195D050800B7D73C /* ASMutableAttributedStringBuilder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASMutableAttributedStringBuilder.m; sourceTree = "<group>"; };
+		058D09F5195D050800B7D73C /* NSMutableAttributedString+TextKitAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSMutableAttributedString+TextKitAdditions.h"; sourceTree = "<group>"; };
+		058D09F6195D050800B7D73C /* NSMutableAttributedString+TextKitAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSMutableAttributedString+TextKitAdditions.m"; sourceTree = "<group>"; };
+		058D09F8195D050800B7D73C /* _ASAsyncTransaction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _ASAsyncTransaction.h; sourceTree = "<group>"; };
+		058D09F9195D050800B7D73C /* _ASAsyncTransaction.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _ASAsyncTransaction.mm; sourceTree = "<group>"; };
+		058D09FA195D050800B7D73C /* _ASAsyncTransactionContainer+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "_ASAsyncTransactionContainer+Private.h"; sourceTree = "<group>"; };
+		058D09FB195D050800B7D73C /* _ASAsyncTransactionContainer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _ASAsyncTransactionContainer.h; sourceTree = "<group>"; };
+		058D09FC195D050800B7D73C /* _ASAsyncTransactionContainer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = _ASAsyncTransactionContainer.m; sourceTree = "<group>"; };
+		058D09FD195D050800B7D73C /* _ASAsyncTransactionGroup.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _ASAsyncTransactionGroup.h; sourceTree = "<group>"; };
+		058D09FE195D050800B7D73C /* _ASAsyncTransactionGroup.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = _ASAsyncTransactionGroup.m; sourceTree = "<group>"; };
+		058D09FF195D050800B7D73C /* UIView+ASConvenience.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIView+ASConvenience.h"; sourceTree = "<group>"; };
+		058D0A02195D050800B7D73C /* _AS-objc-internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "_AS-objc-internal.h"; sourceTree = "<group>"; };
+		058D0A03195D050800B7D73C /* _ASCoreAnimationExtras.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _ASCoreAnimationExtras.h; sourceTree = "<group>"; };
+		058D0A04195D050800B7D73C /* _ASCoreAnimationExtras.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _ASCoreAnimationExtras.mm; sourceTree = "<group>"; };
+		058D0A05195D050800B7D73C /* _ASPendingState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _ASPendingState.h; sourceTree = "<group>"; };
+		058D0A06195D050800B7D73C /* _ASPendingState.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _ASPendingState.mm; sourceTree = "<group>"; };
+		058D0A07195D050800B7D73C /* _ASScopeTimer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _ASScopeTimer.h; sourceTree = "<group>"; };
+		058D0A08195D050800B7D73C /* ASDisplayNode+AsyncDisplay.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "ASDisplayNode+AsyncDisplay.mm"; sourceTree = "<group>"; };
+		058D0A09195D050800B7D73C /* ASDisplayNode+DebugTiming.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ASDisplayNode+DebugTiming.h"; sourceTree = "<group>"; };
+		058D0A0A195D050800B7D73C /* ASDisplayNode+DebugTiming.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "ASDisplayNode+DebugTiming.mm"; sourceTree = "<group>"; };
+		058D0A0B195D050800B7D73C /* ASDisplayNode+UIViewBridge.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "ASDisplayNode+UIViewBridge.mm"; sourceTree = "<group>"; };
+		058D0A0C195D050800B7D73C /* ASDisplayNodeInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASDisplayNodeInternal.h; sourceTree = "<group>"; };
+		058D0A0D195D050800B7D73C /* ASImageNode+CGExtras.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ASImageNode+CGExtras.h"; sourceTree = "<group>"; };
+		058D0A0E195D050800B7D73C /* ASImageNode+CGExtras.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "ASImageNode+CGExtras.m"; sourceTree = "<group>"; };
+		058D0A10195D050800B7D73C /* ASSentinel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASSentinel.h; sourceTree = "<group>"; };
+		058D0A11195D050800B7D73C /* ASSentinel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASSentinel.m; sourceTree = "<group>"; };
+		058D0A12195D050800B7D73C /* ASThread.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASThread.h; sourceTree = "<group>"; };
+		058D0A2D195D057000B7D73C /* ASDisplayLayerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASDisplayLayerTests.m; sourceTree = "<group>"; };
+		058D0A2E195D057000B7D73C /* ASDisplayNodeAppearanceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASDisplayNodeAppearanceTests.m; sourceTree = "<group>"; };
+		058D0A2F195D057000B7D73C /* ASDisplayNodeTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASDisplayNodeTests.m; sourceTree = "<group>"; };
+		058D0A30195D057000B7D73C /* ASDisplayNodeTestsHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASDisplayNodeTestsHelper.h; sourceTree = "<group>"; };
+		058D0A31195D057000B7D73C /* ASDisplayNodeTestsHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASDisplayNodeTestsHelper.m; sourceTree = "<group>"; };
+		058D0A32195D057000B7D73C /* ASMutableAttributedStringBuilderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASMutableAttributedStringBuilderTests.m; sourceTree = "<group>"; };
+		058D0A33195D057000B7D73C /* ASTextKitCoreTextAdditionsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASTextKitCoreTextAdditionsTests.m; sourceTree = "<group>"; };
+		058D0A36195D057000B7D73C /* ASTextNodeTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASTextNodeTests.m; sourceTree = "<group>"; };
+		058D0A37195D057000B7D73C /* ASTextNodeWordKernerTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASTextNodeWordKernerTests.mm; sourceTree = "<group>"; };
+		058D0A43195D058D00B7D73C /* ASAssert.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASAssert.h; sourceTree = "<group>"; };
+		058D0A44195D058D00B7D73C /* ASBaseDefines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASBaseDefines.h; sourceTree = "<group>"; };
+		05A6D05819D0EB64002DD95E /* ASDealloc2MainObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASDealloc2MainObject.h; path = ../Details/ASDealloc2MainObject.h; sourceTree = "<group>"; };
+		05A6D05919D0EB64002DD95E /* ASDealloc2MainObject.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ASDealloc2MainObject.m; path = ../Details/ASDealloc2MainObject.m; sourceTree = "<group>"; };
+		05EA6FE61AC0966E00E35788 /* ASSnapshotTestCase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASSnapshotTestCase.m; sourceTree = "<group>"; };
+		05F20AA31A15733C00DCA68A /* ASImageProtocols.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASImageProtocols.h; sourceTree = "<group>"; };
+		18C2ED7C1B9B7DE800F627B3 /* ASCollectionNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASCollectionNode.h; sourceTree = "<group>"; };
+		18C2ED7D1B9B7DE800F627B3 /* ASCollectionNode.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASCollectionNode.mm; sourceTree = "<group>"; };
+		1950C4481A3BB5C1005C8279 /* ASEqualityHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASEqualityHelpers.h; sourceTree = "<group>"; };
+		204C979D1B362CB3002B1083 /* Default-568h@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "Default-568h@2x.png"; path = "../Default-568h@2x.png"; sourceTree = "<group>"; };
+		205F0E0D1B371875007741D0 /* UICollectionViewLayout+ASConvenience.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UICollectionViewLayout+ASConvenience.h"; sourceTree = "<group>"; };
+		205F0E0E1B371875007741D0 /* UICollectionViewLayout+ASConvenience.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UICollectionViewLayout+ASConvenience.m"; sourceTree = "<group>"; };
+		205F0E111B371BD7007741D0 /* ASScrollDirection.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASScrollDirection.m; sourceTree = "<group>"; };
+		205F0E171B37339C007741D0 /* ASAbstractLayoutController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASAbstractLayoutController.h; sourceTree = "<group>"; };
+		205F0E181B37339C007741D0 /* ASAbstractLayoutController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASAbstractLayoutController.mm; sourceTree = "<group>"; };
+		205F0E1B1B373A2C007741D0 /* ASCollectionViewLayoutController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASCollectionViewLayoutController.h; sourceTree = "<group>"; };
+		205F0E1C1B373A2C007741D0 /* ASCollectionViewLayoutController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASCollectionViewLayoutController.mm; sourceTree = "<group>"; };
+		205F0E1F1B376416007741D0 /* CGRect+ASConvenience.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "CGRect+ASConvenience.h"; sourceTree = "<group>"; };
+		205F0E201B376416007741D0 /* CGRect+ASConvenience.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "CGRect+ASConvenience.m"; sourceTree = "<group>"; };
+		242995D21B29743C00090100 /* ASBasicImageDownloaderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASBasicImageDownloaderTests.m; sourceTree = "<group>"; };
+		251B8EF21BBB3D690087C538 /* ASCollectionDataController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = ASCollectionDataController.h; sourceTree = "<group>"; };
+		251B8EF31BBB3D690087C538 /* ASCollectionDataController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; lineEnding = 0; path = ASCollectionDataController.mm; sourceTree = "<group>"; };
+		251B8EF41BBB3D690087C538 /* ASCollectionViewFlowLayoutInspector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASCollectionViewFlowLayoutInspector.h; sourceTree = "<group>"; };
+		251B8EF51BBB3D690087C538 /* ASCollectionViewFlowLayoutInspector.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASCollectionViewFlowLayoutInspector.m; sourceTree = "<group>"; };
+		251B8EF61BBB3D690087C538 /* ASDataController+Subclasses.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ASDataController+Subclasses.h"; sourceTree = "<group>"; };
+		2538B6F21BC5D2A2003CA0B4 /* ASCollectionViewFlowLayoutInspectorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = ASCollectionViewFlowLayoutInspectorTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
+		254C6B511BF8FE6D003EC431 /* ASTextKitTruncationTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASTextKitTruncationTests.mm; sourceTree = "<group>"; };
+		254C6B531BF8FF2A003EC431 /* ASTextKitTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASTextKitTests.mm; sourceTree = "<group>"; };
+		257754931BEE44CD00737CA5 /* ASTextKitRenderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASTextKitRenderer.h; path = TextKit/ASTextKitRenderer.h; sourceTree = "<group>"; };
+		257754941BEE44CD00737CA5 /* ASTextKitAttributes.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = ASTextKitAttributes.mm; path = TextKit/ASTextKitAttributes.mm; sourceTree = "<group>"; };
+		257754951BEE44CD00737CA5 /* ASTextKitAttributes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASTextKitAttributes.h; path = TextKit/ASTextKitAttributes.h; sourceTree = "<group>"; };
+		257754961BEE44CD00737CA5 /* ASTextKitContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASTextKitContext.h; path = TextKit/ASTextKitContext.h; sourceTree = "<group>"; };
+		257754971BEE44CD00737CA5 /* ASTextKitContext.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = ASTextKitContext.mm; path = TextKit/ASTextKitContext.mm; sourceTree = "<group>"; };
+		257754981BEE44CD00737CA5 /* ASTextKitEntityAttribute.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASTextKitEntityAttribute.h; path = TextKit/ASTextKitEntityAttribute.h; sourceTree = "<group>"; };
+		257754991BEE44CD00737CA5 /* ASTextKitEntityAttribute.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ASTextKitEntityAttribute.m; path = TextKit/ASTextKitEntityAttribute.m; sourceTree = "<group>"; };
+		2577549A1BEE44CD00737CA5 /* ASTextKitRenderer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = ASTextKitRenderer.mm; path = TextKit/ASTextKitRenderer.mm; sourceTree = "<group>"; };
+		2577549B1BEE44CD00737CA5 /* ASTextKitRenderer+Positioning.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "ASTextKitRenderer+Positioning.h"; path = "TextKit/ASTextKitRenderer+Positioning.h"; sourceTree = "<group>"; };
+		2577549C1BEE44CD00737CA5 /* ASTextKitRenderer+Positioning.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = "ASTextKitRenderer+Positioning.mm"; path = "TextKit/ASTextKitRenderer+Positioning.mm"; sourceTree = "<group>"; };
+		2577549D1BEE44CD00737CA5 /* ASTextKitRenderer+TextChecking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "ASTextKitRenderer+TextChecking.h"; path = "TextKit/ASTextKitRenderer+TextChecking.h"; sourceTree = "<group>"; };
+		2577549E1BEE44CD00737CA5 /* ASTextKitRenderer+TextChecking.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = "ASTextKitRenderer+TextChecking.mm"; path = "TextKit/ASTextKitRenderer+TextChecking.mm"; sourceTree = "<group>"; };
+		2577549F1BEE44CD00737CA5 /* ASTextKitShadower.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASTextKitShadower.h; path = TextKit/ASTextKitShadower.h; sourceTree = "<group>"; };
+		257754A01BEE44CD00737CA5 /* ASTextKitShadower.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = ASTextKitShadower.mm; path = TextKit/ASTextKitShadower.mm; sourceTree = "<group>"; };
+		257754A11BEE44CD00737CA5 /* ASTextKitTailTruncater.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASTextKitTailTruncater.h; path = TextKit/ASTextKitTailTruncater.h; sourceTree = "<group>"; };
+		257754A21BEE44CD00737CA5 /* ASTextKitTailTruncater.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = ASTextKitTailTruncater.mm; path = TextKit/ASTextKitTailTruncater.mm; sourceTree = "<group>"; };
+		257754A31BEE44CD00737CA5 /* ASTextKitTruncating.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASTextKitTruncating.h; path = TextKit/ASTextKitTruncating.h; sourceTree = "<group>"; };
+		257754B71BEE458D00737CA5 /* ASTextKitComponents.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ASTextKitComponents.m; path = TextKit/ASTextKitComponents.m; sourceTree = "<group>"; };
+		257754B81BEE458E00737CA5 /* ASTextKitCoreTextAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ASTextKitCoreTextAdditions.m; path = TextKit/ASTextKitCoreTextAdditions.m; sourceTree = "<group>"; };
+		257754B91BEE458E00737CA5 /* ASTextNodeWordKerner.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASTextNodeWordKerner.h; path = TextKit/ASTextNodeWordKerner.h; sourceTree = "<group>"; };
+		257754BA1BEE458E00737CA5 /* ASTextKitComponents.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASTextKitComponents.h; path = TextKit/ASTextKitComponents.h; sourceTree = "<group>"; };
+		257754BB1BEE458E00737CA5 /* ASTextKitCoreTextAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASTextKitCoreTextAdditions.h; path = TextKit/ASTextKitCoreTextAdditions.h; sourceTree = "<group>"; };
+		257754BC1BEE458E00737CA5 /* ASTextNodeTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASTextNodeTypes.h; path = TextKit/ASTextNodeTypes.h; sourceTree = "<group>"; };
+		257754BD1BEE458E00737CA5 /* ASTextNodeWordKerner.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ASTextNodeWordKerner.m; path = TextKit/ASTextNodeWordKerner.m; sourceTree = "<group>"; };
+		25E327541C16819500A2170C /* ASPagerNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = ASPagerNode.h; sourceTree = "<group>"; };
+		25E327551C16819500A2170C /* ASPagerNode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = ASPagerNode.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
+		2911485B1A77147A005D0878 /* ASControlNodeTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASControlNodeTests.m; sourceTree = "<group>"; };
+		292C59991A956527007E5DD6 /* ASLayoutRangeType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASLayoutRangeType.h; sourceTree = "<group>"; };
+		2967F9E11AB0A4CF0072E4AB /* ASBasicImageDownloaderInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ASBasicImageDownloaderInternal.h; sourceTree = "<group>"; };
+		296A0A311A951715005ACEAA /* ASScrollDirection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASScrollDirection.h; path = AsyncDisplayKit/Details/ASScrollDirection.h; sourceTree = SOURCE_ROOT; };
+		296A0A341A951ABF005ACEAA /* ASBatchFetchingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASBatchFetchingTests.m; sourceTree = "<group>"; };
+		299DA1A71A828D2900162D41 /* ASBatchContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASBatchContext.h; sourceTree = "<group>"; };
+		299DA1A81A828D2900162D41 /* ASBatchContext.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASBatchContext.mm; sourceTree = "<group>"; };
+		29CDC2E11AAE70D000833CA4 /* ASBasicImageDownloaderContextTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASBasicImageDownloaderContextTests.m; sourceTree = "<group>"; };
+		3C9C128419E616EF00E942A0 /* ASTableViewTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = ASTableViewTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
+		430E7C8D1B4C23F100697A4C /* ASIndexPath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASIndexPath.h; sourceTree = "<group>"; };
+		430E7C8E1B4C23F100697A4C /* ASIndexPath.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASIndexPath.m; sourceTree = "<group>"; };
+		464052191A3F83C40061C0BA /* ASDataController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = ASDataController.h; sourceTree = "<group>"; };
+		4640521A1A3F83C40061C0BA /* ASDataController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; lineEnding = 0; path = ASDataController.mm; sourceTree = "<group>"; };
+		4640521B1A3F83C40061C0BA /* ASFlowLayoutController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASFlowLayoutController.h; sourceTree = "<group>"; };
+		4640521C1A3F83C40061C0BA /* ASFlowLayoutController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASFlowLayoutController.mm; sourceTree = "<group>"; };
+		4640521D1A3F83C40061C0BA /* ASLayoutController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASLayoutController.h; sourceTree = "<group>"; };
+		683489271D70DE3400327501 /* ASDisplayNode+Deprecated.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ASDisplayNode+Deprecated.h"; sourceTree = "<group>"; };
+		68355B2E1CB5799E001D4E68 /* ASImageNode+AnimatedImage.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "ASImageNode+AnimatedImage.mm"; sourceTree = "<group>"; };
+		68355B361CB57A5A001D4E68 /* ASPINRemoteImageDownloader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASPINRemoteImageDownloader.m; sourceTree = "<group>"; };
+		68355B371CB57A5A001D4E68 /* ASImageContainerProtocolCategories.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASImageContainerProtocolCategories.h; sourceTree = "<group>"; };
+		68355B381CB57A5A001D4E68 /* ASImageContainerProtocolCategories.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASImageContainerProtocolCategories.m; sourceTree = "<group>"; };
+		68355B391CB57A5A001D4E68 /* ASPINRemoteImageDownloader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASPINRemoteImageDownloader.h; sourceTree = "<group>"; };
+		68B027791C1A79CC0041016B /* ASDisplayNode+Beta.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ASDisplayNode+Beta.h"; sourceTree = "<group>"; };
+		68B8A4DB1CBD911D007E4543 /* ASImageNode+AnimatedImagePrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ASImageNode+AnimatedImagePrivate.h"; sourceTree = "<group>"; };
+		68B8A4DF1CBDB958007E4543 /* ASWeakProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASWeakProxy.h; sourceTree = "<group>"; };
+		68B8A4E01CBDB958007E4543 /* ASWeakProxy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASWeakProxy.m; sourceTree = "<group>"; };
+		68EE0DBB1C1B4ED300BA1B99 /* ASMainSerialQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASMainSerialQueue.h; sourceTree = "<group>"; };
+		68EE0DBC1C1B4ED300BA1B99 /* ASMainSerialQueue.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASMainSerialQueue.mm; sourceTree = "<group>"; };
+		68FC85DC1CE29AB700EDD713 /* ASNavigationController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASNavigationController.h; sourceTree = "<group>"; };
+		68FC85DD1CE29AB700EDD713 /* ASNavigationController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASNavigationController.m; sourceTree = "<group>"; };
+		68FC85E01CE29B7E00EDD713 /* ASTabBarController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTabBarController.h; sourceTree = "<group>"; };
+		68FC85E11CE29B7E00EDD713 /* ASTabBarController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASTabBarController.m; sourceTree = "<group>"; };
+		68FC85E71CE29C7D00EDD713 /* ASVisibilityProtocols.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASVisibilityProtocols.h; sourceTree = "<group>"; };
+		68FC85E81CE29C7D00EDD713 /* ASVisibilityProtocols.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASVisibilityProtocols.m; sourceTree = "<group>"; };
+		6959433C1D70815300B0EE1F /* ASDisplayNodeLayout.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASDisplayNodeLayout.mm; sourceTree = "<group>"; };
+		6959433D1D70815300B0EE1F /* ASDisplayNodeLayout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASDisplayNodeLayout.h; sourceTree = "<group>"; };
+		696FCB301D6E46050093471E /* ASBackgroundLayoutSpecSnapshotTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASBackgroundLayoutSpecSnapshotTests.mm; sourceTree = "<group>"; };
+		69708BA41D76386D005C3CF9 /* ASEqualityHashHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASEqualityHashHelpers.h; path = TextKit/ASEqualityHashHelpers.h; sourceTree = "<group>"; };
+		69708BA51D76386D005C3CF9 /* ASEqualityHashHelpers.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = ASEqualityHashHelpers.mm; path = TextKit/ASEqualityHashHelpers.mm; sourceTree = "<group>"; };
+		697B31591CFE4B410049936F /* ASEditableTextNodeTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASEditableTextNodeTests.m; sourceTree = "<group>"; };
+		697C0DE11CF38F28001DE0D4 /* ASLayoutValidation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASLayoutValidation.h; path = AsyncDisplayKit/Layout/ASLayoutValidation.h; sourceTree = "<group>"; };
+		697C0DE21CF38F28001DE0D4 /* ASLayoutValidation.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = ASLayoutValidation.mm; path = AsyncDisplayKit/Layout/ASLayoutValidation.mm; sourceTree = "<group>"; };
+		698548611CA9E025008A345F /* ASEnvironment.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASEnvironment.h; sourceTree = "<group>"; };
+		698C8B601CAB49FC0052DC3F /* ASLayoutableExtensibility.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASLayoutableExtensibility.h; path = AsyncDisplayKit/Layout/ASLayoutableExtensibility.h; sourceTree = "<group>"; };
+		69B225661D72535E00B25B22 /* ASDisplayNodeLayoutTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASDisplayNodeLayoutTests.mm; sourceTree = "<group>"; };
+		69B225681D7265DA00B25B22 /* ASXCTExtensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASXCTExtensions.h; sourceTree = "<group>"; };
+		69CB62A91CB8165900024920 /* _ASDisplayViewAccessiblity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _ASDisplayViewAccessiblity.h; sourceTree = "<group>"; };
+		69CB62AA1CB8165900024920 /* _ASDisplayViewAccessiblity.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _ASDisplayViewAccessiblity.mm; sourceTree = "<group>"; };
+		69E100691CA89CB600D88C1B /* ASEnvironmentInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASEnvironmentInternal.h; sourceTree = "<group>"; };
+		69E1006A1CA89CB600D88C1B /* ASEnvironmentInternal.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASEnvironmentInternal.mm; sourceTree = "<group>"; };
+		69F10C851C84C35D0026140C /* ASRangeControllerUpdateRangeProtocol+Beta.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ASRangeControllerUpdateRangeProtocol+Beta.h"; sourceTree = "<group>"; };
+		6BDC61F51978FEA400E50D21 /* AsyncDisplayKit.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; path = AsyncDisplayKit.h; sourceTree = "<group>"; };
+		764D83D21C8EA515009B4FB8 /* AsyncDisplayKit+Debug.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "AsyncDisplayKit+Debug.h"; sourceTree = "<group>"; };
+		764D83D31C8EA515009B4FB8 /* AsyncDisplayKit+Debug.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "AsyncDisplayKit+Debug.m"; sourceTree = "<group>"; };
+		7A06A7381C35F08800FE8DAA /* ASRelativeLayoutSpec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = ASRelativeLayoutSpec.mm; path = AsyncDisplayKit/Layout/ASRelativeLayoutSpec.mm; sourceTree = "<group>"; };
+		7A06A7391C35F08800FE8DAA /* ASRelativeLayoutSpec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASRelativeLayoutSpec.h; path = AsyncDisplayKit/Layout/ASRelativeLayoutSpec.h; sourceTree = "<group>"; };
+		7AB338681C55B97B0055FDE8 /* ASRelativeLayoutSpecSnapshotTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASRelativeLayoutSpecSnapshotTests.mm; sourceTree = "<group>"; };
+		8021EC1A1D2B00B100799119 /* UIImage+ASConvenience.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImage+ASConvenience.h"; sourceTree = "<group>"; };
+		8021EC1B1D2B00B100799119 /* UIImage+ASConvenience.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImage+ASConvenience.m"; sourceTree = "<group>"; };
+		81E95C131D62639600336598 /* ASTextNodeSnapshotTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASTextNodeSnapshotTests.m; sourceTree = "<group>"; };
+		81EE384D1C8E94F000456208 /* ASRunLoopQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASRunLoopQueue.h; path = ../ASRunLoopQueue.h; sourceTree = "<group>"; };
+		81EE384E1C8E94F000456208 /* ASRunLoopQueue.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = ASRunLoopQueue.mm; path = ../ASRunLoopQueue.mm; sourceTree = "<group>"; };
+		83A7D9581D44542100BF333E /* ASWeakMap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASWeakMap.h; sourceTree = "<group>"; };
+		83A7D9591D44542100BF333E /* ASWeakMap.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASWeakMap.m; sourceTree = "<group>"; };
+		83A7D95D1D446A6E00BF333E /* ASWeakMapTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASWeakMapTests.m; sourceTree = "<group>"; };
+		8B0768B11CE752EC002E1453 /* ASDefaultPlaybackButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASDefaultPlaybackButton.h; sourceTree = "<group>"; };
+		8B0768B21CE752EC002E1453 /* ASDefaultPlaybackButton.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASDefaultPlaybackButton.m; sourceTree = "<group>"; };
+		8BDA5FC31CDBDDE1007D13B2 /* ASVideoPlayerNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASVideoPlayerNode.h; sourceTree = "<group>"; };
+		8BDA5FC41CDBDDE1007D13B2 /* ASVideoPlayerNode.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASVideoPlayerNode.mm; sourceTree = "<group>"; };
+		92074A5F1CC8BA1900918F75 /* ASImageNode+tvOS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ASImageNode+tvOS.h"; sourceTree = "<group>"; };
+		92074A601CC8BA1900918F75 /* ASImageNode+tvOS.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "ASImageNode+tvOS.m"; sourceTree = "<group>"; };
+		92074A651CC8BADA00918F75 /* ASControlNode+tvOS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ASControlNode+tvOS.h"; sourceTree = "<group>"; };
+		92074A661CC8BADA00918F75 /* ASControlNode+tvOS.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "ASControlNode+tvOS.m"; sourceTree = "<group>"; };
+		92DD2FE11BF4B97E0074C9DD /* ASMapNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASMapNode.h; sourceTree = "<group>"; };
+		92DD2FE21BF4B97E0074C9DD /* ASMapNode.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASMapNode.mm; sourceTree = "<group>"; };
+		92DD2FE51BF4D05E0074C9DD /* MapKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MapKit.framework; path = System/Library/Frameworks/MapKit.framework; sourceTree = SDKROOT; };
+		9C49C36E1B853957000B0DD5 /* ASStackLayoutable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASStackLayoutable.h; path = AsyncDisplayKit/Layout/ASStackLayoutable.h; sourceTree = "<group>"; };
+		9C5586671BD549CB00B50E3A /* ASAsciiArtBoxCreator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASAsciiArtBoxCreator.h; path = AsyncDisplayKit/Layout/ASAsciiArtBoxCreator.h; sourceTree = "<group>"; };
+		9C5586681BD549CB00B50E3A /* ASAsciiArtBoxCreator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ASAsciiArtBoxCreator.m; path = AsyncDisplayKit/Layout/ASAsciiArtBoxCreator.m; sourceTree = "<group>"; };
+		9C6BB3B01B8CC9C200F13F52 /* ASStaticLayoutable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASStaticLayoutable.h; path = AsyncDisplayKit/Layout/ASStaticLayoutable.h; sourceTree = "<group>"; };
+		9C70F2011CDA4EFA007D6C76 /* ASTraitCollection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTraitCollection.h; sourceTree = "<group>"; };
+		9C70F2021CDA4EFA007D6C76 /* ASTraitCollection.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASTraitCollection.m; sourceTree = "<group>"; };
+		9C8221931BA237B80037F19A /* ASStackBaselinePositionedLayout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASStackBaselinePositionedLayout.h; sourceTree = "<group>"; };
+		9C8221941BA237B80037F19A /* ASStackBaselinePositionedLayout.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASStackBaselinePositionedLayout.mm; sourceTree = "<group>"; };
+		9C8898BA1C738B9800D6B02E /* ASTextKitFontSizeAdjuster.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = ASTextKitFontSizeAdjuster.mm; path = TextKit/ASTextKitFontSizeAdjuster.mm; sourceTree = "<group>"; };
+		9CDC18CB1B910E12004965E2 /* ASLayoutablePrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASLayoutablePrivate.h; path = AsyncDisplayKit/Layout/ASLayoutablePrivate.h; sourceTree = "<group>"; };
+		9CFFC6BD1CCAC52B006A6476 /* ASEnvironment.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASEnvironment.mm; sourceTree = "<group>"; };
+		9CFFC6BF1CCAC73C006A6476 /* ASViewController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASViewController.mm; sourceTree = "<group>"; };
+		9CFFC6C11CCAC768006A6476 /* ASTableNode.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASTableNode.mm; sourceTree = "<group>"; };
+		9F06E5CC1B4CAF4200F015D8 /* ASCollectionViewTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; lineEnding = 0; path = ASCollectionViewTests.mm; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
+		A2763D771CBDD57D00A9ADBD /* ASPINRemoteImageDownloader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASPINRemoteImageDownloader.h; path = Details/ASPINRemoteImageDownloader.h; sourceTree = "<group>"; };
+		A2763D781CBDD57D00A9ADBD /* ASPINRemoteImageDownloader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ASPINRemoteImageDownloader.m; path = Details/ASPINRemoteImageDownloader.m; sourceTree = "<group>"; };
+		A32FEDD31C501B6A004F642A /* ASTextKitFontSizeAdjuster.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASTextKitFontSizeAdjuster.h; path = TextKit/ASTextKitFontSizeAdjuster.h; sourceTree = "<group>"; };
+		A373200E1C571B050011FC94 /* ASTextNode+Beta.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ASTextNode+Beta.h"; sourceTree = "<group>"; };
+		AC026B571BD3F61800BBC17E /* ASStaticLayoutSpecSnapshotTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASStaticLayoutSpecSnapshotTests.m; sourceTree = "<group>"; };
+		AC026B671BD57D6F00BBC17E /* ASChangeSetDataController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASChangeSetDataController.h; sourceTree = "<group>"; };
+		AC026B681BD57D6F00BBC17E /* ASChangeSetDataController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASChangeSetDataController.mm; sourceTree = "<group>"; };
+		AC026B6D1BD57DBF00BBC17E /* _ASHierarchyChangeSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _ASHierarchyChangeSet.h; sourceTree = "<group>"; };
+		AC026B6E1BD57DBF00BBC17E /* _ASHierarchyChangeSet.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _ASHierarchyChangeSet.mm; sourceTree = "<group>"; };
+		AC21EC0F1B3D0BF600C8B19A /* ASStackLayoutDefines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASStackLayoutDefines.h; path = AsyncDisplayKit/Layout/ASStackLayoutDefines.h; sourceTree = "<group>"; };
+		AC3C4A4F1A1139C100143C57 /* ASCollectionView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = ASCollectionView.h; sourceTree = "<group>"; };
+		AC3C4A501A1139C100143C57 /* ASCollectionView.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; lineEnding = 0; path = ASCollectionView.mm; sourceTree = "<group>"; };
+		AC3C4A531A113EEC00143C57 /* ASCollectionViewProtocols.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASCollectionViewProtocols.h; sourceTree = "<group>"; };
+		AC47D9431B3BB41900AAEE9D /* ASRelativeSize.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASRelativeSize.h; path = AsyncDisplayKit/Layout/ASRelativeSize.h; sourceTree = "<group>"; };
+		AC47D9441B3BB41900AAEE9D /* ASRelativeSize.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = ASRelativeSize.mm; path = AsyncDisplayKit/Layout/ASRelativeSize.mm; sourceTree = "<group>"; };
+		AC6456071B0A335000CF11B8 /* ASCellNode.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASCellNode.mm; sourceTree = "<group>"; };
+		AC7A2C161BDE11DF0093FE1A /* ASTableViewInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTableViewInternal.h; sourceTree = "<group>"; };
+		ACC945A81BA9E7A0005E1FB8 /* ASViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASViewController.h; sourceTree = "<group>"; };
+		ACF6ED011B17843500DA7C62 /* ASBackgroundLayoutSpec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASBackgroundLayoutSpec.h; path = AsyncDisplayKit/Layout/ASBackgroundLayoutSpec.h; sourceTree = "<group>"; };
+		ACF6ED021B17843500DA7C62 /* ASBackgroundLayoutSpec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; lineEnding = 0; name = ASBackgroundLayoutSpec.mm; path = AsyncDisplayKit/Layout/ASBackgroundLayoutSpec.mm; sourceTree = "<group>"; };
+		ACF6ED031B17843500DA7C62 /* ASCenterLayoutSpec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASCenterLayoutSpec.h; path = AsyncDisplayKit/Layout/ASCenterLayoutSpec.h; sourceTree = "<group>"; };
+		ACF6ED041B17843500DA7C62 /* ASCenterLayoutSpec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; lineEnding = 0; name = ASCenterLayoutSpec.mm; path = AsyncDisplayKit/Layout/ASCenterLayoutSpec.mm; sourceTree = "<group>"; };
+		ACF6ED071B17843500DA7C62 /* ASDimension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASDimension.h; path = AsyncDisplayKit/Layout/ASDimension.h; sourceTree = "<group>"; };
+		ACF6ED081B17843500DA7C62 /* ASDimension.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = ASDimension.mm; path = AsyncDisplayKit/Layout/ASDimension.mm; sourceTree = "<group>"; };
+		ACF6ED091B17843500DA7C62 /* ASInsetLayoutSpec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASInsetLayoutSpec.h; path = AsyncDisplayKit/Layout/ASInsetLayoutSpec.h; sourceTree = "<group>"; };
+		ACF6ED0A1B17843500DA7C62 /* ASInsetLayoutSpec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; lineEnding = 0; name = ASInsetLayoutSpec.mm; path = AsyncDisplayKit/Layout/ASInsetLayoutSpec.mm; sourceTree = "<group>"; };
+		ACF6ED0B1B17843500DA7C62 /* ASLayout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASLayout.h; path = AsyncDisplayKit/Layout/ASLayout.h; sourceTree = "<group>"; };
+		ACF6ED0C1B17843500DA7C62 /* ASLayout.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = ASLayout.mm; path = AsyncDisplayKit/Layout/ASLayout.mm; sourceTree = "<group>"; };
+		ACF6ED0D1B17843500DA7C62 /* ASLayoutSpec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASLayoutSpec.h; path = AsyncDisplayKit/Layout/ASLayoutSpec.h; sourceTree = "<group>"; };
+		ACF6ED0E1B17843500DA7C62 /* ASLayoutSpec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; lineEnding = 0; name = ASLayoutSpec.mm; path = AsyncDisplayKit/Layout/ASLayoutSpec.mm; sourceTree = "<group>"; };
+		ACF6ED111B17843500DA7C62 /* ASLayoutable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASLayoutable.h; path = AsyncDisplayKit/Layout/ASLayoutable.h; sourceTree = "<group>"; };
+		ACF6ED121B17843500DA7C62 /* ASOverlayLayoutSpec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASOverlayLayoutSpec.h; path = AsyncDisplayKit/Layout/ASOverlayLayoutSpec.h; sourceTree = "<group>"; };
+		ACF6ED131B17843500DA7C62 /* ASOverlayLayoutSpec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; lineEnding = 0; name = ASOverlayLayoutSpec.mm; path = AsyncDisplayKit/Layout/ASOverlayLayoutSpec.mm; sourceTree = "<group>"; };
+		ACF6ED141B17843500DA7C62 /* ASRatioLayoutSpec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASRatioLayoutSpec.h; path = AsyncDisplayKit/Layout/ASRatioLayoutSpec.h; sourceTree = "<group>"; };
+		ACF6ED151B17843500DA7C62 /* ASRatioLayoutSpec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; lineEnding = 0; name = ASRatioLayoutSpec.mm; path = AsyncDisplayKit/Layout/ASRatioLayoutSpec.mm; sourceTree = "<group>"; };
+		ACF6ED161B17843500DA7C62 /* ASStackLayoutSpec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASStackLayoutSpec.h; path = AsyncDisplayKit/Layout/ASStackLayoutSpec.h; sourceTree = "<group>"; };
+		ACF6ED171B17843500DA7C62 /* ASStackLayoutSpec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = ASStackLayoutSpec.mm; path = AsyncDisplayKit/Layout/ASStackLayoutSpec.mm; sourceTree = "<group>"; };
+		ACF6ED181B17843500DA7C62 /* ASStaticLayoutSpec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASStaticLayoutSpec.h; path = AsyncDisplayKit/Layout/ASStaticLayoutSpec.h; sourceTree = "<group>"; };
+		ACF6ED191B17843500DA7C62 /* ASStaticLayoutSpec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; lineEnding = 0; name = ASStaticLayoutSpec.mm; path = AsyncDisplayKit/Layout/ASStaticLayoutSpec.mm; sourceTree = "<group>"; };
+		ACF6ED431B17847A00DA7C62 /* ASInternalHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASInternalHelpers.h; sourceTree = "<group>"; };
+		ACF6ED441B17847A00DA7C62 /* ASInternalHelpers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASInternalHelpers.m; sourceTree = "<group>"; };
+		ACF6ED451B17847A00DA7C62 /* ASLayoutSpecUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASLayoutSpecUtilities.h; sourceTree = "<group>"; };
+		ACF6ED461B17847A00DA7C62 /* ASStackLayoutSpecUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASStackLayoutSpecUtilities.h; sourceTree = "<group>"; };
+		ACF6ED471B17847A00DA7C62 /* ASStackPositionedLayout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASStackPositionedLayout.h; sourceTree = "<group>"; };
+		ACF6ED481B17847A00DA7C62 /* ASStackPositionedLayout.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASStackPositionedLayout.mm; sourceTree = "<group>"; };
+		ACF6ED491B17847A00DA7C62 /* ASStackUnpositionedLayout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASStackUnpositionedLayout.h; sourceTree = "<group>"; };
+		ACF6ED4A1B17847A00DA7C62 /* ASStackUnpositionedLayout.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; lineEnding = 0; path = ASStackUnpositionedLayout.mm; sourceTree = "<group>"; };
+		ACF6ED531B178DC700DA7C62 /* ASCenterLayoutSpecSnapshotTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASCenterLayoutSpecSnapshotTests.mm; sourceTree = "<group>"; };
+		ACF6ED541B178DC700DA7C62 /* ASDimensionTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASDimensionTests.mm; sourceTree = "<group>"; };
+		ACF6ED551B178DC700DA7C62 /* ASInsetLayoutSpecSnapshotTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASInsetLayoutSpecSnapshotTests.mm; sourceTree = "<group>"; };
+		ACF6ED571B178DC700DA7C62 /* ASLayoutSpecSnapshotTestsHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASLayoutSpecSnapshotTestsHelper.h; sourceTree = "<group>"; };
+		ACF6ED581B178DC700DA7C62 /* ASLayoutSpecSnapshotTestsHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = ASLayoutSpecSnapshotTestsHelper.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
+		ACF6ED591B178DC700DA7C62 /* ASOverlayLayoutSpecSnapshotTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASOverlayLayoutSpecSnapshotTests.mm; sourceTree = "<group>"; };
+		ACF6ED5A1B178DC700DA7C62 /* ASRatioLayoutSpecSnapshotTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASRatioLayoutSpecSnapshotTests.mm; sourceTree = "<group>"; };
+		ACF6ED5B1B178DC700DA7C62 /* ASStackLayoutSpecSnapshotTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASStackLayoutSpecSnapshotTests.mm; sourceTree = "<group>"; };
+		AEB7B0181C5962EA00662EF4 /* ASDefaultPlayButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASDefaultPlayButton.h; sourceTree = "<group>"; };
+		AEB7B0191C5962EA00662EF4 /* ASDefaultPlayButton.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASDefaultPlayButton.m; sourceTree = "<group>"; };
+		AEEC47DF1C20C2DD00EC1693 /* ASVideoNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASVideoNode.h; sourceTree = "<group>"; };
+		AEEC47E01C20C2DD00EC1693 /* ASVideoNode.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASVideoNode.mm; sourceTree = "<group>"; };
+		AEEC47E31C21D3D200EC1693 /* ASVideoNodeTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASVideoNodeTests.m; sourceTree = "<group>"; };
+		B0F880581BEAEC7500D17647 /* ASTableNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTableNode.h; sourceTree = "<group>"; };
+		B13CA0F61C519E9400E031AB /* ASCollectionViewLayoutFacilitatorProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASCollectionViewLayoutFacilitatorProtocol.h; sourceTree = "<group>"; };
+		B13CA0FF1C52004900E031AB /* ASCollectionNode+Beta.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ASCollectionNode+Beta.h"; sourceTree = "<group>"; };
+		B30BF6501C5964B0004FCD53 /* ASLayoutManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASLayoutManager.h; path = TextKit/ASLayoutManager.h; sourceTree = "<group>"; };
+		B30BF6511C5964B0004FCD53 /* ASLayoutManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ASLayoutManager.m; path = TextKit/ASLayoutManager.m; sourceTree = "<group>"; };
+		B35061DA1B010EDF0018CF92 /* AsyncDisplayKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AsyncDisplayKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B35061DD1B010EDF0018CF92 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = "../AsyncDisplayKit-iOS/Info.plist"; sourceTree = "<group>"; };
+		BDC2D162BD55A807C1475DA5 /* Pods-AsyncDisplayKitTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AsyncDisplayKitTests.profile.xcconfig"; path = "Pods/Target Support Files/Pods-AsyncDisplayKitTests/Pods-AsyncDisplayKitTests.profile.xcconfig"; sourceTree = "<group>"; };
+		CC051F1E1D7A286A006434CB /* ASCALayerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASCALayerTests.m; sourceTree = "<group>"; };
+		CC0AEEA31D66316E005D1C78 /* ASUICollectionViewTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASUICollectionViewTests.m; sourceTree = "<group>"; };
+		CC3B20811C3F76D600798563 /* ASPendingStateController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASPendingStateController.h; sourceTree = "<group>"; };
+		CC3B20821C3F76D600798563 /* ASPendingStateController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASPendingStateController.mm; sourceTree = "<group>"; };
+		CC3B20871C3F7A5400798563 /* ASWeakSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASWeakSet.h; sourceTree = "<group>"; };
+		CC3B20881C3F7A5400798563 /* ASWeakSet.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASWeakSet.m; sourceTree = "<group>"; };
+		CC3B208D1C3F7D0A00798563 /* ASWeakSetTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASWeakSetTests.m; sourceTree = "<group>"; };
+		CC3B208F1C3F892D00798563 /* ASBridgedPropertiesTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASBridgedPropertiesTests.mm; sourceTree = "<group>"; };
+		CC446A2D1D80AAE00071FD03 /* ASObjectDescriptionHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASObjectDescriptionHelpers.h; sourceTree = "<group>"; };
+		CC446A2E1D80AAE00071FD03 /* ASObjectDescriptionHelpers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASObjectDescriptionHelpers.m; sourceTree = "<group>"; };
+		CC4981B21D1A02BE004E13CC /* ASTableViewThrashTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASTableViewThrashTests.m; sourceTree = "<group>"; };
+		CC4981BA1D1C7F65004E13CC /* NSIndexSet+ASHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSIndexSet+ASHelpers.h"; sourceTree = "<group>"; };
+		CC4981BB1D1C7F65004E13CC /* NSIndexSet+ASHelpers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSIndexSet+ASHelpers.m"; sourceTree = "<group>"; };
+		CC4C2A751D88E3BF0039ACAB /* ASTraceEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTraceEvent.h; sourceTree = "<group>"; };
+		CC4C2A761D88E3BF0039ACAB /* ASTraceEvent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASTraceEvent.m; sourceTree = "<group>"; };
+		CC54A81B1D70077A00296A24 /* ASDispatch.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ASDispatch.h; sourceTree = "<group>"; };
+		CC54A81D1D7008B300296A24 /* ASDispatchTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASDispatchTests.m; sourceTree = "<group>"; };
+		CC7FD9DC1BB5E962005CCB2B /* ASPhotosFrameworkImageRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASPhotosFrameworkImageRequest.h; sourceTree = "<group>"; };
+		CC7FD9DD1BB5E962005CCB2B /* ASPhotosFrameworkImageRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASPhotosFrameworkImageRequest.m; sourceTree = "<group>"; };
+		CC7FD9E01BB5F750005CCB2B /* ASPhotosFrameworkImageRequestTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASPhotosFrameworkImageRequestTests.m; sourceTree = "<group>"; };
+		CC8B05D41D73836400F54286 /* ASPerformanceTestContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASPerformanceTestContext.h; sourceTree = "<group>"; };
+		CC8B05D51D73836400F54286 /* ASPerformanceTestContext.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASPerformanceTestContext.m; sourceTree = "<group>"; };
+		CC8B05D71D73979700F54286 /* ASTextNodePerformanceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASTextNodePerformanceTests.m; sourceTree = "<group>"; };
+		CCA221D21D6FA7EF00AF6A0F /* ASViewControllerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASViewControllerTests.m; sourceTree = "<group>"; };
+		CCB2F34C1D63CCC6004E6DE9 /* ASDisplayNodeSnapshotTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASDisplayNodeSnapshotTests.m; sourceTree = "<group>"; };
+		D3779BCFF841AD3EB56537ED /* Pods-AsyncDisplayKitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AsyncDisplayKitTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-AsyncDisplayKitTests/Pods-AsyncDisplayKitTests.release.xcconfig"; sourceTree = "<group>"; };
+		D785F6601A74327E00291744 /* ASScrollNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASScrollNode.h; sourceTree = "<group>"; };
+		D785F6611A74327E00291744 /* ASScrollNode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASScrollNode.m; sourceTree = "<group>"; };
+		DB55C25F1C6408D6004EDCF5 /* _ASTransitionContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = _ASTransitionContext.h; path = ../_ASTransitionContext.h; sourceTree = "<group>"; };
+		DB55C2601C6408D6004EDCF5 /* _ASTransitionContext.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = _ASTransitionContext.m; path = ../_ASTransitionContext.m; sourceTree = "<group>"; };
+		DB55C2651C641AE4004EDCF5 /* ASContextTransitioning.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASContextTransitioning.h; sourceTree = "<group>"; };
+		DBC452D91C5BF64600B16017 /* NSArray+Diffing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSArray+Diffing.h"; sourceTree = "<group>"; };
+		DBC452DA1C5BF64600B16017 /* NSArray+Diffing.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSArray+Diffing.m"; sourceTree = "<group>"; };
+		DBC452DD1C5C6A6A00B16017 /* ArrayDiffingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ArrayDiffingTests.m; sourceTree = "<group>"; };
+		DBC453211C5FD97200B16017 /* ASDisplayNodeImplicitHierarchyTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASDisplayNodeImplicitHierarchyTests.m; sourceTree = "<group>"; };
+		DBDB83921C6E879900D0098C /* ASPagerFlowLayout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASPagerFlowLayout.h; sourceTree = "<group>"; };
+		DBDB83931C6E879900D0098C /* ASPagerFlowLayout.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASPagerFlowLayout.m; sourceTree = "<group>"; };
+		DE6EA3211C14000600183B10 /* ASDisplayNode+FrameworkPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ASDisplayNode+FrameworkPrivate.h"; sourceTree = "<group>"; };
+		DE8BEABF1C2DF3FC00D57C12 /* ASDelegateProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASDelegateProxy.h; sourceTree = "<group>"; };
+		DE8BEAC01C2DF3FC00D57C12 /* ASDelegateProxy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASDelegateProxy.m; sourceTree = "<group>"; };
+		DEC146B41C37A16A004A0EE7 /* ASCollectionInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASCollectionInternal.h; path = Details/ASCollectionInternal.h; sourceTree = "<group>"; };
+		DEC146B51C37A16A004A0EE7 /* ASCollectionInternal.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ASCollectionInternal.m; path = Details/ASCollectionInternal.m; sourceTree = "<group>"; };
+		DECBD6E51BE56E1900CF4905 /* ASButtonNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASButtonNode.h; sourceTree = "<group>"; };
+		DECBD6E61BE56E1900CF4905 /* ASButtonNode.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASButtonNode.mm; sourceTree = "<group>"; };
+		E52405B21C8FEF03004DC8E7 /* ASLayoutTransition.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASLayoutTransition.mm; sourceTree = "<group>"; };
+		E52405B41C8FEF16004DC8E7 /* ASLayoutTransition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASLayoutTransition.h; sourceTree = "<group>"; };
+		E55D86311CA8A14000A0C26F /* ASLayoutable.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = ASLayoutable.mm; path = AsyncDisplayKit/Layout/ASLayoutable.mm; sourceTree = "<group>"; };
+		E5711A2A1C840C81009619D4 /* ASIndexedNodeContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASIndexedNodeContext.h; sourceTree = "<group>"; };
+		E5711A2D1C840C96009619D4 /* ASIndexedNodeContext.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASIndexedNodeContext.mm; sourceTree = "<group>"; };
+		EFA731F0396842FF8AB635EE /* libPods-AsyncDisplayKitTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-AsyncDisplayKitTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		F711994D1D20C21100568860 /* ASDisplayNodeExtrasTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASDisplayNodeExtrasTests.m; sourceTree = "<group>"; };
+		FB07EABBCF28656C6297BC2D /* Pods-AsyncDisplayKitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AsyncDisplayKitTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AsyncDisplayKitTests/Pods-AsyncDisplayKitTests.debug.xcconfig"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		057D02BC1AC0A66700C7AC3C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DE0702FC1C3671E900D7DE62 /* libAsyncDisplayKit.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		058D09A9195D04C000B7D73C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				92DD2FE91BF4D4870074C9DD /* MapKit.framework in Frameworks */,
+				051943151A1575670030A7D0 /* Photos.framework in Frameworks */,
+				051943131A1575630030A7D0 /* AssetsLibrary.framework in Frameworks */,
+				058D09B0195D04C000B7D73C /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		058D09B9195D04C000B7D73C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				92DD2FEA1BF4D49B0074C9DD /* MapKit.framework in Frameworks */,
+				0515EA221A1576A100BA8B9A /* AssetsLibrary.framework in Frameworks */,
+				0515EA211A15769900BA8B9A /* Photos.framework in Frameworks */,
+				058D09BE195D04C000B7D73C /* XCTest.framework in Frameworks */,
+				058D09C1195D04C000B7D73C /* UIKit.framework in Frameworks */,
+				058D09C4195D04C000B7D73C /* libAsyncDisplayKit.a in Frameworks */,
+				058D09BF195D04C000B7D73C /* Foundation.framework in Frameworks */,
+				DB7121BCD50849C498C886FB /* libPods-AsyncDisplayKitTests.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B35061D61B010EDF0018CF92 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				92DD2FE61BF4D05E0074C9DD /* MapKit.framework in Frameworks */,
+				B350625F1B0111800018CF92 /* Foundation.framework in Frameworks */,
+				B350625E1B0111780018CF92 /* AssetsLibrary.framework in Frameworks */,
+				B350625D1B0111740018CF92 /* Photos.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		057D02C01AC0A66700C7AC3C /* AsyncDisplayKitTestHost */ = {
+			isa = PBXGroup;
+			children = (
+				204C979D1B362CB3002B1083 /* Default-568h@2x.png */,
+				057D02C51AC0A66700C7AC3C /* AppDelegate.h */,
+				057D02C61AC0A66700C7AC3C /* AppDelegate.mm */,
+				057D02C11AC0A66700C7AC3C /* Supporting Files */,
+			);
+			name = AsyncDisplayKitTestHost;
+			path = ../AsyncDisplayKitTestHost;
+			sourceTree = "<group>";
+		};
+		057D02C11AC0A66700C7AC3C /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				057D02C21AC0A66700C7AC3C /* Info.plist */,
+				057D02C31AC0A66700C7AC3C /* main.m */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		058D09A3195D04C000B7D73C = {
+			isa = PBXGroup;
+			children = (
+				058D09B1195D04C000B7D73C /* AsyncDisplayKit */,
+				058D09C5195D04C000B7D73C /* AsyncDisplayKitTests */,
+				B35061DB1B010EDF0018CF92 /* AsyncDisplayKit-iOS */,
+				058D09AE195D04C000B7D73C /* Frameworks */,
+				058D09AD195D04C000B7D73C /* Products */,
+				FD40E2760492F0CAAEAD552D /* Pods */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		058D09AD195D04C000B7D73C /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				058D09AC195D04C000B7D73C /* libAsyncDisplayKit.a */,
+				058D09BC195D04C000B7D73C /* AsyncDisplayKitTests.xctest */,
+				057D02BF1AC0A66700C7AC3C /* AsyncDisplayKitTestHost.app */,
+				B35061DA1B010EDF0018CF92 /* AsyncDisplayKit.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		058D09AE195D04C000B7D73C /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				92DD2FE51BF4D05E0074C9DD /* MapKit.framework */,
+				051943141A1575670030A7D0 /* Photos.framework */,
+				051943121A1575630030A7D0 /* AssetsLibrary.framework */,
+				058D09AF195D04C000B7D73C /* Foundation.framework */,
+				058D09BD195D04C000B7D73C /* XCTest.framework */,
+				058D09C0195D04C000B7D73C /* UIKit.framework */,
+				EFA731F0396842FF8AB635EE /* libPods-AsyncDisplayKitTests.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		058D09B1195D04C000B7D73C /* AsyncDisplayKit */ = {
+			isa = PBXGroup;
+			children = (
+				DBDB83921C6E879900D0098C /* ASPagerFlowLayout.h */,
+				DBDB83931C6E879900D0098C /* ASPagerFlowLayout.m */,
+				92DD2FE11BF4B97E0074C9DD /* ASMapNode.h */,
+				92DD2FE21BF4B97E0074C9DD /* ASMapNode.mm */,
+				AEEC47DF1C20C2DD00EC1693 /* ASVideoNode.h */,
+				AEEC47E01C20C2DD00EC1693 /* ASVideoNode.mm */,
+				8BDA5FC31CDBDDE1007D13B2 /* ASVideoPlayerNode.h */,
+				8BDA5FC41CDBDDE1007D13B2 /* ASVideoPlayerNode.mm */,
+				055F1A3A19ABD43F004DAFF1 /* ASCellNode.h */,
+				AC6456071B0A335000CF11B8 /* ASCellNode.mm */,
+				18C2ED7C1B9B7DE800F627B3 /* ASCollectionNode.h */,
+				18C2ED7D1B9B7DE800F627B3 /* ASCollectionNode.mm */,
+				B13CA0FF1C52004900E031AB /* ASCollectionNode+Beta.h */,
+				AC3C4A4F1A1139C100143C57 /* ASCollectionView.h */,
+				AC3C4A501A1139C100143C57 /* ASCollectionView.mm */,
+				AC3C4A531A113EEC00143C57 /* ASCollectionViewProtocols.h */,
+				B13CA0F61C519E9400E031AB /* ASCollectionViewLayoutFacilitatorProtocol.h */,
+				DEC146B41C37A16A004A0EE7 /* ASCollectionInternal.h */,
+				DEC146B51C37A16A004A0EE7 /* ASCollectionInternal.m */,
+				058D09D5195D050800B7D73C /* ASControlNode.h */,
+				058D09D6195D050800B7D73C /* ASControlNode.mm */,
+				DECBD6E51BE56E1900CF4905 /* ASButtonNode.h */,
+				DECBD6E61BE56E1900CF4905 /* ASButtonNode.mm */,
+				058D09D7195D050800B7D73C /* ASControlNode+Subclasses.h */,
+				058D09D8195D050800B7D73C /* ASDisplayNode.h */,
+				058D09D9195D050800B7D73C /* ASDisplayNode.mm */,
+				68B027791C1A79CC0041016B /* ASDisplayNode+Beta.h */,
+				683489271D70DE3400327501 /* ASDisplayNode+Deprecated.h */,
+				058D09DA195D050800B7D73C /* ASDisplayNode+Subclasses.h */,
+				058D09DB195D050800B7D73C /* ASDisplayNodeExtras.h */,
+				058D09DC195D050800B7D73C /* ASDisplayNodeExtras.mm */,
+				0587F9BB1A7309ED00AFF0BA /* ASEditableTextNode.h */,
+				0587F9BC1A7309ED00AFF0BA /* ASEditableTextNode.mm */,
+				058D09DD195D050800B7D73C /* ASImageNode.h */,
+				058D09DE195D050800B7D73C /* ASImageNode.mm */,
+				68355B2E1CB5799E001D4E68 /* ASImageNode+AnimatedImage.mm */,
+				8021EC1A1D2B00B100799119 /* UIImage+ASConvenience.h */,
+				8021EC1B1D2B00B100799119 /* UIImage+ASConvenience.m */,
+				0516FA3E1A1563D200B4EBED /* ASMultiplexImageNode.h */,
+				0516FA3F1A1563D200B4EBED /* ASMultiplexImageNode.mm */,
+				68FC85DC1CE29AB700EDD713 /* ASNavigationController.h */,
+				68FC85DD1CE29AB700EDD713 /* ASNavigationController.m */,
+				055B9FA61A1C154B00035D6D /* ASNetworkImageNode.h */,
+				055B9FA71A1C154B00035D6D /* ASNetworkImageNode.mm */,
+				25E327541C16819500A2170C /* ASPagerNode.h */,
+				25E327551C16819500A2170C /* ASPagerNode.m */,
+				A2763D771CBDD57D00A9ADBD /* ASPINRemoteImageDownloader.h */,
+				A2763D781CBDD57D00A9ADBD /* ASPINRemoteImageDownloader.m */,
+				D785F6601A74327E00291744 /* ASScrollNode.h */,
+				D785F6611A74327E00291744 /* ASScrollNode.m */,
+				68FC85E01CE29B7E00EDD713 /* ASTabBarController.h */,
+				68FC85E11CE29B7E00EDD713 /* ASTabBarController.m */,
+				B0F880581BEAEC7500D17647 /* ASTableNode.h */,
+				9CFFC6C11CCAC768006A6476 /* ASTableNode.mm */,
+				055F1A3219ABD3E3004DAFF1 /* ASTableView.h */,
+				055F1A3319ABD3E3004DAFF1 /* ASTableView.mm */,
+				AC7A2C161BDE11DF0093FE1A /* ASTableViewInternal.h */,
+				0574D5E119C110610097DC25 /* ASTableViewProtocols.h */,
+				058D09DF195D050800B7D73C /* ASTextNode.h */,
+				A373200E1C571B050011FC94 /* ASTextNode+Beta.h */,
+				058D09E0195D050800B7D73C /* ASTextNode.mm */,
+				ACC945A81BA9E7A0005E1FB8 /* ASViewController.h */,
+				9CFFC6BF1CCAC73C006A6476 /* ASViewController.mm */,
+				6BDC61F51978FEA400E50D21 /* AsyncDisplayKit.h */,
+				764D83D21C8EA515009B4FB8 /* AsyncDisplayKit+Debug.h */,
+				764D83D31C8EA515009B4FB8 /* AsyncDisplayKit+Debug.m */,
+				DB55C2651C641AE4004EDCF5 /* ASContextTransitioning.h */,
+				68FC85E71CE29C7D00EDD713 /* ASVisibilityProtocols.h */,
+				68FC85E81CE29C7D00EDD713 /* ASVisibilityProtocols.m */,
+				92074A5E1CC8B9DD00918F75 /* tvOS */,
+				058D09E1195D050800B7D73C /* Details */,
+				058D0A01195D050800B7D73C /* Private */,
+				AC6456051B0A333200CF11B8 /* Layout */,
+				257754661BED245B00737CA5 /* TextKit */,
+				058D09B2195D04C000B7D73C /* Supporting Files */,
+			);
+			path = AsyncDisplayKit;
+			sourceTree = "<group>";
+		};
+		058D09B2195D04C000B7D73C /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				058D0A42195D058D00B7D73C /* Base */,
+				058D09B3195D04C000B7D73C /* AsyncDisplayKit-Prefix.pch */,
+				044285011BAA3CC700D16268 /* module.modulemap */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		058D09C5195D04C000B7D73C /* AsyncDisplayKitTests */ = {
+			isa = PBXGroup;
+			children = (
+				CC051F1E1D7A286A006434CB /* ASCALayerTests.m */,
+				CC8B05D71D73979700F54286 /* ASTextNodePerformanceTests.m */,
+				CC8B05D41D73836400F54286 /* ASPerformanceTestContext.h */,
+				CC8B05D51D73836400F54286 /* ASPerformanceTestContext.m */,
+				69B225681D7265DA00B25B22 /* ASXCTExtensions.h */,
+				CC54A81D1D7008B300296A24 /* ASDispatchTests.m */,
+				CCA221D21D6FA7EF00AF6A0F /* ASViewControllerTests.m */,
+				CC0AEEA31D66316E005D1C78 /* ASUICollectionViewTests.m */,
+				CCB2F34C1D63CCC6004E6DE9 /* ASDisplayNodeSnapshotTests.m */,
+				83A7D95D1D446A6E00BF333E /* ASWeakMapTests.m */,
+				DBC453211C5FD97200B16017 /* ASDisplayNodeImplicitHierarchyTests.m */,
+				DBC452DD1C5C6A6A00B16017 /* ArrayDiffingTests.m */,
+				CC3B208F1C3F892D00798563 /* ASBridgedPropertiesTests.mm */,
+				CC3B208D1C3F7D0A00798563 /* ASWeakSetTests.m */,
+				057D02C01AC0A66700C7AC3C /* AsyncDisplayKitTestHost */,
+				056D21501ABCEDA1001107EF /* ASSnapshotTestCase.h */,
+				05EA6FE61AC0966E00E35788 /* ASSnapshotTestCase.m */,
+				056D21541ABCEF50001107EF /* ASImageNodeSnapshotTests.m */,
+				ACF6ED531B178DC700DA7C62 /* ASCenterLayoutSpecSnapshotTests.mm */,
+				7AB338681C55B97B0055FDE8 /* ASRelativeLayoutSpecSnapshotTests.mm */,
+				ACF6ED551B178DC700DA7C62 /* ASInsetLayoutSpecSnapshotTests.mm */,
+				ACF6ED591B178DC700DA7C62 /* ASOverlayLayoutSpecSnapshotTests.mm */,
+				696FCB301D6E46050093471E /* ASBackgroundLayoutSpecSnapshotTests.mm */,
+				ACF6ED5A1B178DC700DA7C62 /* ASRatioLayoutSpecSnapshotTests.mm */,
+				ACF6ED5B1B178DC700DA7C62 /* ASStackLayoutSpecSnapshotTests.mm */,
+				AC026B571BD3F61800BBC17E /* ASStaticLayoutSpecSnapshotTests.m */,
+				81E95C131D62639600336598 /* ASTextNodeSnapshotTests.m */,
+				ACF6ED571B178DC700DA7C62 /* ASLayoutSpecSnapshotTestsHelper.h */,
+				ACF6ED581B178DC700DA7C62 /* ASLayoutSpecSnapshotTestsHelper.m */,
+				242995D21B29743C00090100 /* ASBasicImageDownloaderTests.m */,
+				29CDC2E11AAE70D000833CA4 /* ASBasicImageDownloaderContextTests.m */,
+				CC7FD9E01BB5F750005CCB2B /* ASPhotosFrameworkImageRequestTests.m */,
+				296A0A341A951ABF005ACEAA /* ASBatchFetchingTests.m */,
+				9F06E5CC1B4CAF4200F015D8 /* ASCollectionViewTests.mm */,
+				2911485B1A77147A005D0878 /* ASControlNodeTests.m */,
+				ACF6ED541B178DC700DA7C62 /* ASDimensionTests.mm */,
+				058D0A2D195D057000B7D73C /* ASDisplayLayerTests.m */,
+				058D0A2E195D057000B7D73C /* ASDisplayNodeAppearanceTests.m */,
+				058D0A2F195D057000B7D73C /* ASDisplayNodeTests.m */,
+				69B225661D72535E00B25B22 /* ASDisplayNodeLayoutTests.mm */,
+				058D0A30195D057000B7D73C /* ASDisplayNodeTestsHelper.h */,
+				058D0A31195D057000B7D73C /* ASDisplayNodeTestsHelper.m */,
+				697B31591CFE4B410049936F /* ASEditableTextNodeTests.m */,
+				052EE0651A159FEF002C6279 /* ASMultiplexImageNodeTests.m */,
+				058D0A32195D057000B7D73C /* ASMutableAttributedStringBuilderTests.m */,
+				3C9C128419E616EF00E942A0 /* ASTableViewTests.m */,
+				CC4981B21D1A02BE004E13CC /* ASTableViewThrashTests.m */,
+				058D0A33195D057000B7D73C /* ASTextKitCoreTextAdditionsTests.m */,
+				254C6B511BF8FE6D003EC431 /* ASTextKitTruncationTests.mm */,
+				254C6B531BF8FF2A003EC431 /* ASTextKitTests.mm */,
+				058D0A36195D057000B7D73C /* ASTextNodeTests.m */,
+				058D0A37195D057000B7D73C /* ASTextNodeWordKernerTests.mm */,
+				AEEC47E31C21D3D200EC1693 /* ASVideoNodeTests.m */,
+				F711994D1D20C21100568860 /* ASDisplayNodeExtrasTests.m */,
+				058D09C6195D04C000B7D73C /* Supporting Files */,
+				052EE06A1A15A0D8002C6279 /* TestResources */,
+				2538B6F21BC5D2A2003CA0B4 /* ASCollectionViewFlowLayoutInspectorTests.m */,
+			);
+			path = AsyncDisplayKitTests;
+			sourceTree = "<group>";
+		};
+		058D09C6195D04C000B7D73C /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				058D09C7195D04C000B7D73C /* AsyncDisplayKitTests-Info.plist */,
+				058D09C8195D04C000B7D73C /* InfoPlist.strings */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		058D09E1195D050800B7D73C /* Details */ = {
+			isa = PBXGroup;
+			children = (
+				CC4C2A751D88E3BF0039ACAB /* ASTraceEvent.h */,
+				CC4C2A761D88E3BF0039ACAB /* ASTraceEvent.m */,
+				058D09E2195D050800B7D73C /* _ASDisplayLayer.h */,
+				058D09E3195D050800B7D73C /* _ASDisplayLayer.mm */,
+				058D09E4195D050800B7D73C /* _ASDisplayView.h */,
+				058D09E5195D050800B7D73C /* _ASDisplayView.mm */,
+				69CB62A91CB8165900024920 /* _ASDisplayViewAccessiblity.h */,
+				69CB62AA1CB8165900024920 /* _ASDisplayViewAccessiblity.mm */,
+				205F0E171B37339C007741D0 /* ASAbstractLayoutController.h */,
+				205F0E181B37339C007741D0 /* ASAbstractLayoutController.mm */,
+				054963471A1EA066000F8E56 /* ASBasicImageDownloader.h */,
+				054963481A1EA066000F8E56 /* ASBasicImageDownloader.mm */,
+				299DA1A71A828D2900162D41 /* ASBatchContext.h */,
+				299DA1A81A828D2900162D41 /* ASBatchContext.mm */,
+				251B8EF41BBB3D690087C538 /* ASCollectionViewFlowLayoutInspector.h */,
+				251B8EF51BBB3D690087C538 /* ASCollectionViewFlowLayoutInspector.m */,
+				205F0E1B1B373A2C007741D0 /* ASCollectionViewLayoutController.h */,
+				205F0E1C1B373A2C007741D0 /* ASCollectionViewLayoutController.mm */,
+				05A6D05819D0EB64002DD95E /* ASDealloc2MainObject.h */,
+				05A6D05919D0EB64002DD95E /* ASDealloc2MainObject.m */,
+				698548611CA9E025008A345F /* ASEnvironment.h */,
+				9CFFC6BD1CCAC52B006A6476 /* ASEnvironment.mm */,
+				4640521B1A3F83C40061C0BA /* ASFlowLayoutController.h */,
+				4640521C1A3F83C40061C0BA /* ASFlowLayoutController.mm */,
+				058D09E6195D050800B7D73C /* ASHighlightOverlayLayer.h */,
+				058D09E7195D050800B7D73C /* ASHighlightOverlayLayer.mm */,
+				68355B371CB57A5A001D4E68 /* ASImageContainerProtocolCategories.h */,
+				68355B381CB57A5A001D4E68 /* ASImageContainerProtocolCategories.m */,
+				05F20AA31A15733C00DCA68A /* ASImageProtocols.h */,
+				430E7C8D1B4C23F100697A4C /* ASIndexPath.h */,
+				430E7C8E1B4C23F100697A4C /* ASIndexPath.m */,
+				4640521D1A3F83C40061C0BA /* ASLayoutController.h */,
+				292C59991A956527007E5DD6 /* ASLayoutRangeType.h */,
+				68EE0DBB1C1B4ED300BA1B99 /* ASMainSerialQueue.h */,
+				68EE0DBC1C1B4ED300BA1B99 /* ASMainSerialQueue.mm */,
+				058D09E8195D050800B7D73C /* ASMutableAttributedStringBuilder.h */,
+				058D09E9195D050800B7D73C /* ASMutableAttributedStringBuilder.m */,
+				CC7FD9DC1BB5E962005CCB2B /* ASPhotosFrameworkImageRequest.h */,
+				CC7FD9DD1BB5E962005CCB2B /* ASPhotosFrameworkImageRequest.m */,
+				68355B391CB57A5A001D4E68 /* ASPINRemoteImageDownloader.h */,
+				68355B361CB57A5A001D4E68 /* ASPINRemoteImageDownloader.m */,
+				055F1A3619ABD413004DAFF1 /* ASRangeController.h */,
+				055F1A3719ABD413004DAFF1 /* ASRangeController.mm */,
+				69F10C851C84C35D0026140C /* ASRangeControllerUpdateRangeProtocol+Beta.h */,
+				81EE384D1C8E94F000456208 /* ASRunLoopQueue.h */,
+				81EE384E1C8E94F000456208 /* ASRunLoopQueue.mm */,
+				296A0A311A951715005ACEAA /* ASScrollDirection.h */,
+				205F0E111B371BD7007741D0 /* ASScrollDirection.m */,
+				058D0A12195D050800B7D73C /* ASThread.h */,
+				9C70F2011CDA4EFA007D6C76 /* ASTraitCollection.h */,
+				9C70F2021CDA4EFA007D6C76 /* ASTraitCollection.m */,
+				68B8A4DF1CBDB958007E4543 /* ASWeakProxy.h */,
+				68B8A4E01CBDB958007E4543 /* ASWeakProxy.m */,
+				205F0E1F1B376416007741D0 /* CGRect+ASConvenience.h */,
+				205F0E201B376416007741D0 /* CGRect+ASConvenience.m */,
+				25B171EA1C12242700508A7A /* Data Controller */,
+				CC4981BA1D1C7F65004E13CC /* NSIndexSet+ASHelpers.h */,
+				CC4981BB1D1C7F65004E13CC /* NSIndexSet+ASHelpers.m */,
+				058D09F5195D050800B7D73C /* NSMutableAttributedString+TextKitAdditions.h */,
+				058D09F6195D050800B7D73C /* NSMutableAttributedString+TextKitAdditions.m */,
+				058D09F7195D050800B7D73C /* Transactions */,
+				205F0E0D1B371875007741D0 /* UICollectionViewLayout+ASConvenience.h */,
+				205F0E0E1B371875007741D0 /* UICollectionViewLayout+ASConvenience.m */,
+				058D09FF195D050800B7D73C /* UIView+ASConvenience.h */,
+				CC3B20871C3F7A5400798563 /* ASWeakSet.h */,
+				CC3B20881C3F7A5400798563 /* ASWeakSet.m */,
+				DBC452D91C5BF64600B16017 /* NSArray+Diffing.h */,
+				DBC452DA1C5BF64600B16017 /* NSArray+Diffing.m */,
+			);
+			path = Details;
+			sourceTree = "<group>";
+		};
+		058D09F7195D050800B7D73C /* Transactions */ = {
+			isa = PBXGroup;
+			children = (
+				058D09F8195D050800B7D73C /* _ASAsyncTransaction.h */,
+				058D09F9195D050800B7D73C /* _ASAsyncTransaction.mm */,
+				058D09FA195D050800B7D73C /* _ASAsyncTransactionContainer+Private.h */,
+				058D09FB195D050800B7D73C /* _ASAsyncTransactionContainer.h */,
+				058D09FC195D050800B7D73C /* _ASAsyncTransactionContainer.m */,
+				058D09FD195D050800B7D73C /* _ASAsyncTransactionGroup.h */,
+				058D09FE195D050800B7D73C /* _ASAsyncTransactionGroup.m */,
+			);
+			path = Transactions;
+			sourceTree = "<group>";
+		};
+		058D0A01195D050800B7D73C /* Private */ = {
+			isa = PBXGroup;
+			children = (
+				CC446A2D1D80AAE00071FD03 /* ASObjectDescriptionHelpers.h */,
+				CC446A2E1D80AAE00071FD03 /* ASObjectDescriptionHelpers.m */,
+				CC54A81B1D70077A00296A24 /* ASDispatch.h */,
+				058D0A02195D050800B7D73C /* _AS-objc-internal.h */,
+				058D0A03195D050800B7D73C /* _ASCoreAnimationExtras.h */,
+				058D0A04195D050800B7D73C /* _ASCoreAnimationExtras.mm */,
+				AC026B6D1BD57DBF00BBC17E /* _ASHierarchyChangeSet.h */,
+				AC026B6E1BD57DBF00BBC17E /* _ASHierarchyChangeSet.mm */,
+				058D0A05195D050800B7D73C /* _ASPendingState.h */,
+				058D0A06195D050800B7D73C /* _ASPendingState.mm */,
+				058D0A07195D050800B7D73C /* _ASScopeTimer.h */,
+				DB55C25F1C6408D6004EDCF5 /* _ASTransitionContext.h */,
+				DB55C2601C6408D6004EDCF5 /* _ASTransitionContext.m */,
+				2967F9E11AB0A4CF0072E4AB /* ASBasicImageDownloaderInternal.h */,
+				044285051BAA63FE00D16268 /* ASBatchFetching.h */,
+				044285061BAA63FE00D16268 /* ASBatchFetching.m */,
+				251B8EF61BBB3D690087C538 /* ASDataController+Subclasses.h */,
+				8B0768B11CE752EC002E1453 /* ASDefaultPlaybackButton.h */,
+				8B0768B21CE752EC002E1453 /* ASDefaultPlaybackButton.m */,
+				AEB7B0181C5962EA00662EF4 /* ASDefaultPlayButton.h */,
+				AEB7B0191C5962EA00662EF4 /* ASDefaultPlayButton.m */,
+				058D0A08195D050800B7D73C /* ASDisplayNode+AsyncDisplay.mm */,
+				058D0A09195D050800B7D73C /* ASDisplayNode+DebugTiming.h */,
+				058D0A0A195D050800B7D73C /* ASDisplayNode+DebugTiming.mm */,
+				DE6EA3211C14000600183B10 /* ASDisplayNode+FrameworkPrivate.h */,
+				058D0A0B195D050800B7D73C /* ASDisplayNode+UIViewBridge.mm */,
+				058D0A0C195D050800B7D73C /* ASDisplayNodeInternal.h */,
+				6959433D1D70815300B0EE1F /* ASDisplayNodeLayout.h */,
+				6959433C1D70815300B0EE1F /* ASDisplayNodeLayout.mm */,
+				69E100691CA89CB600D88C1B /* ASEnvironmentInternal.h */,
+				69E1006A1CA89CB600D88C1B /* ASEnvironmentInternal.mm */,
+				68B8A4DB1CBD911D007E4543 /* ASImageNode+AnimatedImagePrivate.h */,
+				058D0A0D195D050800B7D73C /* ASImageNode+CGExtras.h */,
+				058D0A0E195D050800B7D73C /* ASImageNode+CGExtras.m */,
+				ACF6ED431B17847A00DA7C62 /* ASInternalHelpers.h */,
+				ACF6ED441B17847A00DA7C62 /* ASInternalHelpers.m */,
+				ACF6ED451B17847A00DA7C62 /* ASLayoutSpecUtilities.h */,
+				E52405B41C8FEF16004DC8E7 /* ASLayoutTransition.h */,
+				E52405B21C8FEF03004DC8E7 /* ASLayoutTransition.mm */,
+				0442850B1BAA64EC00D16268 /* ASMultidimensionalArrayUtils.h */,
+				0442850C1BAA64EC00D16268 /* ASMultidimensionalArrayUtils.mm */,
+				CC3B20811C3F76D600798563 /* ASPendingStateController.h */,
+				CC3B20821C3F76D600798563 /* ASPendingStateController.mm */,
+				058D0A10195D050800B7D73C /* ASSentinel.h */,
+				058D0A11195D050800B7D73C /* ASSentinel.m */,
+				9C8221931BA237B80037F19A /* ASStackBaselinePositionedLayout.h */,
+				9C8221941BA237B80037F19A /* ASStackBaselinePositionedLayout.mm */,
+				ACF6ED461B17847A00DA7C62 /* ASStackLayoutSpecUtilities.h */,
+				ACF6ED471B17847A00DA7C62 /* ASStackPositionedLayout.h */,
+				ACF6ED481B17847A00DA7C62 /* ASStackPositionedLayout.mm */,
+				ACF6ED491B17847A00DA7C62 /* ASStackUnpositionedLayout.h */,
+				ACF6ED4A1B17847A00DA7C62 /* ASStackUnpositionedLayout.mm */,
+				83A7D9581D44542100BF333E /* ASWeakMap.h */,
+				83A7D9591D44542100BF333E /* ASWeakMap.m */,
+			);
+			path = Private;
+			sourceTree = "<group>";
+		};
+		058D0A42195D058D00B7D73C /* Base */ = {
+			isa = PBXGroup;
+			children = (
+				058D0A43195D058D00B7D73C /* ASAssert.h */,
+				0516FA3A1A15563400B4EBED /* ASAvailability.h */,
+				058D0A44195D058D00B7D73C /* ASBaseDefines.h */,
+				1950C4481A3BB5C1005C8279 /* ASEqualityHelpers.h */,
+				0516FA3B1A15563400B4EBED /* ASLog.h */,
+			);
+			path = Base;
+			sourceTree = SOURCE_ROOT;
+		};
+		257754661BED245B00737CA5 /* TextKit */ = {
+			isa = PBXGroup;
+			children = (
+				69708BA41D76386D005C3CF9 /* ASEqualityHashHelpers.h */,
+				69708BA51D76386D005C3CF9 /* ASEqualityHashHelpers.mm */,
+				B30BF6501C5964B0004FCD53 /* ASLayoutManager.h */,
+				B30BF6511C5964B0004FCD53 /* ASLayoutManager.m */,
+				257754BA1BEE458E00737CA5 /* ASTextKitComponents.h */,
+				257754B71BEE458D00737CA5 /* ASTextKitComponents.m */,
+				257754BB1BEE458E00737CA5 /* ASTextKitCoreTextAdditions.h */,
+				257754B81BEE458E00737CA5 /* ASTextKitCoreTextAdditions.m */,
+				257754B91BEE458E00737CA5 /* ASTextNodeWordKerner.h */,
+				257754BC1BEE458E00737CA5 /* ASTextNodeTypes.h */,
+				257754BD1BEE458E00737CA5 /* ASTextNodeWordKerner.m */,
+				257754941BEE44CD00737CA5 /* ASTextKitAttributes.mm */,
+				257754951BEE44CD00737CA5 /* ASTextKitAttributes.h */,
+				257754961BEE44CD00737CA5 /* ASTextKitContext.h */,
+				257754971BEE44CD00737CA5 /* ASTextKitContext.mm */,
+				257754981BEE44CD00737CA5 /* ASTextKitEntityAttribute.h */,
+				257754991BEE44CD00737CA5 /* ASTextKitEntityAttribute.m */,
+				257754931BEE44CD00737CA5 /* ASTextKitRenderer.h */,
+				2577549A1BEE44CD00737CA5 /* ASTextKitRenderer.mm */,
+				2577549B1BEE44CD00737CA5 /* ASTextKitRenderer+Positioning.h */,
+				2577549C1BEE44CD00737CA5 /* ASTextKitRenderer+Positioning.mm */,
+				2577549D1BEE44CD00737CA5 /* ASTextKitRenderer+TextChecking.h */,
+				2577549E1BEE44CD00737CA5 /* ASTextKitRenderer+TextChecking.mm */,
+				2577549F1BEE44CD00737CA5 /* ASTextKitShadower.h */,
+				257754A01BEE44CD00737CA5 /* ASTextKitShadower.mm */,
+				257754A11BEE44CD00737CA5 /* ASTextKitTailTruncater.h */,
+				257754A21BEE44CD00737CA5 /* ASTextKitTailTruncater.mm */,
+				A32FEDD31C501B6A004F642A /* ASTextKitFontSizeAdjuster.h */,
+				9C8898BA1C738B9800D6B02E /* ASTextKitFontSizeAdjuster.mm */,
+				257754A31BEE44CD00737CA5 /* ASTextKitTruncating.h */,
+			);
+			name = TextKit;
+			sourceTree = "<group>";
+		};
+		25B171EA1C12242700508A7A /* Data Controller */ = {
+			isa = PBXGroup;
+			children = (
+				DE8BEABF1C2DF3FC00D57C12 /* ASDelegateProxy.h */,
+				DE8BEAC01C2DF3FC00D57C12 /* ASDelegateProxy.m */,
+				251B8EF21BBB3D690087C538 /* ASCollectionDataController.h */,
+				251B8EF31BBB3D690087C538 /* ASCollectionDataController.mm */,
+				464052191A3F83C40061C0BA /* ASDataController.h */,
+				4640521A1A3F83C40061C0BA /* ASDataController.mm */,
+				AC026B671BD57D6F00BBC17E /* ASChangeSetDataController.h */,
+				AC026B681BD57D6F00BBC17E /* ASChangeSetDataController.mm */,
+				E5711A2A1C840C81009619D4 /* ASIndexedNodeContext.h */,
+				E5711A2D1C840C96009619D4 /* ASIndexedNodeContext.mm */,
+			);
+			name = "Data Controller";
+			sourceTree = "<group>";
+		};
+		92074A5E1CC8B9DD00918F75 /* tvOS */ = {
+			isa = PBXGroup;
+			children = (
+				92074A5F1CC8BA1900918F75 /* ASImageNode+tvOS.h */,
+				92074A601CC8BA1900918F75 /* ASImageNode+tvOS.m */,
+				92074A651CC8BADA00918F75 /* ASControlNode+tvOS.h */,
+				92074A661CC8BADA00918F75 /* ASControlNode+tvOS.m */,
+			);
+			name = tvOS;
+			sourceTree = "<group>";
+		};
+		AC6456051B0A333200CF11B8 /* Layout */ = {
+			isa = PBXGroup;
+			children = (
+				9C5586671BD549CB00B50E3A /* ASAsciiArtBoxCreator.h */,
+				9C5586681BD549CB00B50E3A /* ASAsciiArtBoxCreator.m */,
+				ACF6ED011B17843500DA7C62 /* ASBackgroundLayoutSpec.h */,
+				ACF6ED021B17843500DA7C62 /* ASBackgroundLayoutSpec.mm */,
+				ACF6ED031B17843500DA7C62 /* ASCenterLayoutSpec.h */,
+				ACF6ED041B17843500DA7C62 /* ASCenterLayoutSpec.mm */,
+				ACF6ED071B17843500DA7C62 /* ASDimension.h */,
+				ACF6ED081B17843500DA7C62 /* ASDimension.mm */,
+				ACF6ED091B17843500DA7C62 /* ASInsetLayoutSpec.h */,
+				ACF6ED0A1B17843500DA7C62 /* ASInsetLayoutSpec.mm */,
+				ACF6ED0B1B17843500DA7C62 /* ASLayout.h */,
+				ACF6ED0C1B17843500DA7C62 /* ASLayout.mm */,
+				ACF6ED111B17843500DA7C62 /* ASLayoutable.h */,
+				E55D86311CA8A14000A0C26F /* ASLayoutable.mm */,
+				698C8B601CAB49FC0052DC3F /* ASLayoutableExtensibility.h */,
+				9CDC18CB1B910E12004965E2 /* ASLayoutablePrivate.h */,
+				ACF6ED0D1B17843500DA7C62 /* ASLayoutSpec.h */,
+				ACF6ED0E1B17843500DA7C62 /* ASLayoutSpec.mm */,
+				697C0DE11CF38F28001DE0D4 /* ASLayoutValidation.h */,
+				697C0DE21CF38F28001DE0D4 /* ASLayoutValidation.mm */,
+				ACF6ED121B17843500DA7C62 /* ASOverlayLayoutSpec.h */,
+				ACF6ED131B17843500DA7C62 /* ASOverlayLayoutSpec.mm */,
+				ACF6ED141B17843500DA7C62 /* ASRatioLayoutSpec.h */,
+				ACF6ED151B17843500DA7C62 /* ASRatioLayoutSpec.mm */,
+				7A06A7391C35F08800FE8DAA /* ASRelativeLayoutSpec.h */,
+				7A06A7381C35F08800FE8DAA /* ASRelativeLayoutSpec.mm */,
+				AC47D9431B3BB41900AAEE9D /* ASRelativeSize.h */,
+				AC47D9441B3BB41900AAEE9D /* ASRelativeSize.mm */,
+				9C49C36E1B853957000B0DD5 /* ASStackLayoutable.h */,
+				AC21EC0F1B3D0BF600C8B19A /* ASStackLayoutDefines.h */,
+				ACF6ED161B17843500DA7C62 /* ASStackLayoutSpec.h */,
+				ACF6ED171B17843500DA7C62 /* ASStackLayoutSpec.mm */,
+				9C6BB3B01B8CC9C200F13F52 /* ASStaticLayoutable.h */,
+				ACF6ED181B17843500DA7C62 /* ASStaticLayoutSpec.h */,
+				ACF6ED191B17843500DA7C62 /* ASStaticLayoutSpec.mm */,
+			);
+			name = Layout;
+			path = ..;
+			sourceTree = "<group>";
+		};
+		B35061DB1B010EDF0018CF92 /* AsyncDisplayKit-iOS */ = {
+			isa = PBXGroup;
+			children = (
+				B35061DC1B010EDF0018CF92 /* Supporting Files */,
+			);
+			name = "AsyncDisplayKit-iOS";
+			path = AsyncDisplayKit;
+			sourceTree = "<group>";
+		};
+		B35061DC1B010EDF0018CF92 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				B35061DD1B010EDF0018CF92 /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		FD40E2760492F0CAAEAD552D /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				FB07EABBCF28656C6297BC2D /* Pods-AsyncDisplayKitTests.debug.xcconfig */,
+				D3779BCFF841AD3EB56537ED /* Pods-AsyncDisplayKitTests.release.xcconfig */,
+				BDC2D162BD55A807C1475DA5 /* Pods-AsyncDisplayKitTests.profile.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		B35061D71B010EDF0018CF92 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				69E0E8A71D356C9400627613 /* ASEqualityHelpers.h in Headers */,
+				698C8B621CAB49FC0052DC3F /* ASLayoutableExtensibility.h in Headers */,
+				698548641CA9E025008A345F /* ASEnvironment.h in Headers */,
+				AC026B6A1BD57D6F00BBC17E /* ASChangeSetDataController.h in Headers */,
+				B35062481B010EFD0018CF92 /* _AS-objc-internal.h in Headers */,
+				69F10C871C84C35D0026140C /* ASRangeControllerUpdateRangeProtocol+Beta.h in Headers */,
+				B350623C1B010EFD0018CF92 /* _ASAsyncTransaction.h in Headers */,
+				9C70F20D1CDBE9CB007D6C76 /* ASDefaultPlayButton.h in Headers */,
+				68355B411CB57A6C001D4E68 /* ASImageContainerProtocolCategories.h in Headers */,
+				7630FFA81C9E267E007A7C0E /* ASVideoNode.h in Headers */,
+				B350623F1B010EFD0018CF92 /* _ASAsyncTransactionContainer.h in Headers */,
+				B13CA1011C52004900E031AB /* ASCollectionNode+Beta.h in Headers */,
+				254C6B7E1BF94DF4003EC431 /* ASTextKitTailTruncater.h in Headers */,
+				B35062411B010EFD0018CF92 /* _ASAsyncTransactionGroup.h in Headers */,
+				B35062491B010EFD0018CF92 /* _ASCoreAnimationExtras.h in Headers */,
+				B350620F1B010EFD0018CF92 /* _ASDisplayLayer.h in Headers */,
+				B35062111B010EFD0018CF92 /* _ASDisplayView.h in Headers */,
+				68EE0DBE1C1B4ED300BA1B99 /* ASMainSerialQueue.h in Headers */,
+				B350624B1B010EFD0018CF92 /* _ASPendingState.h in Headers */,
+				CC54A81C1D70079800296A24 /* ASDispatch.h in Headers */,
+				9C55866C1BD54A3000B50E3A /* ASAsciiArtBoxCreator.h in Headers */,
+				B350624D1B010EFD0018CF92 /* _ASScopeTimer.h in Headers */,
+				254C6B771BF94DF4003EC431 /* ASTextKitAttributes.h in Headers */,
+				509E68611B3AEDA0009B9150 /* ASAbstractLayoutController.h in Headers */,
+				B35062571B010F070018CF92 /* ASAssert.h in Headers */,
+				254C6B7D1BF94DF4003EC431 /* ASTextKitShadower.h in Headers */,
+				B35062581B010F070018CF92 /* ASAvailability.h in Headers */,
+				DE84918D1C8FFF2B003D89E9 /* ASRunLoopQueue.h in Headers */,
+				254C6B731BF94DF4003EC431 /* ASTextKitCoreTextAdditions.h in Headers */,
+				A2763D7A1CBDD57D00A9ADBD /* ASPINRemoteImageDownloader.h in Headers */,
+				254C6B7A1BF94DF4003EC431 /* ASTextKitRenderer.h in Headers */,
+				69CB62AC1CB8165900024920 /* _ASDisplayViewAccessiblity.h in Headers */,
+				68355B3F1CB57A64001D4E68 /* ASPINRemoteImageDownloader.h in Headers */,
+				254C6B7C1BF94DF4003EC431 /* ASTextKitRenderer+TextChecking.h in Headers */,
+				34EFC7611B701C9C00AD841F /* ASBackgroundLayoutSpec.h in Headers */,
+				68AF37DB1CBEF4D80077BF76 /* ASImageNode+AnimatedImagePrivate.h in Headers */,
+				B35062591B010F070018CF92 /* ASBaseDefines.h in Headers */,
+				B35062131B010EFD0018CF92 /* ASBasicImageDownloader.h in Headers */,
+				B35062461B010EFD0018CF92 /* ASBasicImageDownloaderInternal.h in Headers */,
+				B35062151B010EFD0018CF92 /* ASBatchContext.h in Headers */,
+				92074A681CC8BADA00918F75 /* ASControlNode+tvOS.h in Headers */,
+				044285081BAA63FE00D16268 /* ASBatchFetching.h in Headers */,
+				AC026B701BD57DBF00BBC17E /* _ASHierarchyChangeSet.h in Headers */,
+				B35061F31B010EFD0018CF92 /* ASCellNode.h in Headers */,
+				34EFC7631B701CBF00AD841F /* ASCenterLayoutSpec.h in Headers */,
+				9C70F20C1CDBE9B6007D6C76 /* ASCollectionDataController.h in Headers */,
+				18C2ED7F1B9B7DE800F627B3 /* ASCollectionNode.h in Headers */,
+				9C8898BD1C738BB800D6B02E /* ASTextKitFontSizeAdjuster.h in Headers */,
+				B35061F51B010EFD0018CF92 /* ASCollectionView.h in Headers */,
+				254C6B791BF94DF4003EC431 /* ASTextKitEntityAttribute.h in Headers */,
+				509E68631B3AEDB4009B9150 /* ASCollectionViewLayoutController.h in Headers */,
+				CC3B20841C3F76D600798563 /* ASPendingStateController.h in Headers */,
+				92074A621CC8BA1900918F75 /* ASImageNode+tvOS.h in Headers */,
+				B35061F71B010EFD0018CF92 /* ASCollectionViewProtocols.h in Headers */,
+				68FC85E31CE29B7E00EDD713 /* ASTabBarController.h in Headers */,
+				DE6EA3231C14000600183B10 /* ASDisplayNode+FrameworkPrivate.h in Headers */,
+				9C70F20F1CDBE9FF007D6C76 /* ASLayoutManager.h in Headers */,
+				B35061FA1B010EFD0018CF92 /* ASControlNode+Subclasses.h in Headers */,
+				B35061F81B010EFD0018CF92 /* ASControlNode.h in Headers */,
+				B35062171B010EFD0018CF92 /* ASDataController.h in Headers */,
+				B35062191B010EFD0018CF92 /* ASDealloc2MainObject.h in Headers */,
+				34EFC75B1B701BAF00AD841F /* ASDimension.h in Headers */,
+				68FC85EA1CE29C7D00EDD713 /* ASVisibilityProtocols.h in Headers */,
+				A37320101C571B740011FC94 /* ASTextNode+Beta.h in Headers */,
+				DBABFAFC1C6A8D2F0039EA4A /* _ASTransitionContext.h in Headers */,
+				9C70F2061CDA4F0C007D6C76 /* ASTraitCollection.h in Headers */,
+				8021EC1D1D2B00B100799119 /* UIImage+ASConvenience.h in Headers */,
+				B350624F1B010EFD0018CF92 /* ASDisplayNode+DebugTiming.h in Headers */,
+				B35061FD1B010EFD0018CF92 /* ASDisplayNode+Subclasses.h in Headers */,
+				B35061FB1B010EFD0018CF92 /* ASDisplayNode.h in Headers */,
+				B35061FE1B010EFD0018CF92 /* ASDisplayNodeExtras.h in Headers */,
+				B35062521B010EFD0018CF92 /* ASDisplayNodeInternal.h in Headers */,
+				B35062001B010EFD0018CF92 /* ASEditableTextNode.h in Headers */,
+				680346941CE4052A0009FEB4 /* ASNavigationController.h in Headers */,
+				B350621B1B010EFD0018CF92 /* ASFlowLayoutController.h in Headers */,
+				B350621D1B010EFD0018CF92 /* ASHighlightOverlayLayer.h in Headers */,
+				C78F7E2B1BF7809800CDEAFC /* ASTableNode.h in Headers */,
+				AC7A2C181BDE11DF0093FE1A /* ASTableViewInternal.h in Headers */,
+				B35062531B010EFD0018CF92 /* ASImageNode+CGExtras.h in Headers */,
+				254C6B7F1BF94DF4003EC431 /* ASTextKitTruncating.h in Headers */,
+				7AB338671C55B3460055FDE8 /* ASRelativeLayoutSpec.h in Headers */,
+				B35062021B010EFD0018CF92 /* ASImageNode.h in Headers */,
+				B350621F1B010EFD0018CF92 /* ASImageProtocols.h in Headers */,
+				430E7C901B4C23F100697A4C /* ASIndexPath.h in Headers */,
+				9C70F20B1CDBE9A4007D6C76 /* ASDataController+Subclasses.h in Headers */,
+				34EFC75F1B701C8600AD841F /* ASInsetLayoutSpec.h in Headers */,
+				34EFC75D1B701BE900AD841F /* ASInternalHelpers.h in Headers */,
+				34EFC7671B701CD900AD841F /* ASLayout.h in Headers */,
+				DEC146B71C37A16A004A0EE7 /* ASCollectionInternal.h in Headers */,
+				DBDB83951C6E879900D0098C /* ASPagerFlowLayout.h in Headers */,
+				34EFC7691B701CE100AD841F /* ASLayoutable.h in Headers */,
+				9CDC18CD1B910E12004965E2 /* ASLayoutablePrivate.h in Headers */,
+				68B8A4E21CBDB958007E4543 /* ASWeakProxy.h in Headers */,
+				B35062201B010EFD0018CF92 /* ASLayoutController.h in Headers */,
+				697C0DE41CF38F28001DE0D4 /* ASLayoutValidation.h in Headers */,
+				B35062211B010EFD0018CF92 /* ASLayoutRangeType.h in Headers */,
+				34EFC76A1B701CE600AD841F /* ASLayoutSpec.h in Headers */,
+				695943401D70815300B0EE1F /* ASDisplayNodeLayout.h in Headers */,
+				34EFC7791B701D3600AD841F /* ASLayoutSpecUtilities.h in Headers */,
+				B350625C1B010F070018CF92 /* ASLog.h in Headers */,
+				0442850E1BAA64EC00D16268 /* ASMultidimensionalArrayUtils.h in Headers */,
+				CC3B208A1C3F7A5400798563 /* ASWeakSet.h in Headers */,
+				DE8BEAC21C2DF3FC00D57C12 /* ASDelegateProxy.h in Headers */,
+				B35062041B010EFD0018CF92 /* ASMultiplexImageNode.h in Headers */,
+				B350623E1B010EFD0018CF92 /* _ASAsyncTransactionContainer+Private.h in Headers */,
+				DECBD6E81BE56E1900CF4905 /* ASButtonNode.h in Headers */,
+				B35062241B010EFD0018CF92 /* ASMutableAttributedStringBuilder.h in Headers */,
+				B13CA0F81C519EBA00E031AB /* ASCollectionViewLayoutFacilitatorProtocol.h in Headers */,
+				8BBBAB8C1CEBAF1700107FC6 /* ASDefaultPlaybackButton.h in Headers */,
+				B35062061B010EFD0018CF92 /* ASNetworkImageNode.h in Headers */,
+				34EFC76C1B701CED00AD841F /* ASOverlayLayoutSpec.h in Headers */,
+				B35062261B010EFD0018CF92 /* ASRangeController.h in Headers */,
+				34EFC76E1B701CF400AD841F /* ASRatioLayoutSpec.h in Headers */,
+				34EFC7651B701CCC00AD841F /* ASRelativeSize.h in Headers */,
+				254C6B741BF94DF4003EC431 /* ASTextNodeWordKerner.h in Headers */,
+				DB55C2671C641AE4004EDCF5 /* ASContextTransitioning.h in Headers */,
+				68B0277B1C1A79D60041016B /* ASDisplayNode+Beta.h in Headers */,
+				CCF18FF41D2575E300DF5895 /* NSIndexSet+ASHelpers.h in Headers */,
+				83A7D95C1D44548100BF333E /* ASWeakMap.h in Headers */,
+				69708BA61D76386D005C3CF9 /* ASEqualityHashHelpers.h in Headers */,
+				B350622D1B010EFD0018CF92 /* ASScrollDirection.h in Headers */,
+				254C6B751BF94DF4003EC431 /* ASTextKitComponents.h in Headers */,
+				683489281D70DE3400327501 /* ASDisplayNode+Deprecated.h in Headers */,
+				B35062081B010EFD0018CF92 /* ASScrollNode.h in Headers */,
+				25E327571C16819500A2170C /* ASPagerNode.h in Headers */,
+				B35062551B010EFD0018CF92 /* ASSentinel.h in Headers */,
+				9C8221961BA237B80037F19A /* ASStackBaselinePositionedLayout.h in Headers */,
+				9C70F20E1CDBE9E5007D6C76 /* NSArray+Diffing.h in Headers */,
+				9C49C3701B853961000B0DD5 /* ASStackLayoutable.h in Headers */,
+				DE040EF91C2B40AC004692FF /* ASCollectionViewFlowLayoutInspector.h in Headers */,
+				34EFC7701B701CFA00AD841F /* ASStackLayoutDefines.h in Headers */,
+				764D83D51C8EA515009B4FB8 /* AsyncDisplayKit+Debug.h in Headers */,
+				E5711A2C1C840C81009619D4 /* ASIndexedNodeContext.h in Headers */,
+				CC4C2A771D88E3BF0039ACAB /* ASTraceEvent.h in Headers */,
+				254C6B7B1BF94DF4003EC431 /* ASTextKitRenderer+Positioning.h in Headers */,
+				CC7FD9E21BB603FF005CCB2B /* ASPhotosFrameworkImageRequest.h in Headers */,
+				DE4843DC1C93EAC100A1F33B /* ASLayoutTransition.h in Headers */,
+				254C6B761BF94DF4003EC431 /* ASTextNodeTypes.h in Headers */,
+				34EFC7711B701CFF00AD841F /* ASStackLayoutSpec.h in Headers */,
+				2767E9411BB19BD600EA9B77 /* ASViewController.h in Headers */,
+				92DD2FE81BF4D0A80074C9DD /* ASMapNode.h in Headers */,
+				044284FE1BAA387800D16268 /* ASStackLayoutSpecUtilities.h in Headers */,
+				34EFC7751B701D2400AD841F /* ASStackPositionedLayout.h in Headers */,
+				69E1006E1CA89CB600D88C1B /* ASEnvironmentInternal.h in Headers */,
+				34EFC7771B701D2D00AD841F /* ASStackUnpositionedLayout.h in Headers */,
+				9C6BB3B31B8CC9C200F13F52 /* ASStaticLayoutable.h in Headers */,
+				34EFC7731B701D0700AD841F /* ASStaticLayoutSpec.h in Headers */,
+				CC446A2F1D80AAE00071FD03 /* ASObjectDescriptionHelpers.h in Headers */,
+				254C6B781BF94DF4003EC431 /* ASTextKitContext.h in Headers */,
+				B350620A1B010EFD0018CF92 /* ASTableView.h in Headers */,
+				B350620C1B010EFD0018CF92 /* ASTableViewProtocols.h in Headers */,
+				B350620D1B010EFD0018CF92 /* ASTextNode.h in Headers */,
+				B35062391B010EFD0018CF92 /* ASThread.h in Headers */,
+				2C107F5B1BA9F54500F13DE5 /* AsyncDisplayKit.h in Headers */,
+				509E68651B3AEDC5009B9150 /* CGRect+ASConvenience.h in Headers */,
+				B350623A1B010EFD0018CF92 /* NSMutableAttributedString+TextKitAdditions.h in Headers */,
+				044284FF1BAA3BD600D16268 /* UICollectionViewLayout+ASConvenience.h in Headers */,
+				B35062431B010EFD0018CF92 /* UIView+ASConvenience.h in Headers */,
+				8BDA5FC71CDBDF91007D13B2 /* ASVideoPlayerNode.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		057D02BE1AC0A66700C7AC3C /* AsyncDisplayKitTestHost */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 057D02E31AC0A66800C7AC3C /* Build configuration list for PBXNativeTarget "AsyncDisplayKitTestHost" */;
+			buildPhases = (
+				057D02BB1AC0A66700C7AC3C /* Sources */,
+				057D02BC1AC0A66700C7AC3C /* Frameworks */,
+				057D02BD1AC0A66700C7AC3C /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				DEACA2B21C425DC400FA9DDF /* PBXTargetDependency */,
+			);
+			name = AsyncDisplayKitTestHost;
+			productName = AsyncDisplayKitTestHost;
+			productReference = 057D02BF1AC0A66700C7AC3C /* AsyncDisplayKitTestHost.app */;
+			productType = "com.apple.product-type.application";
+		};
+		058D09AB195D04C000B7D73C /* AsyncDisplayKit */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 058D09CF195D04C000B7D73C /* Build configuration list for PBXNativeTarget "AsyncDisplayKit" */;
+			buildPhases = (
+				058D09A8195D04C000B7D73C /* Sources */,
+				058D09A9195D04C000B7D73C /* Frameworks */,
+				058D09AA195D04C000B7D73C /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = AsyncDisplayKit;
+			productName = AsyncDisplayKit;
+			productReference = 058D09AC195D04C000B7D73C /* libAsyncDisplayKit.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		058D09BB195D04C000B7D73C /* AsyncDisplayKitTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 058D09D2195D04C000B7D73C /* Build configuration list for PBXNativeTarget "AsyncDisplayKitTests" */;
+			buildPhases = (
+				2E61B6A0DB0F436A9DDBE86F /* [CP] Check Pods Manifest.lock */,
+				058D09B8195D04C000B7D73C /* Sources */,
+				058D09B9195D04C000B7D73C /* Frameworks */,
+				058D09BA195D04C000B7D73C /* Resources */,
+				3B9D88CDF51B429C8409E4B6 /* [CP] Copy Pods Resources */,
+				B130AB1AC0A1E5162E211C19 /* [CP] Embed Pods Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				058D09C3195D04C000B7D73C /* PBXTargetDependency */,
+				057D02E61AC0A67000C7AC3C /* PBXTargetDependency */,
+			);
+			name = AsyncDisplayKitTests;
+			productName = AsyncDisplayKitTests;
+			productReference = 058D09BC195D04C000B7D73C /* AsyncDisplayKitTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		B35061D91B010EDF0018CF92 /* AsyncDisplayKit-iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B35061ED1B010EDF0018CF92 /* Build configuration list for PBXNativeTarget "AsyncDisplayKit-iOS" */;
+			buildPhases = (
+				B35061D51B010EDF0018CF92 /* Sources */,
+				B35061D61B010EDF0018CF92 /* Frameworks */,
+				B35061D71B010EDF0018CF92 /* Headers */,
+				B35061D81B010EDF0018CF92 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "AsyncDisplayKit-iOS";
+			productName = AsyncDisplayKit;
+			productReference = B35061DA1B010EDF0018CF92 /* AsyncDisplayKit.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		058D09A4195D04C000B7D73C /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				CLASSPREFIX = AS;
+				LastUpgradeCheck = 0720;
+				ORGANIZATIONNAME = Facebook;
+				TargetAttributes = {
+					057D02BE1AC0A66700C7AC3C = {
+						CreatedOnToolsVersion = 6.2;
+					};
+					058D09BB195D04C000B7D73C = {
+						TestTargetID = 057D02BE1AC0A66700C7AC3C;
+					};
+					B35061D91B010EDF0018CF92 = {
+						CreatedOnToolsVersion = 6.3.1;
+					};
+				};
+			};
+			buildConfigurationList = 058D09A7195D04C000B7D73C /* Build configuration list for PBXProject "AsyncDisplayKit" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 058D09A3195D04C000B7D73C;
+			productRefGroup = 058D09AD195D04C000B7D73C /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				058D09AB195D04C000B7D73C /* AsyncDisplayKit */,
+				058D09BB195D04C000B7D73C /* AsyncDisplayKitTests */,
+				057D02BE1AC0A66700C7AC3C /* AsyncDisplayKitTestHost */,
+				B35061D91B010EDF0018CF92 /* AsyncDisplayKit-iOS */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		057D02BD1AC0A66700C7AC3C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				204C979E1B362CB3002B1083 /* Default-568h@2x.png in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		058D09BA195D04C000B7D73C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				052EE06B1A15A0D8002C6279 /* TestResources in Resources */,
+				058D09CA195D04C000B7D73C /* InfoPlist.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B35061D81B010EDF0018CF92 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		2E61B6A0DB0F436A9DDBE86F /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		3B9D88CDF51B429C8409E4B6 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-AsyncDisplayKitTests/Pods-AsyncDisplayKitTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		B130AB1AC0A1E5162E211C19 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-AsyncDisplayKitTests/Pods-AsyncDisplayKitTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		057D02BB1AC0A66700C7AC3C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				057D02C71AC0A66700C7AC3C /* AppDelegate.mm in Sources */,
+				057D02C41AC0A66700C7AC3C /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		058D09A8195D04C000B7D73C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				058D0A22195D050800B7D73C /* _ASAsyncTransaction.mm in Sources */,
+				8B0768B41CE752EC002E1453 /* ASDefaultPlaybackButton.m in Sources */,
+				E55D86321CA8A14000A0C26F /* ASLayoutable.mm in Sources */,
+				68FC85E41CE29B7E00EDD713 /* ASTabBarController.m in Sources */,
+				058D0A23195D050800B7D73C /* _ASAsyncTransactionContainer.m in Sources */,
+				058D0A24195D050800B7D73C /* _ASAsyncTransactionGroup.m in Sources */,
+				68355B3A1CB57A5A001D4E68 /* ASPINRemoteImageDownloader.m in Sources */,
+				DBDB83961C6E879900D0098C /* ASPagerFlowLayout.m in Sources */,
+				058D0A26195D050800B7D73C /* _ASCoreAnimationExtras.mm in Sources */,
+				257754B41BEE44CD00737CA5 /* ASTextKitTailTruncater.mm in Sources */,
+				68B8A4E31CBDB958007E4543 /* ASWeakProxy.m in Sources */,
+				69E1006F1CA89CB600D88C1B /* ASEnvironmentInternal.mm in Sources */,
+				AC026B711BD57DBF00BBC17E /* _ASHierarchyChangeSet.mm in Sources */,
+				257754BF1BEE458E00737CA5 /* ASTextKitCoreTextAdditions.m in Sources */,
+				058D0A18195D050800B7D73C /* _ASDisplayLayer.mm in Sources */,
+				68355B3C1CB57A5A001D4E68 /* ASImageContainerProtocolCategories.m in Sources */,
+				68EE0DBF1C1B4ED300BA1B99 /* ASMainSerialQueue.mm in Sources */,
+				058D0A19195D050800B7D73C /* _ASDisplayView.mm in Sources */,
+				9C55866A1BD549CB00B50E3A /* ASAsciiArtBoxCreator.m in Sources */,
+				69708BA71D76386D005C3CF9 /* ASEqualityHashHelpers.mm in Sources */,
+				058D0A27195D050800B7D73C /* _ASPendingState.mm in Sources */,
+				205F0E1A1B37339C007741D0 /* ASAbstractLayoutController.mm in Sources */,
+				ACF6ED1B1B17843500DA7C62 /* ASBackgroundLayoutSpec.mm in Sources */,
+				0549634A1A1EA066000F8E56 /* ASBasicImageDownloader.mm in Sources */,
+				299DA1AA1A828D2900162D41 /* ASBatchContext.mm in Sources */,
+				AC6456091B0A335000CF11B8 /* ASCellNode.mm in Sources */,
+				DE8BEAC31C2DF3FC00D57C12 /* ASDelegateProxy.m in Sources */,
+				ACF6ED1D1B17843500DA7C62 /* ASCenterLayoutSpec.mm in Sources */,
+				18C2ED801B9B7DE800F627B3 /* ASCollectionNode.mm in Sources */,
+				92DD2FE41BF4B97E0074C9DD /* ASMapNode.mm in Sources */,
+				DBC452DC1C5BF64600B16017 /* NSArray+Diffing.m in Sources */,
+				AC3C4A521A1139C100143C57 /* ASCollectionView.mm in Sources */,
+				9CFFC6C21CCAC768006A6476 /* ASTableNode.mm in Sources */,
+				205F0E1E1B373A2C007741D0 /* ASCollectionViewLayoutController.mm in Sources */,
+				68FC85EB1CE29C7D00EDD713 /* ASVisibilityProtocols.m in Sources */,
+				058D0A13195D050800B7D73C /* ASControlNode.mm in Sources */,
+				464052211A3F83C40061C0BA /* ASDataController.mm in Sources */,
+				B30BF6531C5964B0004FCD53 /* ASLayoutManager.m in Sources */,
+				05A6D05B19D0EB64002DD95E /* ASDealloc2MainObject.m in Sources */,
+				ACF6ED211B17843500DA7C62 /* ASDimension.mm in Sources */,
+				8021EC1E1D2B00B100799119 /* UIImage+ASConvenience.m in Sources */,
+				058D0A28195D050800B7D73C /* ASDisplayNode+AsyncDisplay.mm in Sources */,
+				058D0A29195D050800B7D73C /* ASDisplayNode+DebugTiming.mm in Sources */,
+				764D83D61C8EA515009B4FB8 /* AsyncDisplayKit+Debug.m in Sources */,
+				058D0A2A195D050800B7D73C /* ASDisplayNode+UIViewBridge.mm in Sources */,
+				25E327581C16819500A2170C /* ASPagerNode.m in Sources */,
+				058D0A14195D050800B7D73C /* ASDisplayNode.mm in Sources */,
+				DEC146B81C37A16A004A0EE7 /* ASCollectionInternal.m in Sources */,
+				058D0A15195D050800B7D73C /* ASDisplayNodeExtras.mm in Sources */,
+				AEEC47E21C20C2DD00EC1693 /* ASVideoNode.mm in Sources */,
+				0587F9BE1A7309ED00AFF0BA /* ASEditableTextNode.mm in Sources */,
+				464052231A3F83C40061C0BA /* ASFlowLayoutController.mm in Sources */,
+				257754C41BEE458E00737CA5 /* ASTextNodeWordKerner.m in Sources */,
+				058D0A1A195D050800B7D73C /* ASHighlightOverlayLayer.mm in Sources */,
+				058D0A2B195D050800B7D73C /* ASImageNode+CGExtras.m in Sources */,
+				CC3B208B1C3F7A5400798563 /* ASWeakSet.m in Sources */,
+				058D0A16195D050800B7D73C /* ASImageNode.mm in Sources */,
+				430E7C911B4C23F100697A4C /* ASIndexPath.m in Sources */,
+				ACF6ED231B17843500DA7C62 /* ASInsetLayoutSpec.mm in Sources */,
+				ACF6ED4C1B17847A00DA7C62 /* ASInternalHelpers.m in Sources */,
+				68FC85DF1CE29AB700EDD713 /* ASNavigationController.m in Sources */,
+				ACF6ED251B17843500DA7C62 /* ASLayout.mm in Sources */,
+				CC4981BD1D1C7F65004E13CC /* NSIndexSet+ASHelpers.m in Sources */,
+				DB55C2631C6408D6004EDCF5 /* _ASTransitionContext.m in Sources */,
+				92074A631CC8BA1900918F75 /* ASImageNode+tvOS.m in Sources */,
+				CC446A301D80AAE00071FD03 /* ASObjectDescriptionHelpers.m in Sources */,
+				251B8EFA1BBB3D690087C538 /* ASCollectionViewFlowLayoutInspector.m in Sources */,
+				ACF6ED271B17843500DA7C62 /* ASLayoutSpec.mm in Sources */,
+				257754B01BEE44CD00737CA5 /* ASTextKitRenderer+TextChecking.mm in Sources */,
+				0516FA411A1563D200B4EBED /* ASMultiplexImageNode.mm in Sources */,
+				DECBD6E91BE56E1900CF4905 /* ASButtonNode.mm in Sources */,
+				058D0A1B195D050800B7D73C /* ASMutableAttributedStringBuilder.m in Sources */,
+				055B9FA91A1C154B00035D6D /* ASNetworkImageNode.mm in Sources */,
+				AEB7B01B1C5962EA00662EF4 /* ASDefaultPlayButton.m in Sources */,
+				CC3B20851C3F76D600798563 /* ASPendingStateController.mm in Sources */,
+				ACF6ED2C1B17843500DA7C62 /* ASOverlayLayoutSpec.mm in Sources */,
+				0442850F1BAA64EC00D16268 /* ASMultidimensionalArrayUtils.mm in Sources */,
+				7A06A73A1C35F08800FE8DAA /* ASRelativeLayoutSpec.mm in Sources */,
+				E52405B31C8FEF03004DC8E7 /* ASLayoutTransition.mm in Sources */,
+				69CB62AD1CB8165900024920 /* _ASDisplayViewAccessiblity.mm in Sources */,
+				257754AB1BEE44CD00737CA5 /* ASTextKitEntityAttribute.m in Sources */,
+				055F1A3919ABD413004DAFF1 /* ASRangeController.mm in Sources */,
+				044285091BAA63FE00D16268 /* ASBatchFetching.m in Sources */,
+				257754AE1BEE44CD00737CA5 /* ASTextKitRenderer+Positioning.mm in Sources */,
+				ACF6ED2E1B17843500DA7C62 /* ASRatioLayoutSpec.mm in Sources */,
+				AC47D9461B3BB41900AAEE9D /* ASRelativeSize.mm in Sources */,
+				CC4C2A781D88E3BF0039ACAB /* ASTraceEvent.m in Sources */,
+				205F0E121B371BD7007741D0 /* ASScrollDirection.m in Sources */,
+				9C8898BB1C738B9800D6B02E /* ASTextKitFontSizeAdjuster.mm in Sources */,
+				D785F6631A74327E00291744 /* ASScrollNode.m in Sources */,
+				E5711A2E1C840C96009619D4 /* ASIndexedNodeContext.mm in Sources */,
+				058D0A2C195D050800B7D73C /* ASSentinel.m in Sources */,
+				9C8221971BA237B80037F19A /* ASStackBaselinePositionedLayout.mm in Sources */,
+				251B8EF81BBB3D690087C538 /* ASCollectionDataController.mm in Sources */,
+				ACF6ED301B17843500DA7C62 /* ASStackLayoutSpec.mm in Sources */,
+				257754BE1BEE458E00737CA5 /* ASTextKitComponents.m in Sources */,
+				257754A91BEE44CD00737CA5 /* ASTextKitContext.mm in Sources */,
+				697C0DE51CF38F28001DE0D4 /* ASLayoutValidation.mm in Sources */,
+				ACF6ED501B17847A00DA7C62 /* ASStackPositionedLayout.mm in Sources */,
+				ACF6ED521B17847A00DA7C62 /* ASStackUnpositionedLayout.mm in Sources */,
+				83A7D95A1D44542100BF333E /* ASWeakMap.m in Sources */,
+				257754A61BEE44CD00737CA5 /* ASTextKitAttributes.mm in Sources */,
+				81EE38501C8E94F000456208 /* ASRunLoopQueue.mm in Sources */,
+				9C70F2041CDA4EFA007D6C76 /* ASTraitCollection.m in Sources */,
+				92074A691CC8BADA00918F75 /* ASControlNode+tvOS.m in Sources */,
+				ACF6ED321B17843500DA7C62 /* ASStaticLayoutSpec.mm in Sources */,
+				AC026B6B1BD57D6F00BBC17E /* ASChangeSetDataController.mm in Sources */,
+				68355B311CB5799E001D4E68 /* ASImageNode+AnimatedImage.mm in Sources */,
+				9CFFC6C01CCAC73C006A6476 /* ASViewController.mm in Sources */,
+				055F1A3519ABD3E3004DAFF1 /* ASTableView.mm in Sources */,
+				6959433E1D70815300B0EE1F /* ASDisplayNodeLayout.mm in Sources */,
+				058D0A17195D050800B7D73C /* ASTextNode.mm in Sources */,
+				257754AC1BEE44CD00737CA5 /* ASTextKitRenderer.mm in Sources */,
+				8BDA5FC61CDBDDE1007D13B2 /* ASVideoPlayerNode.mm in Sources */,
+				205F0E221B376416007741D0 /* CGRect+ASConvenience.m in Sources */,
+				257754B21BEE44CD00737CA5 /* ASTextKitShadower.mm in Sources */,
+				9CFFC6BE1CCAC52B006A6476 /* ASEnvironment.mm in Sources */,
+				058D0A21195D050800B7D73C /* NSMutableAttributedString+TextKitAdditions.m in Sources */,
+				205F0E101B371875007741D0 /* UICollectionViewLayout+ASConvenience.m in Sources */,
+				CC7FD9DF1BB5E962005CCB2B /* ASPhotosFrameworkImageRequest.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		058D09B8195D04C000B7D73C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				29CDC2E21AAE70D000833CA4 /* ASBasicImageDownloaderContextTests.m in Sources */,
+				CC051F1F1D7A286A006434CB /* ASCALayerTests.m in Sources */,
+				242995D31B29743C00090100 /* ASBasicImageDownloaderTests.m in Sources */,
+				296A0A351A951ABF005ACEAA /* ASBatchFetchingTests.m in Sources */,
+				ACF6ED5C1B178DC700DA7C62 /* ASCenterLayoutSpecSnapshotTests.mm in Sources */,
+				9F06E5CD1B4CAF4200F015D8 /* ASCollectionViewTests.mm in Sources */,
+				2911485C1A77147A005D0878 /* ASControlNodeTests.m in Sources */,
+				CC3B208E1C3F7D0A00798563 /* ASWeakSetTests.m in Sources */,
+				F711994E1D20C21100568860 /* ASDisplayNodeExtrasTests.m in Sources */,
+				ACF6ED5D1B178DC700DA7C62 /* ASDimensionTests.mm in Sources */,
+				CCA221D31D6FA7EF00AF6A0F /* ASViewControllerTests.m in Sources */,
+				058D0A38195D057000B7D73C /* ASDisplayLayerTests.m in Sources */,
+				2538B6F31BC5D2A2003CA0B4 /* ASCollectionViewFlowLayoutInspectorTests.m in Sources */,
+				058D0A39195D057000B7D73C /* ASDisplayNodeAppearanceTests.m in Sources */,
+				CCB2F34D1D63CCC6004E6DE9 /* ASDisplayNodeSnapshotTests.m in Sources */,
+				058D0A3A195D057000B7D73C /* ASDisplayNodeTests.m in Sources */,
+				696FCB311D6E46050093471E /* ASBackgroundLayoutSpecSnapshotTests.mm in Sources */,
+				CC4981B31D1A02BE004E13CC /* ASTableViewThrashTests.m in Sources */,
+				CC54A81E1D7008B300296A24 /* ASDispatchTests.m in Sources */,
+				058D0A3B195D057000B7D73C /* ASDisplayNodeTestsHelper.m in Sources */,
+				83A7D95E1D446A6E00BF333E /* ASWeakMapTests.m in Sources */,
+				056D21551ABCEF50001107EF /* ASImageNodeSnapshotTests.m in Sources */,
+				AC026B581BD3F61800BBC17E /* ASStaticLayoutSpecSnapshotTests.m in Sources */,
+				ACF6ED5E1B178DC700DA7C62 /* ASInsetLayoutSpecSnapshotTests.mm in Sources */,
+				ACF6ED601B178DC700DA7C62 /* ASLayoutSpecSnapshotTestsHelper.m in Sources */,
+				CC7FD9E11BB5F750005CCB2B /* ASPhotosFrameworkImageRequestTests.m in Sources */,
+				052EE0661A159FEF002C6279 /* ASMultiplexImageNodeTests.m in Sources */,
+				058D0A3C195D057000B7D73C /* ASMutableAttributedStringBuilderTests.m in Sources */,
+				CC8B05D81D73979700F54286 /* ASTextNodePerformanceTests.m in Sources */,
+				697B315A1CFE4B410049936F /* ASEditableTextNodeTests.m in Sources */,
+				ACF6ED611B178DC700DA7C62 /* ASOverlayLayoutSpecSnapshotTests.mm in Sources */,
+				CC8B05D61D73836400F54286 /* ASPerformanceTestContext.m in Sources */,
+				CC0AEEA41D66316E005D1C78 /* ASUICollectionViewTests.m in Sources */,
+				69B225671D72535E00B25B22 /* ASDisplayNodeLayoutTests.mm in Sources */,
+				ACF6ED621B178DC700DA7C62 /* ASRatioLayoutSpecSnapshotTests.mm in Sources */,
+				7AB338691C55B97B0055FDE8 /* ASRelativeLayoutSpecSnapshotTests.mm in Sources */,
+				254C6B541BF8FF2A003EC431 /* ASTextKitTests.mm in Sources */,
+				05EA6FE71AC0966E00E35788 /* ASSnapshotTestCase.m in Sources */,
+				ACF6ED631B178DC700DA7C62 /* ASStackLayoutSpecSnapshotTests.mm in Sources */,
+				81E95C141D62639600336598 /* ASTextNodeSnapshotTests.m in Sources */,
+				3C9C128519E616EF00E942A0 /* ASTableViewTests.m in Sources */,
+				AEEC47E41C21D3D200EC1693 /* ASVideoNodeTests.m in Sources */,
+				254C6B521BF8FE6D003EC431 /* ASTextKitTruncationTests.mm in Sources */,
+				058D0A3D195D057000B7D73C /* ASTextKitCoreTextAdditionsTests.m in Sources */,
+				CC3B20901C3F892D00798563 /* ASBridgedPropertiesTests.mm in Sources */,
+				058D0A40195D057000B7D73C /* ASTextNodeTests.m in Sources */,
+				DBC453221C5FD97200B16017 /* ASDisplayNodeImplicitHierarchyTests.m in Sources */,
+				058D0A41195D057000B7D73C /* ASTextNodeWordKernerTests.mm in Sources */,
+				DBC452DE1C5C6A6A00B16017 /* ArrayDiffingTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B35061D51B010EDF0018CF92 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9C70F2091CDABA36007D6C76 /* ASViewController.mm in Sources */,
+				8BBBAB8D1CEBAF1E00107FC6 /* ASDefaultPlaybackButton.m in Sources */,
+				DE4843DB1C93EAB100A1F33B /* ASLayoutTransition.mm in Sources */,
+				B30BF6541C59D889004FCD53 /* ASLayoutManager.m in Sources */,
+				92DD2FE71BF4D0850074C9DD /* ASMapNode.mm in Sources */,
+				636EA1A51C7FF4EF00EE152F /* ASDefaultPlayButton.m in Sources */,
+				9B92C8861BC2EB7600EE46B2 /* ASCollectionViewFlowLayoutInspector.m in Sources */,
+				9B92C8851BC2EB6E00EE46B2 /* ASCollectionDataController.mm in Sources */,
+				B350623D1B010EFD0018CF92 /* _ASAsyncTransaction.mm in Sources */,
+				B35062401B010EFD0018CF92 /* _ASAsyncTransactionContainer.m in Sources */,
+				AC026B721BD57DBF00BBC17E /* _ASHierarchyChangeSet.mm in Sources */,
+				B35062421B010EFD0018CF92 /* _ASAsyncTransactionGroup.m in Sources */,
+				B350624A1B010EFD0018CF92 /* _ASCoreAnimationExtras.mm in Sources */,
+				68EE0DC01C1B4ED300BA1B99 /* ASMainSerialQueue.mm in Sources */,
+				B35062101B010EFD0018CF92 /* _ASDisplayLayer.mm in Sources */,
+				9C55866B1BD54A1900B50E3A /* ASAsciiArtBoxCreator.m in Sources */,
+				B35062121B010EFD0018CF92 /* _ASDisplayView.mm in Sources */,
+				DEFAD8131CC48914000527C4 /* ASVideoNode.mm in Sources */,
+				B350624C1B010EFD0018CF92 /* _ASPendingState.mm in Sources */,
+				69708BA81D76386D005C3CF9 /* ASEqualityHashHelpers.mm in Sources */,
+				509E68621B3AEDA5009B9150 /* ASAbstractLayoutController.mm in Sources */,
+				254C6B861BF94F8A003EC431 /* ASTextKitContext.mm in Sources */,
+				DBDB83971C6E879900D0098C /* ASPagerFlowLayout.m in Sources */,
+				9C8898BC1C738BA800D6B02E /* ASTextKitFontSizeAdjuster.mm in Sources */,
+				34EFC7621B701CA400AD841F /* ASBackgroundLayoutSpec.mm in Sources */,
+				DE8BEAC41C2DF3FC00D57C12 /* ASDelegateProxy.m in Sources */,
+				9C70F2081CDAA3C6007D6C76 /* ASEnvironment.mm in Sources */,
+				B35062141B010EFD0018CF92 /* ASBasicImageDownloader.mm in Sources */,
+				B35062161B010EFD0018CF92 /* ASBatchContext.mm in Sources */,
+				AC47D9421B3B891B00AAEE9D /* ASCellNode.mm in Sources */,
+				34EFC7641B701CC600AD841F /* ASCenterLayoutSpec.mm in Sources */,
+				18C2ED831B9B7DE800F627B3 /* ASCollectionNode.mm in Sources */,
+				E55D86331CA8A14000A0C26F /* ASLayoutable.mm in Sources */,
+				68FC85EC1CE29C7D00EDD713 /* ASVisibilityProtocols.m in Sources */,
+				68B8A4E41CBDB958007E4543 /* ASWeakProxy.m in Sources */,
+				9C70F20A1CDBE949007D6C76 /* ASTableNode.mm in Sources */,
+				69CB62AE1CB8165900024920 /* _ASDisplayViewAccessiblity.mm in Sources */,
+				B35061F61B010EFD0018CF92 /* ASCollectionView.mm in Sources */,
+				509E68641B3AEDB7009B9150 /* ASCollectionViewLayoutController.mm in Sources */,
+				B35061F91B010EFD0018CF92 /* ASControlNode.mm in Sources */,
+				8021EC1F1D2B00B100799119 /* UIImage+ASConvenience.m in Sources */,
+				B35062181B010EFD0018CF92 /* ASDataController.mm in Sources */,
+				B350621A1B010EFD0018CF92 /* ASDealloc2MainObject.m in Sources */,
+				767E7F8E1C90191D0066C000 /* AsyncDisplayKit+Debug.m in Sources */,
+				34EFC75C1B701BD200AD841F /* ASDimension.mm in Sources */,
+				B350624E1B010EFD0018CF92 /* ASDisplayNode+AsyncDisplay.mm in Sources */,
+				25E327591C16819500A2170C /* ASPagerNode.m in Sources */,
+				636EA1A41C7FF4EC00EE152F /* NSArray+Diffing.m in Sources */,
+				B35062501B010EFD0018CF92 /* ASDisplayNode+DebugTiming.mm in Sources */,
+				DEC146B91C37A16A004A0EE7 /* ASCollectionInternal.m in Sources */,
+				69E100701CA89CB600D88C1B /* ASEnvironmentInternal.mm in Sources */,
+				254C6B891BF94F8A003EC431 /* ASTextKitRenderer+Positioning.mm in Sources */,
+				68355B341CB579B9001D4E68 /* ASImageNode+AnimatedImage.mm in Sources */,
+				E5711A301C840C96009619D4 /* ASIndexedNodeContext.mm in Sources */,
+				B35062511B010EFD0018CF92 /* ASDisplayNode+UIViewBridge.mm in Sources */,
+				B35061FC1B010EFD0018CF92 /* ASDisplayNode.mm in Sources */,
+				B35061FF1B010EFD0018CF92 /* ASDisplayNodeExtras.mm in Sources */,
+				B35062011B010EFD0018CF92 /* ASEditableTextNode.mm in Sources */,
+				254C6B881BF94F8A003EC431 /* ASTextKitRenderer.mm in Sources */,
+				CC3B208C1C3F7A5400798563 /* ASWeakSet.m in Sources */,
+				B350621C1B010EFD0018CF92 /* ASFlowLayoutController.mm in Sources */,
+				B350621E1B010EFD0018CF92 /* ASHighlightOverlayLayer.mm in Sources */,
+				9CC606651D24DF9E006581A0 /* NSIndexSet+ASHelpers.m in Sources */,
+				92074A641CC8BA1900918F75 /* ASImageNode+tvOS.m in Sources */,
+				B35062541B010EFD0018CF92 /* ASImageNode+CGExtras.m in Sources */,
+				CC446A311D80AAE00071FD03 /* ASObjectDescriptionHelpers.m in Sources */,
+				68355B401CB57A69001D4E68 /* ASImageContainerProtocolCategories.m in Sources */,
+				B35062031B010EFD0018CF92 /* ASImageNode.mm in Sources */,
+				254C6B821BF94F8A003EC431 /* ASTextKitComponents.m in Sources */,
+				430E7C921B4C23F100697A4C /* ASIndexPath.m in Sources */,
+				34EFC7601B701C8B00AD841F /* ASInsetLayoutSpec.mm in Sources */,
+				34EFC75E1B701BF000AD841F /* ASInternalHelpers.m in Sources */,
+				34EFC7681B701CDE00AD841F /* ASLayout.mm in Sources */,
+				DECBD6EA1BE56E1900CF4905 /* ASButtonNode.mm in Sources */,
+				254C6B841BF94F8A003EC431 /* ASTextNodeWordKerner.m in Sources */,
+				34EFC76B1B701CEB00AD841F /* ASLayoutSpec.mm in Sources */,
+				CC3B20861C3F76D600798563 /* ASPendingStateController.mm in Sources */,
+				254C6B8C1BF94F8A003EC431 /* ASTextKitTailTruncater.mm in Sources */,
+				B35062051B010EFD0018CF92 /* ASMultiplexImageNode.mm in Sources */,
+				B35062251B010EFD0018CF92 /* ASMutableAttributedStringBuilder.m in Sources */,
+				B35062071B010EFD0018CF92 /* ASNetworkImageNode.mm in Sources */,
+				34EFC76D1B701CF100AD841F /* ASOverlayLayoutSpec.mm in Sources */,
+				044285101BAA64EC00D16268 /* ASMultidimensionalArrayUtils.mm in Sources */,
+				B35062271B010EFD0018CF92 /* ASRangeController.mm in Sources */,
+				0442850A1BAA63FE00D16268 /* ASBatchFetching.m in Sources */,
+				68FC85E61CE29B9400EDD713 /* ASNavigationController.m in Sources */,
+				CC4C2A791D88E3BF0039ACAB /* ASTraceEvent.m in Sources */,
+				34EFC76F1B701CF700AD841F /* ASRatioLayoutSpec.mm in Sources */,
+				254C6B8B1BF94F8A003EC431 /* ASTextKitShadower.mm in Sources */,
+				34EFC7661B701CD200AD841F /* ASRelativeSize.mm in Sources */,
+				254C6B851BF94F8A003EC431 /* ASTextKitAttributes.mm in Sources */,
+				509E68601B3AED8E009B9150 /* ASScrollDirection.m in Sources */,
+				B35062091B010EFD0018CF92 /* ASScrollNode.m in Sources */,
+				B35062561B010EFD0018CF92 /* ASSentinel.m in Sources */,
+				9C8221981BA237B80037F19A /* ASStackBaselinePositionedLayout.mm in Sources */,
+				8BDA5FC81CDBDF95007D13B2 /* ASVideoPlayerNode.mm in Sources */,
+				34EFC7721B701D0300AD841F /* ASStackLayoutSpec.mm in Sources */,
+				34EFC7761B701D2A00AD841F /* ASStackPositionedLayout.mm in Sources */,
+				7AB338661C55B3420055FDE8 /* ASRelativeLayoutSpec.mm in Sources */,
+				697C0DE61CF38F28001DE0D4 /* ASLayoutValidation.mm in Sources */,
+				9C70F2051CDA4F06007D6C76 /* ASTraitCollection.m in Sources */,
+				83A7D95B1D44547700BF333E /* ASWeakMap.m in Sources */,
+				34EFC7781B701D3100AD841F /* ASStackUnpositionedLayout.mm in Sources */,
+				DE84918E1C8FFF9F003D89E9 /* ASRunLoopQueue.mm in Sources */,
+				68FC85E51CE29B7E00EDD713 /* ASTabBarController.m in Sources */,
+				AC026B6C1BD57D6F00BBC17E /* ASChangeSetDataController.mm in Sources */,
+				34EFC7741B701D0A00AD841F /* ASStaticLayoutSpec.mm in Sources */,
+				92074A6A1CC8BADA00918F75 /* ASControlNode+tvOS.m in Sources */,
+				DB78412E1C6BCE1600A9E2B4 /* _ASTransitionContext.m in Sources */,
+				B350620B1B010EFD0018CF92 /* ASTableView.mm in Sources */,
+				B350620E1B010EFD0018CF92 /* ASTextNode.mm in Sources */,
+				6959433F1D70815300B0EE1F /* ASDisplayNodeLayout.mm in Sources */,
+				68355B3E1CB57A60001D4E68 /* ASPINRemoteImageDownloader.m in Sources */,
+				509E68661B3AEDD7009B9150 /* CGRect+ASConvenience.m in Sources */,
+				254C6B871BF94F8A003EC431 /* ASTextKitEntityAttribute.m in Sources */,
+				34566CB31BC1213700715E6B /* ASPhotosFrameworkImageRequest.m in Sources */,
+				254C6B831BF94F8A003EC431 /* ASTextKitCoreTextAdditions.m in Sources */,
+				B350623B1B010EFD0018CF92 /* NSMutableAttributedString+TextKitAdditions.m in Sources */,
+				044284FD1BAA365100D16268 /* UICollectionViewLayout+ASConvenience.m in Sources */,
+				254C6B8A1BF94F8A003EC431 /* ASTextKitRenderer+TextChecking.mm in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		057D02E61AC0A67000C7AC3C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 057D02BE1AC0A66700C7AC3C /* AsyncDisplayKitTestHost */;
+			targetProxy = 057D02E51AC0A67000C7AC3C /* PBXContainerItemProxy */;
+		};
+		058D09C3195D04C000B7D73C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 058D09AB195D04C000B7D73C /* AsyncDisplayKit */;
+			targetProxy = 058D09C2195D04C000B7D73C /* PBXContainerItemProxy */;
+		};
+		DEACA2B21C425DC400FA9DDF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 058D09AB195D04C000B7D73C /* AsyncDisplayKit */;
+			targetProxy = DEACA2B11C425DC400FA9DDF /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		058D09C8195D04C000B7D73C /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				058D09C9195D04C000B7D73C /* en */,
+			);
+			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		057D02DF1AC0A66800C7AC3C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_INSTRUMENT_PROGRAM_FLOW_ARCS = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = AsyncDisplayKitTestHost/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.facebook.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		057D02E01AC0A66800C7AC3C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_INSTRUMENT_PROGRAM_FLOW_ARCS = NO;
+				INFOPLIST_FILE = AsyncDisplayKitTestHost/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.facebook.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		058D09CD195D04C000B7D73C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_CODE_COVERAGE = NO;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_GENERATE_TEST_COVERAGE_FILES = YES;
+				GCC_INSTRUMENT_PROGRAM_FLOW_ARCS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		058D09CE195D04C000B7D73C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_CODE_COVERAGE = NO;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_GENERATE_TEST_COVERAGE_FILES = YES;
+				GCC_INSTRUMENT_PROGRAM_FLOW_ARCS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		058D09D0195D04C000B7D73C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ENABLE_CODE_COVERAGE = YES;
+				DSTROOT = /tmp/AsyncDisplayKit.dst;
+				GCC_INPUT_FILETYPE = automatic;
+				GCC_INSTRUMENT_PROGRAM_FLOW_ARCS = NO;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "AsyncDisplayKit/AsyncDisplayKit-Prefix.pch";
+				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
+				GCC_WARN_ABOUT_MISSING_NEWLINE = YES;
+				GCC_WARN_INITIALIZER_NOT_FULLY_BRACKETED = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				OTHER_CFLAGS = "-Wall";
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "include/$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		058D09D1195D04C000B7D73C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ENABLE_CODE_COVERAGE = YES;
+				DSTROOT = /tmp/AsyncDisplayKit.dst;
+				GCC_INPUT_FILETYPE = automatic;
+				GCC_INSTRUMENT_PROGRAM_FLOW_ARCS = NO;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "AsyncDisplayKit/AsyncDisplayKit-Prefix.pch";
+				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
+				GCC_WARN_ABOUT_MISSING_NEWLINE = YES;
+				GCC_WARN_INITIALIZER_NOT_FULLY_BRACKETED = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				OTHER_CFLAGS = "-Wall";
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "include/$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		058D09D3195D04C000B7D73C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FB07EABBCF28656C6297BC2D /* Pods-AsyncDisplayKitTests.debug.xcconfig */;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ENABLE_CODE_COVERAGE = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+				);
+				GCC_INSTRUMENT_PROGRAM_FLOW_ARCS = NO;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "AsyncDisplayKit/AsyncDisplayKit-Prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+					"COCOAPODS=1",
+					"FB_REFERENCE_IMAGE_DIR=\"\\\"$(SOURCE_ROOT)/$(PROJECT_NAME)Tests/ReferenceImages\\\"\"",
+				);
+				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
+				GCC_WARN_INITIALIZER_NOT_FULLY_BRACKETED = YES;
+				INFOPLIST_FILE = "AsyncDisplayKitTests/AsyncDisplayKitTests-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.facebook.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AsyncDisplayKitTestHost.app/AsyncDisplayKitTestHost";
+				WRAPPER_EXTENSION = xctest;
+			};
+			name = Debug;
+		};
+		058D09D4195D04C000B7D73C /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = D3779BCFF841AD3EB56537ED /* Pods-AsyncDisplayKitTests.release.xcconfig */;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ENABLE_CODE_COVERAGE = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+				);
+				GCC_INSTRUMENT_PROGRAM_FLOW_ARCS = NO;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "AsyncDisplayKit/AsyncDisplayKit-Prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"COCOAPODS=1",
+					"FB_REFERENCE_IMAGE_DIR=\"\\\"$(SOURCE_ROOT)/$(PROJECT_NAME)Tests/ReferenceImages\\\"\"",
+				);
+				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
+				GCC_WARN_INITIALIZER_NOT_FULLY_BRACKETED = YES;
+				INFOPLIST_FILE = "AsyncDisplayKitTests/AsyncDisplayKitTests-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.facebook.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AsyncDisplayKitTestHost.app/AsyncDisplayKitTestHost";
+				WRAPPER_EXTENSION = xctest;
+			};
+			name = Release;
+		};
+		B35061EE1B010EDF0018CF92 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_CODE_COVERAGE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_INSTRUMENT_PROGRAM_FLOW_ARCS = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREFIX_HEADER = "AsyncDisplayKit/AsyncDisplayKit-Prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = "$(SRCROOT)/AsyncDisplayKit-iOS/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = AsyncDisplayKit/module.modulemap;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.facebook.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = AsyncDisplayKit;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		B35061EF1B010EDF0018CF92 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_CODE_COVERAGE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_INSTRUMENT_PROGRAM_FLOW_ARCS = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREFIX_HEADER = "AsyncDisplayKit/AsyncDisplayKit-Prefix.pch";
+				INFOPLIST_FILE = "$(SRCROOT)/AsyncDisplayKit-iOS/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = AsyncDisplayKit/module.modulemap;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.facebook.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = AsyncDisplayKit;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		DB1020801CBCA2AD00FA6FE1 /* Profile */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_CODE_COVERAGE = NO;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_GENERATE_TEST_COVERAGE_FILES = YES;
+				GCC_INSTRUMENT_PROGRAM_FLOW_ARCS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Profile;
+		};
+		DB1020811CBCA2AD00FA6FE1 /* Profile */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ENABLE_CODE_COVERAGE = YES;
+				DSTROOT = /tmp/AsyncDisplayKit.dst;
+				GCC_INPUT_FILETYPE = automatic;
+				GCC_INSTRUMENT_PROGRAM_FLOW_ARCS = NO;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "AsyncDisplayKit/AsyncDisplayKit-Prefix.pch";
+				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
+				GCC_WARN_ABOUT_MISSING_NEWLINE = YES;
+				GCC_WARN_INITIALIZER_NOT_FULLY_BRACKETED = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				OTHER_CFLAGS = "-Wall";
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "include/$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Profile;
+		};
+		DB1020821CBCA2AD00FA6FE1 /* Profile */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = BDC2D162BD55A807C1475DA5 /* Pods-AsyncDisplayKitTests.profile.xcconfig */;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ENABLE_CODE_COVERAGE = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+				);
+				GCC_INSTRUMENT_PROGRAM_FLOW_ARCS = NO;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "AsyncDisplayKit/AsyncDisplayKit-Prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"COCOAPODS=1",
+					"FB_REFERENCE_IMAGE_DIR=\"\\\"$(SOURCE_ROOT)/$(PROJECT_NAME)Tests/ReferenceImages\\\"\"",
+				);
+				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
+				GCC_WARN_INITIALIZER_NOT_FULLY_BRACKETED = YES;
+				INFOPLIST_FILE = "AsyncDisplayKitTests/AsyncDisplayKitTests-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.facebook.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AsyncDisplayKitTestHost.app/AsyncDisplayKitTestHost";
+				WRAPPER_EXTENSION = xctest;
+			};
+			name = Profile;
+		};
+		DB1020831CBCA2AD00FA6FE1 /* Profile */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_INSTRUMENT_PROGRAM_FLOW_ARCS = NO;
+				INFOPLIST_FILE = AsyncDisplayKitTestHost/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.facebook.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Profile;
+		};
+		DB1020841CBCA2AD00FA6FE1 /* Profile */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_CODE_COVERAGE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_INSTRUMENT_PROGRAM_FLOW_ARCS = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREFIX_HEADER = "AsyncDisplayKit/AsyncDisplayKit-Prefix.pch";
+				INFOPLIST_FILE = "$(SRCROOT)/AsyncDisplayKit-iOS/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = AsyncDisplayKit/module.modulemap;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.facebook.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = AsyncDisplayKit;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Profile;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		057D02E31AC0A66800C7AC3C /* Build configuration list for PBXNativeTarget "AsyncDisplayKitTestHost" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				057D02DF1AC0A66800C7AC3C /* Debug */,
+				057D02E01AC0A66800C7AC3C /* Release */,
+				DB1020831CBCA2AD00FA6FE1 /* Profile */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		058D09A7195D04C000B7D73C /* Build configuration list for PBXProject "AsyncDisplayKit" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				058D09CD195D04C000B7D73C /* Debug */,
+				058D09CE195D04C000B7D73C /* Release */,
+				DB1020801CBCA2AD00FA6FE1 /* Profile */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		058D09CF195D04C000B7D73C /* Build configuration list for PBXNativeTarget "AsyncDisplayKit" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				058D09D0195D04C000B7D73C /* Debug */,
+				058D09D1195D04C000B7D73C /* Release */,
+				DB1020811CBCA2AD00FA6FE1 /* Profile */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		058D09D2195D04C000B7D73C /* Build configuration list for PBXNativeTarget "AsyncDisplayKitTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				058D09D3195D04C000B7D73C /* Debug */,
+				058D09D4195D04C000B7D73C /* Release */,
+				DB1020821CBCA2AD00FA6FE1 /* Profile */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		B35061ED1B010EDF0018CF92 /* Build configuration list for PBXNativeTarget "AsyncDisplayKit-iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B35061EE1B010EDF0018CF92 /* Debug */,
+				B35061EF1B010EDF0018CF92 /* Release */,
+				DB1020841CBCA2AD00FA6FE1 /* Profile */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 058D09A4195D04C000B7D73C /* Project object */;
+}

--- a/AsyncDisplayKit/TextKit/ASTextKitFontSizeAdjuster.mm
+++ b/AsyncDisplayKit/TextKit/ASTextKitFontSizeAdjuster.mm
@@ -150,7 +150,7 @@
     }
     
     NSUInteger scaleIndex = 0;
-    NSAttributedString *scaledString = [[NSMutableAttributedString alloc] initWithAttributedString:textStorage];
+    NSMutableAttributedString *scaledString = [[NSMutableAttributedString alloc] initWithAttributedString:textStorage];
 
     // find the longest word and make sure it fits in the constrained width
     if ([longestWordNeedingResize length] > 0) {
@@ -196,7 +196,6 @@
           
           if ([self lineCountForString:scaledString] <= _attributes.maximumNumberOfLines) {
             // we fit! we are done
-            [[self class] adjustFontSizeForAttributeString:scaledString withScaleFactor:adjustedScale];
             break;
           }
         }

--- a/AsyncDisplayKit/TextKit/ASTextKitFontSizeAdjuster.mm
+++ b/AsyncDisplayKit/TextKit/ASTextKitFontSizeAdjuster.mm
@@ -185,6 +185,10 @@
       if (numberOfLines > _attributes.maximumNumberOfLines) {
         
         for (NSUInteger index = scaleIndex; index < scaleFactors.count; index++) {
+          // we are going to have to scale the string more. Reset it so we apply the scale factor to the full font size, not the scaled font size
+          // e.g., Say we scaled 90% of the original 16pt font so the longest word will fit. scaledString now has a font size of 14.4. If 14.4pt is
+          // still too large to fit in our max number of lines we will scale by the next factor, say 80%. We don't want to multiple 14.4 * .8, but
+          // the original 16pt * .8 to get a point size of 12.8
           scaledString = [[NSMutableAttributedString alloc] initWithAttributedString:textStorage];
           
           // save away this scale factor. Even if we don't fit completely we should still scale down
@@ -206,6 +210,7 @@
     CGSize stringSize = [scaledString boundingRectWithSize:CGSizeMake(_constrainedSize.width, CGFLOAT_MAX) options:NSStringDrawingUsesLineFragmentOrigin context:nil].size;
     if (stringSize.height > _constrainedSize.height) {
       for (NSUInteger index = scaleIndex; index < scaleFactors.count; index++) {
+        // we are going to have to scale the string more. Reset it so we apply the scale factor to the full font size, not the scaled font size
         scaledString = [[NSMutableAttributedString alloc] initWithAttributedString:textStorage];
         
         // save away this scale factor. Even if we don't fit completely we should still scale down

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # **** Update me when new Xcode versions are released! ****
-PLATFORM="platform=iOS Simulator,OS=9.3,name=iPhone 6"
+PLATFORM="platform=iOS Simulator,OS=10.0,name=iPhone 7"
 SDK="iphonesimulator10.0"
 
 

--- a/examples/Swift/Sample.xcodeproj/project.pbxproj
+++ b/examples/Swift/Sample.xcodeproj/project.pbxproj
@@ -109,12 +109,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 050E7C8D19D22E1A004363C2 /* Build configuration list for PBXNativeTarget "Sample" */;
 			buildPhases = (
-				B8824BD0ED824BAD8268EC35 /* Check Pods Manifest.lock */,
+				B8824BD0ED824BAD8268EC35 /* [CP] Check Pods Manifest.lock */,
 				050E7C6A19D22E19004363C2 /* Sources */,
 				050E7C6B19D22E19004363C2 /* Frameworks */,
 				050E7C6C19D22E19004363C2 /* Resources */,
-				941C5E41C54B4613A2D3B760 /* Copy Pods Resources */,
-				1F5A9F09F5875F61862D0783 /* Embed Pods Frameworks */,
+				941C5E41C54B4613A2D3B760 /* [CP] Copy Pods Resources */,
+				1F5A9F09F5875F61862D0783 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -138,6 +138,7 @@
 				TargetAttributes = {
 					050E7C6D19D22E19004363C2 = {
 						CreatedOnToolsVersion = 6.0.1;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -173,14 +174,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		1F5A9F09F5875F61862D0783 /* Embed Pods Frameworks */ = {
+		1F5A9F09F5875F61862D0783 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Embed Pods Frameworks";
+			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -188,14 +189,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Sample/Pods-Sample-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		941C5E41C54B4613A2D3B760 /* Copy Pods Resources */ = {
+		941C5E41C54B4613A2D3B760 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Copy Pods Resources";
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -203,14 +204,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Sample/Pods-Sample-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		B8824BD0ED824BAD8268EC35 /* Check Pods Manifest.lock */ = {
+		B8824BD0ED824BAD8268EC35 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Check Pods Manifest.lock";
+			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -321,6 +322,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.facebook.AsyncDisplayKit.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -333,6 +335,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.facebook.AsyncDisplayKit.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};

--- a/examples/Swift/Sample/TailLoadingCellNode.swift
+++ b/examples/Swift/Sample/TailLoadingCellNode.swift
@@ -55,7 +55,7 @@ final class SpinnerNode: ASDisplayNode {
   override init() {
     super.init(viewBlock: { UIActivityIndicatorView(activityIndicatorStyle: .Gray) }, didLoadBlock: nil)
     
-    size.minHeight = ASDimensionMakeWithPoints(44.0)
+    self.style.minHeight = ASDimensionMakeWithPoints(44.0)
   }
 
   override func didLoad() {

--- a/examples/Videos/Sample/ViewController.m
+++ b/examples/Videos/Sample/ViewController.m
@@ -54,17 +54,17 @@
   _rootNode.layoutSpecBlock = ^ASLayoutSpec *(ASDisplayNode * _Nonnull node, ASSizeRange constrainedSize) {
     
     // Layout all nodes absolute in a static layout spec
-    [guitarVideoNode setSizeWithCGSize:CGSizeMake(mainScreenBoundsSize.width, mainScreenBoundsSize.height / 3.0)];
-    guitarVideoNode.layoutPosition = CGPointMake(0, 0);
+    guitarVideoNode.style.size = ASLayoutableSizeMakeFromCGSize(CGSizeMake(mainScreenBoundsSize.width, mainScreenBoundsSize.height / 3.0));
+    guitarVideoNode.style.layoutPosition = CGPointMake(0, 0);
     
-    [nicCageVideoNode setSizeWithCGSize:CGSizeMake(mainScreenBoundsSize.width/2, mainScreenBoundsSize.height / 3.0)];
-    nicCageVideoNode.layoutPosition = CGPointMake(mainScreenBoundsSize.width / 2.0, mainScreenBoundsSize.height / 3.0);
+    nicCageVideoNode.style.size = ASLayoutableSizeMakeFromCGSize(CGSizeMake(mainScreenBoundsSize.width/2, mainScreenBoundsSize.height / 3.0));
+    nicCageVideoNode.style.layoutPosition = CGPointMake(mainScreenBoundsSize.width / 2.0, mainScreenBoundsSize.height / 3.0);
     
-    [simonVideoNode setSizeWithCGSize:CGSizeMake(mainScreenBoundsSize.width/2, mainScreenBoundsSize.height / 3.0)];
-    simonVideoNode.layoutPosition = CGPointMake(0.0, mainScreenBoundsSize.height - (mainScreenBoundsSize.height / 3.0));
+    simonVideoNode.style.size = ASLayoutableSizeMakeFromCGSize(CGSizeMake(mainScreenBoundsSize.width/2, mainScreenBoundsSize.height / 3.0));
+    simonVideoNode.style.layoutPosition = CGPointMake(0.0, mainScreenBoundsSize.height - (mainScreenBoundsSize.height / 3.0));
     
-    [hlsVideoNode setSizeWithCGSize:CGSizeMake(mainScreenBoundsSize.width / 2.0, mainScreenBoundsSize.height / 3.0)];
-    hlsVideoNode.layoutPosition = CGPointMake(0.0, mainScreenBoundsSize.height / 3.0);
+    hlsVideoNode.style.size = ASLayoutableSizeMakeFromCGSize(CGSizeMake(mainScreenBoundsSize.width / 2.0, mainScreenBoundsSize.height / 3.0));
+    hlsVideoNode.style.layoutPosition = CGPointMake(0.0, mainScreenBoundsSize.height / 3.0);
     
     return [ASStaticLayoutSpec staticLayoutSpecWithChildren:@[guitarVideoNode, nicCageVideoNode, simonVideoNode, hlsVideoNode]];
   };

--- a/examples_extra/ASTraitCollection/Sample/KittenNode.m
+++ b/examples_extra/ASTraitCollection/Sample/KittenNode.m
@@ -77,7 +77,7 @@ static const CGFloat kInnerPadding = 10.0f;
   // kitten image, with a solid background colour serving as placeholder
   _imageNode = [[ASNetworkImageNode alloc] init];
   _imageNode.backgroundColor = ASDisplayNodeDefaultPlaceholderColor();
-  _imageNode.size = ASRelativeSizeRangeMakeWithExactCGSize(_kittenSize);
+  _imageNode.style.size = (ASLayoutableSize){ .width = ASDimensionMakeWithPoints(_kittenSize.width), .height = ASDimensionMakeWithPoints(_kittenSize.height) };
   [_imageNode addTarget:self action:@selector(imageTapped:) forControlEvents:ASControlNodeEventTouchUpInside];
   
   CGFloat scale = [UIScreen mainScreen].scale;
@@ -91,8 +91,8 @@ static const CGFloat kInnerPadding = 10.0f;
   _textNode = [[ASTextNode alloc] init];
   _textNode.attributedText = [[NSAttributedString alloc] initWithString:[self kittyIpsum]
                                                                attributes:[self textStyle]];
-  _textNode.flexShrink = YES;
-  _textNode.flexGrow = YES;
+  _textNode.style.flexShrink = YES;
+  _textNode.style.flexGrow = YES;
   [self addSubnode:_textNode];
   
   return self;
@@ -141,10 +141,10 @@ static const CGFloat kInnerPadding = 10.0f;
   [stackSpec setChildren:@[_imageNode, _textNode]];
   
   if (self.asyncTraitCollection.horizontalSizeClass == UIUserInterfaceSizeClassRegular) {
-    _imageNode.alignSelf = ASStackLayoutAlignSelfStart;
+    _imageNode.style.alignSelf = ASStackLayoutAlignSelfStart;
     stackSpec.direction = ASStackLayoutDirectionHorizontal;
   } else {
-    _imageNode.alignSelf = ASStackLayoutAlignSelfCenter;
+    _imageNode.style.alignSelf = ASStackLayoutAlignSelfCenter;
     stackSpec.direction = ASStackLayoutDirectionVertical;
   }
   

--- a/examples_extra/ASTraitCollection/Sample/OverrideViewController.m
+++ b/examples_extra/ASTraitCollection/Sample/OverrideViewController.m
@@ -33,8 +33,8 @@ static NSString *kLinkAttributeName = @"PlaceKittenNodeLinkAttributeName";
     return nil;
   
   _textNode = [[ASTextNode alloc] init];
-  _textNode.flexGrow = YES;
-  _textNode.flexShrink = YES;
+  _textNode.style.flexGrow = YES;
+  _textNode.style.flexShrink = YES;
   _textNode.maximumNumberOfLines = 3;
   [self addSubnode:_textNode];
   

--- a/smoke-tests/Framework/Sample.xcodeproj/project.pbxproj
+++ b/smoke-tests/Framework/Sample.xcodeproj/project.pbxproj
@@ -189,6 +189,7 @@
 				TargetAttributes = {
 					050E7C6D19D22E19004363C2 = {
 						CreatedOnToolsVersion = 6.0.1;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -368,6 +369,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.facebook.AsyncDisplayKit.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -380,6 +382,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.facebook.AsyncDisplayKit.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Previously we used `maximumNumberOfLines` and the longest word in a string to scale font size. This adds taking the `constrainedSize`’s height into consideration. If, without scaling, a string’s height is larger than the `constrainedSize` height, apply scaling.

Also fixed up the ASTraitCollection sample to work with the new layout API.