### PR TITLE
[Layout] Introduce layoutElementThatFits:

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode+Beta.h
+++ b/AsyncDisplayKit/ASDisplayNode+Beta.h
@@ -63,9 +63,6 @@ typedef struct {
 + (BOOL)suppressesInvalidCollectionUpdateExceptions AS_WARN_UNUSED_RESULT;
 + (void)setSuppressesInvalidCollectionUpdateExceptions:(BOOL)suppresses;
 
-/** @name Layout */
-
-
 /**
  * @abstract Recursively ensures node and all subnodes are displayed.
  * @see Full documentation in ASDisplayNode+FrameworkPrivate.h
@@ -88,6 +85,23 @@ typedef struct {
 @property (nonatomic, copy, nullable) ASDisplayNodeContextModifier didDisplayNodeContentWithRenderingContext;
 
 /**
+ * @abstract Return a layout element that describes the layout of the receiver and its children.
+ *
+ * @param constrainedSize The minimum and maximum sizes the receiver should fit in.
+ *
+ * @discussion Subclasses that override should expect this method to be called on a non-main thread. The returned layout element
+ * is used to calculate an ASLayout and cached by ASDisplayNode for quick access during -layout. Other expensive work that needs to
+ * be done before display can be performed here, and using ivars to cache any valuable intermediate results is
+ * encouraged.
+ *
+ * @note This method should not be called directly outside of ASDisplayNode; use -measure: or -calculatedLayout instead.
+ *
+ * @warning Subclasses that implement -layoutElementThatFits: must not also implement -layoutSpecThatFits: or use
+ * .layoutSpecBlock. Doing so will trigger an exception.
+ */
+- (id<ASLayoutElement>)layoutElementThatFits:(ASSizeRange)constrainedSize;
+
+/**
  * @abstract A bitmask representing which actions (layout spec, layout generation) should be measured.
  */
 @property (nonatomic, assign) ASDisplayNodePerformanceMeasurementOptions measurementOptions;
@@ -96,8 +110,6 @@ typedef struct {
  * @abstract A simple struct representing performance measurements collected.
  */
 @property (nonatomic, assign, readonly) ASDisplayNodePerformanceMeasurements performanceMeasurements;
-
-/** @name Layout Transitioning */
 
 /**
  * @abstract Currently used by ASNetworkImageNode and ASMultiplexImageNode to allow their placeholders to stay if they are loading an image from the network.

--- a/AsyncDisplayKit/ASDisplayNode+Subclasses.h
+++ b/AsyncDisplayKit/ASDisplayNode+Subclasses.h
@@ -41,6 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ASDisplayNode (Subclassing)
 
+#pragma mark - Properties
 /** @name Properties */
 
 /**
@@ -64,8 +65,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nullable, nonatomic, readonly, assign) ASLayout *calculatedLayout;
 
+#pragma mark - View Lifecycle
 /** @name View Lifecycle */
-
 
 /**
  * @abstract Called on the main thread immediately after self.view is created.
@@ -75,8 +76,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)didLoad ASDISPLAYNODE_REQUIRES_SUPER;
 
 
+#pragma mark - Layout
 /** @name Layout */
-
 
 /**
  * @abstract Called on the main thread by the view's -layoutSubviews.
@@ -101,6 +102,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)calculatedLayoutDidChange ASDISPLAYNODE_REQUIRES_SUPER;
 
+
+#pragma mark - Layout calculation
 /** @name Layout calculation */
 
 /**
@@ -159,9 +162,9 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @note This method should not be called directly outside of ASDisplayNode; use -measure: or -calculatedLayout instead.
  *
- * @warning Subclasses that implement -layoutSpecThatFits: must not also use .layoutSpecBlock. Doing so will trigger
- * an exception. A future version of the framework may support using both, calling them serially, with the
- * .layoutSpecBlock superseding any values set by the method override.
+ * @warning Subclasses that implement -layoutSpecThatFits: must not also implement layoutElementThatFits or use
+ * .layoutSpecBlock. Doing so will trigger an exception. A future version of the framework may support using both,
+ * calling them serially, with the .layoutSpecBlock superseding any values set by the method override.
  */
 - (ASLayoutSpec *)layoutSpecThatFits:(ASSizeRange)constrainedSize;
 
@@ -174,8 +177,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)invalidateCalculatedLayout;
 
 
+#pragma mark - Drawing
 /** @name Drawing */
-
 
 /**
  * @summary Delegate method to draw layer contents into a CGBitmapContext. The current UIGraphics context will be set
@@ -407,8 +410,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign, readonly) CGFloat contentsScaleForDisplay;
 
 
+#pragma mark - Touch handling
 /** @name Touch handling */
-
 
 /**
  * @abstract Tells the node when touches began in its view.
@@ -443,8 +446,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)touchesCancelled:(nullable NSSet<UITouch *> *)touches withEvent:(nullable UIEvent *)event ASDISPLAYNODE_REQUIRES_SUPER;
 
 
+#pragma mark - Managing Gesture Recognizers
 /** @name Managing Gesture Recognizers */
-
 
 /**
  * @abstract Asks the node if a gesture recognizer should continue tracking touches.
@@ -454,8 +457,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer;
 
 
-/** @name Hit Testing */
+#pragma mark - Hit Testing
 
+/** @name Hit Testing */
 
 /**
  * @abstract Returns the view that contains the point.
@@ -472,6 +476,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (nullable UIView *)hitTest:(CGPoint)point withEvent:(nullable UIEvent *)event;
 
+
+#pragma mark - Placeholders
 /** @name Placeholders */
 
 /**
@@ -492,6 +498,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable UIImage *)placeholderImage;
 
 
+#pragma mark - Description
 /** @name Description */
 
 /**

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -179,6 +179,9 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   if (ASDisplayNodeSubclassOverridesSelector(c, @selector(layoutSpecThatFits:))) {
     overrides |= ASDisplayNodeMethodOverrideLayoutSpecThatFits;
   }
+  if (ASDisplayNodeSubclassOverridesSelector(c, @selector(layoutElementThatFits:))) {
+    overrides |= ASDisplayNodeMethodOverrideLayoutElementThatFits;
+  }
 
   return overrides;
 }
@@ -186,10 +189,11 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   // At most a layoutSpecBlock or one of the three layout methods is overridden
 #define __ASDisplayNodeCheckForLayoutMethodOverrides \
     ASDisplayNodeAssert(_layoutSpecBlock != NULL || \
-    (ASDisplayNodeSubclassOverridesSelector(self.class, @selector(calculateSizeThatFits:)) ? 1 : 0) \
+    ((ASDisplayNodeSubclassOverridesSelector(self.class, @selector(calculateSizeThatFits:)) ? 1 : 0) \
     + (ASDisplayNodeSubclassOverridesSelector(self.class, @selector(layoutSpecThatFits:)) ? 1 : 0) \
-    + (ASDisplayNodeSubclassOverridesSelector(self.class, @selector(calculateLayoutThatFits:)) ? 1 : 0) <= 1, \
-    @"Subclass %@ must at least provide a layoutSpecBlock or override at most one of the three layout methods: calculateLayoutThatFits, layoutSpecThatFits or calculateSizeThatFits", NSStringFromClass(self.class))
+    + (ASDisplayNodeSubclassOverridesSelector(self.class, @selector(layoutElementThatFits:)) ? 1 : 0) \
+    + (ASDisplayNodeSubclassOverridesSelector(self.class, @selector(calculateLayoutThatFits:)) ? 1 : 0)) <= 1, \
+    @"Subclass %@ must at least provide a layoutSpecBlock or override at most one of the four layout methods: calculateLayoutThatFits:, layoutSpecThatFits:, layoutElementThatFits:, or calculateSizeThatFits:", NSStringFromClass(self.class))
 
 + (void)initialize
 {
@@ -232,18 +236,17 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   
   
 #if DEBUG
-  // Check if subnodes where modified during layoutSpecThatFits:
-  if (self == [ASDisplayNode class] || ASSubclassOverridesSelector([ASDisplayNode class], self, @selector(layoutSpecThatFits:)))
-  {
-    __block IMP originalLayoutSpecThatFitsIMP = ASReplaceMethodWithBlock(self, @selector(layoutSpecThatFits:), ^(ASDisplayNode *_self, ASSizeRange sizeRange) {
+  // Check if subnodes where modified during the creation of the layout
+  if (self == [ASDisplayNode class]) {
+    __block IMP originalLayoutSpecThatFitsIMP = ASReplaceMethodWithBlock(self, @selector(_layoutElementThatFits:), ^(ASDisplayNode *_self, ASSizeRange sizeRange) {
       NSArray *oldSubnodes = _self.subnodes;
-      ASLayoutSpec *layoutSpec = ((ASLayoutSpec *( *)(id, SEL, ASSizeRange))originalLayoutSpecThatFitsIMP)(_self, @selector(layoutSpecThatFits:), sizeRange);
+      ASLayoutSpec *layoutElement = ((ASLayoutSpec *( *)(id, SEL, ASSizeRange))originalLayoutSpecThatFitsIMP)(_self, @selector(_layoutElementThatFits:), sizeRange);
       NSArray *subnodes = _self.subnodes;
-      ASDisplayNodeAssert(oldSubnodes.count == subnodes.count, @"Adding or removing nodes in layoutSpecThatFits: is verboten.");
+      ASDisplayNodeAssert(oldSubnodes.count == subnodes.count, @"Adding or removing nodes in layoutElementThatFits or layoutSpecBlock or layoutElementThatFits: is not allowed and can cause unexpected behavior.");
       for (NSInteger i = 0; i < oldSubnodes.count; i++) {
-        ASDisplayNodeAssert(oldSubnodes[i] == subnodes[i], @"Adding and removing nodes in layoutSpecThatFits: is verboten.");
+        ASDisplayNodeAssert(oldSubnodes[i] == subnodes[i], @"Adding or removing nodes in layoutElementThatFits or layoutSpecBlock or layoutElementThatFits: is not allowed and can cause unexpected behavior.");
       }
-      return layoutSpec;
+      return layoutElement;
     });
   }
 #endif
@@ -2425,62 +2428,68 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
   __ASDisplayNodeCheckForLayoutMethodOverrides;
 
   ASDN::MutexLocker l(__instanceLock__);
-  if ((_methodOverrides & ASDisplayNodeMethodOverrideLayoutSpecThatFits) || _layoutSpecBlock != NULL) {
-    BOOL measureLayoutSpec = _measurementOptions & ASDisplayNodePerformanceMeasurementOptionLayoutSpec;
-    if (measureLayoutSpec) {
-      _layoutSpecNumberOfPasses++;
-    }
 
-    ASLayoutSpec *layoutSpec = ({
-      ASDN::SumScopeTimer t(_layoutSpecTotalTime, measureLayoutSpec);
-      [self layoutSpecThatFits:constrainedSize];
-    });
+  // Manual size calculation via calculateSizeThatFits:
+  if (((_methodOverrides & ASDisplayNodeMethodOverrideLayoutSpecThatFits) ||
+      (_methodOverrides & ASDisplayNodeMethodOverrideLayoutElementThatFits) ||
+      (_layoutSpecBlock != NULL)) == NO) {
+    CGSize size = [self calculateSizeThatFits:constrainedSize.max];
+    ASDisplayNodeLogEvent(self, @"calculatedSize: %@", NSStringFromCGSize(size));
+    return [ASLayout layoutWithLayoutElement:self size:ASSizeRangeClamp(constrainedSize, size) sublayouts:nil];
+  }
+  
+  // Size calcualtion with layout elements
+  BOOL measureLayoutSpec = _measurementOptions & ASDisplayNodePerformanceMeasurementOptionLayoutSpec;
+  if (measureLayoutSpec) {
+    _layoutSpecNumberOfPasses++;
+  }
 
-#if AS_DEDUPE_LAYOUT_SPEC_TREE
+  // Get layout element from the node
+  id<ASLayoutElement> layoutElement = [self _layoutElementThatFits:constrainedSize];
+
+  // Certain properties are necessary to set on an element of type ASLayoutSpec
+  if (layoutElement.layoutElementType == ASLayoutElementTypeLayoutSpec) {
+    ASLayoutSpec *layoutSpec = (ASLayoutSpec *)layoutElement;
+    
     NSSet *duplicateElements = [layoutSpec findDuplicatedElementsInSubtree];
     if (duplicateElements.count > 0) {
       ASDisplayNodeFailAssert(@"Node %@ returned a layout spec that contains the same elements in multiple positions. Elements: %@", self, duplicateElements);
       // Use an empty layout spec to avoid crash.
       layoutSpec = [[ASLayoutSpec alloc] init];
     }
-#endif
-
+    
     ASDisplayNodeAssert(layoutSpec.isMutable, @"Node %@ returned layout spec %@ that has already been used. Layout specs should always be regenerated.", self, layoutSpec);
-
-    layoutSpec.parent = self; // This causes upward propogation of any non-default layoutElement values.
-    
-    // manually propagate the trait collection here so that any layoutSpec children of layoutSpec will get a traitCollection
-    {
-      ASDN::SumScopeTimer t(_layoutSpecTotalTime, measureLayoutSpec);
-      ASEnvironmentStatePropagateDown(layoutSpec, self.environmentTraitCollection);
-    }
-    
+    layoutSpec.parent = self;
     layoutSpec.isMutable = NO;
-    BOOL measureLayoutComputation = _measurementOptions & ASDisplayNodePerformanceMeasurementOptionLayoutComputation;
-    if (measureLayoutComputation) {
-      _layoutComputationNumberOfPasses++;
-    }
-
-    ASLayout *layout = ({
-      ASDN::SumScopeTimer t(_layoutComputationTotalTime, measureLayoutComputation);
-      [layoutSpec layoutThatFits:constrainedSize];
-    });
-
-    ASDisplayNodeAssertNotNil(layout, @"[ASLayoutSpec measureWithSizeRange:] should never return nil! %@, %@", self, layoutSpec);
-      
-    // Make sure layoutElementObject of the root layout is `self`, so that the flattened layout will be structurally correct.
-    BOOL isFinalLayoutElement = (layout.layoutElement != self);
-    if (isFinalLayoutElement) {
-      layout.position = CGPointZero;
-      layout = [ASLayout layoutWithLayoutElement:self size:layout.size sublayouts:@[layout]];
-    }
-    ASDisplayNodeLogEvent(self, @"computedLayout: %@", layout);
-    return [layout filteredNodeLayoutTree];
-  } else {
-    CGSize size = [self calculateSizeThatFits:constrainedSize.max];
-    ASDisplayNodeLogEvent(self, @"calculatedSize: %@", NSStringFromCGSize(size));
-    return [ASLayout layoutWithLayoutElement:self size:ASSizeRangeClamp(constrainedSize, size) sublayouts:nil];
   }
+  
+  // Manually propagate the trait collection here so that any layoutSpec children of layoutSpec will get a traitCollection
+  {
+    ASDN::SumScopeTimer t(_layoutSpecTotalTime, measureLayoutSpec);
+    ASEnvironmentStatePropagateDown(layoutElement, self.environmentTraitCollection);
+  }
+  
+  BOOL measureLayoutComputation = _measurementOptions & ASDisplayNodePerformanceMeasurementOptionLayoutComputation;
+  if (measureLayoutComputation) {
+    _layoutComputationNumberOfPasses++;
+  }
+
+  // Layout element layout creation
+  ASLayout *layout = ({
+    ASDN::SumScopeTimer t(_layoutComputationTotalTime, measureLayoutComputation);
+    [layoutElement layoutThatFits:constrainedSize];
+  });
+  ASDisplayNodeAssertNotNil(layout, @"[ASLayoutElement layoutThatFits:] should never return nil! %@, %@", self, layout);
+    
+  // Make sure layoutElementObject of the root layout is `self`, so that the flattened layout will be structurally correct.
+  BOOL isFinalLayoutElement = (layout.layoutElement != self);
+  if (isFinalLayoutElement) {
+    layout.position = CGPointZero;
+    layout = [ASLayout layoutWithLayoutElement:self size:layout.size sublayouts:@[layout]];
+  }
+  ASDisplayNodeLogEvent(self, @"computedLayout: %@", layout);
+
+  return [layout filteredNodeLayoutTree];
 }
 
 - (CGSize)calculateSizeThatFits:(CGSize)constrainedSize
@@ -2490,24 +2499,56 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
   return CGSizeZero;
 }
 
+- (id<ASLayoutElement>)_layoutElementThatFits:(ASSizeRange)constrainedSize
+{
+  __ASDisplayNodeCheckForLayoutMethodOverrides;
+  
+  BOOL measureLayoutSpec = _measurementOptions & ASDisplayNodePerformanceMeasurementOptionLayoutSpec;
+  if ((_methodOverrides & ASDisplayNodeMethodOverrideLayoutElementThatFits)) {
+    return ({
+      ASDN::SumScopeTimer t(_layoutSpecTotalTime, measureLayoutSpec);
+      [self layoutElementThatFits:constrainedSize];
+    });
+  } else if (_layoutSpecBlock != NULL) {
+    return ({
+      ASDN::MutexLocker l(__instanceLock__);
+      ASDN::SumScopeTimer t(_layoutSpecTotalTime, measureLayoutSpec);
+      _layoutSpecBlock(self, constrainedSize);
+    });
+  } else {
+    return ({
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+      ASDN::SumScopeTimer t(_layoutSpecTotalTime, measureLayoutSpec);
+      [self layoutSpecThatFits:constrainedSize];
+#pragma clang diagnostic pop
+    });
+  }
+}
+
 - (ASLayoutSpec *)layoutSpecThatFits:(ASSizeRange)constrainedSize
 {
   __ASDisplayNodeCheckForLayoutMethodOverrides;
 
   ASDN::MutexLocker l(__instanceLock__);
   
-  if (_layoutSpecBlock != NULL) {
-    return _layoutSpecBlock(self, constrainedSize);
-  }
-  
   ASDisplayNodeAssert(NO, @"-[ASDisplayNode layoutSpecThatFits:] should never return an empty value. One way this is caused is by calling -[super layoutSpecThatFits:] which is not currently supported.");
+  return [[ASLayoutSpec alloc] init];
+}
+
+- (id<ASLayoutElement>)layoutElementThatFits:(ASSizeRange)constrainedSize
+{
+  __ASDisplayNodeCheckForLayoutMethodOverrides;
+  
+  ASDisplayNodeAssert(NO, @"-[ASDisplayNode layoutElementThatFits:] should never return an empty value. One way this is caused is by calling -[super layoutElementThatFits:] which is not currently supported.");
   return [[ASLayoutSpec alloc] init];
 }
 
 - (void)setLayoutSpecBlock:(ASLayoutSpecBlock)layoutSpecBlock
 {
-  // For now there should never be a overwrite of layoutSpecThatFits: and a layoutSpecThatFitsBlock: be provided
+  // For now there should never be an overwrite of layoutSpecThatFits: / layoutElementThatFits: and a layoutSpecBlock
   ASDisplayNodeAssert(!(_methodOverrides & ASDisplayNodeMethodOverrideLayoutSpecThatFits), @"Overwriting layoutSpecThatFits: and providing a layoutSpecBlock block is currently not supported");
+  ASDisplayNodeAssert(!(_methodOverrides & ASDisplayNodeMethodOverrideLayoutElementThatFits), @"Overwriting layoutElementThatFits: and providing a layoutSpecBlock block is currently not supported");
 
   ASDN::MutexLocker l(__instanceLock__);
   _layoutSpecBlock = layoutSpecBlock;
@@ -3419,11 +3460,6 @@ static const char *ASDisplayNodeDrawingPriorityKey = "ASDrawingPriority";
 - (NSArray<ASDisplayNode *> *)children
 {
   return self.subnodes;
-}
-
-- (BOOL)supportsUpwardPropagation
-{
-  return ASEnvironmentStatePropagationEnabled();
 }
 
 - (BOOL)supportsTraitsCollectionPropagation

--- a/AsyncDisplayKit/Details/ASEnvironment.h
+++ b/AsyncDisplayKit/Details/ASEnvironment.h
@@ -110,8 +110,9 @@ ASDISPLAYNODE_EXTERN_C_END
 /// Returns all children of an object which class conforms to the ASEnvironment protocol
 - (nullable NSArray<id<ASEnvironment>> *)children;
 
-/// Classes should implement this method and return YES / NO dependent if upward propagation is enabled or not 
-- (BOOL)supportsUpwardPropagation;
+/// Classes should implement this method and return YES / NO dependent if upward propagation is enabled or not
+// Currently disabled as it was used previously and propagation is not implemented at the moment
+// - (BOOL)supportsUpwardPropagation;
 
 /// Classes should implement this method and return YES / NO dependent if downware propagation is enabled or not
 - (BOOL)supportsTraitsCollectionPropagation;

--- a/AsyncDisplayKit/Layout/ASLayoutSpec+Subclasses.mm
+++ b/AsyncDisplayKit/Layout/ASLayoutSpec+Subclasses.mm
@@ -88,10 +88,6 @@
   
   // Replace object at the given index with the layoutElement
   _childrenArray[index] = layoutElement;
-  
-  // TODO: Should we propagate up the layoutElement at it could happen that multiple children will propagated up their
-  //       layout options and one child will overwrite values from another child
-  // [self propagateUpLayoutElement:finalLayoutElement];
 }
 
 - (id<ASLayoutElement>)childAtIndex:(NSUInteger)index

--- a/AsyncDisplayKit/Layout/ASLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASLayoutSpec.mm
@@ -105,19 +105,6 @@
   return [ASLayout layoutWithLayoutElement:self size:constrainedSize.min];
 }
 
-
-#pragma mark - Parent
-
-- (void)setParent:(id<ASLayoutElement>)parent
-{
-  // FIXME: Locking should be evaluated here.  _parent is not widely used yet, though.
-  _parent = parent;
-  
-  if ([parent supportsUpwardPropagation]) {
-    ASEnvironmentStatePropagateUp(parent, self.environmentState.layoutOptionsState);
-  }
-}
-
 #pragma mark - Child
 
 - (void)setChild:(id<ASLayoutElement>)child
@@ -129,7 +116,6 @@
     id<ASLayoutElement> finalLayoutElement = [self layoutElementToAddFromLayoutElement:child];
     if (finalLayoutElement) {
       _childrenArray[0] = finalLayoutElement;
-      [self propagateUpLayoutElement:finalLayoutElement];
     }
   } else {
     if (_childrenArray.count) {
@@ -185,26 +171,9 @@
   _environmentState = environmentState;
 }
 
-// Subclasses can override this method to return NO, because upward propagation is not enabled if a layout
-// specification has more than one child. Currently ASStackLayoutSpec and ASAbsoluteLayoutSpec are currently
-// the specifications that are known to have more than one.
-- (BOOL)supportsUpwardPropagation
-{
-  return ASEnvironmentStatePropagationEnabled();
-}
-
 - (BOOL)supportsTraitsCollectionPropagation
 {
   return ASEnvironmentStateTraitCollectionPropagationEnabled();
-}
-
-- (void)propagateUpLayoutElement:(id<ASLayoutElement>)layoutElement
-{
-  if ([layoutElement isKindOfClass:[ASLayoutSpec class]]) {
-    [(ASLayoutSpec *)layoutElement setParent:self]; // This will trigger upward propogation if needed.
-  } else if ([self supportsUpwardPropagation]) {
-    ASEnvironmentStatePropagateUp(self, layoutElement.environmentState.layoutOptionsState); // Probably an ASDisplayNode
-  }
 }
 
 - (ASEnvironmentTraitCollection)environmentTraitCollection

--- a/AsyncDisplayKit/Layout/ASStackLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASStackLayoutSpec.mm
@@ -182,15 +182,6 @@
 
 @end
 
-@implementation ASStackLayoutSpec (ASEnvironment)
-
-- (BOOL)supportsUpwardPropagation
-{
-  return NO;
-}
-
-@end
-
 @implementation ASStackLayoutSpec (Debugging)
 
 #pragma mark - ASLayoutElementAsciiArtProtocol

--- a/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
+++ b/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
@@ -44,7 +44,8 @@ typedef NS_OPTIONS(NSUInteger, ASDisplayNodeMethodOverrides)
   ASDisplayNodeMethodOverrideTouchesCancelled   = 1 << 1,
   ASDisplayNodeMethodOverrideTouchesEnded       = 1 << 2,
   ASDisplayNodeMethodOverrideTouchesMoved       = 1 << 3,
-  ASDisplayNodeMethodOverrideLayoutSpecThatFits = 1 << 4
+  ASDisplayNodeMethodOverrideLayoutSpecThatFits = 1 << 4,
+  ASDisplayNodeMethodOverrideLayoutElementThatFits = 1 << 5
 };
 
 FOUNDATION_EXPORT NSString * const ASRenderingEngineDidDisplayScheduledNodesNotification;

--- a/examples/ASDKgram/Sample/CommentsNode.m
+++ b/examples/ASDKgram/Sample/CommentsNode.m
@@ -41,7 +41,7 @@
   return self;
 }
 
-- (ASLayoutSpec *)layoutSpecThatFits:(ASSizeRange)constrainedSize
+- (id<ASLayoutElement>)layoutElementThatFits:(ASSizeRange)constrainedSize
 {
   ASStackLayoutSpec *verticalStack = [ASStackLayoutSpec verticalStackLayoutSpec];
   verticalStack.spacing            = INTER_COMMENT_SPACING;

--- a/examples/ASDKgram/Sample/PhotoCellNode.m
+++ b/examples/ASDKgram/Sample/PhotoCellNode.m
@@ -110,7 +110,7 @@
   return self;
 }
 
-- (ASLayoutSpec *)layoutSpecThatFits:(ASSizeRange)constrainedSize
+- (id<ASLayoutElement>)layoutElementThatFits:(ASSizeRange)constrainedSize
 {
   // username / photo location header vertical stack
   _photoLocationLabel.style.flexShrink    = 1.0;


### PR DESCRIPTION
With the changes we did for 2.0 we are now able to return an object that conforms to the `ASLayoutElement` protocol from `layoutSpecThatFits:`. Unfortunately `layoutSpecThatFits:` only allows to return objects from  type `ASLayoutSpec`, so just one kind of class of objects that currently conforms to the `ASLayoutElement` protocol can be returned.

With this PR we would introduce a new method with the name `layoutElementThatFits:` and it would be possible to return any object that conforms to the `ASLayoutElement` protocol than.

What would be the benefits?
For now this would allow us to remove the `ASWrapperLayoutSpec` class completely before we even introduce it. E.g in Pinterest we could change the following code:
```Objc
- (ASLayoutSpec *)layoutSpecThatFits:(ASSizeRange)constrainedSize
{
    self.controlNode.layoutPosition = CGPointZero;
    self.controlNode.sizeRange = ASRelativeSizeRangeMakeWithExactCGSize(…);
    return [ASStaticLayoutSpec staticLayoutSpecWithChildren:@[self.controlNode]];
}
```
to currently:
```Objc
- (ASLayoutSpec *)layoutSpecThatFits:(ASSizeRange)constrainedSize
{
  self.controlNode.style.preferredSize = CGSizeMake(…);
  return [ASWrapperLayoutSpec wrapperWithLayoutElement:self.controlNode];
}
```

and with `layoutElementThatFits:` support:
```Objc
- (id<ASLayoutElement>)layoutElementThatFits:(ASSizeRange)constrainedSize
{
   self.controlNode.style.preferredSize = CGSizeMake(…);
   return self.controlNode;
}
```
or even:
```Objc
- (id<ASLayoutElement>)layoutElementThatFits:(ASSizeRange)constrainedSize
{
  return [self.controlNode styledWithBlock:^(ASLayoutElementStyle *style) {
    style.preferredSize = CGSizeMake(...);
  }]
}
```
In the future the idea and idea would be to also allow to return an `ASLayoutElement` that involves `self` in `layoutElementThatFits:` to be able to remove the internal `finalLayoutable` property that was kind of a hack …

What should we do with `layoutSpecThatFits:`?
I think it should be deprecated as it’s mostly a search and replace

What should we do with `layoutSpecBlock`?
`layoutSpecBlock` is a difficult topic and I don’t like the current idea around it, as it does not provide subclass / chaining support with other `layoutSpecBlocks` or `layoutSpecThatFits`. I tend to to also deprecate it and for now advice to create a subclass and implement `layoutElementThatFits:`.