### PR TITLE
[Layout] Rename ASStackLayoutable to ASStackLayoutElement

### DIFF
--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -260,11 +260,11 @@
 		92DD2FEA1BF4D49B0074C9DD /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 92DD2FE51BF4D05E0074C9DD /* MapKit.framework */; };
 		9B92C8851BC2EB6E00EE46B2 /* ASCollectionDataController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 251B8EF31BBB3D690087C538 /* ASCollectionDataController.mm */; };
 		9B92C8861BC2EB7600EE46B2 /* ASCollectionViewFlowLayoutInspector.m in Sources */ = {isa = PBXBuildFile; fileRef = 251B8EF51BBB3D690087C538 /* ASCollectionViewFlowLayoutInspector.m */; };
-		9C49C3701B853961000B0DD5 /* ASStackLayoutable.h in Headers */ = {isa = PBXBuildFile; fileRef = 9C49C36E1B853957000B0DD5 /* ASStackLayoutable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9C49C3701B853961000B0DD5 /* ASStackLayoutElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 9C49C36E1B853957000B0DD5 /* ASStackLayoutElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9C55866A1BD549CB00B50E3A /* ASAsciiArtBoxCreator.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C5586681BD549CB00B50E3A /* ASAsciiArtBoxCreator.m */; };
 		9C55866B1BD54A1900B50E3A /* ASAsciiArtBoxCreator.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C5586681BD549CB00B50E3A /* ASAsciiArtBoxCreator.m */; };
 		9C55866C1BD54A3000B50E3A /* ASAsciiArtBoxCreator.h in Headers */ = {isa = PBXBuildFile; fileRef = 9C5586671BD549CB00B50E3A /* ASAsciiArtBoxCreator.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9C6BB3B31B8CC9C200F13F52 /* ASAbsoluteLayoutable.h in Headers */ = {isa = PBXBuildFile; fileRef = 9C6BB3B01B8CC9C200F13F52 /* ASAbsoluteLayoutable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9C6BB3B31B8CC9C200F13F52 /* ASAbsoluteLayoutElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 9C6BB3B01B8CC9C200F13F52 /* ASAbsoluteLayoutElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9C70F2041CDA4EFA007D6C76 /* ASTraitCollection.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C70F2021CDA4EFA007D6C76 /* ASTraitCollection.m */; };
 		9C70F2051CDA4F06007D6C76 /* ASTraitCollection.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C70F2021CDA4EFA007D6C76 /* ASTraitCollection.m */; };
 		9C70F2061CDA4F0C007D6C76 /* ASTraitCollection.h in Headers */ = {isa = PBXBuildFile; fileRef = 9C70F2011CDA4EFA007D6C76 /* ASTraitCollection.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -565,10 +565,10 @@
 		F7CE6C651D2CDB3E00BE4C15 /* ASRatioLayoutSpec.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = ACF6ED141B17843500DA7C62 /* ASRatioLayoutSpec.h */; };
 		F7CE6C661D2CDB3E00BE4C15 /* ASRelativeLayoutSpec.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 7A06A7391C35F08800FE8DAA /* ASRelativeLayoutSpec.h */; };
 		F7CE6C671D2CDB3E00BE4C15 /* ASRelativeSize.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = AC47D9431B3BB41900AAEE9D /* ASRelativeSize.h */; };
-		F7CE6C681D2CDB3E00BE4C15 /* ASStackLayoutable.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9C49C36E1B853957000B0DD5 /* ASStackLayoutable.h */; };
+		F7CE6C681D2CDB3E00BE4C15 /* ASStackLayoutElement.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9C49C36E1B853957000B0DD5 /* ASStackLayoutElement.h */; };
 		F7CE6C691D2CDB3E00BE4C15 /* ASStackLayoutDefines.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = AC21EC0F1B3D0BF600C8B19A /* ASStackLayoutDefines.h */; };
 		F7CE6C6A1D2CDB3E00BE4C15 /* ASStackLayoutSpec.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = ACF6ED161B17843500DA7C62 /* ASStackLayoutSpec.h */; };
