### PR TITLE
[ASNetworkImageNode] Test and Improve the Progress Block Handling

### DIFF
--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -418,6 +418,7 @@
 		C78F7E2B1BF7809800CDEAFC /* ASTableNode.h in Headers */ = {isa = PBXBuildFile; fileRef = B0F880581BEAEC7500D17647 /* ASTableNode.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CC051F1F1D7A286A006434CB /* ASCALayerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CC051F1E1D7A286A006434CB /* ASCALayerTests.m */; };
 		CC0AEEA41D66316E005D1C78 /* ASUICollectionViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CC0AEEA31D66316E005D1C78 /* ASUICollectionViewTests.m */; };
+		CC11F97A1DB181180024D77B /* ASNetworkImageNodeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CC11F9791DB181180024D77B /* ASNetworkImageNodeTests.m */; };
 		CC3B20841C3F76D600798563 /* ASPendingStateController.h in Headers */ = {isa = PBXBuildFile; fileRef = CC3B20811C3F76D600798563 /* ASPendingStateController.h */; };
 		CC3B20851C3F76D600798563 /* ASPendingStateController.mm in Sources */ = {isa = PBXBuildFile; fileRef = CC3B20821C3F76D600798563 /* ASPendingStateController.mm */; };
 		CC3B20861C3F76D600798563 /* ASPendingStateController.mm in Sources */ = {isa = PBXBuildFile; fileRef = CC3B20821C3F76D600798563 /* ASPendingStateController.mm */; };
