### PR TITLE
Revert "Scrollable direction is invalid until a relayout. (#2375)"

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -1368,13 +1368,7 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
     // If, for example, a vertical flow layout has its height changed due to a status bar
     // appearance update, we do not need to relayout all nodes.
     // For a more permanent fix to the unsafety mentioned above, see https://github.com/facebook/AsyncDisplayKit/pull/2182
-    
-    // If the bounds have changed, scrollable directions may be invalid until relayout has
-    // occurred.
-    [[self collectionViewLayout] invalidateLayout];
-    [self layoutIfNeeded];
     ASScrollDirection scrollDirection = self.scrollableDirections;
-    
     BOOL fixedVertically = (ASScrollDirectionContainsVerticalDirection(scrollDirection) == NO);
     BOOL fixedHorizontally = (ASScrollDirectionContainsHorizontalDirection(scrollDirection) == NO);
 


### PR DESCRIPTION
Tragically, this is failing some of our rotation unit tests so we need to revert it until we adjust the tests or adjust the implementation. #2375 