### PR TITLE
Add PINCache subspec for PINRemoteImage.

### DIFF
--- a/AsyncDisplayKit.podspec
+++ b/AsyncDisplayKit.podspec
@@ -60,6 +60,7 @@ Pod::Spec.new do |spec|
   spec.subspec 'PINRemoteImage' do |pin|
       pin.xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) PIN_REMOTE_IMAGE=1' }
       pin.dependency 'PINRemoteImage/iOS', '>= 3.0.0-beta.3'
+      pin.dependency 'PINRemoteImage/PINCache', '>= 3.0.0-beta.3'
       pin.dependency 'AsyncDisplayKit/Core'
   end
   

--- a/AsyncDisplayKit/Details/ASPINRemoteImageDownloader.m
+++ b/AsyncDisplayKit/Details/ASPINRemoteImageDownloader.m
@@ -27,6 +27,7 @@
 
 #import <PINRemoteImage/PINRemoteImageManager.h>
 #import <PINRemoteImage/NSData+ImageDetectors.h>
+#import <PINRemoteImage/PINRemoteImageCaching.h>
 #import <PINCache/PINCache.h>
 
 #if PIN_ANIMATED_AVAILABLE
@@ -165,7 +166,7 @@
 {
   PINRemoteImageManager *manager = [self sharedPINRemoteImageManager];
   NSString *key = [manager cacheKeyForURL:URL processorKey:nil];
-  [[[manager cache] memoryCache] removeObjectForKey:key];
+  [[manager cache] removeObjectForKey:key];
 }
 
 - (nullable id)downloadImageWithURL:(NSURL *)URL


### PR DESCRIPTION
Currently the Cocoapods podspec fails to build because of the dependency on PINCache which this change resolves.