### PR TITLE
[ASLayoutElementStyle] ASLayoutElementStyle improvements

### DIFF
--- a/AsyncDisplayKit/Layout/ASLayoutElement.mm
+++ b/AsyncDisplayKit/Layout/ASLayoutElement.mm
@@ -243,22 +243,33 @@ do {\
 
 #pragma mark - ASLayoutElementStyleSizeHelpers
 
+// We explicitly not call the setter for (max/min) width and height to avoid locking overhead
+
 - (void)setPreferredSize:(CGSize)preferredSize
 {
-  self.width = ASDimensionMakeWithPoints(preferredSize.width);
-  self.height = ASDimensionMakeWithPoints(preferredSize.height);
+  ASDN::MutexLocker l(__instanceLock__);
+  _size.width = ASDimensionMakeWithPoints(preferredSize.width);
+  _size.height = ASDimensionMakeWithPoints(preferredSize.height);
+  ASLayoutElementStyleCallDelegate(ASLayoutElementStyleWidthProperty);
+  ASLayoutElementStyleCallDelegate(ASLayoutElementStyleHeightProperty);
 }
 
 - (void)setMinSize:(CGSize)minSize
 {
-  self.minWidth = ASDimensionMakeWithPoints(minSize.width);
-  self.minHeight = ASDimensionMakeWithPoints(minSize.height);
+  ASDN::MutexLocker l(__instanceLock__);
+  _size.minWidth = ASDimensionMakeWithPoints(minSize.width);
+  _size.minHeight = ASDimensionMakeWithPoints(minSize.height);
+  ASLayoutElementStyleCallDelegate(ASLayoutElementStyleMinWidthProperty);
+  ASLayoutElementStyleCallDelegate(ASLayoutElementStyleMinHeightProperty);
 }
 
 - (void)setMaxSize:(CGSize)maxSize
 {
-  self.maxWidth = ASDimensionMakeWithPoints(maxSize.width);
-  self.maxHeight = ASDimensionMakeWithPoints(maxSize.height);
+  ASDN::MutexLocker l(__instanceLock__);
+  _size.maxWidth = ASDimensionMakeWithPoints(maxSize.width);
+  _size.maxHeight = ASDimensionMakeWithPoints(maxSize.height);
+  ASLayoutElementStyleCallDelegate(ASLayoutElementStyleMaxWidthProperty);
+  ASLayoutElementStyleCallDelegate(ASLayoutElementStyleMaxHeightProperty);
 }
 
 - (ASLayoutSize)preferredLayoutSize
@@ -269,8 +280,11 @@ do {\
 
 - (void)setPreferredLayoutSize:(ASLayoutSize)preferredLayoutSize
 {
-  self.width = preferredLayoutSize.width;
-  self.height = preferredLayoutSize.height;
+  ASDN::MutexLocker l(__instanceLock__);
+  _size.width = preferredLayoutSize.width;
+  _size.height = preferredLayoutSize.height;
+  ASLayoutElementStyleCallDelegate(ASLayoutElementStyleWidthProperty);
+  ASLayoutElementStyleCallDelegate(ASLayoutElementStyleHeightProperty);
 }
 
 - (ASLayoutSize)minLayoutSize
@@ -281,8 +295,11 @@ do {\
 
 - (void)setMinLayoutSize:(ASLayoutSize)minLayoutSize
 {
-  self.minWidth = minLayoutSize.width;
-  self.minHeight = minLayoutSize.height;
+  ASDN::MutexLocker l(__instanceLock__);
+  _size.minWidth = minLayoutSize.width;
+  _size.minHeight = minLayoutSize.height;
+  ASLayoutElementStyleCallDelegate(ASLayoutElementStyleMinWidthProperty);
+  ASLayoutElementStyleCallDelegate(ASLayoutElementStyleMinHeightProperty);
 }
 
 - (ASLayoutSize)maxLayoutSize
@@ -293,8 +310,11 @@ do {\
 
 - (void)setMaxLayoutSize:(ASLayoutSize)maxLayoutSize
 {
-  self.maxWidth = maxLayoutSize.width;
-  self.maxHeight = maxLayoutSize.height;
+  ASDN::MutexLocker l(__instanceLock__);
+  _size.maxWidth = maxLayoutSize.width;
+  _size.maxHeight = maxLayoutSize.height;
+  ASLayoutElementStyleCallDelegate(ASLayoutElementStyleMaxWidthProperty);
+  ASLayoutElementStyleCallDelegate(ASLayoutElementStyleMaxHeightProperty);
 }
 
 

--- a/AsyncDisplayKit/Layout/ASLayoutElement.mm
+++ b/AsyncDisplayKit/Layout/ASLayoutElement.mm
@@ -13,6 +13,7 @@
 #import "ASDisplayNodeInternal.h"
 
 #import <map>
+#import <atomic>
 
 CGFloat const ASLayoutElementParentDimensionUndefined = NAN;
 CGSize const ASLayoutElementParentSizeUndefined = {ASLayoutElementParentDimensionUndefined, ASLayoutElementParentDimensionUndefined};
@@ -110,20 +111,20 @@ do {\
 @implementation ASLayoutElementStyle {
   ASDN::RecursiveMutex __instanceLock__;
   ASLayoutElementSize _size;
+  
+  std::atomic<CGFloat> _spacingBefore;
+  std::atomic<CGFloat> _spacingAfter;
+  std::atomic<CGFloat> _flexGrow;
+  std::atomic<CGFloat> _flexShrink;
+  std::atomic<ASDimension> _flexBasis;
+  std::atomic<ASStackLayoutAlignSelf> _alignSelf;
+  std::atomic<CGFloat> _ascender;
+  std::atomic<CGFloat> _descender;
+  std::atomic<CGPoint> _layoutPosition;
 }
 
 @dynamic width, height, minWidth, maxWidth, minHeight, maxHeight;
 @dynamic preferredSize, minSize, maxSize, preferredLayoutSize, minLayoutSize, maxLayoutSize;
-
-@synthesize spacingBefore = _spacingBefore;
-@synthesize spacingAfter = _spacingAfter;
-@synthesize flexGrow = _flexGrow;
-@synthesize flexShrink = _flexShrink;
-@synthesize flexBasis = _flexBasis;
-@synthesize alignSelf = _alignSelf;
-@synthesize ascender = _ascender;
-@synthesize descender = _descender;
-@synthesize layoutPosition = _layoutPosition;
 
 #pragma mark - Lifecycle
 
@@ -301,121 +302,103 @@ do {\
 
 - (void)setSpacingBefore:(CGFloat)spacingBefore
 {
-  ASDN::MutexLocker l(__instanceLock__);
-  _spacingBefore = spacingBefore;
+  _spacingBefore.store(spacingBefore);
   ASLayoutElementStyleCallDelegate(ASLayoutElementStyleSpacingBeforeProperty);
 }
 
 - (CGFloat)spacingBefore
 {
-  ASDN::MutexLocker l(__instanceLock__);
-  return _spacingBefore;
+  return _spacingBefore.load();
 }
 
 - (void)setSpacingAfter:(CGFloat)spacingAfter
 {
-  ASDN::MutexLocker l(__instanceLock__);
-  _spacingAfter = spacingAfter;
+  _spacingAfter.store(spacingAfter);
   ASLayoutElementStyleCallDelegate(ASLayoutElementStyleSpacingAfterProperty);
 }
 
 - (CGFloat)spacingAfter
 {
-  ASDN::MutexLocker l(__instanceLock__);
-  return _spacingAfter;
+  return _spacingAfter.load();
 }
 
 - (void)setFlexGrow:(CGFloat)flexGrow
 {
-  ASDN::MutexLocker l(__instanceLock__);
-  _flexGrow = flexGrow;
+  _flexGrow.store(flexGrow);
   ASLayoutElementStyleCallDelegate(ASLayoutElementStyleFlexGrowProperty);
 }
 
 - (CGFloat)flexGrow
 {
-  ASDN::MutexLocker l(__instanceLock__);
-  return _flexGrow;
+  return _flexGrow.load();
 }
 
 - (void)setFlexShrink:(CGFloat)flexShrink
 {
-  ASDN::MutexLocker l(__instanceLock__);
-  _flexShrink = flexShrink;
+  _flexShrink.store(flexShrink);
   ASLayoutElementStyleCallDelegate(ASLayoutElementStyleFlexShrinkProperty);
 }
 
 - (CGFloat)flexShrink
 {
-  ASDN::MutexLocker l(__instanceLock__);
-  return _flexShrink;
+  return _flexShrink.load();
 }
 
 - (void)setFlexBasis:(ASDimension)flexBasis
 {
-  ASDN::MutexLocker l(__instanceLock__);
-  _flexBasis = flexBasis;
+  _flexBasis.store(flexBasis);
   ASLayoutElementStyleCallDelegate(ASLayoutElementStyleFlexBasisProperty);
 }
 
 - (ASDimension)flexBasis
 {
-  ASDN::MutexLocker l(__instanceLock__);
-  return _flexBasis;
+  return _flexBasis.load();
 }
 
 - (void)setAlignSelf:(ASStackLayoutAlignSelf)alignSelf
 {
-  ASDN::MutexLocker l(__instanceLock__);
-  _alignSelf = alignSelf;
+  _alignSelf.store(alignSelf);
   ASLayoutElementStyleCallDelegate(ASLayoutElementStyleAlignSelfProperty);
 }
 
 - (ASStackLayoutAlignSelf)alignSelf
 {
-  ASDN::MutexLocker l(__instanceLock__);
-  return _alignSelf;
+  return _alignSelf.load();
 }
 
 - (void)setAscender:(CGFloat)ascender
 {
-  ASDN::MutexLocker l(__instanceLock__);
-  _ascender = ascender;
+  _ascender.store(ascender);
   ASLayoutElementStyleCallDelegate(ASLayoutElementStyleAscenderProperty);
 }
 
 - (CGFloat)ascender
 {
-  ASDN::MutexLocker l(__instanceLock__);
-  return _ascender;
+  return _ascender.load();
 }
 
 - (void)setDescender:(CGFloat)descender
 {
-  ASDN::MutexLocker l(__instanceLock__);
-  _descender = descender;
+  _descender.store(descender);
   ASLayoutElementStyleCallDelegate(ASLayoutElementStyleDescenderProperty);
 }
 
 - (CGFloat)descender
 {
-  ASDN::MutexLocker l(__instanceLock__);
-  return _descender;
+  return _descender.load();
 }
 
 #pragma mark - ASAbsoluteLayoutElement
 
 - (void)setLayoutPosition:(CGPoint)layoutPosition
 {
-  ASDN::MutexLocker l(__instanceLock__);
-  _layoutPosition = layoutPosition;
+  _layoutPosition.store(layoutPosition);
   ASLayoutElementStyleCallDelegate(ASLayoutElementStyleLayoutPositionProperty);
 }
 
 - (CGPoint)layoutPosition
 {
-  ASDN::MutexLocker l(__instanceLock__);
-  return _layoutPosition;
+  return _layoutPosition.load();
 }
 
 @end


### PR DESCRIPTION
- Move `ASLayoutElement` properties to use std::atomic
- Remove some `objc_msgSend` and locking overhead for sizing properties

@appleguy Let's give it a try and let me know