### PR TITLE
[ASAsyncTransaction] Make System Less Specific to Layer Display, More Readable

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -856,7 +856,7 @@ extern NSInteger const ASDefaultDrawingPriority;
  * ASDisplayNode participates in ASAsyncTransactions, so you can determine when your subnodes are done rendering.
  * See: -(void)asyncdisplaykit_asyncTransactionContainerStateDidChange in ASDisplayNodeSubclass.h
  */
-@interface ASDisplayNode (ASDisplayNodeAsyncTransactionContainer) <ASDisplayNodeAsyncTransactionContainer>
+@interface ASDisplayNode (ASAsyncTransactionContainer) <ASAsyncTransactionContainer>
 @end
 
 /** UIVIew(AsyncDisplayKit) defines convenience method for adding sub-ASDisplayNode to an UIView. */

--- a/AsyncDisplayKit/Details/Transactions/_ASAsyncTransaction.h
+++ b/AsyncDisplayKit/Details/Transactions/_ASAsyncTransaction.h
@@ -10,14 +10,16 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 #define ASDISPLAYNODE_DELAY_DISPLAY 0
 
 @class _ASAsyncTransaction;
 
 typedef void(^asyncdisplaykit_async_transaction_completion_block_t)(_ASAsyncTransaction *completedTransaction, BOOL canceled);
-typedef id<NSObject>(^asyncdisplaykit_async_transaction_operation_block_t)(void);
-typedef void(^asyncdisplaykit_async_transaction_operation_completion_block_t)(id<NSObject> value, BOOL canceled);
-typedef void(^asyncdisplaykit_async_transaction_complete_async_operation_block_t)(id<NSObject> value);
+typedef id<NSObject> _Nullable(^asyncdisplaykit_async_transaction_operation_block_t)(void);
+typedef void(^asyncdisplaykit_async_transaction_operation_completion_block_t)(id<NSObject> _Nullable value, BOOL canceled);
+typedef void(^asyncdisplaykit_async_transaction_complete_async_operation_block_t)(id<NSObject> _Nullable value);
 typedef void(^asyncdisplaykit_async_transaction_async_operation_block_t)(asyncdisplaykit_async_transaction_complete_async_operation_block_t completeOperationBlock);
 
 /**
@@ -54,11 +56,11 @@ extern NSInteger const ASDefaultTransactionPriority;
  @summary Initialize a transaction that can start collecting async operations.
 
  @see initWithCallbackQueue:commitBlock:completionBlock:executeConcurrently:
- @param callbackQueue The dispatch queue that the completion blocks will be called on.
- @param completionBlock A block that is called when the transaction is completed. May be NULL.
+ @param callbackQueue The dispatch queue that the completion blocks will be called on. Default is the main queue.
+ @param completionBlock A block that is called when the transaction is completed.
  */
-- (instancetype)initWithCallbackQueue:(dispatch_queue_t)callbackQueue
-                      completionBlock:(asyncdisplaykit_async_transaction_completion_block_t)completionBlock;
+- (instancetype)initWithCallbackQueue:(nullable dispatch_queue_t)callbackQueue
+                      completionBlock:(nullable asyncdisplaykit_async_transaction_completion_block_t)completionBlock;
 
 /**
  @summary Block the main thread until the transaction is complete, including callbacks.
@@ -70,18 +72,18 @@ extern NSInteger const ASDefaultTransactionPriority;
 /**
  The dispatch queue that the completion blocks will be called on.
  */
-@property (nonatomic, readonly, retain) dispatch_queue_t callbackQueue;
+@property (nonatomic, readonly, strong) dispatch_queue_t callbackQueue;
 
 /**
  A block that is called when the transaction is completed.
  */
-@property (nonatomic, readonly, copy) asyncdisplaykit_async_transaction_completion_block_t completionBlock;
+@property (nonatomic, readonly, copy, nullable) asyncdisplaykit_async_transaction_completion_block_t completionBlock;
 
 /**
  The state of the transaction.
  @see ASAsyncTransactionState
  */
-@property (nonatomic, readonly, assign) ASAsyncTransactionState state;
+@property (readonly, assign) ASAsyncTransactionState state;
 
 /**
  @summary Adds a synchronous operation to the transaction.  The execution block will be executed immediately.
@@ -97,7 +99,7 @@ extern NSInteger const ASDefaultTransactionPriority;
  */
 - (void)addOperationWithBlock:(asyncdisplaykit_async_transaction_operation_block_t)block
                         queue:(dispatch_queue_t)queue
