### PR TITLE
[ASCellNode] Add subclass method cache; skip visibility rect calculations in the common case.

### DIFF
--- a/AsyncDisplayKit/ASCellNode.mm
+++ b/AsyncDisplayKit/ASCellNode.mm
@@ -11,6 +11,7 @@
 #import "ASCellNode+Internal.h"
 
 #import "ASEqualityHelpers.h"
+#import "ASInternalHelpers.h"
 #import "ASDisplayNodeInternal.h"
 #import "ASDisplayNode+FrameworkPrivate.h"
 #import "ASCollectionView+Undeprecated.h"
@@ -41,6 +42,7 @@
 
 @implementation ASCellNode
 @synthesize interactionDelegate = _interactionDelegate;
+static NSMutableSet *__cellClassesForVisibilityNotifications = nil; // See +initialize.
 
 - (instancetype)init
 {
@@ -271,10 +273,26 @@
   [self handleVisibilityChange:NO];
 }
 
++ (void)initialize
+{
+  [super initialize];
+  if (ASSubclassOverridesSelector([ASCellNode class], self, @selector(cellNodeVisibilityEvent:inScrollView:withCellFrame:))) {
+    if (__cellClassesForVisibilityNotifications == nil) {
+      __cellClassesForVisibilityNotifications = [NSMutableSet set];
+    }
+    [__cellClassesForVisibilityNotifications addObject:self];
+  }
+}
+
 - (void)handleVisibilityChange:(BOOL)isVisible
 {
+  if ([__cellClassesForVisibilityNotifications containsObject:[self class]] == NO) {
+    return; // The work below is expensive, and only valuable for subclasses watching visibility events.
+  }
+  
   // NOTE: This assertion is failing in some apps and will be enabled soon.
   // ASDisplayNodeAssert(self.isNodeLoaded, @"Node should be loaded in order for it to become visible or invisible.  If not in this situation, we shouldn't trigger creating the view.");
+  
   UIView *view = self.view;
   CGRect cellFrame = CGRectZero;
   
@@ -287,7 +305,8 @@
   
   // If we did not convert, we'll pass along CGRectZero and a nil scrollView.  The EventInvisible call is thus equivalent to
   // didExitVisibileState, but is more convenient for the developer than implementing multiple methods.
-  [self cellNodeVisibilityEvent:isVisible ? ASCellNodeVisibilityEventVisible : ASCellNodeVisibilityEventInvisible
+  [self cellNodeVisibilityEvent:isVisible ? ASCellNodeVisibilityEventVisible
+                                          : ASCellNodeVisibilityEventInvisible
                    inScrollView:scrollView
                   withCellFrame:cellFrame];
 }

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -3516,7 +3516,7 @@ ASEnvironmentLayoutExtensibilityForwarding
   creationTypeString = [NSString stringWithFormat:@"cr8:%.2lfms dl:%.2lfms ap:%.2lfms ad:%.2lfms",  1000 * _debugTimeToCreateView, 1000 * _debugTimeForDidLoad, 1000 * _debugTimeToApplyPendingState, 1000 * _debugTimeToAddSubnodeViews];
 #endif
 
-  return [NSString stringWithFormat:@"<%@ alpha:%.2f isLayerBacked:%d %@>", self.description, self.alpha, self.isLayerBacked, creationTypeString];
+  return [NSString stringWithFormat:@"<%@ alpha:%.2f isLayerBacked:%d frame:%@ %@>", self.description, self.alpha, self.isLayerBacked, NSStringFromCGRect(self.frame), creationTypeString];
 }
 
 - (NSString *)displayNodeRecursiveDescription

--- a/AsyncDisplayKit/Private/ASInternalHelpers.m
+++ b/AsyncDisplayKit/Private/ASInternalHelpers.m
@@ -17,6 +17,7 @@
 
 BOOL ASSubclassOverridesSelector(Class superclass, Class subclass, SEL selector)
 {
+  if (superclass == subclass) return NO; // Even if the class implements the selector, it doesn't override itself.
   Method superclassMethod = class_getInstanceMethod(superclass, selector);
   Method subclassMethod = class_getInstanceMethod(subclass, selector);
   IMP superclassIMP = superclassMethod ? method_getImplementation(superclassMethod) : NULL;
@@ -26,6 +27,7 @@ BOOL ASSubclassOverridesSelector(Class superclass, Class subclass, SEL selector)
 
 BOOL ASSubclassOverridesClassSelector(Class superclass, Class subclass, SEL selector)
 {
+  if (superclass == subclass) return NO; // Even if the class implements the selector, it doesn't override itself.
   Method superclassMethod = class_getClassMethod(superclass, selector);
   Method subclassMethod = class_getClassMethod(subclass, selector);
   IMP superclassIMP = superclassMethod ? method_getImplementation(superclassMethod) : NULL;


### PR DESCRIPTION
Profiling showed this area as the most expensive part of ASRangeController propogation of .interfaceState, when scrolling an ASTableView.

This is very much on the critical path for sustained 60FPS in these views.

Before **This is filtered to only the method in question**, meaning a total of 1.4% impact on main with a single moderate-speed swipe.  It is also triggered in a different runloop stage offscreen:
<img width="804" alt="screen shot 2016-10-14 at 8 09 29 pm" src="https://cloud.githubusercontent.com/assets/565251/19407494/6d8086ae-9258-11e6-822a-fea907ed8c7e.png">

After *not directly comparable* but shows the absence of the method:
<img width="895" alt="screen shot 2016-10-14 at 8 36 10 pm" src="https://cloud.githubusercontent.com/assets/565251/19407495/6d985342-9258-11e6-985e-11cfac89651e.png">
