### PR TITLE
[ASCellNode] Restore Layout Attributes Fix + iOS 10 Modification

### DIFF
--- a/AsyncDisplayKit/ASCellNode+Internal.h
+++ b/AsyncDisplayKit/ASCellNode+Internal.h
@@ -12,6 +12,8 @@
 
 #import "ASCellNode.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @protocol ASCellNodeInteractionDelegate <NSObject>
 
 /**
@@ -49,4 +51,13 @@
 - (void)__setSelectedFromUIKit:(BOOL)selected;
 - (void)__setHighlightedFromUIKit:(BOOL)highlighted;
 
+/**
+ * @note This could be declared @c copy, but since this is only settable internally, we can ensure
+ *   that it's always safe simply to retain it, and copy if needed. Since @c UICollectionViewLayoutAttributes
+ *   is always mutable, @c copy is never "free" like it is for e.g. NSString.
+ */
+@property (nonatomic, strong, nullable) UICollectionViewLayoutAttributes *layoutAttributes;
+
 @end
+
+NS_ASSUME_NONNULL_END

--- a/AsyncDisplayKit/ASCellNode.h
+++ b/AsyncDisplayKit/ASCellNode.h
@@ -75,6 +75,15 @@ typedef NS_ENUM(NSUInteger, ASCellNodeVisibilityEvent) {
 @property (nonatomic, assign) BOOL neverShowPlaceholders;
 
 /*
+ * The layout attributes currently assigned to this node, if any.
+ *
+ * @discussion This property is useful because it is set before @c collectionView:willDisplayNode:forItemAtIndexPath:
+ *   is called, when the node is not yet in the hierarchy and its frame cannot be converted to/from other nodes. Instead
+ *   you can use the layout attributes object to learn where and how the cell will be displayed.
+ */
+@property (nonatomic, strong, readonly, nullable) UICollectionViewLayoutAttributes *layoutAttributes;
+
+/*
  * ASTableView uses these properties when configuring UITableViewCells that host ASCellNodes.
  */
 //@property (nonatomic, retain) UIColor *backgroundColor;

--- a/AsyncDisplayKit/ASCellNode.mm
+++ b/AsyncDisplayKit/ASCellNode.mm
@@ -233,6 +233,17 @@
 
 #pragma clang diagnostic pop
 
+- (void)setLayoutAttributes:(UICollectionViewLayoutAttributes *)layoutAttributes
+{
+  ASDisplayNodeAssertMainThread();
+  if (ASObjectIsEqual(layoutAttributes, _layoutAttributes) == NO) {
+    _layoutAttributes = layoutAttributes;
+    if (layoutAttributes != nil) {
+      [self applyLayoutAttributes:layoutAttributes];
+    }
+  }
+}
+
 - (void)applyLayoutAttributes:(UICollectionViewLayoutAttributes *)layoutAttributes
 {
   // To be overriden by subclasses

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -726,6 +726,7 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   [_cellsForVisibilityUpdates removeObject:cell];
   
   cellNode.scrollView = nil;
+  cellNode.layoutAttributes = nil;
 }
 
 


### PR DESCRIPTION
#2321 was reverted because its test was failing under iOS 10. iOS 10 seems to use a much larger reuse queue for collection cells, which revealed an issue with the previous implementation of this feature.

This restores #2321, plus:
- We used to clear the layout attributes only in `prepareForReuse` but now we clear it in `didEndDisplayingCell:`. 

Ready for review @maicki @appleguy 