### PR TITLE
[ASCollectionNode] Add waitUntilAllUpdatesAreCommitted Method

### DIFF
--- a/AsyncDisplayKit/ASCollectionNode.h
+++ b/AsyncDisplayKit/ASCollectionNode.h
@@ -160,6 +160,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)performBatchUpdates:(nullable __attribute((noescape)) void (^)())updates completion:(nullable void (^)(BOOL finished))completion;
 
 /**
+ *  Blocks execution of the main thread until all section and item updates are committed to the view. This method must be called from the main thread.
+ */
+- (void)waitUntilAllUpdatesAreCommitted;
+
+/**
  * Inserts one or more sections.
  *
  * @param sections An index set that specifies the sections to insert.

--- a/AsyncDisplayKit/ASCollectionNode.mm
+++ b/AsyncDisplayKit/ASCollectionNode.mm
@@ -323,6 +323,11 @@
   [self.view performBatchUpdates:updates completion:completion];
 }
 
+- (void)waitUntilAllUpdatesAreCommitted
+{
+  [self.view waitUntilAllUpdatesAreCommitted];
+}
+
 - (void)reloadDataWithCompletion:(void (^)())completion
 {
   [self.view reloadDataWithCompletion:completion];


### PR DESCRIPTION
Can't believe I forgot this.

We had previously planned to update the name of this method, but since this particular change is urgent for Pinterest, and since the ideal name might change in light of the recent behavior change of `nodeForRowAtIndexPath:`, this diff does not do that.