### PR TITLE
[Umbrella] Add warn_unused_result Attribute to Public Headers

### DIFF
--- a/AsyncDisplayKit/ASButtonNode.h
+++ b/AsyncDisplayKit/ASButtonNode.h
@@ -68,7 +68,7 @@ typedef NS_ENUM(NSInteger, ASButtonNodeImageAlignment) {
  *
  *  @return The title for the specified state.
  */
-- (NSAttributedString * _Nullable)attributedTitleForState:(ASControlState)state;
+- (NSAttributedString * _Nullable)attributedTitleForState:(ASControlState)state AS_WARN_UNUSED_RESULT;
 
 /**
  *  Sets the styled title to use for the specified state. This will reset styled title previously set with -setTitle:withFont:withColor:forState.
@@ -96,7 +96,7 @@ typedef NS_ENUM(NSInteger, ASButtonNodeImageAlignment) {
  *
  *  @return The image used for the specified state.
  */
-- (nullable UIImage *)imageForState:(ASControlState)state;
+- (nullable UIImage *)imageForState:(ASControlState)state AS_WARN_UNUSED_RESULT;
 
 /**
  *  Sets the image to use for the specified state.
@@ -122,7 +122,7 @@ typedef NS_ENUM(NSInteger, ASButtonNodeImageAlignment) {
  *
  *  @return The background image used for the specified state.
  */
-- (nullable UIImage *)backgroundImageForState:(ASControlState)state;
+- (nullable UIImage *)backgroundImageForState:(ASControlState)state AS_WARN_UNUSED_RESULT;
 
 @end
 

--- a/AsyncDisplayKit/ASCollectionNode.h
+++ b/AsyncDisplayKit/ASCollectionNode.h
@@ -46,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @see ASLayoutRangeMode
  * @see ASLayoutRangeType
  */
-- (ASRangeTuningParameters)tuningParametersForRangeType:(ASLayoutRangeType)rangeType;
+- (ASRangeTuningParameters)tuningParametersForRangeType:(ASLayoutRangeType)rangeType AS_WARN_UNUSED_RESULT;
 
 /**
  * Set the tuning parameters for a range type in full mode.
@@ -70,7 +70,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @see ASLayoutRangeMode
  * @see ASLayoutRangeType
  */
-- (ASRangeTuningParameters)tuningParametersForRangeMode:(ASLayoutRangeMode)rangeMode rangeType:(ASLayoutRangeType)rangeType;
+- (ASRangeTuningParameters)tuningParametersForRangeMode:(ASLayoutRangeMode)rangeMode rangeType:(ASLayoutRangeType)rangeType AS_WARN_UNUSED_RESULT;
 
 /**
  * Set the tuning parameters for a range type in the specified mode.

--- a/AsyncDisplayKit/ASCollectionView.h
+++ b/AsyncDisplayKit/ASCollectionView.h
@@ -92,7 +92,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @see ASLayoutRangeMode
  * @see ASLayoutRangeType
  */
-- (ASRangeTuningParameters)tuningParametersForRangeType:(ASLayoutRangeType)rangeType __attribute((warn_unused_result));
+- (ASRangeTuningParameters)tuningParametersForRangeType:(ASLayoutRangeType)rangeType AS_WARN_UNUSED_RESULT;
 
 /**
  * Set the tuning parameters for a range type in full mode.
@@ -116,7 +116,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @see ASLayoutRangeMode
  * @see ASLayoutRangeType
  */
-- (ASRangeTuningParameters)tuningParametersForRangeMode:(ASLayoutRangeMode)rangeMode rangeType:(ASLayoutRangeType)rangeType __attribute((warn_unused_result));
+- (ASRangeTuningParameters)tuningParametersForRangeMode:(ASLayoutRangeMode)rangeMode rangeType:(ASLayoutRangeType)rangeType AS_WARN_UNUSED_RESULT;
 
 /**
  * Set the tuning parameters for a range type in the specified mode.
@@ -262,7 +262,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)moveSection:(NSInteger)section toSection:(NSInteger)newSection;
 
-- (nullable id<ASSectionContext>)contextForSection:(NSInteger)section __attribute((warn_unused_result));
+- (nullable id<ASSectionContext>)contextForSection:(NSInteger)section AS_WARN_UNUSED_RESULT;
 
 /**
  * Inserts items at the locations identified by an array of index paths.
@@ -313,7 +313,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return a node for display at this indexpath or nil
  */
-- (nullable ASCellNode *)nodeForItemAtIndexPath:(NSIndexPath *)indexPath __attribute((warn_unused_result));
+- (nullable ASCellNode *)nodeForItemAtIndexPath:(NSIndexPath *)indexPath AS_WARN_UNUSED_RESULT;
 
 
 /**
@@ -324,7 +324,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return The specified supplementary node or nil
  */
-- (nullable ASCellNode *)supplementaryNodeForElementKind:(NSString *)elementKind atIndexPath:(NSIndexPath *)indexPath __attribute((warn_unused_result));
+- (nullable ASCellNode *)supplementaryNodeForElementKind:(NSString *)elementKind atIndexPath:(NSIndexPath *)indexPath AS_WARN_UNUSED_RESULT;
 
 /**
  * Similar to -indexPathForCell:.
@@ -333,35 +333,35 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return an indexPath for this cellNode
  */
-- (NSIndexPath *)indexPathForNode:(ASCellNode *)cellNode __attribute((warn_unused_result));
+- (NSIndexPath *)indexPathForNode:(ASCellNode *)cellNode AS_WARN_UNUSED_RESULT;
 
 /**
  * Similar to -visibleCells.
  *
  * @return an array containing the nodes being displayed on screen.
  */
-- (NSArray<__kindof ASCellNode *> *)visibleNodes __attribute((warn_unused_result));
+- (NSArray<__kindof ASCellNode *> *)visibleNodes AS_WARN_UNUSED_RESULT;
 
 /**
  * Query the sized node at `indexPath` for its calculatedSize.
  *
  * @param indexPath The index path for the node of interest.
  */
-- (CGSize)calculatedSizeForNodeAtIndexPath:(NSIndexPath *)indexPath __attribute((warn_unused_result));
+- (CGSize)calculatedSizeForNodeAtIndexPath:(NSIndexPath *)indexPath AS_WARN_UNUSED_RESULT;
 
 /**
  * Determines collection view's current scroll direction. Supports 2-axis collection views.
  *
  * @return a bitmask of ASScrollDirection values.
  */
-- (ASScrollDirection)scrollDirection;
+@property (nonatomic, readonly) ASScrollDirection scrollDirection;
 
 /**
  * Determines collection view's scrollable directions.
  *
  * @return a bitmask of ASScrollDirection values.
  */
-- (ASScrollDirection)scrollableDirections;
+@property (nonatomic, readonly) ASScrollDirection scrollableDirections;
 
 /**
  * Triggers all loaded ASCellNodes to destroy displayed contents (freeing a lot of memory).

--- a/AsyncDisplayKit/ASCollectionView.h
+++ b/AsyncDisplayKit/ASCollectionView.h
@@ -92,7 +92,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @see ASLayoutRangeMode
  * @see ASLayoutRangeType
  */
-- (ASRangeTuningParameters)tuningParametersForRangeType:(ASLayoutRangeType)rangeType;
+- (ASRangeTuningParameters)tuningParametersForRangeType:(ASLayoutRangeType)rangeType __attribute((warn_unused_result));
 
 /**
  * Set the tuning parameters for a range type in full mode.
@@ -116,7 +116,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @see ASLayoutRangeMode
  * @see ASLayoutRangeType
  */
-- (ASRangeTuningParameters)tuningParametersForRangeMode:(ASLayoutRangeMode)rangeMode rangeType:(ASLayoutRangeType)rangeType;
+- (ASRangeTuningParameters)tuningParametersForRangeMode:(ASLayoutRangeMode)rangeMode rangeType:(ASLayoutRangeType)rangeType __attribute((warn_unused_result));
 
 /**
  * Set the tuning parameters for a range type in the specified mode.
@@ -262,7 +262,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)moveSection:(NSInteger)section toSection:(NSInteger)newSection;
 
-- (nullable id<ASSectionContext>)contextForSection:(NSInteger)section;
+- (nullable id<ASSectionContext>)contextForSection:(NSInteger)section __attribute((warn_unused_result));
 
 /**
  * Inserts items at the locations identified by an array of index paths.
@@ -313,7 +313,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return a node for display at this indexpath or nil
  */
-- (nullable ASCellNode *)nodeForItemAtIndexPath:(NSIndexPath *)indexPath;
+- (nullable ASCellNode *)nodeForItemAtIndexPath:(NSIndexPath *)indexPath __attribute((warn_unused_result));
 
 
 /**
@@ -324,7 +324,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return The specified supplementary node or nil
  */
-- (nullable ASCellNode *)supplementaryNodeForElementKind:(NSString *)elementKind atIndexPath:(NSIndexPath *)indexPath;
+- (nullable ASCellNode *)supplementaryNodeForElementKind:(NSString *)elementKind atIndexPath:(NSIndexPath *)indexPath __attribute((warn_unused_result));
 
 /**
  * Similar to -indexPathForCell:.
@@ -333,21 +333,21 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return an indexPath for this cellNode
  */
-- (NSIndexPath *)indexPathForNode:(ASCellNode *)cellNode;
+- (NSIndexPath *)indexPathForNode:(ASCellNode *)cellNode __attribute((warn_unused_result));
 
 /**
  * Similar to -visibleCells.
  *
  * @return an array containing the nodes being displayed on screen.
  */
-- (NSArray<ASCellNode *> *)visibleNodes;
+- (NSArray<__kindof ASCellNode *> *)visibleNodes __attribute((warn_unused_result));
 
 /**
  * Query the sized node at `indexPath` for its calculatedSize.
  *
  * @param indexPath The index path for the node of interest.
  */
-- (CGSize)calculatedSizeForNodeAtIndexPath:(NSIndexPath *)indexPath;
+- (CGSize)calculatedSizeForNodeAtIndexPath:(NSIndexPath *)indexPath __attribute((warn_unused_result));
 
 /**
  * Determines collection view's current scroll direction. Supports 2-axis collection views.

--- a/AsyncDisplayKit/ASControlNode.h
+++ b/AsyncDisplayKit/ASControlNode.h
@@ -102,13 +102,13 @@ typedef NS_OPTIONS(NSUInteger, ASControlState) {
   @param controlEvent A single constant of type ASControlNodeEvent that specifies a particular user action on the control; for a list of these constants, see "Control Events". May not be 0 or ASControlNodeEventAllEvents.
   @result An array of selector names as NSString objects, or nil if there are no action selectors associated with controlEvent.
  */
-- (nullable NSArray<NSString *> *)actionsForTarget:(id)target forControlEvent:(ASControlNodeEvent)controlEvent;
+- (nullable NSArray<NSString *> *)actionsForTarget:(id)target forControlEvent:(ASControlNodeEvent)controlEvent AS_WARN_UNUSED_RESULT;
 
 /**
   @abstract Returns all target objects associated with the receiver.
   @result A set of all targets for the receiver. The set may include NSNull to indicate at least one nil target (meaning, the responder chain is searched for a target.)
  */
-- (NSSet *)allTargets;
+- (NSSet *)allTargets AS_WARN_UNUSED_RESULT;
 
 /**
   @abstract Removes a target-action pair for a particular event.

--- a/AsyncDisplayKit/ASDisplayNode+Beta.h
+++ b/AsyncDisplayKit/ASDisplayNode+Beta.h
@@ -60,7 +60,7 @@ typedef struct {
  *
  * This property defaults to NO. It will be removed in a future release.
  */
-+ (BOOL)suppressesInvalidCollectionUpdateExceptions;
++ (BOOL)suppressesInvalidCollectionUpdateExceptions AS_WARN_UNUSED_RESULT;
 + (void)setSuppressesInvalidCollectionUpdateExceptions:(BOOL)suppresses;
 
 /** @name Layout */
@@ -103,7 +103,7 @@ typedef struct {
  * @abstract Currently used by ASNetworkImageNode and ASMultiplexImageNode to allow their placeholders to stay if they are loading an image from the network.
  * Otherwise, a display pass is scheduled and completes, but does not actually draw anything - and ASDisplayNode considers the element finished.
  */
-- (BOOL)placeholderShouldPersist;
+- (BOOL)placeholderShouldPersist AS_WARN_UNUSED_RESULT;
 
 /**
  * @abstract Indicates that the receiver and all subnodes have finished displaying. May be called more than once, for example if the receiver has

--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -554,7 +554,7 @@ extern NSInteger const ASDefaultDrawingPriority;
  *
  * @return YES if point is inside the receiver's bounds; otherwise, NO.
  */
-- (BOOL)pointInside:(CGPoint)point withEvent:(nullable UIEvent *)event;
+- (BOOL)pointInside:(CGPoint)point withEvent:(nullable UIEvent *)event AS_WARN_UNUSED_RESULT;
 
 
 /** @name Converting Between View Coordinate Systems */
@@ -568,7 +568,7 @@ extern NSInteger const ASDefaultDrawingPriority;
  *
  * @return The point converted to the coordinate system of node.
  */
-- (CGPoint)convertPoint:(CGPoint)point toNode:(nullable ASDisplayNode *)node;
+- (CGPoint)convertPoint:(CGPoint)point toNode:(nullable ASDisplayNode *)node AS_WARN_UNUSED_RESULT;
 
 
 /** 
@@ -579,7 +579,7 @@ extern NSInteger const ASDefaultDrawingPriority;
  *
  * @return The point converted to the local coordinate system (bounds) of the receiver.
  */
-- (CGPoint)convertPoint:(CGPoint)point fromNode:(nullable ASDisplayNode *)node;
+- (CGPoint)convertPoint:(CGPoint)point fromNode:(nullable ASDisplayNode *)node AS_WARN_UNUSED_RESULT;
 
 
 /** 
@@ -590,7 +590,7 @@ extern NSInteger const ASDefaultDrawingPriority;
  *
  * @return The converted rectangle.
  */
-- (CGRect)convertRect:(CGRect)rect toNode:(nullable ASDisplayNode *)node;
+- (CGRect)convertRect:(CGRect)rect toNode:(nullable ASDisplayNode *)node AS_WARN_UNUSED_RESULT;
 
 /** 
  * @abstract Converts a rectangle from the coordinate system of another node to that of the receiver.
@@ -600,7 +600,7 @@ extern NSInteger const ASDefaultDrawingPriority;
  *
  * @return The converted rectangle.
  */
-- (CGRect)convertRect:(CGRect)rect fromNode:(nullable ASDisplayNode *)node;
+- (CGRect)convertRect:(CGRect)rect fromNode:(nullable ASDisplayNode *)node AS_WARN_UNUSED_RESULT;
 
 @end
 
@@ -614,7 +614,7 @@ extern NSInteger const ASDefaultDrawingPriority;
  *
  * @discussion For debugging: (lldb) po [node displayNodeRecursiveDescription]
  */
-- (NSString *)displayNodeRecursiveDescription;
+- (NSString *)displayNodeRecursiveDescription AS_WARN_UNUSED_RESULT;
 
 @end
 

--- a/AsyncDisplayKit/ASDisplayNodeExtras.h
+++ b/AsyncDisplayKit/ASDisplayNodeExtras.h
@@ -64,22 +64,22 @@ ASDISPLAYNODE_EXTERN_C_BEGIN
 /**
  Returns the appropriate interface state for a given ASDisplayNode and window
  */
-extern ASInterfaceState ASInterfaceStateForDisplayNode(ASDisplayNode *displayNode, UIWindow *window);
+extern ASInterfaceState ASInterfaceStateForDisplayNode(ASDisplayNode *displayNode, UIWindow *window) AS_WARN_UNUSED_RESULT;
 
 /**
  Given a layer, returns the associated display node, if any.
  */
-extern ASDisplayNode * _Nullable ASLayerToDisplayNode(CALayer * _Nullable layer);
+extern ASDisplayNode * _Nullable ASLayerToDisplayNode(CALayer * _Nullable layer) AS_WARN_UNUSED_RESULT;
 
 /**
  Given a view, returns the associated display node, if any.
  */
-extern ASDisplayNode * _Nullable ASViewToDisplayNode(UIView * _Nullable view);
+extern ASDisplayNode * _Nullable ASViewToDisplayNode(UIView * _Nullable view) AS_WARN_UNUSED_RESULT;
 
 /**
  Given a node, returns the root of the node heirarchy (where supernode == nil)
  */
-extern ASDisplayNode *ASDisplayNodeUltimateParentOfNode(ASDisplayNode *node);
+extern ASDisplayNode *ASDisplayNodeUltimateParentOfNode(ASDisplayNode *node) AS_WARN_UNUSED_RESULT;
 
 /**
  If traverseSublayers == YES, this function will walk the layer hierarchy, spanning discontinuous sections of the node hierarchy\
@@ -104,12 +104,12 @@ extern void ASDisplayNodePerformBlockOnEverySubnode(ASDisplayNode *node, BOOL tr
 /**
  Given a display node, traverses up the layer tree hierarchy, returning the first display node that passes block.
  */
-extern ASDisplayNode * _Nullable ASDisplayNodeFindFirstSupernode(ASDisplayNode * _Nullable node, BOOL (^block)(ASDisplayNode *node));
+extern ASDisplayNode * _Nullable ASDisplayNodeFindFirstSupernode(ASDisplayNode * _Nullable node, BOOL (^block)(ASDisplayNode *node)) AS_WARN_UNUSED_RESULT;
 
 /**
  Given a display node, traverses up the layer tree hierarchy, returning the first display node of kind class.
  */
-extern __kindof ASDisplayNode * _Nullable ASDisplayNodeFindFirstSupernodeOfClass(ASDisplayNode *start, Class c);
+extern __kindof ASDisplayNode * _Nullable ASDisplayNodeFindFirstSupernodeOfClass(ASDisplayNode *start, Class c) AS_WARN_UNUSED_RESULT;
 
 /**
  * Given two nodes, finds their most immediate common parent.  Used for geometry conversion methods.
@@ -119,40 +119,40 @@ extern __kindof ASDisplayNode * _Nullable ASDisplayNodeFindFirstSupernodeOfClass
  * undefined and undocumented behavior of UIKit in ASDisplayNode, this operation is defined to be incorrect in all
  * circumstances and must be fixed wherever encountered.
  */
-extern ASDisplayNode * _Nullable ASDisplayNodeFindClosestCommonAncestor(ASDisplayNode *node1, ASDisplayNode *node2);
+extern ASDisplayNode * _Nullable ASDisplayNodeFindClosestCommonAncestor(ASDisplayNode *node1, ASDisplayNode *node2) AS_WARN_UNUSED_RESULT;
 
 /**
  Given a display node, collects all descendants. This is a specialization of ASCollectContainer() that walks the Core Animation layer tree as opposed to the display node tree, thus supporting non-continues display node hierarchies.
  */
-extern NSArray<ASDisplayNode *> *ASCollectDisplayNodes(ASDisplayNode *node);
+extern NSArray<ASDisplayNode *> *ASCollectDisplayNodes(ASDisplayNode *node) AS_WARN_UNUSED_RESULT;
 
 /**
  Given a display node, traverses down the node hierarchy, returning all the display nodes that pass the block.
  */
-extern NSArray<ASDisplayNode *> *ASDisplayNodeFindAllSubnodes(ASDisplayNode *start, BOOL (^block)(ASDisplayNode *node));
+extern NSArray<ASDisplayNode *> *ASDisplayNodeFindAllSubnodes(ASDisplayNode *start, BOOL (^block)(ASDisplayNode *node)) AS_WARN_UNUSED_RESULT;
 
 /**
  Given a display node, traverses down the node hierarchy, returning all the display nodes of kind class.
  */
-extern NSArray<__kindof ASDisplayNode *> *ASDisplayNodeFindAllSubnodesOfClass(ASDisplayNode *start, Class c);
+extern NSArray<__kindof ASDisplayNode *> *ASDisplayNodeFindAllSubnodesOfClass(ASDisplayNode *start, Class c) AS_WARN_UNUSED_RESULT;
 
 /**
  Given a display node, traverses down the node hierarchy, returning the depth-first display node, including the start node that pass the block.
  */
-extern __kindof ASDisplayNode * _Nullable ASDisplayNodeFindFirstNode(ASDisplayNode *start, BOOL (^block)(ASDisplayNode *node));
+extern __kindof ASDisplayNode * _Nullable ASDisplayNodeFindFirstNode(ASDisplayNode *start, BOOL (^block)(ASDisplayNode *node)) AS_WARN_UNUSED_RESULT;
 
 /**
  Given a display node, traverses down the node hierarchy, returning the depth-first display node, excluding the start node, that pass the block
  */
-extern __kindof ASDisplayNode * _Nullable ASDisplayNodeFindFirstSubnode(ASDisplayNode *start, BOOL (^block)(ASDisplayNode *node));
+extern __kindof ASDisplayNode * _Nullable ASDisplayNodeFindFirstSubnode(ASDisplayNode *start, BOOL (^block)(ASDisplayNode *node)) AS_WARN_UNUSED_RESULT;
 
 /**
  Given a display node, traverses down the node hierarchy, returning the depth-first display node of kind class.
  */
-extern __kindof ASDisplayNode * _Nullable ASDisplayNodeFindFirstSubnodeOfClass(ASDisplayNode *start, Class c);
+extern __kindof ASDisplayNode * _Nullable ASDisplayNodeFindFirstSubnodeOfClass(ASDisplayNode *start, Class c) AS_WARN_UNUSED_RESULT;
 
-extern UIColor *ASDisplayNodeDefaultPlaceholderColor();
-extern UIColor *ASDisplayNodeDefaultTintColor();
+extern UIColor *ASDisplayNodeDefaultPlaceholderColor() AS_WARN_UNUSED_RESULT;
+extern UIColor *ASDisplayNodeDefaultTintColor() AS_WARN_UNUSED_RESULT;
 
 /**
  Disable willAppear / didAppear / didDisappear notifications for a sub-hierarchy, then re-enable when done. Nested calls are supported.

--- a/AsyncDisplayKit/ASEditableTextNode.h
+++ b/AsyncDisplayKit/ASEditableTextNode.h
@@ -68,7 +68,7 @@ NS_ASSUME_NONNULL_BEGIN
   @discussion To update the placeholder, see the <attributedPlaceholderText> property.
   @result YES if the placeholder is currently displayed; NO otherwise.
  */
-- (BOOL)isDisplayingPlaceholder;
+- (BOOL)isDisplayingPlaceholder AS_WARN_UNUSED_RESULT;
 
 /**
   @abstract The styled placeholder text displayed by the text node while no text is entered
@@ -108,7 +108,7 @@ NS_ASSUME_NONNULL_BEGIN
   @abstract Indicates whether the receiver's text view is the first responder, and thus has the keyboard visible and is prepared for editing by the user.
   @result YES if the receiver's text view is the first-responder; NO otherwise.
  */
-- (BOOL)isFirstResponder;
+- (BOOL)isFirstResponder AS_WARN_UNUSED_RESULT;
 
 //! @abstract Makes the receiver's text view the first responder.
 - (BOOL)becomeFirstResponder;
@@ -123,7 +123,7 @@ NS_ASSUME_NONNULL_BEGIN
   @discussion This method raises an exception if `textRange` is not a valid range of characters within the receiver's attributed text.
   @result A CGRect that is the bounding box of the glyphs covered by the given range of characters, in the coordinate system of the receiver.
  */
-- (CGRect)frameForTextRange:(NSRange)textRange;
+- (CGRect)frameForTextRange:(NSRange)textRange AS_WARN_UNUSED_RESULT;
 
 @end
 

--- a/AsyncDisplayKit/ASMultiplexImageNode.h
+++ b/AsyncDisplayKit/ASMultiplexImageNode.h
@@ -270,7 +270,7 @@ didFinishDownloadingImageWithIdentifier:(ASImageIdentifier)imageIdentifier
 + (NSURL *)URLWithAssetLocalIdentifier:(NSString *)assetLocalIdentifier
                             targetSize:(CGSize)targetSize
                            contentMode:(PHImageContentMode)contentMode
-                               options:(PHImageRequestOptions *)options;
+                               options:(PHImageRequestOptions *)options AS_WARN_UNUSED_RESULT;
 
 @end
 #endif

--- a/AsyncDisplayKit/ASPagerNode.h
+++ b/AsyncDisplayKit/ASPagerNode.h
@@ -87,14 +87,14 @@ NS_ASSUME_NONNULL_BEGIN
  * Data Source is required, and uses a different protocol from ASCollectionNode.
  */
 - (void)setDataSource:(nullable id <ASPagerDataSource>)dataSource;
-- (nullable id <ASPagerDataSource>)dataSource;
+- (nullable id <ASPagerDataSource>)dataSource AS_WARN_UNUSED_RESULT;
 
 /**
  * Delegate is optional.
  * This includes UIScrollViewDelegate as well as most methods from UICollectionViewDelegate, like willDisplay...
  */
 - (void)setDelegate:(nullable id <ASPagerDelegate>)delegate;
-- (nullable id <ASPagerDelegate>)delegate;
+- (nullable id <ASPagerDelegate>)delegate AS_WARN_UNUSED_RESULT;
 
 /**
  * The underlying ASCollectionView object.
@@ -114,7 +114,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Returns the node for the passed page index
  */
-- (ASCellNode *)nodeForPageAtIndex:(NSInteger)index;
+- (ASCellNode *)nodeForPageAtIndex:(NSInteger)index AS_WARN_UNUSED_RESULT;
 
 @end
 

--- a/AsyncDisplayKit/ASTableView.h
+++ b/AsyncDisplayKit/ASTableView.h
@@ -57,7 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @see ASLayoutRangeMode
  * @see ASLayoutRangeType
  */
-- (ASRangeTuningParameters)tuningParametersForRangeType:(ASLayoutRangeType)rangeType;
+- (ASRangeTuningParameters)tuningParametersForRangeType:(ASLayoutRangeType)rangeType AS_WARN_UNUSED_RESULT;
 
 /**
  * Set the tuning parameters for a range type in full mode.
@@ -81,7 +81,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @see ASLayoutRangeMode
  * @see ASLayoutRangeType
  */
-- (ASRangeTuningParameters)tuningParametersForRangeMode:(ASLayoutRangeMode)rangeMode rangeType:(ASLayoutRangeType)rangeType;
+- (ASRangeTuningParameters)tuningParametersForRangeMode:(ASLayoutRangeMode)rangeMode rangeType:(ASLayoutRangeType)rangeType AS_WARN_UNUSED_RESULT;
 
 /**
  * Set the tuning parameters for a range type in the specified mode.
@@ -278,7 +278,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return a node for display at this indexpath.
  */
-- (ASCellNode *)nodeForRowAtIndexPath:(NSIndexPath *)indexPath;
+- (ASCellNode *)nodeForRowAtIndexPath:(NSIndexPath *)indexPath AS_WARN_UNUSED_RESULT;
 
 /**
  * Similar to -indexPathForCell:.
@@ -287,14 +287,14 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return an indexPath for this cellNode
  */
-- (nullable NSIndexPath *)indexPathForNode:(ASCellNode *)cellNode;
+- (nullable NSIndexPath *)indexPathForNode:(ASCellNode *)cellNode AS_WARN_UNUSED_RESULT;
 
 /**
  * Similar to -visibleCells.
  *
  * @return an array containing the cell nodes being displayed on screen.
  */
-- (NSArray<ASCellNode *> *)visibleNodes;
+- (NSArray<ASCellNode *> *)visibleNodes AS_WARN_UNUSED_RESULT;
 
 /**
  * YES to automatically adjust the contentOffset when cells are inserted or deleted "before"
@@ -339,7 +339,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @return a node for display at this indexpath. This will be called on the main thread and should not implement reuse (it will be called once per row). Unlike UITableView's version, this method
  * is not called when the row is about to display.
  */
-- (ASCellNode *)tableView:(ASTableView *)tableView nodeForRowAtIndexPath:(NSIndexPath *)indexPath;
+- (ASCellNode *)tableView:(ASTableView *)tableView nodeForRowAtIndexPath:(NSIndexPath *)indexPath AS_WARN_UNUSED_RESULT;
 
 
 /**
@@ -354,7 +354,7 @@ NS_ASSUME_NONNULL_BEGIN
  *   queue) and should not implement reuse (it will be called once per row).
  */
 
-- (ASCellNodeBlock)tableView:(ASTableView *)tableView nodeBlockForRowAtIndexPath:(NSIndexPath *)indexPath;
+- (ASCellNodeBlock)tableView:(ASTableView *)tableView nodeBlockForRowAtIndexPath:(NSIndexPath *)indexPath AS_WARN_UNUSED_RESULT;
 
 /**
  * Indicator to lock the data source for data fetching in async mode.
@@ -445,7 +445,7 @@ NS_ASSUME_NONNULL_BEGIN
  * If not implemented, the tableView assumes that it should notify its asyncDelegate when batch fetching
  * should occur.
  */
-- (BOOL)shouldBatchFetchForTableView:(ASTableView *)tableView;
+- (BOOL)shouldBatchFetchForTableView:(ASTableView *)tableView AS_WARN_UNUSED_RESULT;
 
 /**
  * Provides the constrained size range for measuring the row at the index path.
@@ -457,7 +457,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A constrained size range for layout the node at this index path.
  */
-- (ASSizeRange)tableView:(ASTableView *)tableView constrainedSizeForRowAtIndexPath:(NSIndexPath *)indexPath;
+- (ASSizeRange)tableView:(ASTableView *)tableView constrainedSizeForRowAtIndexPath:(NSIndexPath *)indexPath AS_WARN_UNUSED_RESULT;
 
 /**
  * Informs the delegate that the table view will add the node

--- a/AsyncDisplayKit/ASTextNode.h
+++ b/AsyncDisplayKit/ASTextNode.h
@@ -140,7 +140,7 @@ typedef NS_ENUM(NSUInteger, ASTextNodeHighlightStyle) {
  a line break, the rects returned will be on opposite sides and different lines). The rects returned
  are in the coordinate system of the receiver.
  */
-- (NSArray<NSValue *> *)rectsForTextRange:(NSRange)textRange;
+- (NSArray<NSValue *> *)rectsForTextRange:(NSRange)textRange AS_WARN_UNUSED_RESULT;
 
 /**
  @abstract Returns an array of rects used for highlighting the characters in a given text range.
@@ -151,7 +151,7 @@ typedef NS_ENUM(NSUInteger, ASTextNodeHighlightStyle) {
  are in the coordinate system of the receiver. This method is useful for visual coordination with a
  highlighted range of text.
  */
-- (NSArray<NSValue *> *)highlightRectsForTextRange:(NSRange)textRange;
+- (NSArray<NSValue *> *)highlightRectsForTextRange:(NSRange)textRange AS_WARN_UNUSED_RESULT;
 
 /**
  @abstract Returns a bounding rect for the given text range.
@@ -160,14 +160,14 @@ typedef NS_ENUM(NSUInteger, ASTextNodeHighlightStyle) {
  cap-height and descenders is not performed. This method raises an exception if textRange is not
  a valid substring range of the receiver's string.
  */
-- (CGRect)frameForTextRange:(NSRange)textRange;
+- (CGRect)frameForTextRange:(NSRange)textRange AS_WARN_UNUSED_RESULT;
 
 /**
  @abstract Returns the trailing rectangle of space in the receiver, after the final character.
  @discussion Use this method to detect which portion of the receiver is not occupied by characters.
  The rect returned is in the coordinate system of the receiver.
  */
-- (CGRect)trailingRect;
+- (CGRect)trailingRect AS_WARN_UNUSED_RESULT;
 
 
 #pragma mark - Actions
@@ -184,7 +184,7 @@ typedef NS_ENUM(NSUInteger, ASTextNodeHighlightStyle) {
  @param rangeOut The ultimate range of the found text. Can be NULL.
  @result YES if an entity exists at `point`; NO otherwise.
  */
-- (nullable id)linkAttributeValueAtPoint:(CGPoint)point attributeName:(out NSString * _Nullable * _Nullable)attributeNameOut range:(out NSRange * _Nullable)rangeOut;
+- (nullable id)linkAttributeValueAtPoint:(CGPoint)point attributeName:(out NSString * _Nullable * _Nullable)attributeNameOut range:(out NSRange * _Nullable)rangeOut AS_WARN_UNUSED_RESULT;
 
 /**
  @abstract The style to use when highlighting text.

--- a/AsyncDisplayKit/ASViewController.h
+++ b/AsyncDisplayKit/ASViewController.h
@@ -72,7 +72,7 @@ typedef ASTraitCollection * _Nonnull (^ASDisplayTraitsForTraitWindowSizeBlock)(C
  * both the min and max definitions. Override this method to provide a custom size range to the
  * backing node.
  */
-- (ASSizeRange)nodeConstrainedSize;
+- (ASSizeRange)nodeConstrainedSize AS_WARN_UNUSED_RESULT;
 
 @end
 

--- a/AsyncDisplayKit/Details/ASWeakSet.h
+++ b/AsyncDisplayKit/Details/ASWeakSet.h
@@ -11,6 +11,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <AsyncDisplayKit/ASBaseDefines.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -20,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, getter=isEmpty) BOOL empty;
 
 /// Returns YES if `object` is in the receiver, NO otherwise.
-- (BOOL)containsObject:(ObjectType)object;
+- (BOOL)containsObject:(ObjectType)object AS_WARN_UNUSED_RESULT;
 
 /// Insets `object` into the set.
 - (void)addObject:(ObjectType)object;
@@ -32,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)removeAllObjects;
 
 /// Returns a standard *retained* NSArray of all objects.  Not free to generate, but useful for iterating over contents.
-- (NSArray *)allObjects;
+- (NSArray *)allObjects AS_WARN_UNUSED_RESULT;
 
 /**
  * How many objects are contained in this set.

--- a/AsyncDisplayKit/Layout/ASAbsoluteLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASAbsoluteLayoutSpec.h
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  @param children Children to be positioned at fixed positions, each conforms to ASAbsoluteLayoutElement
  */
-+ (instancetype)absoluteLayoutSpecWithChildren:(NSArray<id<ASAbsoluteLayoutElement>> *)children;
++ (instancetype)absoluteLayoutSpecWithChildren:(NSArray<id<ASAbsoluteLayoutElement>> *)children AS_WARN_UNUSED_RESULT;
 
 @end
 

--- a/AsyncDisplayKit/Layout/ASBackgroundLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASBackgroundLayoutSpec.h
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param child A child that is laid out to determine the size of this spec.
  * @param background A layoutElement object that is laid out behind the child. If this is nil, the background is omitted.
  */
-+ (instancetype)backgroundLayoutSpecWithChild:(id<ASLayoutElement>)child background:(nullable id<ASLayoutElement>)background;
++ (instancetype)backgroundLayoutSpecWithChild:(id<ASLayoutElement>)child background:(nullable id<ASLayoutElement>)background AS_WARN_UNUSED_RESULT;
 
 @end
 

--- a/AsyncDisplayKit/Layout/ASCenterLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASCenterLayoutSpec.h
@@ -56,7 +56,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (instancetype)centerLayoutSpecWithCenteringOptions:(ASCenterLayoutSpecCenteringOptions)centeringOptions
                                        sizingOptions:(ASCenterLayoutSpecSizingOptions)sizingOptions
-                                               child:(id<ASLayoutElement>)child;
+                                               child:(id<ASLayoutElement>)child AS_WARN_UNUSED_RESULT;
 
 @end
 

--- a/AsyncDisplayKit/Layout/ASDimension.h
+++ b/AsyncDisplayKit/Layout/ASDimension.h
@@ -13,12 +13,12 @@
 #import <AsyncDisplayKit/ASBaseDefines.h>
 #import <AsyncDisplayKit/ASAssert.h>
 
-ASDISPLAYNODE_INLINE BOOL ASPointsAreValidForLayout(CGFloat points)
+ASDISPLAYNODE_INLINE BOOL AS_WARN_UNUSED_RESULT ASPointsAreValidForLayout(CGFloat points)
 {
   return ((isnormal(points) || points == 0.0) && points >= 0.0 && points < (CGFLOAT_MAX / 2.0));
 }
 
-ASDISPLAYNODE_INLINE BOOL ASIsCGSizeValidForLayout(CGSize size)
+ASDISPLAYNODE_INLINE BOOL AS_WARN_UNUSED_RESULT ASIsCGSizeValidForLayout(CGSize size)
 {
   return (ASPointsAreValidForLayout(size.width) && ASPointsAreValidForLayout(size.height));  
 }
@@ -105,7 +105,7 @@ ASOVERLOADABLE ASDISPLAYNODE_INLINE ASDimension ASDimensionMake(ASDimensionUnit 
 /**
  * Returns a dimension with the specified points value.
  */
-ASOVERLOADABLE ASDISPLAYNODE_INLINE ASDimension ASDimensionMake(CGFloat points)
+ASOVERLOADABLE ASDISPLAYNODE_INLINE AS_WARN_UNUSED_RESULT ASDimension ASDimensionMake(CGFloat points)
 {
   return ASDimensionMake(ASDimensionUnitPoints, points);
 }
@@ -115,12 +115,12 @@ ASOVERLOADABLE ASDISPLAYNODE_INLINE ASDimension ASDimensionMake(CGFloat points)
  * Examples: ASDimensionMake(@"0.5%") = ASDimensionMake(ASDimensionUnitFraction, 0.5)
  *           ASDimensionMake(@"0.5pt") = ASDimensionMake(ASDimensionUnitPoints, 0.5)
  */
-ASOVERLOADABLE extern ASDimension ASDimensionMake(NSString *dimension);
+ASOVERLOADABLE AS_WARN_UNUSED_RESULT extern ASDimension ASDimensionMake(NSString *dimension);
 
 /**
  * Returns a dimension with the specified points value.
  */
-ASDISPLAYNODE_INLINE ASDimension ASDimensionMakeWithPoints(CGFloat points)
+ASDISPLAYNODE_INLINE AS_WARN_UNUSED_RESULT ASDimension ASDimensionMakeWithPoints(CGFloat points)
 {
   ASDisplayNodeCAssertPositiveReal(@"Points", points);
   return ASDimensionMake(ASDimensionUnitPoints, points);
@@ -129,7 +129,7 @@ ASDISPLAYNODE_INLINE ASDimension ASDimensionMakeWithPoints(CGFloat points)
 /**
  * Returns a dimension with the specified fraction value.
  */
-ASDISPLAYNODE_INLINE ASDimension ASDimensionMakeWithFraction(CGFloat fraction)
+ASDISPLAYNODE_INLINE AS_WARN_UNUSED_RESULT ASDimension ASDimensionMakeWithFraction(CGFloat fraction)
 {
   ASDisplayNodeCAssert( 0 <= fraction && fraction <= 1.0, @"ASDimension fraction value (%f) must be between 0 and 1.", fraction);
   return ASDimensionMake(ASDimensionUnitFraction, fraction);
@@ -138,7 +138,7 @@ ASDISPLAYNODE_INLINE ASDimension ASDimensionMakeWithFraction(CGFloat fraction)
 /**
  * Returns whether two dimensions are equal.
  */
-ASDISPLAYNODE_INLINE BOOL ASDimensionEqualToDimension(ASDimension lhs, ASDimension rhs)
+ASDISPLAYNODE_INLINE AS_WARN_UNUSED_RESULT BOOL ASDimensionEqualToDimension(ASDimension lhs, ASDimension rhs)
 {
   return (lhs.unit == rhs.unit && lhs.value == rhs.value);
 }
@@ -146,12 +146,12 @@ ASDISPLAYNODE_INLINE BOOL ASDimensionEqualToDimension(ASDimension lhs, ASDimensi
 /**
  * Returns a NSString representation of a dimension.
  */
-extern NSString *NSStringFromASDimension(ASDimension dimension);
+extern AS_WARN_UNUSED_RESULT NSString *NSStringFromASDimension(ASDimension dimension);
 
 /**
  * Resolve this dimension to a parent size.
  */
-ASDISPLAYNODE_INLINE CGFloat ASDimensionResolve(ASDimension dimension, CGFloat parentSize, CGFloat autoSize)
+ASDISPLAYNODE_INLINE AS_WARN_UNUSED_RESULT CGFloat ASDimensionResolve(ASDimension dimension, CGFloat parentSize, CGFloat autoSize)
 {
   switch (dimension.unit) {
     case ASDimensionUnitAuto:
@@ -185,7 +185,7 @@ typedef struct {
 /*
  * Creates an ASRelativeSize with provided min and max dimensions.
  */
-ASDISPLAYNODE_INLINE ASRelativeSize ASRelativeSizeMake(ASDimension width, ASDimension height)
+ASDISPLAYNODE_INLINE AS_WARN_UNUSED_RESULT ASRelativeSize ASRelativeSizeMake(ASDimension width, ASDimension height)
 {
   ASRelativeSize size;
   size.width = width;
@@ -196,14 +196,14 @@ ASDISPLAYNODE_INLINE ASRelativeSize ASRelativeSizeMake(ASDimension width, ASDime
 /*
  * Returns a string representation of a relative size.
  */
-ASDISPLAYNODE_INLINE NSString *NSStringFromASRelativeSize(ASRelativeSize size);
+ASDISPLAYNODE_INLINE AS_WARN_UNUSED_RESULT NSString *NSStringFromASRelativeSize(ASRelativeSize size);
 
 #pragma mark - ASSizeRange
 
 /**
  * Creates an ASSizeRange with provided min and max size.
  */
-ASOVERLOADABLE ASDISPLAYNODE_INLINE ASSizeRange ASSizeRangeMake(CGSize min, CGSize max)
+ASOVERLOADABLE ASDISPLAYNODE_INLINE AS_WARN_UNUSED_RESULT ASSizeRange ASSizeRangeMake(CGSize min, CGSize max)
 {
   ASDisplayNodeCAssertPositiveReal(@"Range min width", min.width);
   ASDisplayNodeCAssertPositiveReal(@"Range min height", min.height);
@@ -222,7 +222,7 @@ ASOVERLOADABLE ASDISPLAYNODE_INLINE ASSizeRange ASSizeRangeMake(CGSize min, CGSi
 /**
  * Creates an ASSizeRange with provided size as both min and max.
  */
-ASOVERLOADABLE ASDISPLAYNODE_INLINE ASSizeRange ASSizeRangeMake(CGSize exactSize)
+ASOVERLOADABLE ASDISPLAYNODE_INLINE AS_WARN_UNUSED_RESULT ASSizeRange ASSizeRangeMake(CGSize exactSize)
 {
   return ASSizeRangeMake(exactSize, exactSize);
 }
@@ -230,7 +230,7 @@ ASOVERLOADABLE ASDISPLAYNODE_INLINE ASSizeRange ASSizeRangeMake(CGSize exactSize
 /**
  * Clamps the provided CGSize between the [min, max] bounds of this ASSizeRange.
  */
-ASDISPLAYNODE_INLINE CGSize ASSizeRangeClamp(ASSizeRange sizeRange, CGSize size)
+ASDISPLAYNODE_INLINE AS_WARN_UNUSED_RESULT CGSize ASSizeRangeClamp(ASSizeRange sizeRange, CGSize size)
 {
   return CGSizeMake(MAX(sizeRange.min.width, MIN(sizeRange.max.width, size.width)),
                     MAX(sizeRange.min.height, MIN(sizeRange.max.height, size.height)));
@@ -240,12 +240,12 @@ ASDISPLAYNODE_INLINE CGSize ASSizeRangeClamp(ASSizeRange sizeRange, CGSize size)
  * Intersects another size range. If the other size range does not overlap in either dimension, this size range
  * "wins" by returning a single point within its own range that is closest to the non-overlapping range.
  */
-extern ASSizeRange ASSizeRangeIntersect(ASSizeRange sizeRange, ASSizeRange otherSizeRange);
+extern AS_WARN_UNUSED_RESULT ASSizeRange ASSizeRangeIntersect(ASSizeRange sizeRange, ASSizeRange otherSizeRange);
 
 /**
  * Returns whether two size ranges are equal in min and max size.
  */
-ASDISPLAYNODE_INLINE BOOL ASSizeRangeEqualToSizeRange(ASSizeRange lhs, ASSizeRange rhs)
+ASDISPLAYNODE_INLINE AS_WARN_UNUSED_RESULT BOOL ASSizeRangeEqualToSizeRange(ASSizeRange lhs, ASSizeRange rhs)
 {
   return CGSizeEqualToSize(lhs.min, rhs.min) && CGSizeEqualToSize(lhs.max, rhs.max);
 }
@@ -253,7 +253,7 @@ ASDISPLAYNODE_INLINE BOOL ASSizeRangeEqualToSizeRange(ASSizeRange lhs, ASSizeRan
 /**
  * Returns a string representation of a size range
  */
-extern NSString *NSStringFromASSizeRange(ASSizeRange sizeRange);
+extern AS_WARN_UNUSED_RESULT NSString *NSStringFromASSizeRange(ASSizeRange sizeRange);
 
 
 #pragma mark - ASLayoutElementSize
@@ -261,7 +261,7 @@ extern NSString *NSStringFromASSizeRange(ASSizeRange sizeRange);
 /**
  * Returns an ASLayoutElementSize with default values.
  */
-ASDISPLAYNODE_INLINE ASLayoutElementSize ASLayoutElementSizeMake()
+ASDISPLAYNODE_INLINE AS_WARN_UNUSED_RESULT ASLayoutElementSize ASLayoutElementSizeMake()
 {
   return (ASLayoutElementSize){
     .width = ASDimensionAuto,
@@ -276,7 +276,7 @@ ASDISPLAYNODE_INLINE ASLayoutElementSize ASLayoutElementSizeMake()
 /**
  * Returns an ASLayoutElementSize with the specified CGSize values as width and height.
  */
-ASDISPLAYNODE_INLINE ASLayoutElementSize ASLayoutElementSizeMakeFromCGSize(CGSize size)
+ASDISPLAYNODE_INLINE AS_WARN_UNUSED_RESULT ASLayoutElementSize ASLayoutElementSizeMakeFromCGSize(CGSize size)
 {
   ASLayoutElementSize s = ASLayoutElementSizeMake();
   s.width = ASDimensionMakeWithPoints(size.width);
@@ -287,7 +287,7 @@ ASDISPLAYNODE_INLINE ASLayoutElementSize ASLayoutElementSizeMakeFromCGSize(CGSiz
 /**
  * Returns whether two sizes are equal.
  */
-ASDISPLAYNODE_INLINE BOOL ASLayoutElementSizeEqualToLayoutElementSize(ASLayoutElementSize lhs, ASLayoutElementSize rhs)
+ASDISPLAYNODE_INLINE AS_WARN_UNUSED_RESULT BOOL ASLayoutElementSizeEqualToLayoutElementSize(ASLayoutElementSize lhs, ASLayoutElementSize rhs)
 {
   return (ASDimensionEqualToDimension(lhs.width, rhs.width)
   && ASDimensionEqualToDimension(lhs.height, rhs.height)
@@ -300,7 +300,7 @@ ASDISPLAYNODE_INLINE BOOL ASLayoutElementSizeEqualToLayoutElementSize(ASLayoutEl
 /**
  * Returns a string formatted to contain the data from an ASLayoutElementSize.
  */
-extern NSString *NSStringFromASLayoutElementSize(ASLayoutElementSize size);
+extern AS_WARN_UNUSED_RESULT NSString *NSStringFromASLayoutElementSize(ASLayoutElementSize size);
 
 /**
  * Resolve the given size relative to a parent size and an auto size.
@@ -309,13 +309,13 @@ extern NSString *NSStringFromASLayoutElementSize(ASLayoutElementSize size);
  * dimension with unit ASDimensionUnitAuto the given autoASSizeRange value will be used.
  * Based on the calculated exact, min and max size constraints the final size range will be calculated.
  */
-extern ASSizeRange ASLayoutElementSizeResolveAutoSize(ASLayoutElementSize size, const CGSize parentSize, ASSizeRange autoASSizeRange);
+extern AS_WARN_UNUSED_RESULT ASSizeRange ASLayoutElementSizeResolveAutoSize(ASLayoutElementSize size, const CGSize parentSize, ASSizeRange autoASSizeRange);
 
 /**
  * Resolve the given size to a parent size. Uses internally ASLayoutElementSizeResolveAutoSize with {INFINITY, INFINITY} as
  * as autoASSizeRange. For more information look at ASLayoutElementSizeResolveAutoSize.
  */
-ASDISPLAYNODE_INLINE ASSizeRange ASLayoutElementSizeResolve(ASLayoutElementSize size, const CGSize parentSize)
+ASDISPLAYNODE_INLINE AS_WARN_UNUSED_RESULT ASSizeRange ASLayoutElementSizeResolve(ASLayoutElementSize size, const CGSize parentSize)
 {
   return ASLayoutElementSizeResolveAutoSize(size, parentSize, ASSizeRangeMake(CGSizeZero, CGSizeMake(INFINITY, INFINITY)));
 }
@@ -326,7 +326,7 @@ ASDISPLAYNODE_INLINE ASSizeRange ASLayoutElementSizeResolve(ASLayoutElementSize 
 /**
  * Function is deprecated. Use ASSizeRangeMakeWithExactCGSize instead.
  */
-extern ASSizeRange ASSizeRangeMakeExactSize(CGSize size) ASDISPLAYNODE_DEPRECATED;
+extern AS_WARN_UNUSED_RESULT ASSizeRange ASSizeRangeMakeExactSize(CGSize size) ASDISPLAYNODE_DEPRECATED;
 
 NS_ASSUME_NONNULL_END
 ASDISPLAYNODE_EXTERN_C_END

--- a/AsyncDisplayKit/Layout/ASInsetLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASInsetLayoutSpec.h
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param insets The amount of space to inset on each side.
  @param child The wrapped child to inset.
  */
-+ (instancetype)insetLayoutSpecWithInsets:(UIEdgeInsets)insets child:(id<ASLayoutElement>)child;
++ (instancetype)insetLayoutSpecWithInsets:(UIEdgeInsets)insets child:(id<ASLayoutElement>)child AS_WARN_UNUSED_RESULT;
 
 @end
 

--- a/AsyncDisplayKit/Layout/ASLayout.h
+++ b/AsyncDisplayKit/Layout/ASLayout.h
@@ -97,7 +97,7 @@ ASDISPLAYNODE_EXTERN_C_END
 + (instancetype)layoutWithLayoutElement:(id<ASLayoutElement>)layoutElement
                                    size:(CGSize)size
                                position:(CGPoint)position
-                             sublayouts:(nullable NSArray<ASLayout *> *)sublayouts;
+                             sublayouts:(nullable NSArray<ASLayout *> *)sublayouts AS_WARN_UNUSED_RESULT;
 
 /**
  * Convenience initializer that has CGPointNull position.
@@ -111,7 +111,7 @@ ASDISPLAYNODE_EXTERN_C_END
  */
 + (instancetype)layoutWithLayoutElement:(id<ASLayoutElement>)layoutElement
                                    size:(CGSize)size
-                             sublayouts:(nullable NSArray<ASLayout *> *)sublayouts;
+                             sublayouts:(nullable NSArray<ASLayout *> *)sublayouts AS_WARN_UNUSED_RESULT;
 
 /**
  * Convenience that has CGPointNull position and no sublayouts.
@@ -122,19 +122,19 @@ ASDISPLAYNODE_EXTERN_C_END
  * @param size             The size of this layout.
  */
 + (instancetype)layoutWithLayoutElement:(id<ASLayoutElement>)layoutElement
-                                   size:(CGSize)size;
+                                   size:(CGSize)size AS_WARN_UNUSED_RESULT;
 /**
  * Convenience initializer that creates a layout based on the values of the given layout, with a new position
  *
  * @param layout           The layout to use to create the new layout
  * @param position         The position of the new layout
  */
-+ (instancetype)layoutWithLayout:(ASLayout *)layout position:(CGPoint)position;
++ (instancetype)layoutWithLayout:(ASLayout *)layout position:(CGPoint)position AS_WARN_UNUSED_RESULT;
 
 /**
  * Traverses the existing layout tree and generates a new tree that represents only ASDisplayNode layouts
  */
-- (ASLayout *)filteredNodeLayoutTree;
+- (ASLayout *)filteredNodeLayoutTree AS_WARN_UNUSED_RESULT;
 
 @end
 

--- a/AsyncDisplayKit/Layout/ASLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASLayoutSpec.h
@@ -70,7 +70,7 @@ NS_ASSUME_NONNULL_BEGIN
 /*
  * Returns an ASWrapperLayoutSpec object with the given layoutElement as child
  */
-+ (instancetype)wrapperWithLayoutElement:(id<ASLayoutElement>)layoutElement;
++ (instancetype)wrapperWithLayoutElement:(id<ASLayoutElement>)layoutElement AS_WARN_UNUSED_RESULT;
 
 /*
  * Returns an ASWrapperLayoutSpec object initialized with the given layoutElement as child

--- a/AsyncDisplayKit/Layout/ASOverlayLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASOverlayLayoutSpec.h
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param child A child that is laid out to determine the size of this spec.
  * @param overlay A layoutElement object that is laid out over the child. If this is nil, the overlay is omitted.
  */
-+ (instancetype)overlayLayoutSpecWithChild:(id<ASLayoutElement>)child overlay:(nullable id<ASLayoutElement>)overlay;
++ (instancetype)overlayLayoutSpecWithChild:(id<ASLayoutElement>)child overlay:(nullable id<ASLayoutElement>)overlay AS_WARN_UNUSED_RESULT;
 
 @end
 

--- a/AsyncDisplayKit/Layout/ASRatioLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASRatioLayoutSpec.h
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, assign) CGFloat ratio;
 
-+ (instancetype)ratioLayoutSpecWithRatio:(CGFloat)ratio child:(id<ASLayoutElement>)child;
++ (instancetype)ratioLayoutSpecWithRatio:(CGFloat)ratio child:(id<ASLayoutElement>)child AS_WARN_UNUSED_RESULT;
 
 @end
 

--- a/AsyncDisplayKit/Layout/ASRelativeLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASRelativeLayoutSpec.h
@@ -57,7 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)relativePositionLayoutSpecWithHorizontalPosition:(ASRelativeLayoutSpecPosition)horizontalPosition
                                                 verticalPosition:(ASRelativeLayoutSpecPosition)verticalPosition
                                                     sizingOption:(ASRelativeLayoutSpecSizingOption)sizingOption
-                                                           child:(id<ASLayoutElement>)child;
+                                                           child:(id<ASLayoutElement>)child AS_WARN_UNUSED_RESULT;
 
 /*!
  * @discussion convenience initializer for a ASRelativeLayoutSpec

--- a/AsyncDisplayKit/Layout/ASStackLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASStackLayoutSpec.h
@@ -71,17 +71,17 @@ NS_ASSUME_NONNULL_BEGIN
  @param alignItems Orientation of the children along the cross axis
  @param children ASLayoutElement children to be positioned.
  */
-+ (instancetype)stackLayoutSpecWithDirection:(ASStackLayoutDirection)direction spacing:(CGFloat)spacing justifyContent:(ASStackLayoutJustifyContent)justifyContent alignItems:(ASStackLayoutAlignItems)alignItems children:(NSArray<id<ASLayoutElement>> *)children;
++ (instancetype)stackLayoutSpecWithDirection:(ASStackLayoutDirection)direction spacing:(CGFloat)spacing justifyContent:(ASStackLayoutJustifyContent)justifyContent alignItems:(ASStackLayoutAlignItems)alignItems children:(NSArray<id<ASLayoutElement>> *)children AS_WARN_UNUSED_RESULT;
 
 /**
  * @return A stack layout spec with direction of ASStackLayoutDirectionVertical
  **/
-+ (instancetype)verticalStackLayoutSpec;
++ (instancetype)verticalStackLayoutSpec AS_WARN_UNUSED_RESULT;
 
 /**
  * @return A stack layout spec with direction of ASStackLayoutDirectionHorizontal
  **/
-+ (instancetype)horizontalStackLayoutSpec;
++ (instancetype)horizontalStackLayoutSpec AS_WARN_UNUSED_RESULT;
 
 @end
 

--- a/AsyncDisplayKit/Private/ASMultidimensionalArrayUtils.h
+++ b/AsyncDisplayKit/Private/ASMultidimensionalArrayUtils.h
@@ -23,13 +23,13 @@ ASDISPLAYNODE_EXTERN_C_BEGIN
  * Deep mutable copy of an array that contains arrays, which contain objects.  It will go one level deep into the array to copy.
  * This method is substantially faster than the generalized version, e.g. about 10x faster, so use it whenever it fits the need.
  */
-extern NSMutableArray<NSMutableArray *> *ASTwoDimensionalArrayDeepMutableCopy(NSArray<NSArray *> *array);
+extern NSMutableArray<NSMutableArray *> *ASTwoDimensionalArrayDeepMutableCopy(NSArray<NSArray *> *array) AS_WARN_UNUSED_RESULT;
 
 /**
  * Deep mutable copy of multidimensional array.  This is completely generalized and supports copying mixed-depth arrays,
  * where some subarrays might contain both elements and other subarrays. It will recursively do the multiple copy for each subarray.
  */
-extern NSObject<NSCopying> *ASMultidimensionalArrayDeepMutableCopy(NSObject<NSCopying> *obj);
+extern NSObject<NSCopying> *ASMultidimensionalArrayDeepMutableCopy(NSObject<NSCopying> *obj) AS_WARN_UNUSED_RESULT;
 
 /**
  * Insert the elements into the mutable multidimensional array at given index paths.
@@ -44,12 +44,12 @@ extern void ASDeleteElementsInMultidimensionalArrayAtIndexPaths(NSMutableArray *
 /**
  * Find the elements of the mutable multidimensional array at given index paths.
  */
-extern NSArray *ASFindElementsInMultidimensionalArrayAtIndexPaths(NSMutableArray *mutableArray, NSArray *indexPaths);
+extern NSArray *ASFindElementsInMultidimensionalArrayAtIndexPaths(NSMutableArray *mutableArray, NSArray *indexPaths) AS_WARN_UNUSED_RESULT;
 
 /**
  * Return all the index paths of mutable multidimensional array at given index set, in ascending order.
  */
-extern NSArray *ASIndexPathsForMultidimensionalArrayAtIndexSet(NSArray *multidimensionalArray, NSIndexSet *indexSet);
+extern NSArray *ASIndexPathsForMultidimensionalArrayAtIndexSet(NSArray *multidimensionalArray, NSIndexSet *indexSet) AS_WARN_UNUSED_RESULT;
 
 /**
  * Moves the object at `sourceIndexPath` to `destinationIndexPath`.
@@ -59,17 +59,17 @@ extern void ASMoveElementInTwoDimensionalArray(NSMutableArray *mutableArray, NSI
 /**
  * Return the index paths of the given multidimensional array that are present in the given index paths array.
  */
-extern NSArray<NSIndexPath *> *ASIndexPathsInMultidimensionalArrayIntersectingIndexPaths(NSArray *multidimensionalArray, NSArray<NSIndexPath *> *indexPaths);
+extern NSArray<NSIndexPath *> *ASIndexPathsInMultidimensionalArrayIntersectingIndexPaths(NSArray *multidimensionalArray, NSArray<NSIndexPath *> *indexPaths) AS_WARN_UNUSED_RESULT;
 
 /**
  * Return all the index paths of a two-dimensional array, in ascending order.
  */
-extern NSArray *ASIndexPathsForTwoDimensionalArray(NSArray <NSArray *>* twoDimensionalArray);
+extern NSArray *ASIndexPathsForTwoDimensionalArray(NSArray <NSArray *>* twoDimensionalArray) AS_WARN_UNUSED_RESULT;
 
 /**
  * Return all the index paths of a multidimensional array, in ascending order.
  */
-extern NSArray *ASIndexPathsForMultidimensionalArray(NSArray *MultidimensionalArray);
+extern NSArray *ASIndexPathsForMultidimensionalArray(NSArray *MultidimensionalArray) AS_WARN_UNUSED_RESULT;
 
 
 ASDISPLAYNODE_EXTERN_C_END

--- a/AsyncDisplayKit/Private/ASMultidimensionalArrayUtils.mm
+++ b/AsyncDisplayKit/Private/ASMultidimensionalArrayUtils.mm
@@ -12,7 +12,7 @@
 #import "ASMultidimensionalArrayUtils.h"
 
 // Import UIKit to get [NSIndexPath indexPathForItem:inSection:] which uses
-// static memory addresses rather than allocating new index path objects.
+// tagged pointers.
 #import <UIKit/UIKit.h>
 
 #pragma mark - Internal Methods

--- a/AsyncDisplayKit/Private/ASWeakMap.h
+++ b/AsyncDisplayKit/Private/ASWeakMap.h
@@ -11,6 +11,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <AsyncDisplayKit/ASBaseDefines.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -46,12 +47,12 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Read from the cache.  The Value object is accessible from the returned ASWeakMapEntry.
  */
-- (nullable ASWeakMapEntry<Value> *)entryForKey:(Key)key;
+- (nullable ASWeakMapEntry<Value> *)entryForKey:(Key)key AS_WARN_UNUSED_RESULT;
 
 /**
  * Put a value into the cache.  If an entry with an equal key already exists, then the value is updated on the existing entry.
  */
-- (ASWeakMapEntry<Value> *)setObject:(Value)value forKey:(Key)key;
+- (ASWeakMapEntry<Value> *)setObject:(Value)value forKey:(Key)key AS_WARN_UNUSED_RESULT;
 
 @end
 

--- a/AsyncDisplayKit/UIImage+ASConvenience.h
+++ b/AsyncDisplayKit/UIImage+ASConvenience.h
@@ -12,6 +12,7 @@
 
 #import <UIKit/UIImage.h>
 #import <UIKit/UIBezierPath.h>
+#import <AsyncDisplayKit/ASBaseDefines.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -33,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (UIImage *)as_resizableRoundedImageWithCornerRadius:(CGFloat)cornerRadius
                                           cornerColor:(UIColor *)cornerColor
-                                            fillColor:(UIColor *)fillColor;
+                                            fillColor:(UIColor *)fillColor AS_WARN_UNUSED_RESULT;
 
 /**
  * This generates a flat-color, rounded-corner resizeable image with a border
@@ -48,7 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
                                           cornerColor:(UIColor *)cornerColor
                                             fillColor:(UIColor *)fillColor
                                           borderColor:(nullable UIColor *)borderColor
-                                          borderWidth:(CGFloat)borderWidth;
+                                          borderWidth:(CGFloat)borderWidth AS_WARN_UNUSED_RESULT;
 
 /**
  * This generates a flat-color, rounded-corner resizeable image with a border
@@ -67,7 +68,7 @@ NS_ASSUME_NONNULL_BEGIN
                                           borderColor:(nullable UIColor *)borderColor
                                           borderWidth:(CGFloat)borderWidth
                                        roundedCorners:(UIRectCorner)roundedCorners
-                                                scale:(CGFloat)scale;
+                                                scale:(CGFloat)scale AS_WARN_UNUSED_RESULT;
 
 @end
 

--- a/Base/ASBaseDefines.h
+++ b/Base/ASBaseDefines.h
@@ -152,4 +152,12 @@
 #endif
 #endif
 
+#ifndef AS_WARN_UNUSED_RESULT
+#if __has_attribute(warn_unused_result)
+#define AS_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
+#else
+#define AS_WARN_UNUSED_RESULT
+#endif
+#endif
+
 #define ASOVERLOADABLE __attribute__((overloadable))


### PR DESCRIPTION
This attribute triggers compiler warnings/errors (in ASDK it's errors) when calling a function or method and not using its result.

This diff also makes `scrollableDirections` and `scrollDirection` properties for a slightly cleaner Swift import. I'm willing to revert this if someone thinks it's bad.