### PR TITLE
[ASDisplayNode] Change _pendingDisplayNodes from NSMutableSet to ASWeakSet

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -2235,7 +2235,7 @@ static NSInteger incrementIfFound(NSInteger i) {
   ASDisplayNodeAssertMainThread();
 
   if (!_pendingDisplayNodes) {
-    _pendingDisplayNodes = [[NSMutableSet alloc] init];
+    _pendingDisplayNodes = [[ASWeakSet alloc] init];
   }
 
   [_pendingDisplayNodes addObject:node];

--- a/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
+++ b/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
@@ -21,6 +21,7 @@
 #import "ASLayoutTransition.h"
 #import "ASEnvironment.h"
 #import "ASObjectDescriptionHelpers.h"
+#import "ASWeakSet.h"
 
 #import "ASDisplayNode+Beta.h"
 
@@ -145,7 +146,7 @@ FOUNDATION_EXPORT NSString * const ASRenderingEngineDidDisplayNodesScheduledBefo
   CALayer *_placeholderLayer;
 
   // keeps track of nodes/subnodes that have not finished display, used with placeholders
-  NSMutableSet *_pendingDisplayNodes;
+  ASWeakSet *_pendingDisplayNodes;
 
   ASDisplayNodeContextModifier _willDisplayNodeContentWithRenderingContext;
   ASDisplayNodeContextModifier _didDisplayNodeContentWithRenderingContext;


### PR DESCRIPTION
In at least some cases, _pendingDisplayNodes referencing self can cause the
object to live longer than the application needs, e.g. while tearing down views.

It also appears there may be a cancellation condition where this state is
not balanced properly, which can cause a reference-cycle leak.  This change
safely fixes this problem when tested against a repro case for it.

I'm filing a followup task to make sure all cancellation edge cases have
proper accounting for this codepath, even though the leak is fixed.