### PR TITLE
[ASLayout - Performance] Avoid weak ivar access & method call to check layoutElementType.

### DIFF
--- a/AsyncDisplayKit/Layout/ASLayout.mm
+++ b/AsyncDisplayKit/Layout/ASLayout.mm
@@ -40,7 +40,9 @@ static inline NSString * descriptionIndents(NSUInteger indents)
 }
 
 @interface ASLayout () <ASDescriptionProvider>
-
+{
+  ASLayoutElementType _layoutElementType;
+}
 /**
  * A boolean describing if the current layout has been flattened.
  */
@@ -68,6 +70,7 @@ static inline NSString * descriptionIndents(NSUInteger indents)
 #endif
     
     _layoutElement = layoutElement;
+    _layoutElementType = layoutElement.layoutElementType;
     
     if (!ASIsCGSizeValidForLayout(size)) {
       ASDisplayNodeAssert(NO, @"layoutSize is invalid and unsafe to provide to Core Animation! Release configurations will force to 0, 0.  Size = %@, node = %@", NSStringFromCGSize(size), layoutElement);
@@ -173,7 +176,7 @@ static inline NSString * descriptionIndents(NSUInteger indents)
 
 - (ASLayoutElementType)type
 {
-  return _layoutElement.layoutElementType;
+  return _layoutElementType;
 }
 
 - (CGRect)frame

--- a/AsyncDisplayKit/Layout/ASLayout.mm
+++ b/AsyncDisplayKit/Layout/ASLayout.mm
@@ -70,6 +70,7 @@ static inline NSString * descriptionIndents(NSUInteger indents)
 #endif
     
     _layoutElement = layoutElement;
+    // Read this now to avoid @c weak overhead later.
     _layoutElementType = layoutElement.layoutElementType;
     
     if (!ASIsCGSizeValidForLayout(size)) {


### PR DESCRIPTION
This shows up in benchmarking profiles for layout-bound workloads.

@maicki @Adlai-Holler @garrettmoon 

<img width="1322" alt="screen shot 2016-10-16 at 11 55 42 am" src="https://cloud.githubusercontent.com/assets/565251/19420015/d195cc4a-9397-11e6-9089-e8ccac6b25dc.png">