-		F7CE6C6B1D2CDB3E00BE4C15 /* ASAbsoluteLayoutable.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9C6BB3B01B8CC9C200F13F52 /* ASAbsoluteLayoutable.h */; };
+		F7CE6C6B1D2CDB3E00BE4C15 /* ASAbsoluteLayoutElement.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9C6BB3B01B8CC9C200F13F52 /* ASAbsoluteLayoutElement.h */; };
 		F7CE6C6C1D2CDB3E00BE4C15 /* ASAbsoluteLayoutSpec.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = ACF6ED181B17843500DA7C62 /* ASAbsoluteLayoutSpec.h */; };
 		F7CE6C6D1D2CDB3E00BE4C15 /* ASTextKitComponents.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 257754BA1BEE458E00737CA5 /* ASTextKitComponents.h */; };
 		F7CE6C6E1D2CDB3E00BE4C15 /* ASTextNodeWordKerner.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 257754B91BEE458E00737CA5 /* ASTextNodeWordKerner.h */; };
@@ -736,10 +736,10 @@
 				F7CE6C651D2CDB3E00BE4C15 /* ASRatioLayoutSpec.h in CopyFiles */,
 				F7CE6C661D2CDB3E00BE4C15 /* ASRelativeLayoutSpec.h in CopyFiles */,
 				F7CE6C671D2CDB3E00BE4C15 /* ASRelativeSize.h in CopyFiles */,
-				F7CE6C681D2CDB3E00BE4C15 /* ASStackLayoutable.h in CopyFiles */,
+				F7CE6C681D2CDB3E00BE4C15 /* ASStackLayoutElement.h in CopyFiles */,
 				F7CE6C691D2CDB3E00BE4C15 /* ASStackLayoutDefines.h in CopyFiles */,
 				F7CE6C6A1D2CDB3E00BE4C15 /* ASStackLayoutSpec.h in CopyFiles */,
-				F7CE6C6B1D2CDB3E00BE4C15 /* ASAbsoluteLayoutable.h in CopyFiles */,
+				F7CE6C6B1D2CDB3E00BE4C15 /* ASAbsoluteLayoutElement.h in CopyFiles */,
 				F7CE6C6C1D2CDB3E00BE4C15 /* ASAbsoluteLayoutSpec.h in CopyFiles */,
 				F7CE6C6D1D2CDB3E00BE4C15 /* ASTextKitComponents.h in CopyFiles */,
 				F7CE6C6E1D2CDB3E00BE4C15 /* ASTextNodeWordKerner.h in CopyFiles */,
@@ -1023,10 +1023,10 @@
 		92DD2FE11BF4B97E0074C9DD /* ASMapNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASMapNode.h; sourceTree = "<group>"; };
 		92DD2FE21BF4B97E0074C9DD /* ASMapNode.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASMapNode.mm; sourceTree = "<group>"; };
 		92DD2FE51BF4D05E0074C9DD /* MapKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MapKit.framework; path = System/Library/Frameworks/MapKit.framework; sourceTree = SDKROOT; };
-		9C49C36E1B853957000B0DD5 /* ASStackLayoutable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASStackLayoutable.h; path = AsyncDisplayKit/Layout/ASStackLayoutable.h; sourceTree = "<group>"; };
+		9C49C36E1B853957000B0DD5 /* ASStackLayoutElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASStackLayoutElement.h; path = AsyncDisplayKit/Layout/ASStackLayoutElement.h; sourceTree = "<group>"; };
 		9C5586671BD549CB00B50E3A /* ASAsciiArtBoxCreator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASAsciiArtBoxCreator.h; path = AsyncDisplayKit/Layout/ASAsciiArtBoxCreator.h; sourceTree = "<group>"; };
 		9C5586681BD549CB00B50E3A /* ASAsciiArtBoxCreator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ASAsciiArtBoxCreator.m; path = AsyncDisplayKit/Layout/ASAsciiArtBoxCreator.m; sourceTree = "<group>"; };
-		9C6BB3B01B8CC9C200F13F52 /* ASAbsoluteLayoutable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASAbsoluteLayoutable.h; path = AsyncDisplayKit/Layout/ASAbsoluteLayoutable.h; sourceTree = "<group>"; };
+		9C6BB3B01B8CC9C200F13F52 /* ASAbsoluteLayoutElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASAbsoluteLayoutElement.h; path = AsyncDisplayKit/Layout/ASAbsoluteLayoutElement.h; sourceTree = "<group>"; };
 		9C70F2011CDA4EFA007D6C76 /* ASTraitCollection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTraitCollection.h; sourceTree = "<group>"; };
 		9C70F2021CDA4EFA007D6C76 /* ASTraitCollection.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASTraitCollection.m; sourceTree = "<group>"; };
 		9C8221931BA237B80037F19A /* ASStackBaselinePositionedLayout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASStackBaselinePositionedLayout.h; sourceTree = "<group>"; };
@@ -1694,11 +1694,11 @@
 				7A06A7381C35F08800FE8DAA /* ASRelativeLayoutSpec.mm */,
 				AC47D9431B3BB41900AAEE9D /* ASRelativeSize.h */,
 				AC47D9441B3BB41900AAEE9D /* ASRelativeSize.mm */,
