### PR TITLE
[Layout] Don't Copy Layout Tree During Filtering

### DIFF
--- a/AsyncDisplayKit/Layout/ASLayout.mm
+++ b/AsyncDisplayKit/Layout/ASLayout.mm
@@ -40,12 +40,6 @@ static inline NSString * descriptionIndents(NSUInteger indents)
 }
 
 @interface ASLayout () <ASDescriptionProvider>
-
-/**
- * A boolean describing if the current layout has been flattened.
- */
-@property (nonatomic, getter=isFlattened) BOOL flattened;
-
 @end
 
 @implementation ASLayout
@@ -84,7 +78,6 @@ static inline NSString * descriptionIndents(NSUInteger indents)
     }
 
     _sublayouts = sublayouts != nil ? [sublayouts copy] : @[];
-    _flattened = NO;
   }
   return self;
 }
@@ -154,15 +147,12 @@ static inline NSString * descriptionIndents(NSUInteger indents)
     queue.pop();
 
     if (self != context.layout && context.layout.type == ASLayoutElementTypeDisplayNode) {
-      ASLayout *layout = [ASLayout layoutWithLayout:context.layout position:context.absolutePosition];
-      layout.flattened = YES;
-      [flattenedSublayouts addObject:layout];
+      context.layout.position = context.absolutePosition;
+      [flattenedSublayouts addObject:context.layout];
     }
     
     for (ASLayout *sublayout in context.layout.sublayouts) {
-      if (sublayout.isFlattened == NO) {
-        queue.push({sublayout, context.absolutePosition + sublayout.position});
-      }
+      queue.push({sublayout, context.absolutePosition + sublayout.position});
     }
   }
 

--- a/AsyncDisplayKit/Layout/ASLayout.mm
+++ b/AsyncDisplayKit/Layout/ASLayout.mm
@@ -129,9 +129,13 @@ static inline NSString * descriptionIndents(NSUInteger indents)
 
 #pragma mark - Layout Flattening
 
+/**
+ * NOTE: This method has the side effect of updating the @c position values of all the
+ *   ASLayout objects in the layout tree.
+ */
 - (ASLayout *)filteredNodeLayoutTree
 {
-  NSMutableArray *flattenedSublayouts = [NSMutableArray array];
+  NSMutableArray<ASLayout *> *flattenedSublayouts = [NSMutableArray array];
   
   struct Context {
     ASLayout *layout;


### PR DESCRIPTION
I haven't profiled this yet, but it should be very safe and quite a nice performance win.

As @appleguy identified in #2392, there's a lot of headroom in terms of reducing object allocations and `weak` object handling.

I removed the `flattened` flag because I don't believe it serves a purpose. During the filtering, we only travel _down_ the tree. In the prior implementation, we only marked the newly-copied ASLayout objects as `flattened` so it's impossible that we would encounter a flattened layout as we traverse down the sublayouts.

After this change, the `position` value of the sublayouts will be changed by calling `filteredNodeLayoutTree`. I think this is fine. Nobody cares about the old `position` values.

This needs some profiling!