### PR TITLE
[ASButtonNode] Only change state if it's different

### DIFF
--- a/AsyncDisplayKit/ASButtonNode.mm
+++ b/AsyncDisplayKit/ASButtonNode.mm
@@ -110,25 +110,31 @@
 
 - (void)setEnabled:(BOOL)enabled
 {
-  [super setEnabled:enabled];
-  if (enabled) {
-    self.accessibilityTraits = UIAccessibilityTraitButton;
-  } else {
-    self.accessibilityTraits = UIAccessibilityTraitButton | UIAccessibilityTraitNotEnabled;
+  if (self.enabled != enabled) {
+    [super setEnabled:enabled];
+    if (enabled) {
+      self.accessibilityTraits = UIAccessibilityTraitButton;
+    } else {
+      self.accessibilityTraits = UIAccessibilityTraitButton | UIAccessibilityTraitNotEnabled;
+    }
+    [self updateButtonContent];
   }
-  [self updateButtonContent];
 }
 
 - (void)setHighlighted:(BOOL)highlighted
 {
-  [super setHighlighted:highlighted];
-  [self updateButtonContent];
+  if (self.highlighted != highlighted) {
+    [super setHighlighted:highlighted];
+    [self updateButtonContent];
+  }
 }
 
 - (void)setSelected:(BOOL)selected
 {
-  [super setSelected:selected];
-  [self updateButtonContent];
+  if (self.selected != selected) {
+    [super setSelected:selected];
+    [self updateButtonContent];
+  }
 }
 
 - (void)updateButtonContent


### PR DESCRIPTION
To avoid unnecessary layout pass in Pin Closeup. 

While testing the sync candidate branch for Pinterest, I noticed that the pin-to-pin closeup swipe seemed slower than normal. Unnecessary layout passes are being called every time the action bar buttons are updated for a new pin. 

Before
<img width="1271" alt="before" src="https://cloud.githubusercontent.com/assets/3419380/18980186/ab3e6278-8686-11e6-9248-3d6a1f338494.png">

After
<img width="1275" alt="after" src="https://cloud.githubusercontent.com/assets/3419380/18980185/a931c43e-8686-11e6-90ce-f790b653fa08.png">

@appleguy: could you review & merge so I can get this into `6.12` and `6.13` tonight?