-				9C49C36E1B853957000B0DD5 /* ASStackLayoutable.h */,
+				9C49C36E1B853957000B0DD5 /* ASStackLayoutElement.h */,
 				AC21EC0F1B3D0BF600C8B19A /* ASStackLayoutDefines.h */,
 				ACF6ED161B17843500DA7C62 /* ASStackLayoutSpec.h */,
 				ACF6ED171B17843500DA7C62 /* ASStackLayoutSpec.mm */,
-				9C6BB3B01B8CC9C200F13F52 /* ASAbsoluteLayoutable.h */,
+				9C6BB3B01B8CC9C200F13F52 /* ASAbsoluteLayoutElement.h */,
 				ACF6ED181B17843500DA7C62 /* ASAbsoluteLayoutSpec.h */,
 				ACF6ED191B17843500DA7C62 /* ASAbsoluteLayoutSpec.mm */,
 			);
@@ -1869,7 +1869,7 @@
 				B35062551B010EFD0018CF92 /* ASSentinel.h in Headers */,
 				9C8221961BA237B80037F19A /* ASStackBaselinePositionedLayout.h in Headers */,
 				9C70F20E1CDBE9E5007D6C76 /* NSArray+Diffing.h in Headers */,
-				9C49C3701B853961000B0DD5 /* ASStackLayoutable.h in Headers */,
+				9C49C3701B853961000B0DD5 /* ASStackLayoutElement.h in Headers */,
 				DE040EF91C2B40AC004692FF /* ASCollectionViewFlowLayoutInspector.h in Headers */,
 				34EFC7701B701CFA00AD841F /* ASStackLayoutDefines.h in Headers */,
 				764D83D51C8EA515009B4FB8 /* AsyncDisplayKit+Debug.h in Headers */,
@@ -1886,7 +1886,7 @@
 				34EFC7751B701D2400AD841F /* ASStackPositionedLayout.h in Headers */,
 				69E1006E1CA89CB600D88C1B /* ASEnvironmentInternal.h in Headers */,
 				34EFC7771B701D2D00AD841F /* ASStackUnpositionedLayout.h in Headers */,
-				9C6BB3B31B8CC9C200F13F52 /* ASAbsoluteLayoutable.h in Headers */,
+				9C6BB3B31B8CC9C200F13F52 /* ASAbsoluteLayoutElement.h in Headers */,
 				34EFC7731B701D0700AD841F /* ASAbsoluteLayoutSpec.h in Headers */,
 				CC446A2F1D80AAE00071FD03 /* ASObjectDescriptionHelpers.h in Headers */,
 				254C6B781BF94DF4003EC431 /* ASTextKitContext.h in Headers */,

--- a/AsyncDisplayKit/Layout/ASAbsoluteLayoutElement.h
+++ b/AsyncDisplayKit/Layout/ASAbsoluteLayoutElement.h
@@ -1,5 +1,5 @@
 //
-//  ASAbsoluteLayoutable.h
+//  ASAbsoluteLayoutElement.h
 //  AsyncDisplayKit
 //
 //  Copyright (c) 2014-present, Facebook, Inc.  All rights reserved.
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  Layout options that can be defined for an ASLayoutElement being added to a ASAbsoluteLayoutSpec.
  */
-@protocol ASAbsoluteLayoutable
+@protocol ASAbsoluteLayoutElement
 
 /**
  * @abstract The position of this object within its parent spec.

--- a/AsyncDisplayKit/Layout/ASAbsoluteLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASAbsoluteLayoutSpec.h
@@ -20,9 +20,9 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ASAbsoluteLayoutSpec : ASLayoutSpec
 
 /**
- @param children Children to be positioned at fixed positions, each conforms to ASAbsoluteLayoutable
+ @param children Children to be positioned at fixed positions, each conforms to ASAbsoluteLayoutElement
  */
