### PR TITLE
[ASDisplayNode] Return constrainedSize in ASDisplayNode

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -2491,7 +2491,7 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
 {
   __ASDisplayNodeCheckForLayoutMethodOverrides;
 
-  return CGSizeZero;
+  return constrainedSize;
 }
 
 - (id<ASLayoutElement>)_layoutElementThatFits:(ASSizeRange)constrainedSize

--- a/AsyncDisplayKit/ASImageNode.mm
+++ b/AsyncDisplayKit/ASImageNode.mm
@@ -190,7 +190,7 @@ struct ASImageNodeDrawParameters {
   ASDN::MutexLocker l(__instanceLock__);
 
   if (_image == nil) {
-    return constrainedSize;
+    return [super calculateSizeThatFits:constrainedSize];
   }
 
   return _image.size;

--- a/AsyncDisplayKit/ASNetworkImageNode.mm
+++ b/AsyncDisplayKit/ASNetworkImageNode.mm
@@ -341,7 +341,8 @@ static const CGSize kMinReleaseImageOnBackgroundSize = {20.0, 20.0};
   // being.
   // TODO: After 2.0 is stable we should remove this behavior as a ASNetworkImageNode is a replaced element and the
   // client code should set the size of an image or it's container it's embedded in
-  if (ASIsCGSizeValidForSize(constrainedSize) == NO && _URL != nil && self.image == nil) {
+  if (ASIsCGSizeValidForSize(constrainedSize) == NO && self.image == nil) {
+    ASDisplayNodeAssert(_URL != nil, @"An NSURL must be set on ASNetworkImageNode before layout unless a valid size is provided.");
     return CGSizeZero;
   }
     

--- a/AsyncDisplayKit/ASNetworkImageNode.mm
+++ b/AsyncDisplayKit/ASNetworkImageNode.mm
@@ -331,24 +331,6 @@ static const CGSize kMinReleaseImageOnBackgroundSize = {20.0, 20.0};
   }
 }
 
-#pragma mark - Layout and Sizing
-
-- (CGSize)calculateSizeThatFits:(CGSize)constrainedSize
-{
-  ASDN::MutexLocker l(__instanceLock__);
-
-  // If the image node is currently in the loading process and no valid size is applied return CGSizeZero for the time
-  // being.
-  // TODO: After 2.0 is stable we should remove this behavior as a ASNetworkImageNode is a replaced element and the
-  // client code should set the size of an image or it's container it's embedded in
-  if (ASIsCGSizeValidForSize(constrainedSize) == NO && self.image == nil) {
-    ASDisplayNodeAssert(_URL != nil, @"An NSURL must be set on ASNetworkImageNode before layout unless a valid size is provided.");
-    return CGSizeZero;
-  }
-    
-  return [super calculateSizeThatFits:constrainedSize];
-}
-
 #pragma mark - Private methods, safe to call without lock
 
 - (void)handleProgressImage:(UIImage *)progressImage progress:(CGFloat)progress downloadIdentifier:(nullable id)downloadIdentifier

--- a/AsyncDisplayKitTests/ASDisplayNodeImplicitHierarchyTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeImplicitHierarchyTests.m
@@ -59,11 +59,20 @@
 
 - (void)testInitialNodeInsertionWithOrdering
 {
+  static CGSize kSize = {100, 100};
+  
   ASDisplayNode *node1 = [[ASDisplayNode alloc] init];
   ASDisplayNode *node2 = [[ASDisplayNode alloc] init];
   ASDisplayNode *node3 = [[ASDisplayNode alloc] init];
   ASDisplayNode *node4 = [[ASDisplayNode alloc] init];
   ASDisplayNode *node5 = [[ASDisplayNode alloc] init];
+  
+  // As we will involve a stack spec we have to give the nodes an intrinsic content size
+  node1.style.preferredSize = kSize;
+  node2.style.preferredSize = kSize;
+  node3.style.preferredSize = kSize;
+  node4.style.preferredSize = kSize;
+  node5.style.preferredSize = kSize;
 
   ASSpecTestDisplayNode *node = [[ASSpecTestDisplayNode alloc] init];
   node.automaticallyManagesSubnodes = YES;
@@ -88,9 +97,16 @@
 
 - (void)testCalculatedLayoutHierarchyTransitions
 {
+  static CGSize kSize = {100, 100};
+  
   ASDisplayNode *node1 = [[ASDisplayNode alloc] init];
   ASDisplayNode *node2 = [[ASDisplayNode alloc] init];
   ASDisplayNode *node3 = [[ASDisplayNode alloc] init];
+  
+  // As we will involve a stack spec we have to give the nodes an intrinsic content size
+  node1.style.preferredSize = kSize;
+  node2.style.preferredSize = kSize;
+  node3.style.preferredSize = kSize;
   
   ASSpecTestDisplayNode *node = [[ASSpecTestDisplayNode alloc] init];
   node.automaticallyManagesSubnodes = YES;
@@ -99,7 +115,9 @@
     if ([strongNode.layoutState isEqualToNumber:@1]) {
       return [ASAbsoluteLayoutSpec absoluteLayoutSpecWithChildren:@[node1, node2]];
     } else {
-      ASStackLayoutSpec *stackLayout = [[ASStackLayoutSpec alloc] init];
+      ASStackLayoutSpec *stackLayout = [ASStackLayoutSpec horizontalStackLayoutSpec];
+      stackLayout.alignItems = ASStackLayoutAlignItemsStart;
+
       [stackLayout setChildren:@[node3, node2]];
       return [ASAbsoluteLayoutSpec absoluteLayoutSpecWithChildren:@[node1, stackLayout]];
     }


### PR DESCRIPTION
This change will return `constrainedSize` from ASDisplayNode in `calculateSizeThatFits:` instead of CGSizeZero. The reason for that is that the `constrainedSize` usually is within the range of the `style.preferredSize`. The old behavior did not consider that.

* Removes the invalid `constrainedSize` check within `ASNetworkImageNode`.
* Fix tests: As ASDisplayNode does not return CGSizeZero anymore we have to give the display nodes we use in tests and are involving a stack spec an intrinsic content size.,