### PR TITLE
[ASLayout] Improve ASLayout

### DIFF
--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -196,6 +196,7 @@
 		68FC85EA1CE29C7D00EDD713 /* ASVisibilityProtocols.h in Headers */ = {isa = PBXBuildFile; fileRef = 68FC85E71CE29C7D00EDD713 /* ASVisibilityProtocols.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		68FC85EB1CE29C7D00EDD713 /* ASVisibilityProtocols.m in Sources */ = {isa = PBXBuildFile; fileRef = 68FC85E81CE29C7D00EDD713 /* ASVisibilityProtocols.m */; };
 		68FC85EC1CE29C7D00EDD713 /* ASVisibilityProtocols.m in Sources */ = {isa = PBXBuildFile; fileRef = 68FC85E81CE29C7D00EDD713 /* ASVisibilityProtocols.m */; };
+		690457F71DB5131A00B5EE68 /* ASLayoutPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 690457F61DB5131A00B5EE68 /* ASLayoutPrivate.h */; };
 		6959433E1D70815300B0EE1F /* ASDisplayNodeLayout.mm in Sources */ = {isa = PBXBuildFile; fileRef = 6959433C1D70815300B0EE1F /* ASDisplayNodeLayout.mm */; };
 		6959433F1D70815300B0EE1F /* ASDisplayNodeLayout.mm in Sources */ = {isa = PBXBuildFile; fileRef = 6959433C1D70815300B0EE1F /* ASDisplayNodeLayout.mm */; };
 		695943401D70815300B0EE1F /* ASDisplayNodeLayout.h in Headers */ = {isa = PBXBuildFile; fileRef = 6959433D1D70815300B0EE1F /* ASDisplayNodeLayout.h */; };
@@ -978,6 +979,7 @@
 		68FC85E11CE29B7E00EDD713 /* ASTabBarController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASTabBarController.m; sourceTree = "<group>"; };
 		68FC85E71CE29C7D00EDD713 /* ASVisibilityProtocols.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASVisibilityProtocols.h; sourceTree = "<group>"; };
 		68FC85E81CE29C7D00EDD713 /* ASVisibilityProtocols.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASVisibilityProtocols.m; sourceTree = "<group>"; };
+		690457F61DB5131A00B5EE68 /* ASLayoutPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASLayoutPrivate.h; path = AsyncDisplayKit/Layout/ASLayoutPrivate.h; sourceTree = "<group>"; };
 		6959433C1D70815300B0EE1F /* ASDisplayNodeLayout.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASDisplayNodeLayout.mm; sourceTree = "<group>"; };
 		6959433D1D70815300B0EE1F /* ASDisplayNodeLayout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASDisplayNodeLayout.h; sourceTree = "<group>"; };
 		696FCB301D6E46050093471E /* ASBackgroundLayoutSpecSnapshotTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASBackgroundLayoutSpecSnapshotTests.mm; sourceTree = "<group>"; };
@@ -1108,8 +1110,8 @@
 		BDC2D162BD55A807C1475DA5 /* Pods-AsyncDisplayKitTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AsyncDisplayKitTests.profile.xcconfig"; path = "Pods/Target Support Files/Pods-AsyncDisplayKitTests/Pods-AsyncDisplayKitTests.profile.xcconfig"; sourceTree = "<group>"; };
 		CC051F1E1D7A286A006434CB /* ASCALayerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASCALayerTests.m; sourceTree = "<group>"; };
 		CC0AEEA31D66316E005D1C78 /* ASUICollectionViewTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASUICollectionViewTests.m; sourceTree = "<group>"; };
-		CC2E317F1DAC353700EEE891 /* ASCollectionView+Undeprecated.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ASCollectionView+Undeprecated.h"; sourceTree = "<group>"; };
 		CC11F9791DB181180024D77B /* ASNetworkImageNodeTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASNetworkImageNodeTests.m; sourceTree = "<group>"; };
+		CC2E317F1DAC353700EEE891 /* ASCollectionView+Undeprecated.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ASCollectionView+Undeprecated.h"; sourceTree = "<group>"; };
 		CC3B20811C3F76D600798563 /* ASPendingStateController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASPendingStateController.h; sourceTree = "<group>"; };
 		CC3B20821C3F76D600798563 /* ASPendingStateController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASPendingStateController.mm; sourceTree = "<group>"; };
 		CC3B20871C3F7A5400798563 /* ASWeakSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASWeakSet.h; sourceTree = "<group>"; };
@@ -1710,6 +1712,7 @@
 				9C49C36E1B853957000B0DD5 /* ASStackLayoutElement.h */,
 				ACF6ED161B17843500DA7C62 /* ASStackLayoutSpec.h */,
 				ACF6ED171B17843500DA7C62 /* ASStackLayoutSpec.mm */,