-+ (instancetype)absoluteLayoutSpecWithChildren:(NSArray<id<ASAbsoluteLayoutable>> *)children;
++ (instancetype)absoluteLayoutSpecWithChildren:(NSArray<id<ASAbsoluteLayoutElement>> *)children;
 
 @end
 

--- a/AsyncDisplayKit/Layout/ASBackgroundLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASBackgroundLayoutSpec.h
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ASBackgroundLayoutSpec : ASLayoutSpec
 
 /**
- * Background layoutable for this layout spec
+ * Background layoutElement for this layout spec
  */
 @property (nullable, nonatomic, strong) id<ASLayoutElement> background;
 

--- a/AsyncDisplayKit/Layout/ASLayoutElement.h
+++ b/AsyncDisplayKit/Layout/ASLayoutElement.h
@@ -10,8 +10,8 @@
 
 #import <AsyncDisplayKit/ASDimension.h>
 #import <AsyncDisplayKit/ASStackLayoutDefines.h>
-#import <AsyncDisplayKit/ASStackLayoutable.h>
-#import <AsyncDisplayKit/ASAbsoluteLayoutable.h>
+#import <AsyncDisplayKit/ASStackLayoutElement.h>
+#import <AsyncDisplayKit/ASAbsoluteLayoutElement.h>
 #import <AsyncDisplayKit/ASLayoutElementPrivate.h>
 #import <AsyncDisplayKit/ASEnvironment.h>
 #import <AsyncDisplayKit/ASLayoutElementExtensibility.h>
@@ -174,10 +174,10 @@ extern NSString * const ASLayoutElementStyleLayoutPositionProperty;
 - (void)style:(__kindof ASLayoutElementStyle *)style propertyDidChange:(NSString *)propertyName;
 @end
 
-@interface ASLayoutElementStyle : NSObject <ASStackLayoutable, ASAbsoluteLayoutable>
+@interface ASLayoutElementStyle : NSObject <ASStackLayoutElement, ASAbsoluteLayoutElement>
 
 /**
- * @abstract Initializes the layoutable style with a specified delegate
+ * @abstract Initializes the layoutElement style with a specified delegate
  */
 - (instancetype)initWithDelegate:(id<ASLayoutElementStyleDelegate>)delegate;
 
@@ -252,7 +252,7 @@ extern NSString * const ASLayoutElementStyleLayoutPositionProperty;
 - (void)setExactSizeWithCGSize:(CGSize)size;
 
 
-#pragma mark - ASStackLayoutable
+#pragma mark - ASStackLayoutElement
 
 /**
  * @abstract Additional space to place before this object in the stacking direction.
@@ -303,7 +303,7 @@ extern NSString * const ASLayoutElementStyleLayoutPositionProperty;
  */
 @property (nonatomic, assign) CGFloat descender;
 
-#pragma mark - ASAbsoluteLayoutable
+#pragma mark - ASAbsoluteLayoutElement
 
 /**
  * @abstract The position of this object within its parent spec.

--- a/AsyncDisplayKit/Layout/ASLayoutElement.mm
+++ b/AsyncDisplayKit/Layout/ASLayoutElement.mm
@@ -235,7 +235,7 @@ do {\
   self.maxHeight = ASDimensionMakeWithPoints(size.height);
 }
 
-#pragma mark - ASStackLayoutable
+#pragma mark - ASStackLayoutElement
 
 - (void)setSpacingBefore:(CGFloat)spacingBefore
 {
@@ -293,7 +293,7 @@ do {\
   ASLayoutElementStyleCallDelegate(ASLayoutElementStyleDescenderProperty);
 }
 
-#pragma mark - ASStaticLayoutable
+#pragma mark - ASStaticLayoutElement
 
 - (void)setLayoutPosition:(CGPoint)layoutPosition
 {

--- a/AsyncDisplayKit/Layout/ASLayoutElement.mm
+++ b/AsyncDisplayKit/Layout/ASLayoutElement.mm
@@ -293,7 +293,7 @@ do {\
   ASLayoutElementStyleCallDelegate(ASLayoutElementStyleDescenderProperty);
 }
 
-#pragma mark - ASStaticLayoutElement
+#pragma mark - ASAbsoluteLayoutElement
 
 - (void)setLayoutPosition:(CGPoint)layoutPosition
 {

--- a/AsyncDisplayKit/Layout/ASLayoutSpec+Subclasses.h
+++ b/AsyncDisplayKit/Layout/ASLayoutSpec+Subclasses.h
@@ -13,25 +13,25 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ASLayoutSpec (Subclassing)
 
 /**
- * Helper method for finalLayoutable support
+ * Helper method for finalLayoutElement support
  *
- * @warning If you are getting recursion crashes here after implementing finalLayoutable, make sure
- * that you are setting isFinalLayoutable flag to YES. This must be one BEFORE adding a child
+ * @warning If you are getting recursion crashes here after implementing finalLayoutElement, make sure
+ * that you are setting isFinalLayoutElement flag to YES. This must be one BEFORE adding a child
  * to the new ASLayoutElement.
  *
  * For example:
- * - (id<ASLayoutElement>)finalLayoutable
+ * - (id<ASLayoutElement>)finalLayoutElement
  * {
  *   ASInsetLayoutSpec *insetSpec = [[ASInsetLayoutSpec alloc] init];
  *   insetSpec.insets = UIEdgeInsetsMake(10,10,10,10);
- *   insetSpec.isFinalLayoutable = YES;
+ *   insetSpec.isFinalLayoutElement = YES;
  *   [insetSpec setChild:self];
  *   return insetSpec;
  * }
  *
- * @see finalLayoutable
+ * @see finalLayoutElement
  */