@@ -1108,6 +1109,7 @@
 		CC051F1E1D7A286A006434CB /* ASCALayerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASCALayerTests.m; sourceTree = "<group>"; };
 		CC0AEEA31D66316E005D1C78 /* ASUICollectionViewTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASUICollectionViewTests.m; sourceTree = "<group>"; };
 		CC2E317F1DAC353700EEE891 /* ASCollectionView+Undeprecated.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ASCollectionView+Undeprecated.h"; sourceTree = "<group>"; };
+		CC11F9791DB181180024D77B /* ASNetworkImageNodeTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASNetworkImageNodeTests.m; sourceTree = "<group>"; };
 		CC3B20811C3F76D600798563 /* ASPendingStateController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASPendingStateController.h; sourceTree = "<group>"; };
 		CC3B20821C3F76D600798563 /* ASPendingStateController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASPendingStateController.mm; sourceTree = "<group>"; };
 		CC3B20871C3F7A5400798563 /* ASWeakSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASWeakSet.h; sourceTree = "<group>"; };
@@ -1368,6 +1370,7 @@
 		058D09C5195D04C000B7D73C /* AsyncDisplayKitTests */ = {
 			isa = PBXGroup;
 			children = (
+				CC11F9791DB181180024D77B /* ASNetworkImageNodeTests.m */,
 				CC051F1E1D7A286A006434CB /* ASCALayerTests.m */,
 				CC8B05D71D73979700F54286 /* ASTextNodePerformanceTests.m */,
 				CC8B05D41D73836400F54286 /* ASPerformanceTestContext.h */,
@@ -2296,6 +2299,7 @@
 				DBC453221C5FD97200B16017 /* ASDisplayNodeImplicitHierarchyTests.m in Sources */,
 				058D0A41195D057000B7D73C /* ASTextNodeWordKernerTests.mm in Sources */,
 				DBC452DE1C5C6A6A00B16017 /* ArrayDiffingTests.m in Sources */,
+				CC11F97A1DB181180024D77B /* ASNetworkImageNodeTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AsyncDisplayKit/ASNetworkImageNode.mm
+++ b/AsyncDisplayKit/ASNetworkImageNode.mm
@@ -38,6 +38,8 @@ static const CGSize kMinReleaseImageOnBackgroundSize = {20.0, 20.0};
 
   NSUUID *_cacheUUID;
   id _downloadIdentifier;
+  // The download identifier that we have set a progress block on, if any.
+  id _downloadIdentifierForProgressBlock;
 
   BOOL _imageLoaded;
   CGFloat _currentImageQuality;
@@ -222,16 +224,12 @@ static const CGSize kMinReleaseImageOnBackgroundSize = {20.0, 20.0};
 
 - (void)setShouldRenderProgressImages:(BOOL)shouldRenderProgressImages
 {
-  __instanceLock__.lock();
+  ASDN::MutexLocker l(__instanceLock__);
   if (shouldRenderProgressImages == _shouldRenderProgressImages) {
-    __instanceLock__.unlock();
     return;
   }
-  
   _shouldRenderProgressImages = shouldRenderProgressImages;
-  
-  
-  __instanceLock__.unlock();
+
   [self _updateProgressImageBlockOnDownloaderIfNeeded];
 }
 
@@ -283,9 +281,9 @@ static const CGSize kMinReleaseImageOnBackgroundSize = {20.0, 20.0};
 - (void)didEnterVisibleState
 {
   [super didEnterVisibleState];
-  
+  ASDN::MutexLocker l(__instanceLock__);
+
   if (_downloaderFlags.downloaderImplementsSetPriority) {
-    ASDN::MutexLocker l(__instanceLock__);
     if (_downloadIdentifier != nil) {
       [_downloader setPriority:ASImageDownloaderPriorityVisible withDownloadIdentifier:_downloadIdentifier];
     }
@@ -297,9 +295,9 @@ static const CGSize kMinReleaseImageOnBackgroundSize = {20.0, 20.0};
 - (void)didExitVisibleState
 {
   [super didExitVisibleState];
-  
+  ASDN::MutexLocker l(__instanceLock__);
+
   if (_downloaderFlags.downloaderImplementsSetPriority) {
-    ASDN::MutexLocker l(__instanceLock__);
     if (_downloadIdentifier != nil) {
       [_downloader setPriority:ASImageDownloaderPriorityPreload withDownloadIdentifier:_downloadIdentifier];
     }
@@ -350,41 +348,56 @@ static const CGSize kMinReleaseImageOnBackgroundSize = {20.0, 20.0};
   return [super calculateSizeThatFits:constrainedSize];
 }
 
-#pragma mark - Private methods -- only call with lock.
+#pragma mark - Private methods, safe to call without lock
+
+- (void)handleProgressImage:(UIImage *)progressImage progress:(CGFloat)progress downloadIdentifier:(nullable id)downloadIdentifier
+{
+  ASDN::MutexLocker l(__instanceLock__);
+  // Getting a result back for a different download identifier, download must not have been successfully canceled
+  if (ASObjectIsEqual(_downloadIdentifier, downloadIdentifier) == NO && downloadIdentifier != nil) {
+    return;
+  }
+  self.image = progressImage;
+  dispatch_async(dispatch_get_main_queue(), ^{
+    // See comment in -displayDidFinish for why this must be dispatched to main
+    self.currentImageQuality = progress;
+  });
+}
+
+#pragma mark - Private methods, call with lock held
 
 - (void)_updateProgressImageBlockOnDownloaderIfNeeded
 {
-  ASDN::MutexLocker l(__instanceLock__);
-  
-  BOOL shouldRenderProgressImages = _shouldRenderProgressImages;
-  ASInterfaceState interfaceState = self.interfaceState;
-
-  if (!_downloaderFlags.downloaderImplementsSetProgress || _downloadIdentifier == nil) {
+  // If the downloader doesn't do progress, we are done.
+  if (_downloaderFlags.downloaderImplementsSetProgress == NO) {
     return;
   }
 
-  ASImageDownloaderProgressImage progress = nil;
-  if (shouldRenderProgressImages && ASInterfaceStateIncludesVisible(interfaceState)) {
-    __weak __typeof__(self) weakSelf = self;
-    progress = ^(UIImage * _Nonnull progressImage, CGFloat progress, id _Nullable downloadIdentifier) {
-      __typeof__(self) strongSelf = weakSelf;
-      if (strongSelf == nil) {
-        return;
-      }
+  // Read state.
+  BOOL shouldRender = _shouldRenderProgressImages && ASInterfaceStateIncludesVisible(_interfaceState);
+  id oldDownloadIDForProgressBlock = _downloadIdentifierForProgressBlock;
+  id newDownloadIDForProgressBlock = shouldRender ? _downloadIdentifier : nil;
 
-      ASDN::MutexLocker l(strongSelf->__instanceLock__);
-      //Getting a result back for a different download identifier, download must not have been successfully canceled
-      if (ASObjectIsEqual(strongSelf->_downloadIdentifier, downloadIdentifier) == NO && downloadIdentifier != nil) {
-        return;
-      }
-      strongSelf.image = progressImage;
-      dispatch_async(dispatch_get_main_queue(), ^{
-        // See comment in -displayDidFinish for why this must be dispatched to main
-        strongSelf.currentImageQuality = progress;
-      });
-    };
+  // If we're already bound to the correct download, we're done.
+  if (ASObjectIsEqual(oldDownloadIDForProgressBlock, newDownloadIDForProgressBlock)) {
+    return;
   }
-  [_downloader setProgressImageBlock:progress callbackQueue:dispatch_get_main_queue() withDownloadIdentifier:_downloadIdentifier];
+
+  // Unbind from the previous download.
+  if (oldDownloadIDForProgressBlock != nil) {
+    [_downloader setProgressImageBlock:nil callbackQueue:dispatch_get_main_queue() withDownloadIdentifier:oldDownloadIDForProgressBlock];
+  }
+
+  // Bind to the current download.
+  if (newDownloadIDForProgressBlock != nil) {
+    __weak __typeof(self) weakSelf = self;
+    [_downloader setProgressImageBlock:^(UIImage * _Nonnull progressImage, CGFloat progress, id  _Nullable downloadIdentifier) {
+      [weakSelf handleProgressImage:progressImage progress:progress downloadIdentifier:downloadIdentifier];
+    } callbackQueue:dispatch_get_main_queue() withDownloadIdentifier:newDownloadIDForProgressBlock];
+  }
+
+  // Update state.
+  _downloadIdentifierForProgressBlock = newDownloadIDForProgressBlock;
 }
 
 - (void)_clearImage

--- a/AsyncDisplayKitTests/ASNetworkImageNodeTests.m
+++ b/AsyncDisplayKitTests/ASNetworkImageNodeTests.m
@@ -1,0 +1,95 @@
+//
+//  ASNetworkImageNodeTests.m
+//  AsyncDisplayKit
+//
+//  Created by Adlai Holler on 10/14/16.
+//  Copyright © 2016 Facebook. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import <OCMock/OCMock.h>
+#import <AsyncDisplayKit/AsyncDisplayKit.h>
+#import "ASDisplayNode+FrameworkPrivate.h"
+
+@interface ASNetworkImageNodeTests : XCTestCase
+
+@end
+
+@interface ASTestImageDownloader : NSObject <ASImageDownloaderProtocol>
+@end
+@interface ASTestImageCache : NSObject <ASImageCacheProtocol>
+@end
+
+@implementation ASNetworkImageNodeTests {
+  ASNetworkImageNode *node;
+  id downloader;
+  id cache;
+}
+
+- (void)setUp
+{
+  [super setUp];
+  cache = [OCMockObject partialMockForObject:[[ASTestImageCache alloc] init]];
+  downloader = [OCMockObject partialMockForObject:[[ASTestImageDownloader alloc] init]];
+  node = [[ASNetworkImageNode alloc] initWithCache:cache downloader:downloader];
+}
+
+- (void)testThatProgressBlockIsSetAndClearedCorrectlyOnVisibility
+{
+  node.URL = [NSURL URLWithString:@"http://imageA"];
+  [[downloader expect] setProgressImageBlock:[OCMArg isNotNil] callbackQueue:OCMOCK_ANY withDownloadIdentifier:@0];
+  [node enterInterfaceState:ASInterfaceStateInHierarchy];
+  [downloader verify];
+  [[downloader expect] setProgressImageBlock:[OCMArg isNil] callbackQueue:OCMOCK_ANY withDownloadIdentifier:@0];
+  [node exitInterfaceState:ASInterfaceStateInHierarchy];
+  [downloader verify];
+}
+
+- (void)testThatProgressBlockIsSetAndClearedCorrectlyOnChangeURL
+{
+  [node enterInterfaceState:ASInterfaceStateInHierarchy];
+
+  // Set URL while visible, should set progress block
+  [[downloader expect] setProgressImageBlock:[OCMArg isNotNil] callbackQueue:OCMOCK_ANY withDownloadIdentifier:@0];
+  node.URL = [NSURL URLWithString:@"http://imageA"];
+  [downloader verifyWithDelay:5];
+
+  // Change URL while visible, should clear prior block and set new one
+  [[downloader expect] setProgressImageBlock:[OCMArg isNil] callbackQueue:OCMOCK_ANY withDownloadIdentifier:@0];
+  [[downloader expect] cancelImageDownloadForIdentifier:@0];
+  [[downloader expect] setProgressImageBlock:[OCMArg isNotNil] callbackQueue:OCMOCK_ANY withDownloadIdentifier:@1];
+  node.URL = [NSURL URLWithString:@"http://imageB"];
+  [downloader verifyWithDelay:5];
+}
+
+@end
+
+@implementation ASTestImageCache
+
+- (void)cachedImageWithURL:(NSURL *)URL callbackQueue:(dispatch_queue_t)callbackQueue completion:(ASImageCacherCompletion)completion
+{
+  ASDisplayNodeAssert(callbackQueue == dispatch_get_main_queue(), @"ASTestImageCache expects main queue for callback.");
+  completion(nil);
+}
+
+@end
+
+@implementation ASTestImageDownloader {
+  NSInteger _currentDownloadID;
+}
+
+- (void)cancelImageDownloadForIdentifier:(id)downloadIdentifier
+{
+  // nop
+}
+
+- (id)downloadImageWithURL:(NSURL *)URL callbackQueue:(dispatch_queue_t)callbackQueue downloadProgress:(ASImageDownloaderProgress)downloadProgress completion:(ASImageDownloaderCompletion)completion
+{
+  return @(_currentDownloadID++);
+}
+
+- (void)setProgressImageBlock:(ASImageDownloaderProgressImage)progressBlock callbackQueue:(dispatch_queue_t)callbackQueue withDownloadIdentifier:(id)downloadIdentifier
+{
+  // nop
+}
+@end


### PR DESCRIPTION
I found the old logic hard to reason about, and I had no confidence that it behaved ideally. In fact, specifically when the download identifier changed the old download's progress block was not unbound which could have led to drawing the wrong image.

In practice that rarely matters, but this adds our first `ASNetworkImageNode` tests which we desperately need, fixes that issue, and makes the progress image binding logic much much more reliable.

Ready for review @maicki @appleguy 