### PR TITLE
[ASDisplayNode] Add -displayWillStartAsynchronously: method to allow skipping synchronous image cache check.

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode+Subclasses.h
+++ b/AsyncDisplayKit/ASDisplayNode+Subclasses.h
@@ -229,6 +229,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @note Called on the main thread only
  */
 - (void)displayWillStart ASDISPLAYNODE_REQUIRES_SUPER;
+- (void)displayWillStartAsynchronously:(BOOL)asynchronously ASDISPLAYNODE_REQUIRES_SUPER;
 
 /**
  * @abstract Indicates that the receiver has finished displaying.

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -1601,10 +1601,11 @@ static inline CATransform3D _calculateTransformFromReferenceToTarget(ASDisplayNo
 
 #pragma mark - _ASDisplayLayerDelegate
 
-- (void)willDisplayAsyncLayer:(_ASDisplayLayer *)layer
+- (void)willDisplayAsyncLayer:(_ASDisplayLayer *)layer asynchronously:(BOOL)asynchronously
 {
   // Subclass hook.
   [self displayWillStart];
+  [self displayWillStartAsynchronously:asynchronously];
 }
 
 - (void)didDisplayAsyncLayer:(_ASDisplayLayer *)layer
@@ -2981,14 +2982,16 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
 
 #pragma mark - Display
 
-- (void)displayWillStart
+- (void)displayWillStart {}
+- (void)displayWillStartAsynchronously:(BOOL)asynchronously
 {
+  [self displayWillStart]; // Subclass override
   ASDisplayNodeAssertMainThread();
 
   ASDisplayNodeLogEvent(self, @"displayWillStart");
   // in case current node takes longer to display than it's subnodes, treat it as a dependent node
   [self _pendingNodeWillDisplay:self];
-
+  
   [_supernode subnodeDisplayWillStart:self];
 }
 

--- a/AsyncDisplayKit/ASNetworkImageNode.mm
+++ b/AsyncDisplayKit/ASNetworkImageNode.mm
@@ -249,11 +249,11 @@ static const CGSize kMinReleaseImageOnBackgroundSize = {20.0, 20.0};
 
 /* displayWillStart in ASMultiplexImageNode has a very similar implementation. Changes here are likely necessary
  in ASMultiplexImageNode as well. */
-- (void)displayWillStart
+- (void)displayWillStartAsynchronously:(BOOL)asynchronously
 {
-  [super displayWillStart];
+  [super displayWillStartAsynchronously:asynchronously];
   
-  if (_cacheFlags.cacheSupportsSynchronousFetch) {
+  if (asynchronously == NO && _cacheFlags.cacheSupportsSynchronousFetch) {
     ASDN::MutexLocker l(__instanceLock__);
     if (_imageLoaded == NO && _URL && _downloadIdentifier == nil) {
       UIImage *result = [[_cache synchronouslyFetchedCachedImageWithURL:_URL] asdk_image];

--- a/AsyncDisplayKit/Details/_ASDisplayLayer.h
+++ b/AsyncDisplayKit/Details/_ASDisplayLayer.h
@@ -128,7 +128,7 @@ typedef BOOL(^asdisplaynode_iscancelled_block_t)(void);
 /**
  @summary Delegate override for willDisplay
  */
-- (void)willDisplayAsyncLayer:(_ASDisplayLayer *)layer;
+- (void)willDisplayAsyncLayer:(_ASDisplayLayer *)layer asynchronously:(BOOL)asynchronously;
 
 /**
  @summary Delegate override for didDisplay

--- a/AsyncDisplayKit/Private/ASDisplayNode+AsyncDisplay.mm
+++ b/AsyncDisplayKit/Private/ASDisplayNode+AsyncDisplay.mm
@@ -311,7 +311,7 @@
   };
 
   // Call willDisplay immediately in either case
-  [self willDisplayAsyncLayer:self.asyncLayer];
+  [self willDisplayAsyncLayer:self.asyncLayer asynchronously:asynchronously];
 
   if (asynchronously) {
     // Async rendering operations are contained by a transaction, which allows them to proceed and concurrently


### PR DESCRIPTION
This is an optimization for displays where synchronous image caching is not needed, e.g. standard display-ahead in a range controller.

The first highlighted line here is the relevant one:

![pasted_image_at_2016_10_04_03_28_pm_1024](https://cloud.githubusercontent.com/assets/565251/19100266/108205c4-8a72-11e6-8b62-431d89e68f08.png)