### PR TITLE
[ASCollectionView] Allow User to Submit Updates Before Initial Data Load

### DIFF
--- a/AsyncDisplayKit/Details/ASChangeSetDataController.mm
+++ b/AsyncDisplayKit/Details/ASChangeSetDataController.mm
@@ -48,7 +48,13 @@
   [_changeSet addCompletionHandler:completion];
   if (_changeSetBatchUpdateCounter == 0) {
     void (^batchCompletion)(BOOL finished) = _changeSet.completionHandler;
-
+    
+    /**
+     * If the initial reloadData has not been called, just bail because we don't have
+     * our old data source counts.
+     * See ASUICollectionViewTests.testThatIssuingAnUpdateBeforeInitialReloadIsUnacceptable
+     * For the issue that UICollectionView has that we're choosing to workaround.
+     */
     if (!self.initialReloadDataHasBeenCalled) {
       if (batchCompletion != nil) {
         batchCompletion(YES);

--- a/AsyncDisplayKit/Details/ASChangeSetDataController.mm
+++ b/AsyncDisplayKit/Details/ASChangeSetDataController.mm
@@ -47,8 +47,6 @@
   
   [_changeSet addCompletionHandler:completion];
   if (_changeSetBatchUpdateCounter == 0) {
-    [self invalidateDataSourceItemCounts];
-    [_changeSet markCompletedWithNewItemCounts:[self itemCountsFromDataSource]];
     void (^batchCompletion)(BOOL finished) = _changeSet.completionHandler;
 
     if (!self.initialReloadDataHasBeenCalled) {
@@ -58,6 +56,9 @@
       _changeSet = nil;
       return;
     }
+
+    [self invalidateDataSourceItemCounts];
+    [_changeSet markCompletedWithNewItemCounts:[self itemCountsFromDataSource]];
     
     [super beginUpdates];
     

--- a/AsyncDisplayKit/Private/_ASHierarchyChangeSet.h
+++ b/AsyncDisplayKit/Private/_ASHierarchyChangeSet.h
@@ -98,7 +98,6 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType);
 /**
  * The combined completion handler.
  *
- * @precondition The change set must be completed.
  * @warning The completion block is discarded after reading because it may have captured
  *   significant resources that we would like to reclaim as soon as possible.
  */

--- a/AsyncDisplayKit/Private/_ASHierarchyChangeSet.mm
+++ b/AsyncDisplayKit/Private/_ASHierarchyChangeSet.mm
@@ -135,8 +135,6 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
 
 - (void (^)(BOOL finished))completionHandler
 {
-  [self _ensureCompleted];
-
   void (^completionHandler)(BOOL) = _completionHandler;
   _completionHandler = nil;
   return completionHandler;

--- a/AsyncDisplayKitTests/ASCollectionViewTests.mm
+++ b/AsyncDisplayKitTests/ASCollectionViewTests.mm
@@ -589,7 +589,7 @@
 }
 
 /// See the same test in ASUICollectionViewTests for the reference behavior.
-- (void)testThatIssuingAnUpdateBeforeInitialReloadIsUnacceptable
+- (void)testThatIssuingAnUpdateBeforeInitialReloadIsAcceptable
 {
   ASCollectionViewTestDelegate *del = [[ASCollectionViewTestDelegate alloc] initWithNumberOfSections:0 numberOfItemsInSection:0];
   ASCollectionView *cv = [[ASCollectionView alloc] initWithCollectionViewLayout:[UICollectionViewFlowLayout new]];
@@ -598,9 +598,10 @@
 
   // Add a section to the data source
   del->_itemCounts.push_back(0);
-  // Attempt to insert section into collection view. Throws. See corresponding test
-  // in ASUICollectionViewTests for explanation of why.
-  XCTAssertThrowsSpecificNamed([cv insertSections:[NSIndexSet indexSetWithIndex:0]], NSException, NSInternalInconsistencyException);
+  // Attempt to insert section into collection view. We ignore it to workaround
+  // the bug demonstrated by
+  // ASUICollectionViewTests.testThatIssuingAnUpdateBeforeInitialReloadIsUnacceptable
+  XCTAssertNoThrow([cv insertSections:[NSIndexSet indexSetWithIndex:0]]);
 }
 
 @end

--- a/AsyncDisplayKitTests/ASCollectionViewTests.mm
+++ b/AsyncDisplayKitTests/ASCollectionViewTests.mm
@@ -588,4 +588,19 @@
   }
 }
 
+/// See the same test in ASUICollectionViewTests for the reference behavior.
+- (void)testThatIssuingAnUpdateBeforeInitialReloadIsUnacceptable
+{
+  ASCollectionViewTestDelegate *del = [[ASCollectionViewTestDelegate alloc] initWithNumberOfSections:0 numberOfItemsInSection:0];
+  ASCollectionView *cv = [[ASCollectionView alloc] initWithCollectionViewLayout:[UICollectionViewFlowLayout new]];
+  cv.asyncDataSource = del;
+  cv.asyncDelegate = del;
+
+  // Add a section to the data source
+  del->_itemCounts.push_back(0);
+  // Attempt to insert section into collection view. Throws. See corresponding test
+  // in ASUICollectionViewTests for explanation of why.
+  XCTAssertThrowsSpecificNamed([cv insertSections:[NSIndexSet indexSetWithIndex:0]], NSException, NSInternalInconsistencyException);
+}
+
 @end

--- a/AsyncDisplayKitTests/ASUICollectionViewTests.m
+++ b/AsyncDisplayKitTests/ASUICollectionViewTests.m
@@ -106,4 +106,35 @@
   [layoutMock verify];
 }
 
