### PR TITLE
[ASNetworkImageNode] Make Test More Stable

### DIFF
--- a/AsyncDisplayKitTests/ASNetworkImageNodeTests.m
+++ b/AsyncDisplayKitTests/ASNetworkImageNodeTests.m
@@ -37,9 +37,18 @@
 - (void)testThatProgressBlockIsSetAndClearedCorrectlyOnVisibility
 {
   node.URL = [NSURL URLWithString:@"http://imageA"];
+
+  // Enter preload range, wait for download start.
+  [[[downloader expect] andForwardToRealObject] downloadImageWithURL:[OCMArg isNotNil] callbackQueue:OCMOCK_ANY downloadProgress:OCMOCK_ANY completion:OCMOCK_ANY];
+  [node enterInterfaceState:ASInterfaceStatePreload];
+  [downloader verifyWithDelay:5];
+
+  // Make the node visible.
   [[downloader expect] setProgressImageBlock:[OCMArg isNotNil] callbackQueue:OCMOCK_ANY withDownloadIdentifier:@0];
   [node enterInterfaceState:ASInterfaceStateInHierarchy];
   [downloader verify];
+
+  // Make the node invisible.
   [[downloader expect] setProgressImageBlock:[OCMArg isNil] callbackQueue:OCMOCK_ANY withDownloadIdentifier:@0];
   [node exitInterfaceState:ASInterfaceStateInHierarchy];
   [downloader verify];


### PR DESCRIPTION
This test is designed to ensure that network image nodes set and clear their progress blocks when the node becomes visible/invisible. This avoids extra progressive image renders.

Previously, the test had a race condition where the download might not have started (it starts asynchronously) before the node becomes visible and we verify that the progress image block is set.

Now the test waits for the download to start before making the node visible/invisible.