### PR TITLE
[Layout] Return CGSizeZero in case a ASNetworkImageNode is asked for the size and the image did not load yet

### DIFF
--- a/AsyncDisplayKit/ASNetworkImageNode.mm
+++ b/AsyncDisplayKit/ASNetworkImageNode.mm
@@ -333,6 +333,23 @@ static const CGSize kMinReleaseImageOnBackgroundSize = {20.0, 20.0};
   }
 }
 
+#pragma mark - Layout and Sizing
+
+- (CGSize)calculateSizeThatFits:(CGSize)constrainedSize
+{
+  ASDN::MutexLocker l(__instanceLock__);
+
+  // If the image node is currently in the loading process and no valid size is applied return CGSizeZero for the time
+  // being.
+  // TODO: After 2.0 is stable we should remove this behavior as a ASNetworkImageNode is a replaced element and the
+  // client code should set the size of an image or it's container it's embedded in
+  if (ASIsCGSizeValidForSize(constrainedSize) == NO && _URL != nil && self.image == nil) {
+    return CGSizeZero;
+  }
+    
+  return [super calculateSizeThatFits:constrainedSize];
+}
+
 #pragma mark - Private methods -- only call with lock.
 
 - (void)_updateProgressImageBlockOnDownloaderIfNeeded

--- a/AsyncDisplayKit/Layout/ASAbsoluteLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASAbsoluteLayoutSpec.mm
@@ -39,8 +39,8 @@
 {
   // TODO: layout: isValidForLayout() call should not be necessary if INFINITY is used
   CGSize size = {
-    (isinf(constrainedSize.max.width) || !ASPointsAreValidForLayout(constrainedSize.max.width)) ? ASLayoutElementParentDimensionUndefined : constrainedSize.max.width,
-    (isinf(constrainedSize.max.height) || !ASPointsAreValidForLayout(constrainedSize.max.height)) ? ASLayoutElementParentDimensionUndefined : constrainedSize.max.height
+    (isinf(constrainedSize.max.width) || !ASPointsValidForLayout(constrainedSize.max.width)) ? ASLayoutElementParentDimensionUndefined : constrainedSize.max.width,
+    (isinf(constrainedSize.max.height) || !ASPointsValidForLayout(constrainedSize.max.height)) ? ASLayoutElementParentDimensionUndefined : constrainedSize.max.height
   };
   
   NSArray *children = self.children;

--- a/AsyncDisplayKit/Layout/ASDimension.h
+++ b/AsyncDisplayKit/Layout/ASDimension.h
@@ -13,14 +13,24 @@
 #import <AsyncDisplayKit/ASBaseDefines.h>
 #import <AsyncDisplayKit/ASAssert.h>
 
-ASDISPLAYNODE_INLINE BOOL AS_WARN_UNUSED_RESULT ASPointsAreValidForLayout(CGFloat points)
+ASDISPLAYNODE_INLINE BOOL AS_WARN_UNUSED_RESULT ASPointsValidForLayout(CGFloat points)
 {
   return ((isnormal(points) || points == 0.0) && points >= 0.0 && points < (CGFLOAT_MAX / 2.0));
 }
 
 ASDISPLAYNODE_INLINE BOOL AS_WARN_UNUSED_RESULT ASIsCGSizeValidForLayout(CGSize size)
 {
-  return (ASPointsAreValidForLayout(size.width) && ASPointsAreValidForLayout(size.height));  
+    return (ASPointsValidForLayout(size.width) && ASPointsValidForLayout(size.height));
+}
+
+ASDISPLAYNODE_INLINE BOOL AS_WARN_UNUSED_RESULT ASPointsValidForSize(CGFloat points)
+{
+    return ((isnormal(points) || points == 0.0) && points >= 0.0 && points < (FLT_MAX / 2.0));
+}
+
+ASDISPLAYNODE_INLINE BOOL AS_WARN_UNUSED_RESULT ASIsCGSizeValidForSize(CGSize size)
+{
+    return (ASPointsValidForSize(size.width) && ASPointsValidForSize(size.height));
 }
 
 /**

--- a/AsyncDisplayKit/Layout/ASRatioLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASRatioLayoutSpec.mm
@@ -51,14 +51,14 @@
 {
   std::vector<CGSize> sizeOptions;
   // TODO: layout: isValidForLayout() call should not be necessary if INFINITY is used
-  if (!isinf(constrainedSize.max.width) && ASPointsAreValidForLayout(constrainedSize.max.width)) {
+  if (!isinf(constrainedSize.max.width) && ASPointsValidForLayout(constrainedSize.max.width)) {
     sizeOptions.push_back(ASSizeRangeClamp(constrainedSize, {
       constrainedSize.max.width,
       ASFloorPixelValue(_ratio * constrainedSize.max.width)
     }));
   }
   // TODO: layout: isValidForLayout() call should not be necessary if INFINITY is used
-  if (!isinf(constrainedSize.max.height) && ASPointsAreValidForLayout(constrainedSize.max.width)) {
+  if (!isinf(constrainedSize.max.height) && ASPointsValidForLayout(constrainedSize.max.width)) {
     sizeOptions.push_back(ASSizeRangeClamp(constrainedSize, {
       ASFloorPixelValue(constrainedSize.max.height / _ratio),
       constrainedSize.max.height

--- a/AsyncDisplayKit/Layout/ASRelativeLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASRelativeLayoutSpec.mm
@@ -59,8 +59,8 @@
   // as the size will depend on the content
   // TODO: layout: isValidForLayout() call should not be necessary if INFINITY is used
   CGSize size = {
-    isinf(constrainedSize.max.width) || !ASPointsAreValidForLayout(constrainedSize.max.width) ? ASLayoutElementParentDimensionUndefined : constrainedSize.max.width,
-    isinf(constrainedSize.max.height) || !ASPointsAreValidForLayout(constrainedSize.max.height) ? ASLayoutElementParentDimensionUndefined : constrainedSize.max.height
+    isinf(constrainedSize.max.width) || !ASPointsValidForLayout(constrainedSize.max.width) ? ASLayoutElementParentDimensionUndefined : constrainedSize.max.width,
+    isinf(constrainedSize.max.height) || !ASPointsValidForLayout(constrainedSize.max.height) ? ASLayoutElementParentDimensionUndefined : constrainedSize.max.height
   };
   
   BOOL reduceWidth = (_horizontalPosition & ASRelativeLayoutSpecPositionCenter) != 0 ||


### PR DESCRIPTION
We are catching the behavior if a developer set an URL and asks for the size of the node but the image was not loaded yet.

This is not the right behavior in my opinion, but we should add it for the transition time. That's also the reason we only added it to `ASNetworkImageNode` as it's the most common case.

We also will flag that and in the future we should think about removing that check.