### PR TITLE
[ASCollectionNode] Add scrollableDirections method to ASCollectionViewLayoutInspecting p…

### DIFF
--- a/AsyncDisplayKit/Details/ASCollectionViewFlowLayoutInspector.h
+++ b/AsyncDisplayKit/Details/ASCollectionViewFlowLayoutInspector.h
@@ -12,7 +12,7 @@
 
 #import <Foundation/Foundation.h>
 #import <AsyncDisplayKit/ASDimension.h>
-#import "ASScrollDirection.h"
+#import <AsyncDisplayKit/ASScrollDirection.h>
 
 @class ASCollectionView;
 @protocol ASCollectionDataSource;

--- a/AsyncDisplayKit/Details/ASCollectionViewFlowLayoutInspector.h
+++ b/AsyncDisplayKit/Details/ASCollectionViewFlowLayoutInspector.h
@@ -12,6 +12,7 @@
 
 #import <Foundation/Foundation.h>
 #import <AsyncDisplayKit/ASDimension.h>
+#import "ASScrollDirection.h"
 
 @class ASCollectionView;
 @protocol ASCollectionDataSource;
@@ -51,6 +52,11 @@ NS_ASSUME_NONNULL_BEGIN
  * @discussion A great time to update perform selector caches!
  */
 - (void)didChangeCollectionViewDataSource:(nullable id<ASCollectionDataSource>)dataSource;
+
+/**
+ * Return the directions in which your collection view can scroll
+ */
+- (ASScrollDirection)scrollableDirections;
 
 #pragma mark Deprecated Methods
 

--- a/AsyncDisplayKit/Details/ASCollectionViewFlowLayoutInspector.m
+++ b/AsyncDisplayKit/Details/ASCollectionViewFlowLayoutInspector.m
@@ -176,6 +176,11 @@ static inline ASSizeRange NodeConstrainedSizeForScrollDirection(ASCollectionView
   return [self layoutHasSupplementaryViewOfKind:kind inSection:section collectionView:collectionView] ? 1 : 0;
 }
 
+- (ASScrollDirection)scrollableDirections
+{
+  return (self.layout.scrollDirection == UICollectionViewScrollDirectionHorizontal) ? ASScrollDirectionHorizontalDirections : ASScrollDirectionVerticalDirections;
+}
+
 #pragma mark - Private helpers
 
 - (CGSize)sizeForSupplementaryViewOfKind:(NSString *)kind inSection:(NSUInteger)section collectionView:(ASCollectionView *)collectionView


### PR DESCRIPTION
…rotocol

ASViewController's default method will not always return the correct scrollable
directions in cases where size changes may not have been applied. This allows
us to ignore this issue for a little while longer by allowing the layout
inspector to explicitly vend this.

@Adlai-Holler, @maicki ready for review