### PR TITLE
[Layout] Check Layout Spec Tree for Duplicated Elements

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -36,6 +36,10 @@
 #import "ASWeakProxy.h"
 #import "ASLayoutSpecPrivate.h"
 
+#if DEBUG
+  #define AS_DEDUPE_LAYOUT_SPEC_TREE 1
+#endif
+
 NSInteger const ASDefaultDrawingPriority = ASDefaultTransactionPriority;
 NSString * const ASRenderingEngineDidDisplayScheduledNodesNotification = @"ASRenderingEngineDidDisplayScheduledNodes";
 NSString * const ASRenderingEngineDidDisplayNodesScheduledBeforeTimestamp = @"ASRenderingEngineDidDisplayNodesScheduledBeforeTimestamp";
@@ -2427,12 +2431,14 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
       [self layoutSpecThatFits:constrainedSize];
     });
 
+#if AS_DEDUPE_LAYOUT_SPEC_TREE
     NSSet *duplicateElements = [layoutSpec findDuplicatedElementsInSubtree];
     if (duplicateElements.count > 0) {
       ASDisplayNodeFailAssert(@"Node %@ returned a layout spec that contains the same elements in multiple positions. Elements: %@", self, duplicateElements);
-      // Use an empty layout spec as a production workaround.
+      // Use an empty layout spec to avoid crash.
       layoutSpec = [[ASLayoutSpec alloc] init];
     }
+#endif
 
     ASDisplayNodeAssert(layoutSpec.isMutable, @"Node %@ returned layout spec %@ that has already been used. Layout specs should always be regenerated.", self, layoutSpec);
 

--- a/AsyncDisplayKit/Layout/ASLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASLayoutSpec.mm
@@ -148,11 +148,7 @@
 {
   ASDisplayNodeAssert(_childrenArray.count < 2, @"This layout spec does not support more than one child. Use the setChildren: or the setChild:AtIndex: API");
   
-  if (_childrenArray.count) {
-    return _childrenArray[0];
-  }
-  
-  return nil;
+  return _childrenArray.firstObject;
 }
 
 #pragma mark - Children
@@ -234,6 +230,51 @@
 }
 
 ASEnvironmentLayoutExtensibilityForwarding
+
+#pragma mark - Framework Private
+
+- (nullable NSSet<id<ASLayoutElement>> *)findDuplicatedElementsInSubtree
+{
+  NSMutableSet *result = nil;
+  NSUInteger count = 0;
+  [self _findDuplicatedElementsInSubtreeWithWorkingSet:[[NSMutableSet alloc] init] workingCount:&count result:&result];
+  return result;
+}
+
+/**
+ * This method is extremely performance-sensitive, so we do some strange things.
+ *
+ * @param workingSet A working set of elements for use in the recursion.
+ * @param workingCount The current count of the set for use in the recursion.
+ * @param result The set into which to put the result. This initially points to @c nil to save time if no duplicates exist.
+ */
+- (void)_findDuplicatedElementsInSubtreeWithWorkingSet:(NSMutableSet<id<ASLayoutElement>> *)workingSet workingCount:(NSUInteger *)workingCount result:(NSMutableSet<id<ASLayoutElement>>  * _Nullable *)result
+{
+  Class layoutSpecClass = [ASLayoutSpec class];
+
+  for (id<ASLayoutElement> child in self) {
+    // Add the object into the set.
+    [workingSet addObject:child];
+
+    // Check that addObject: caused the count to increase.
+    // This is faster than using containsObject.
+    NSUInteger oldCount = *workingCount;
+    NSUInteger newCount = workingSet.count;
+    BOOL objectAlreadyExisted = (newCount != oldCount + 1);
+    if (objectAlreadyExisted) {
+      if (*result == nil) {
+        *result = [[NSMutableSet alloc] init];
+      }
+      [*result addObject:child];
+    } else {
+      *workingCount = newCount;
+      // If child is a layout spec we haven't visited, recurse its children.
+      if ([child isKindOfClass:layoutSpecClass]) {
+        [(ASLayoutSpec *)child _findDuplicatedElementsInSubtreeWithWorkingSet:workingSet workingCount:workingCount result:result];
+      }
+    }
+  }
+}
 
 @end
 

--- a/AsyncDisplayKit/Private/ASLayoutSpecPrivate.h
+++ b/AsyncDisplayKit/Private/ASLayoutSpecPrivate.h
@@ -15,11 +15,20 @@
 #import "ASEnvironmentInternal.h"
 #import "ASThread.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface ASLayoutSpec() {
   ASDN::RecursiveMutex __instanceLock__;
   ASEnvironmentState _environmentState;
   ASLayoutElementStyle *_style;
   NSMutableArray *_childrenArray;
 }
+
+/**
+ * Recursively search the subtree for elements that occur more than once.
+ */
+- (nullable NSSet<id<ASLayoutElement>> *)findDuplicatedElementsInSubtree;
+
 @end
 
+NS_ASSUME_NONNULL_END

--- a/AsyncDisplayKitTests/ASDisplayNodeTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeTests.m
@@ -21,6 +21,8 @@
 #import "UIView+ASConvenience.h"
 #import "ASCellNode.h"
 #import "ASImageNode.h"
+#import "ASOverlayLayoutSpec.h"
+#import "ASInsetLayoutSpec.h"
 
 // Conveniences for making nodes named a certain way
 #define DeclareNodeNamed(n) ASDisplayNode *n = [[ASDisplayNode alloc] init]; n.name = @#n
@@ -2137,6 +2139,16 @@ static bool stringContainsPointer(NSString *description, id p) {
     XCTAssertEqualObjects(subnode, subnodes[i]);
     i++;
   }
+}
+
+- (void)testThatHavingTheSameNodeTwiceInALayoutSpecCausesExceptionOnLayoutCalculation
+{
+  ASDisplayNode *node = [[ASDisplayNode alloc] init];
+  ASDisplayNode *subnode = [[ASDisplayNode alloc] init];
+  node.layoutSpecBlock = ^ASLayoutSpec *(ASDisplayNode *node, ASSizeRange constrainedSize) {
+    return [ASOverlayLayoutSpec overlayLayoutSpecWithChild:[ASInsetLayoutSpec insetLayoutSpecWithInsets:UIEdgeInsetsZero child:subnode] overlay:subnode];
+  };
+  XCTAssertThrowsSpecificNamed([node calculateLayoutThatFits:ASSizeRangeMake(CGSizeMake(100, 100))], NSException, NSInternalInconsistencyException);
 }
 
 @end


### PR DESCRIPTION
Currently we have a major issue where, if the user returns a layout spec tree that contains duplicated elements (nodes or specs) there will be a hard crash when the layout gets applied.

This diff adds an assertion that the tree contains no duplicated elements. In production, we will use an empty `ASLayoutSpec` in this case.

This is an extremely performance-sensitive method. It avoids allocating a result set unless needed, and it avoids membership checking in favor of checking `count`.

I considered using `NSHashTable` with `NSHashTableObjectPointerPersonality` to avoid the retains and hashing etc but avoided it because of [this table](https://www.objc.io/issues/7-foundation/collections/#performance-characteristics-of-nshashtable). It's possible that the table they used was configured differently, but it's more important to keep moving.