+				690457F61DB5131A00B5EE68 /* ASLayoutPrivate.h */,
 			);
 			name = Layout;
 			path = ..;
@@ -1759,6 +1762,7 @@
 				9C70F20D1CDBE9CB007D6C76 /* ASDefaultPlayButton.h in Headers */,
 				68355B411CB57A6C001D4E68 /* ASImageContainerProtocolCategories.h in Headers */,
 				7630FFA81C9E267E007A7C0E /* ASVideoNode.h in Headers */,
+				690457F71DB5131A00B5EE68 /* ASLayoutPrivate.h in Headers */,
 				B350623F1B010EFD0018CF92 /* _ASAsyncTransactionContainer.h in Headers */,
 				B13CA1011C52004900E031AB /* ASCollectionNode+Beta.h in Headers */,
 				254C6B7E1BF94DF4003EC431 /* ASTextKitTailTruncater.h in Headers */,

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -30,7 +30,7 @@
 #import "ASLayoutElementStylePrivate.h"
 
 #import "ASInternalHelpers.h"
-#import "ASLayout.h"
+#import "ASLayoutPrivate.h"
 #import "ASLayoutSpec.h"
 #import "ASCellNode+Internal.h"
 #import "ASWeakProxy.h"

--- a/AsyncDisplayKit/Layout/ASAbsoluteLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASAbsoluteLayoutSpec.mm
@@ -11,7 +11,7 @@
 #import "ASAbsoluteLayoutSpec.h"
 
 #import "ASLayoutSpecUtilities.h"
-#import "ASLayout.h"
+#import "ASLayoutPrivate.h"
 #import "ASLayoutElementStylePrivate.h"
 
 @implementation ASAbsoluteLayoutSpec

--- a/AsyncDisplayKit/Layout/ASBackgroundLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASBackgroundLayoutSpec.mm
@@ -12,7 +12,7 @@
 #import "ASLayoutSpec+Subclasses.h"
 
 #import "ASAssert.h"
-#import "ASLayout.h"
+#import "ASLayoutPrivate.h"
 
 static NSUInteger const kForegroundChildIndex = 0;
 static NSUInteger const kBackgroundChildIndex = 1;

--- a/AsyncDisplayKit/Layout/ASInsetLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASInsetLayoutSpec.mm
@@ -13,7 +13,7 @@
 #import "ASAssert.h"
 
 #import "ASInternalHelpers.h"