-                   completion:(asyncdisplaykit_async_transaction_operation_completion_block_t)completion;
+                   completion:(nullable asyncdisplaykit_async_transaction_operation_completion_block_t)completion;
 
 /**
  @summary Adds a synchronous operation to the transaction.  The execution block will be executed immediately.
@@ -115,7 +117,7 @@ extern NSInteger const ASDefaultTransactionPriority;
 - (void)addOperationWithBlock:(asyncdisplaykit_async_transaction_operation_block_t)block
                      priority:(NSInteger)priority
                         queue:(dispatch_queue_t)queue
-                   completion:(asyncdisplaykit_async_transaction_operation_completion_block_t)completion;
+                   completion:(nullable asyncdisplaykit_async_transaction_operation_completion_block_t)completion;
 
 
 /**
@@ -134,7 +136,7 @@ extern NSInteger const ASDefaultTransactionPriority;
  */
 - (void)addAsyncOperationWithBlock:(asyncdisplaykit_async_transaction_async_operation_block_t)block
                              queue:(dispatch_queue_t)queue
-                        completion:(asyncdisplaykit_async_transaction_operation_completion_block_t)completion;
+                        completion:(nullable asyncdisplaykit_async_transaction_operation_completion_block_t)completion;
 
 /**
  @summary Adds an async operation to the transaction.  The execution block will be executed immediately.
@@ -154,7 +156,7 @@ extern NSInteger const ASDefaultTransactionPriority;
 - (void)addAsyncOperationWithBlock:(asyncdisplaykit_async_transaction_async_operation_block_t)block
                           priority:(NSInteger)priority
                              queue:(dispatch_queue_t)queue
-                        completion:(asyncdisplaykit_async_transaction_operation_completion_block_t)completion;
+                        completion:(nullable asyncdisplaykit_async_transaction_operation_completion_block_t)completion;
 
 
 
@@ -189,3 +191,5 @@ extern NSInteger const ASDefaultTransactionPriority;
 - (void)commit;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/AsyncDisplayKit/Details/Transactions/_ASAsyncTransaction.mm
+++ b/AsyncDisplayKit/Details/Transactions/_ASAsyncTransaction.mm
@@ -8,7 +8,9 @@
 //  of patent rights can be found in the PATENTS file in the same directory.
 //
 
+// We need this import for UITrackingRunLoopMode
 #import <UIKit/UIApplication.h>
+
 #import "_ASAsyncTransaction.h"
 #import "_ASAsyncTransactionGroup.h"
 

--- a/AsyncDisplayKit/Details/Transactions/_ASAsyncTransactionContainer+Private.h
+++ b/AsyncDisplayKit/Details/Transactions/_ASAsyncTransactionContainer+Private.h
@@ -10,11 +10,13 @@
 
 #import <AsyncDisplayKit/_ASAsyncTransactionContainer.h>
 
+NS_ASSUME_NONNULL_BEGIN
 
 @interface CALayer (ASAsyncTransactionContainerTransactions)
-@property (nonatomic, strong, setter=asyncdisplaykit_setAsyncLayerTransactions:) NSHashTable *asyncdisplaykit_asyncLayerTransactions;
-@property (nonatomic, strong, setter=asyncdisplaykit_setCurrentAsyncLayerTransaction:) _ASAsyncTransaction *asyncdisplaykit_currentAsyncLayerTransaction;
+@property (nonatomic, strong, nullable, setter=asyncdisplaykit_setAsyncLayerTransactions:) NSHashTable<_ASAsyncTransaction *> *asyncdisplaykit_asyncLayerTransactions;
 
 - (void)asyncdisplaykit_asyncTransactionContainerWillBeginTransaction:(_ASAsyncTransaction *)transaction;
 - (void)asyncdisplaykit_asyncTransactionContainerDidCompleteTransaction:(_ASAsyncTransaction *)transaction;
 @end
+
+NS_ASSUME_NONNULL_END

--- a/AsyncDisplayKit/Details/Transactions/_ASAsyncTransactionContainer.h
+++ b/AsyncDisplayKit/Details/Transactions/_ASAsyncTransactionContainer.h
@@ -10,6 +10,7 @@
 
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
 
 @class _ASAsyncTransaction;
 
@@ -26,11 +27,11 @@ typedef NS_ENUM(NSUInteger, ASAsyncTransactionContainerState) {
   ASAsyncTransactionContainerStatePendingTransactions,
 };
 
-@protocol ASDisplayNodeAsyncTransactionContainer
+@protocol ASAsyncTransactionContainer
 
 /**
- @summary If YES, the receiver is marked as a container for async display, grouping all of the async display calls
- in the layer hierarchy below the receiver together in a single ASAsyncTransaction.
+ @summary If YES, the receiver is marked as a container for async transactions, grouping all of the transactions
+ in the container hierarchy below the receiver together in a single ASAsyncTransaction.
 
  @default NO
  */