-- (id<ASLayoutElement>)layoutableToAddFromLayoutable:(id<ASLayoutElement>)child;
+- (id<ASLayoutElement>)layoutElementToAddFromLayoutElement:(id<ASLayoutElement>)child;
 
 /**
  * Adds a child with the given identifier to this layout spec.

--- a/AsyncDisplayKit/Layout/ASLayoutSpec+Subclasses.mm
+++ b/AsyncDisplayKit/Layout/ASLayoutSpec+Subclasses.mm
@@ -46,9 +46,9 @@
 
 @implementation ASLayoutSpec (Subclassing)
 
-#pragma mark - Final layoutable
+#pragma mark - Final layoutElement
 
-- (id<ASLayoutElement>)layoutableToAddFromLayoutable:(id<ASLayoutElement>)child
+- (id<ASLayoutElement>)layoutElementToAddFromLayoutElement:(id<ASLayoutElement>)child
 {
   if (self.isFinalLayoutElement == NO) {
     id<ASLayoutElement> finalLayoutElement = [child finalLayoutElement];
@@ -73,7 +73,7 @@
 {
   ASDisplayNodeAssert(self.isMutable, @"Cannot set properties when layout spec is not mutable");
   
-  id<ASLayoutElement> layoutable = child ? [self layoutableToAddFromLayoutable:child] : [ASNullLayoutSpec null];
+  id<ASLayoutElement> layoutElement = child ? [self layoutElementToAddFromLayoutElement:child] : [ASNullLayoutSpec null];
   
   if (child) {
     if (_childrenArray.count < index) {
@@ -86,25 +86,25 @@
     }
   }
   
-  // Replace object at the given index with the layoutable
-  _childrenArray[index] = layoutable;
+  // Replace object at the given index with the layoutElement
+  _childrenArray[index] = layoutElement;
   
-  // TODO: Should we propagate up the layoutable at it could happen that multiple children will propagated up their
+  // TODO: Should we propagate up the layoutElement at it could happen that multiple children will propagated up their
   //       layout options and one child will overwrite values from another child
-  // [self propagateUpLayoutable:finalLayoutElement];
+  // [self propagateUpLayoutElement:finalLayoutElement];
 }
 
 - (id<ASLayoutElement>)childAtIndex:(NSUInteger)index
 {
-  id<ASLayoutElement> layoutable = nil;
+  id<ASLayoutElement> layoutElement = nil;
   if (index < _childrenArray.count) {
-    layoutable = _childrenArray[index];
+    layoutElement = _childrenArray[index];
   }
   
-  // Null layoutable should not be accessed
-  ASDisplayNodeAssert(layoutable != [ASNullLayoutSpec null], @"Access child at index without set a child at that index");
+  // Null layoutElement should not be accessed
+  ASDisplayNodeAssert(layoutElement != [ASNullLayoutSpec null], @"Access child at index without set a child at that index");
 
-  return layoutable;
+  return layoutElement;
 }
 
 @end

--- a/AsyncDisplayKit/Layout/ASLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASLayoutSpec.mm
@@ -55,7 +55,7 @@
   return YES;
 }
 
-#pragma mark - Final Layoutable
+#pragma mark - Final LayoutElement
 
 - (id<ASLayoutElement>)finalLayoutElement
 {
@@ -122,7 +122,7 @@
   ASDisplayNodeAssert(_childrenArray.count < 2, @"This layout spec does not support more than one child. Use the setChildren: or the setChild:AtIndex: API");
   
   if (child) {
-    id<ASLayoutElement> finalLayoutElement = [self layoutableToAddFromLayoutable:child];
+    id<ASLayoutElement> finalLayoutElement = [self layoutElementToAddFromLayoutElement:child];
     if (finalLayoutElement) {
       _childrenArray[0] = finalLayoutElement;
       [self propagateUpLayoutElement:finalLayoutElement];
@@ -156,7 +156,7 @@
   NSUInteger i = 0;
   for (id<ASLayoutElement> child in children) {
     ASDisplayNodeAssert([child conformsToProtocol:NSProtocolFromString(@"ASLayoutElement")], @"Child %@ of spec %@ is not an ASLayoutElement!", child, self);
-    _childrenArray[i] = [self layoutableToAddFromLayoutable:child];
+    _childrenArray[i] = [self layoutElementToAddFromLayoutElement:child];
     i += 1;
   }
 }

--- a/AsyncDisplayKit/Layout/ASOverlayLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASOverlayLayoutSpec.h
@@ -18,15 +18,15 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ASOverlayLayoutSpec : ASLayoutSpec
 
 /**
- * Overlay layoutable of this layout spec
+ * Overlay layoutElement of this layout spec
  */
 @property (nullable, nonatomic, strong) id<ASLayoutElement> overlay;
 
 /**
- * Creates and returns an ASOverlayLayoutSpec object with a given child and an layoutable that act as overlay.
+ * Creates and returns an ASOverlayLayoutSpec object with a given child and an layoutElement that act as overlay.
  *
  * @param child A child that is laid out to determine the size of this spec.
- * @param overlay A layoutable object that is laid out over the child. If this is nil, the overlay is omitted.
+ * @param overlay A layoutElement object that is laid out over the child. If this is nil, the overlay is omitted.
  */
 + (instancetype)overlayLayoutSpecWithChild:(id<ASLayoutElement>)child overlay:(nullable id<ASLayoutElement>)overlay;
 

