### PR TITLE
[ASCollectionView] Layout inspector instance variable should be weak

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -113,7 +113,7 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   ASRangeController *_rangeController;
   ASCollectionViewLayoutController *_layoutController;
   id<ASCollectionViewLayoutInspecting> _defaultLayoutInspector;
-  id<ASCollectionViewLayoutInspecting> _layoutInspector;
+  __weak id<ASCollectionViewLayoutInspecting> _layoutInspector;
   NSMutableSet *_cellsForVisibilityUpdates;
   id<ASCollectionViewLayoutFacilitatorProtocol> _layoutFacilitator;
   


### PR DESCRIPTION
Current layout inspector property is declared weak in the public header but the ivar is not weak in ASCollectionView. This can cause retain cycles.

Adresses: #2400