### PR TITLE
Changed relative spec position and sizing options to start at 1

### DIFF
--- a/AsyncDisplayKit/Layout/ASRelativeLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASRelativeLayoutSpec.h
@@ -13,23 +13,25 @@
 #import <AsyncDisplayKit/ASLayoutSpec.h>
 
 /** How the child is positioned within the spec. */
-typedef NS_OPTIONS(NSUInteger, ASRelativeLayoutSpecPosition) {
+typedef NS_ENUM(NSUInteger, ASRelativeLayoutSpecPosition) {
     /** The child is positioned at point 0 relatively to the layout axis (ie left / top most) */
-    ASRelativeLayoutSpecPositionStart = 1 << 0,
+    ASRelativeLayoutSpecPositionStart = 0,
     /** The child is centered along the specified axis */
-    ASRelativeLayoutSpecPositionCenter = 1 << 1,
+    ASRelativeLayoutSpecPositionCenter = 1,
     /** The child is positioned at the maximum point of the layout axis (ie right / bottom most) */
-    ASRelativeLayoutSpecPositionEnd = 1 << 2,
+    ASRelativeLayoutSpecPositionEnd = 2,
 };
 
-/** How much space the spec will take up. */
+/** How much space the spec will take up. 
+ *  Note: To use the ASRelativeLayoutSpecSizingOptionDefault sizing option in Swift use []
+ */
 typedef NS_OPTIONS(NSUInteger, ASRelativeLayoutSpecSizingOption) {
     /** The spec will take up the maximum size possible */
-    ASRelativeLayoutSpecSizingOptionDefault = 1 << 0,
+    ASRelativeLayoutSpecSizingOptionDefault,
     /** The spec will take up the minimum size possible along the X axis */
-    ASRelativeLayoutSpecSizingOptionMinimumWidth = 1 << 1,
+    ASRelativeLayoutSpecSizingOptionMinimumWidth = 1 << 0,
     /** The spec will take up the minimum size possible along the Y axis */
-    ASRelativeLayoutSpecSizingOptionMinimumHeight = 1 << 2,
+    ASRelativeLayoutSpecSizingOptionMinimumHeight = 1 << 1,
     /** Convenience option to take up the minimum size along both the X and Y axis */
     ASRelativeLayoutSpecSizingOptionMinimumSize = ASRelativeLayoutSpecSizingOptionMinimumWidth | ASRelativeLayoutSpecSizingOptionMinimumHeight,
 };

--- a/AsyncDisplayKit/Layout/ASRelativeLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASRelativeLayoutSpec.h
@@ -15,21 +15,21 @@
 /** How the child is positioned within the spec. */
 typedef NS_OPTIONS(NSUInteger, ASRelativeLayoutSpecPosition) {
     /** The child is positioned at point 0 relatively to the layout axis (ie left / top most) */
-    ASRelativeLayoutSpecPositionStart = 0,
+    ASRelativeLayoutSpecPositionStart = 1 << 0,
     /** The child is centered along the specified axis */
-    ASRelativeLayoutSpecPositionCenter = 1 << 0,
+    ASRelativeLayoutSpecPositionCenter = 1 << 1,
     /** The child is positioned at the maximum point of the layout axis (ie right / bottom most) */
-    ASRelativeLayoutSpecPositionEnd = 1 << 1,
+    ASRelativeLayoutSpecPositionEnd = 1 << 2,
 };
 
 /** How much space the spec will take up. */
 typedef NS_OPTIONS(NSUInteger, ASRelativeLayoutSpecSizingOption) {
     /** The spec will take up the maximum size possible */
-    ASRelativeLayoutSpecSizingOptionDefault,
+    ASRelativeLayoutSpecSizingOptionDefault = 1 << 0,
     /** The spec will take up the minimum size possible along the X axis */
-    ASRelativeLayoutSpecSizingOptionMinimumWidth = 1 << 0,
+    ASRelativeLayoutSpecSizingOptionMinimumWidth = 1 << 1,
     /** The spec will take up the minimum size possible along the Y axis */
-    ASRelativeLayoutSpecSizingOptionMinimumHeight = 1 << 1,
+    ASRelativeLayoutSpecSizingOptionMinimumHeight = 1 << 2,
     /** Convenience option to take up the minimum size along both the X and Y axis */
     ASRelativeLayoutSpecSizingOptionMinimumSize = ASRelativeLayoutSpecSizingOptionMinimumWidth | ASRelativeLayoutSpecSizingOptionMinimumHeight,
 };


### PR DESCRIPTION
Starting NS_ENUM definitions at 0 doesn't automatically convert to Swift 3 correctly.

Doing so will only reveal options 1..n in the autocomplete/auto-generated headers.
<img width="796" alt="screen shot 2016-10-13 at 11 43 54 pm" src="https://cloud.githubusercontent.com/assets/432875/19377865/3988af9e-919e-11e6-9e24-00bc83072827.png">

So if you want to use ASRelativeLayoutSpecPositionStart or ASRelativeLayoutSpecSizingOptionDefault your layout spec definition will look something like this.

<img width="369" alt="screen shot 2016-10-13 at 11 44 12 pm" src="https://cloud.githubusercontent.com/assets/432875/19377877/4d5a5c2a-919e-11e6-8cf7-1ad650ca9b87.png">