@@ -46,22 +47,26 @@ typedef NS_ENUM(NSUInteger, ASAsyncTransactionContainerState) {
  */
 - (void)asyncdisplaykit_cancelAsyncTransactions;
 
+@property (nonatomic, strong, nullable, setter=asyncdisplaykit_setCurrentAsyncTransaction:) _ASAsyncTransaction *asyncdisplaykit_currentAsyncTransaction;
+
 @end
 
-@interface CALayer (ASDisplayNodeAsyncTransactionContainer) <ASDisplayNodeAsyncTransactionContainer>
+@interface CALayer (ASAsyncTransactionContainer) <ASAsyncTransactionContainer>
 /**
- @summary Returns the current async transaction for this container layer. A new transaction is created if one
+ @summary Returns the current async transaction for this layer. A new transaction is created if one
  did not already exist. This method will always return an open, uncommitted transaction.
  @desc asyncdisplaykit_isAsyncTransactionContainer does not need to be YES for this to return a transaction.
  */
-@property (nonatomic, readonly, strong) _ASAsyncTransaction *asyncdisplaykit_asyncTransaction;
+@property (nonatomic, readonly, strong, nullable) _ASAsyncTransaction *asyncdisplaykit_asyncTransaction;
 
 /**
  @summary Goes up the superlayer chain until it finds the first layer with asyncdisplaykit_isAsyncTransactionContainer=YES (including the receiver) and returns it.
  Returns nil if no parent container is found.
  */
-@property (nonatomic, readonly, strong) CALayer *asyncdisplaykit_parentTransactionContainer;
+@property (nonatomic, readonly, strong, nullable) CALayer *asyncdisplaykit_parentTransactionContainer;
 @end
 
-@interface UIView (ASDisplayNodeAsyncTransactionContainer) <ASDisplayNodeAsyncTransactionContainer>
+@interface UIView (ASAsyncTransactionContainer) <ASAsyncTransactionContainer>
 @end
+
+NS_ASSUME_NONNULL_END

--- a/AsyncDisplayKit/Details/Transactions/_ASAsyncTransactionGroup.h
+++ b/AsyncDisplayKit/Details/Transactions/_ASAsyncTransactionGroup.h
@@ -8,19 +8,20 @@
 //  of patent rights can be found in the PATENTS file in the same directory.
 //
 
-#import <UIKit/UIKit.h>
-
+NS_ASSUME_NONNULL_BEGIN
 
 @class _ASAsyncTransaction;
+@protocol ASAsyncTransactionContainer;
 
-/// A group of transaction container layers, for which the current transactions are committed together at the end of the next runloop tick.
+/// A group of transaction containers, for which the current transactions are committed together at the end of the next runloop tick.
 @interface _ASAsyncTransactionGroup : NSObject
 /// The main transaction group is scheduled to commit on every tick of the main runloop.
-+ (instancetype)mainTransactionGroup;
++ (_ASAsyncTransactionGroup *)mainTransactionGroup;
 + (void)commit;
 
 /// Add a transaction container to be committed.
-/// @param containerLayer A layer containing a transaction to be committed. May or may not be a container layer.
 /// @see ASAsyncTransactionContainer
-- (void)addTransactionContainer:(CALayer *)containerLayer;
+- (void)addTransactionContainer:(id<ASAsyncTransactionContainer>)container;
 @end
+
+NS_ASSUME_NONNULL_END

--- a/AsyncDisplayKit/Private/ASDisplayNode+UIViewBridge.mm
+++ b/AsyncDisplayKit/Private/ASDisplayNode+UIViewBridge.mm
@@ -974,4 +974,14 @@ nodeProperty = nodeValueExpr; _setToViewOnly(viewAndPendingViewStateProperty, vi
   [_layer asyncdisplaykit_cancelAsyncTransactions];
 }
 
+- (void)asyncdisplaykit_setCurrentAsyncTransaction:(_ASAsyncTransaction *)transaction
+{
+  _layer.asyncdisplaykit_currentAsyncTransaction = transaction;
+}
+
+- (_ASAsyncTransaction *)asyncdisplaykit_currentAsyncTransaction
+{
+  return _layer.asyncdisplaykit_currentAsyncTransaction;
+}
+
 @end


### PR DESCRIPTION
The `ASAsyncTransaction` system is one of the most fundamental components of AsyncDisplayKit. It powers the asynchronous layer display process which is possibly the most reliable & performance-tuned component of the framework.

It provides lightweight, cancellable, waitable, transactionable operation semantics. It seems like it could be useful in other contexts than drawing, such as layout, or updating UIKit/CALayer properties from background threads. There's a ton of promise here.

The only problem with it, is that it works so reliably that @appleguy is the only maintainer who understands how it works and how it could be applied in other contexts.

This diff contains no functional changes. Its only purpose is to help make the system easier to understand and open the door for more general usage:

- Add nullability and generics to the system.
- Rename and move the `asyncdisplaykit_currentAsyncLayerTransaction` property out from the special `CALayer (ASAsyncTransaction)` category up into the `ASAsyncTransaction` protocol itself with the new name `asyncdisplaykit_currentAsyncTransaction`. Matching other cases like this, `UIView` and `ASDisplayNode` pass through to the layer in their conformance.
- Shorten names e.g. `ASDisplayNodeAsyncTransactionContainer` -> `ASAsyncTransactionContainer`
- Reduce underscores in `ASAsyncTransaction` so it's less scary.
- Replace references to `container layers` – which appear to be an old subclass of `CALayer` that's gone now – with either `layer` or `container` based on the context.

Ready for review @maicki @levi @appleguy