--- a/AsyncDisplayKit/Layout/ASStackLayoutElement.h
+++ b/AsyncDisplayKit/Layout/ASStackLayoutElement.h
@@ -1,5 +1,5 @@
 //
-//  ASStackLayoutable.h
+//  ASStackLayoutElement.h
 //  AsyncDisplayKit
 //
 //  Copyright (c) 2014-present, Facebook, Inc.  All rights reserved.
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  Layout options that can be defined for an ASLayoutElement being added to a ASStackLayoutSpec.
  */
-@protocol ASStackLayoutable <NSObject>
+@protocol ASStackLayoutElement <NSObject>
 
 /**
  * @abstract Additional space to place before this object in the stacking direction.

--- a/AsyncDisplayKitTests/ASDisplayNodeImplicitHierarchyTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeImplicitHierarchyTests.m
@@ -68,13 +68,13 @@
   ASSpecTestDisplayNode *node = [[ASSpecTestDisplayNode alloc] init];
   node.automaticallyManagesSubnodes = YES;
   node.layoutSpecBlock = ^(ASDisplayNode *weakNode, ASSizeRange constrainedSize) {
-    ASAbsoluteLayoutSpec *staticLayout = [ASAbsoluteLayoutSpec absoluteLayoutSpecWithChildren:@[node4]];
+    ASAbsoluteLayoutSpec *absoluteLayout = [ASAbsoluteLayoutSpec absoluteLayoutSpecWithChildren:@[node4]];
     
     ASStackLayoutSpec *stack1 = [[ASStackLayoutSpec alloc] init];
     [stack1 setChildren:@[node1, node2]];
 
     ASStackLayoutSpec *stack2 = [[ASStackLayoutSpec alloc] init];
-    [stack2 setChildren:@[node3, staticLayout]];
+    [stack2 setChildren:@[node3, absoluteLayout]];
     
     return [ASAbsoluteLayoutSpec absoluteLayoutSpecWithChildren:@[stack1, stack2, node5]];
   };


### PR DESCRIPTION
This replaces #2289 (really messy rebase).  

Renaming for clarity:
- `ASStackLayoutable` —> `ASStackLayoutElement`