-#import "ASLayout.h"
+#import "ASLayoutPrivate.h"
 
 @interface ASInsetLayoutSpec ()
 {

--- a/AsyncDisplayKit/Layout/ASLayout.h
+++ b/AsyncDisplayKit/Layout/ASLayout.h
@@ -65,7 +65,7 @@ ASDISPLAYNODE_EXTERN_C_END
  * 
  * @discussion When being used as a sublayout, this property must not equal CGPointNull.
  */
-@property (nonatomic, assign, readwrite) CGPoint position;
+@property (nonatomic, assign, readonly) CGPoint position;
 
 /**
  * Array of ASLayouts. Each must have a valid non-null position.

--- a/AsyncDisplayKit/Layout/ASLayout.mm
+++ b/AsyncDisplayKit/Layout/ASLayout.mm
@@ -8,7 +8,7 @@
 //  of patent rights can be found in the PATENTS file in the same directory.
 //
 
-#import "ASLayout.h"
+#import "ASLayoutPrivate.h"
 
 #import "ASDimension.h"
 #import "ASInternalHelpers.h"

--- a/AsyncDisplayKit/Layout/ASLayoutPrivate.h
+++ b/AsyncDisplayKit/Layout/ASLayoutPrivate.h
@@ -1,0 +1,25 @@
+//
+//  ASLayoutPrivate.h
+//  AsyncDisplayKit
+//
+//  Created by Michael Schneider on 10/17/16.
+//  Copyright © 2016 Facebook. All rights reserved.
+//
+
+#pragma once
+
+#import "ASLayout.h"
+
+/**
+ * Private header of ASLayout for internal usage in the framework
+ */
+@interface ASLayout ()
+
+/**
+ * Position in parent. Default to CGPointNull.
+ *
+ * @discussion When being used as a sublayout, this property must not equal CGPointNull.
+ */
+@property (nonatomic, assign, readwrite) CGPoint position;
+
+@end

--- a/AsyncDisplayKit/Layout/ASLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASLayoutSpec.mm
@@ -11,7 +11,7 @@
 #import "ASLayoutSpec.h"
 #import "ASLayoutSpecPrivate.h"
 #import "ASLayoutSpec+Subclasses.h"
-
+#import "ASLayoutPrivate.h"
 #import "ASLayoutElementStylePrivate.h"
 
 @implementation ASLayoutSpec

--- a/AsyncDisplayKit/Layout/ASOverlayLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASOverlayLayoutSpec.mm
@@ -12,7 +12,7 @@
 #import "ASLayoutSpec+Subclasses.h"
 
 #import "ASAssert.h"
-#import "ASLayout.h"
+#import "ASLayoutPrivate.h"
 
 static NSUInteger const kUnderlayChildIndex = 0;
 static NSUInteger const kOverlayChildIndex = 1;

--- a/AsyncDisplayKit/Layout/ASRatioLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASRatioLayoutSpec.mm
@@ -17,7 +17,7 @@
 #import "ASAssert.h"
 
 #import "ASInternalHelpers.h"
-#import "ASLayout.h"
+#import "ASLayoutPrivate.h"
 
 @implementation ASRatioLayoutSpec
 {

--- a/AsyncDisplayKit/Layout/ASRelativeLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASRelativeLayoutSpec.mm
@@ -13,7 +13,7 @@
 #import "ASRelativeLayoutSpec.h"
 
 #import "ASInternalHelpers.h"
-#import "ASLayout.h"
+#import "ASLayoutPrivate.h"
 
 @implementation ASRelativeLayoutSpec
 

--- a/AsyncDisplayKit/Private/ASStackBaselinePositionedLayout.mm
+++ b/AsyncDisplayKit/Private/ASStackBaselinePositionedLayout.mm
@@ -11,6 +11,7 @@
 #import "ASStackBaselinePositionedLayout.h"
 
 #import "ASLayoutSpecUtilities.h"
+#import "ASLayoutPrivate.h"
 
 static CGFloat baselineForItem(const ASStackLayoutSpecStyle &style,
                                const ASLayout *layout) {

--- a/AsyncDisplayKit/Private/ASStackPositionedLayout.mm
+++ b/AsyncDisplayKit/Private/ASStackPositionedLayout.mm
@@ -14,6 +14,7 @@
 
 #import "ASInternalHelpers.h"
 #import "ASLayoutSpecUtilities.h"
+#import "ASLayoutPrivate.h"
 
 static CGFloat crossOffset(const ASStackLayoutSpecStyle &style,
                            const ASStackUnpositionedItem &l,


### PR DESCRIPTION
Add a private `ASLayout` header to let us move the `position` to readonly in the public API. `ASLayout` should be an immutable object and exposing properties as readwrite defeats this.

Also integrates: #2398