+- (void)testThatIssuingAnUpdateBeforeInitialReloadIsUnacceptable
+{
+  UICollectionViewFlowLayout *layout = [[UICollectionViewFlowLayout alloc] init];
+  UICollectionView *cv = [[UICollectionView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) collectionViewLayout:layout];
+  id dataSource = [OCMockObject niceMockForProtocol:@protocol(UICollectionViewDataSource)];
+
+  // Setup empty data source – 0 sections, 0 items
+  [[[dataSource stub] andDo:^(NSInvocation *invocation) {
+    NSIndexPath *indexPath = [invocation getArgumentAtIndexAsObject:3];
+    __autoreleasing UICollectionViewCell *view = [cv dequeueReusableCellWithReuseIdentifier:@"CellID" forIndexPath:indexPath];
+    [invocation setReturnValue:&view];
+  }] collectionView:cv cellForItemAtIndexPath:OCMOCK_ANY];
+  [[[dataSource stub] andReturnValue:[NSNumber numberWithInteger:0]] numberOfSectionsInCollectionView:cv];
+  [[[dataSource stub] andReturnValue:[NSNumber numberWithInteger:0]] collectionView:cv numberOfItemsInSection:0];
+  [cv registerClass:[UICollectionViewCell class] forCellWithReuseIdentifier:@"CellID"];
+  cv.dataSource = dataSource;
+
+  // Update data source – 1 section, 0 items
+  [[[dataSource stub] andReturnValue:[NSNumber numberWithInteger:1]] numberOfSectionsInCollectionView:cv];
+
+  /**
+   * Inform collection view – insert section 0
+   * Throws exception because collection view never saw the data source have 0 sections.
+   * so it's going to read "oldSectionCount" now and get 1. It will also read
+   * "newSectionCount" and get 1. Then it'll throw because "oldSectionCount(1) + insertedCount(1) != newSectionCount(1)".
+   * To workaround this, you could add `[cv numberOfSections]` before the data source is updated to
+   * trigger the collection view to read oldSectionCount=0.
+   */
+  XCTAssertThrowsSpecificNamed([cv insertSections:[NSIndexSet indexSetWithIndex:0]], NSException, NSInternalInconsistencyException);
+}
+
 @end


### PR DESCRIPTION
There is an issue with UICollectionView (tested and documented in this diff) where issuing an update before the initial data load will cause an exception to be thrown.

Since #2274 , ASCollectionView has had the same issue. Since it's so infuriating, and since it's relatively easy for us to workaround on the user's behalf, this diff restores the old behavior of ignoring updates before initial data load.