### PR TITLE
[Examples] Playground swift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,8 @@ build
 *.gcov
 *.gcno
 *.gcda
+
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+

--- a/examples/ASLayoutSpecPlayground-Swift/Podfile
+++ b/examples/ASLayoutSpecPlayground-Swift/Podfile
@@ -1,0 +1,7 @@
+source 'https://github.com/CocoaPods/Specs.git'
+platform :ios, '7.1'
+use_frameworks!
+target 'Sample' do
+	pod 'AsyncDisplayKit', :path => '../..'
+end
+

--- a/examples/ASLayoutSpecPlayground-Swift/Sample.xcodeproj/project.pbxproj
+++ b/examples/ASLayoutSpecPlayground-Swift/Sample.xcodeproj/project.pbxproj
@@ -194,7 +194,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/examples/ASLayoutSpecPlayground-Swift/Sample.xcodeproj/project.pbxproj
+++ b/examples/ASLayoutSpecPlayground-Swift/Sample.xcodeproj/project.pbxproj
@@ -1,0 +1,380 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		5E6D34211DB4C9D000FB9B0A /* Sample.h in Headers */ = {isa = PBXBuildFile; fileRef = 5E6D341F1DB4C9D000FB9B0A /* Sample.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FF896945AEA7EF2D9CD93A65 /* Pods_Sample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC767A9EB720B4BF08C89936 /* Pods_Sample.framework */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		088AA6578212BE9BFBB07B70 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
+		3D24B17D1E4A4E7A9566C5E9 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		5C5154389F056C672F4E9EEA /* Pods-Sample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Sample.release.xcconfig"; path = "Pods/Target Support Files/Pods-Sample/Pods-Sample.release.xcconfig"; sourceTree = "<group>"; };
+		5E6D341D1DB4C9D000FB9B0A /* Sample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Sample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5E6D341F1DB4C9D000FB9B0A /* Sample.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Sample.h; sourceTree = "<group>"; };
+		5E6D34201DB4C9D000FB9B0A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		5E6D34251DB4CA8E00FB9B0A /* libPods-Sample.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libPods-Sample.a"; path = "Pods/../build/Debug-iphoneos/libPods-Sample.a"; sourceTree = "<group>"; };
+		5E6D34271DB4CBAA00FB9B0A /* Sample.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = Sample.playground; sourceTree = "<group>"; };
+		C068F1D3F0CC317E895FCDAB /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
+		EC767A9EB720B4BF08C89936 /* Pods_Sample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Sample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		FDF496F367580DF9280D36EA /* Pods-Sample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Sample.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Sample/Pods-Sample.debug.xcconfig"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		5E6D34191DB4C9D000FB9B0A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FF896945AEA7EF2D9CD93A65 /* Pods_Sample.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		05E2127819D4DB510098F589 = {
+			isa = PBXGroup;
+			children = (
+				5E6D341E1DB4C9D000FB9B0A /* Sample */,
+				05E2128219D4DB510098F589 /* Products */,
+				1A943BF0259746F18D6E423F /* Frameworks */,
+				1AE410B73DA5C3BD087ACDD7 /* Pods */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		05E2128219D4DB510098F589 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				5E6D341D1DB4C9D000FB9B0A /* Sample.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		1A943BF0259746F18D6E423F /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				5E6D34251DB4CA8E00FB9B0A /* libPods-Sample.a */,
+				3D24B17D1E4A4E7A9566C5E9 /* libPods.a */,
+				EC767A9EB720B4BF08C89936 /* Pods_Sample.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		1AE410B73DA5C3BD087ACDD7 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				C068F1D3F0CC317E895FCDAB /* Pods.debug.xcconfig */,
+				088AA6578212BE9BFBB07B70 /* Pods.release.xcconfig */,
+				FDF496F367580DF9280D36EA /* Pods-Sample.debug.xcconfig */,
+				5C5154389F056C672F4E9EEA /* Pods-Sample.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+		5E6D341E1DB4C9D000FB9B0A /* Sample */ = {
+			isa = PBXGroup;
+			children = (
+				5E6D341F1DB4C9D000FB9B0A /* Sample.h */,
+				5E6D34201DB4C9D000FB9B0A /* Info.plist */,
+				5E6D34271DB4CBAA00FB9B0A /* Sample.playground */,
+			);
+			path = Sample;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		5E6D341A1DB4C9D000FB9B0A /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5E6D34211DB4C9D000FB9B0A /* Sample.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		5E6D341C1DB4C9D000FB9B0A /* Sample */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5E6D34221DB4C9D000FB9B0A /* Build configuration list for PBXNativeTarget "Sample" */;
+			buildPhases = (
+				43927A700F47FC31FA2FB429 /* [CP] Check Pods Manifest.lock */,
+				5E6D34181DB4C9D000FB9B0A /* Sources */,
+				5E6D34191DB4C9D000FB9B0A /* Frameworks */,
+				5E6D341A1DB4C9D000FB9B0A /* Headers */,
+				5E6D341B1DB4C9D000FB9B0A /* Resources */,
+				0FF30A537A157312FD5042F7 /* [CP] Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Sample;
+			productName = Sample;
+			productReference = 5E6D341D1DB4C9D000FB9B0A /* Sample.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		05E2127919D4DB510098F589 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0720;
+				ORGANIZATIONNAME = Facebook;
+				TargetAttributes = {
+					5E6D341C1DB4C9D000FB9B0A = {
+						CreatedOnToolsVersion = 8.0;
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = 05E2127C19D4DB510098F589 /* Build configuration list for PBXProject "Sample" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 05E2127819D4DB510098F589;
+			productRefGroup = 05E2128219D4DB510098F589 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				5E6D341C1DB4C9D000FB9B0A /* Sample */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		5E6D341B1DB4C9D000FB9B0A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		0FF30A537A157312FD5042F7 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Sample/Pods-Sample-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		43927A700F47FC31FA2FB429 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		5E6D34181DB4C9D000FB9B0A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		05E212A219D4DB510098F589 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		05E212A319D4DB510098F589 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		5E6D34231DB4C9D000FB9B0A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FDF496F367580DF9280D36EA /* Pods-Sample.debug.xcconfig */;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = Sample/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = com.facebook.AsyncDisplayKit.Sample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		5E6D34241DB4C9D000FB9B0A /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 5C5154389F056C672F4E9EEA /* Pods-Sample.release.xcconfig */;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CODE_SIGN_IDENTITY = "";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = Sample/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = com.facebook.AsyncDisplayKit.Sample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		05E2127C19D4DB510098F589 /* Build configuration list for PBXProject "Sample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				05E212A219D4DB510098F589 /* Debug */,
+				05E212A319D4DB510098F589 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		5E6D34221DB4C9D000FB9B0A /* Build configuration list for PBXNativeTarget "Sample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5E6D34231DB4C9D000FB9B0A /* Debug */,
+				5E6D34241DB4C9D000FB9B0A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 05E2127919D4DB510098F589 /* Project object */;
+}

--- a/examples/ASLayoutSpecPlayground-Swift/Sample.xcodeproj/xcshareddata/xcschemes/Sample.xcscheme
+++ b/examples/ASLayoutSpecPlayground-Swift/Sample.xcodeproj/xcshareddata/xcschemes/Sample.xcscheme
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5E6D341C1DB4C9D000FB9B0A"
+               BuildableName = "Sample.framework"
+               BlueprintName = "Sample"
+               ReferencedContainer = "container:Sample.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5E6D341C1DB4C9D000FB9B0A"
+            BuildableName = "Sample.framework"
+            BlueprintName = "Sample"
+            ReferencedContainer = "container:Sample.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5E6D341C1DB4C9D000FB9B0A"
+            BuildableName = "Sample.framework"
+            BlueprintName = "Sample"
+            ReferencedContainer = "container:Sample.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5E6D341C1DB4C9D000FB9B0A"
+            BuildableName = "Sample.framework"
+            BlueprintName = "Sample"
+            ReferencedContainer = "container:Sample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/examples/ASLayoutSpecPlayground-Swift/Sample/Info.plist
+++ b/examples/ASLayoutSpecPlayground-Swift/Sample/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.h
+++ b/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.h
@@ -1,0 +1,18 @@
+//
+//  Sample.h
+//  Sample
+//
+//  Copyright © 2016 Facebook. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for Sample.
+FOUNDATION_EXPORT double SampleVersionNumber;
+
+//! Project version string for Sample.
+FOUNDATION_EXPORT const unsigned char SampleVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <Sample/PublicHeader.h>
+
+

--- a/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Pages/HorizontalStackWithSpacer.xcplaygroundpage/Contents.swift
+++ b/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Pages/HorizontalStackWithSpacer.xcplaygroundpage/Contents.swift
@@ -1,0 +1,46 @@
+//: [Photo With Outset Icon Overlay](PhotoWithOutsetIconOverlay)
+
+import AsyncDisplayKit
+
+extension HorizontalStackWithSpacer {
+
+  override public func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
+    usernameNode.style.flexShrink = 1.0
+    postLocationNode.style.flexShrink = 1.0
+
+    let verticalStackSpec = ASStackLayoutSpec.vertical()
+    verticalStackSpec.style.flexShrink = 1.0
+
+    // if fetching post location data from server, check if it is available yet
+    if postLocationNode.attributedText != nil {
+      verticalStackSpec.children = [usernameNode, postLocationNode]
+    } else {
+      verticalStackSpec.children = [usernameNode]
+    }
+
+    let spacerSpec = ASLayoutSpec()
+    spacerSpec.style.flexGrow = 1.0
+    spacerSpec.style.flexShrink = 1.0
+
+    // horizontal stack
+    let horizontalStack = ASStackLayoutSpec.horizontal()
+    horizontalStack.alignItems = .center // center items vertically in horiz stack
+    horizontalStack.justifyContent = .start // justify content to left
+    horizontalStack.style.flexShrink = 1.0
+    horizontalStack.style.flexGrow = 1.0
+    horizontalStack.children = [verticalStackSpec, spacerSpec, postTimeNode]
+
+    // inset horizontal stack
+    let insets = UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10)
+    let headerInsetSpec = ASInsetLayoutSpec(insets: insets, child: horizontalStack)
+    headerInsetSpec.style.flexShrink = 1.0
+    headerInsetSpec.style.flexGrow = 1.0
+
+    return headerInsetSpec
+  }
+
+}
+
+HorizontalStackWithSpacer().show()
+
+//: [Index](Index)

--- a/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Pages/Index.xcplaygroundpage/Contents.swift
+++ b/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Pages/Index.xcplaygroundpage/Contents.swift
@@ -16,5 +16,5 @@ Tips:
     - (cmd + opt/alt + ⮐)
     - View → Assistant Editor → Show Assistant Editor, to see the preview
  1. Make sure that **Timeline** as the element selected in the Assistant Editor
-
+ 1. You might have to click on stop/start (the one at the bottom of the screen, under the editor) a few times in case the timeline isn't updating.
 */

--- a/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Pages/Index.xcplaygroundpage/Contents.swift
+++ b/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Pages/Index.xcplaygroundpage/Contents.swift
@@ -1,0 +1,19 @@
+/*:
+ ## ⚠️ You must start by building the Sample framework ⚠️
+ Once that succeeds, you should not have to build until you update AsyncDisplayKit!
+ What you see here isn't comprehensive, but you should be able to tweak the variables to familiarize yourself with the layout APIs.
+ - - -
+
+ ## Table of Contents
+ * [Photo With Inset Text Overlay](PhotoWithInsetTextOverlay)
+ * [Stack Layout](StackLayout)
+ 
+
+ - - -
+Tips:
+ 1. Make sure to show the Assistant Editor in order to preview your code changes. You can do this with either of the following:
+    - (cmd + opt/alt + ⮐)
+    - View → Assistant Editor → Show Assistant Editor, to see the preview
+ 1. Make sure that **Timeline** as the element selected in the Assistant Editor
+
+*/

--- a/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Pages/Index.xcplaygroundpage/Contents.swift
+++ b/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Pages/Index.xcplaygroundpage/Contents.swift
@@ -8,7 +8,7 @@
  * [Stack Layout](StackLayout)
  * [Photo With Inset Text Overlay](PhotoWithInsetTextOverlay)
  * [Photo With Outset Icon Overlay](PhotoWithOutsetIconOverlay)
-
+ * [Horizontal Stack With Spacer](HorizontalStackWithSpacer)
 
  - - -
 Tips:

--- a/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Pages/Index.xcplaygroundpage/Contents.swift
+++ b/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Pages/Index.xcplaygroundpage/Contents.swift
@@ -17,4 +17,8 @@ Tips:
     - View → Assistant Editor → Show Assistant Editor, to see the preview
  1. Make sure that **Timeline** as the element selected in the Assistant Editor
  1. You might have to click on stop/start (the one at the bottom of the screen, under the editor) a few times in case the timeline isn't updating.
+ - - -
+Solutions to Common Issues:
+ 1. If you're getting errors regarding **import Sample_Sources**, simply restart Xcode and try again.
+ 1. If you're getting issues with threading, restart the test until it works.
 */

--- a/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Pages/Index.xcplaygroundpage/Contents.swift
+++ b/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Pages/Index.xcplaygroundpage/Contents.swift
@@ -5,9 +5,10 @@
  - - -
 
  ## Table of Contents
- * [Photo With Inset Text Overlay](PhotoWithInsetTextOverlay)
  * [Stack Layout](StackLayout)
- 
+ * [Photo With Inset Text Overlay](PhotoWithInsetTextOverlay)
+ * [Photo With Outset Icon Overlay](PhotoWithOutsetIconOverlay)
+
 
  - - -
 Tips:

--- a/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Pages/PhotoWithInsetTextOverlay.xcplaygroundpage/Contents.swift
+++ b/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Pages/PhotoWithInsetTextOverlay.xcplaygroundpage/Contents.swift
@@ -1,4 +1,4 @@
-//: [Previous](@previous)
+//: [Stack Layout](StackLayout)
 
 import AsyncDisplayKit
 
@@ -23,4 +23,4 @@ extension PhotoWithInsetTextOverlay {
 
 PhotoWithInsetTextOverlay().show()
 
-//: [Next](@next)
+//: [Photo With Outset Icon Overlay](PhotoWithOutsetIconOverlay)

--- a/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Pages/PhotoWithInsetTextOverlay.xcplaygroundpage/Contents.swift
+++ b/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Pages/PhotoWithInsetTextOverlay.xcplaygroundpage/Contents.swift
@@ -1,0 +1,26 @@
+//: [Previous](@previous)
+
+import AsyncDisplayKit
+
+let userImageHeight = 60
+
+extension PhotoWithInsetTextOverlay {
+
+  override public func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
+    photoNode.style.preferredSize = CGSize(width: userImageHeight * 2, height: userImageHeight * 2)
+    let backgroundImageAbsoluteSpec = ASAbsoluteLayoutSpec(children: [photoNode])
+
+    let insets = UIEdgeInsets(top: CGFloat.infinity, left: 12, bottom: 12, right: 12)
+    let textInsetSpec = ASInsetLayoutSpec(insets: insets,
+                                          child: titleNode)
+
+    let textOverlaySpec = ASOverlayLayoutSpec(child: backgroundImageAbsoluteSpec, overlay: textInsetSpec)
+
+    return textOverlaySpec
+  }
+
+}
+
+PhotoWithInsetTextOverlay().show()
+
+//: [Next](@next)

--- a/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Pages/PhotoWithOutsetIconOverlay.xcplaygroundpage/Contents.swift
+++ b/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Pages/PhotoWithOutsetIconOverlay.xcplaygroundpage/Contents.swift
@@ -1,0 +1,28 @@
+//: [Photo With Inset Text Overlay](PhotoWithInsetTextOverlay)
+
+import AsyncDisplayKit
+
+extension PhotoWithOutsetIconOverlay {
+
+  override public func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
+    let iconWidth: CGFloat = 40
+    let iconHeight: CGFloat = 40
+    
+    iconNode.style.preferredSize = CGSize(width: iconWidth, height: iconWidth)
+    photoNode.style.preferredSize = CGSize(width: 150, height: 150)
+
+    let x: CGFloat = 150
+    let y: CGFloat = 0
+
+    iconNode.style.layoutPosition = CGPoint(x: x, y: y)
+    photoNode.style.layoutPosition = CGPoint(x: iconWidth * 0.5, y: iconHeight * 0.5);
+
+    let absoluteLayoutSpec = ASAbsoluteLayoutSpec(children: [photoNode, iconNode])
+    return absoluteLayoutSpec;
+  }
+
+}
+
+PhotoWithOutsetIconOverlay().show()
+
+//: [Index](Index)

--- a/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Pages/PhotoWithOutsetIconOverlay.xcplaygroundpage/Contents.swift
+++ b/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Pages/PhotoWithOutsetIconOverlay.xcplaygroundpage/Contents.swift
@@ -25,4 +25,4 @@ extension PhotoWithOutsetIconOverlay {
 
 PhotoWithOutsetIconOverlay().show()
 
-//: [Index](Index)
+//: [Horizontal Stack With Spacer](HorizontalStackWithSpacer)

--- a/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Pages/StackLayout.xcplaygroundpage/Contents.swift
+++ b/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Pages/StackLayout.xcplaygroundpage/Contents.swift
@@ -1,0 +1,31 @@
+//: [Previous](@previous)
+/*:
+ In this example, you can experiment with stack layouts.
+ */
+import AsyncDisplayKit
+
+extension StackLayout {
+
+  override public func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
+    // Try commenting out the flexShrink to see its consequences.
+    subtitleNode.style.flexShrink = 1.0
+
+    let stackSpec = ASStackLayoutSpec(direction: .horizontal,
+                                      spacing: 5,
+                                      justifyContent: .start,
+                                      alignItems: .start,
+                                      children: [titleNode, subtitleNode])
+
+    let insetSpec = ASInsetLayoutSpec(insets: UIEdgeInsets(top: 5,
+                                                           left: 5,
+                                                           bottom: 5,
+                                                           right: 5),
+                                      child: stackSpec)
+    return insetSpec
+  }
+
+}
+
+StackLayout().show()
+
+//: [Next](@next)

--- a/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Pages/StackLayout.xcplaygroundpage/Contents.swift
+++ b/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Pages/StackLayout.xcplaygroundpage/Contents.swift
@@ -1,4 +1,4 @@
-//: [Previous](@previous)
+//: [Index](Index)
 /*:
  In this example, you can experiment with stack layouts.
  */
@@ -28,4 +28,4 @@ extension StackLayout {
 
 StackLayout().show()
 
-//: [Next](@next)
+//: [Photo With Inset Text Overlay](PhotoWithInsetTextOverlay)

--- a/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Sources/ASPlayground.swift
+++ b/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Sources/ASPlayground.swift
@@ -1,0 +1,26 @@
+import PlaygroundSupport
+import AsyncDisplayKit
+
+public protocol ASPlayground: class {
+  func display(inRect: CGRect)
+}
+
+extension ASPlayground {
+  public func display(inRect rect: CGRect) {
+    var rect = rect
+    if rect.size == .zero {
+      rect.size = CGSize(width: 400, height: 400)
+    }
+
+    guard let nodeSelf = self as? ASDisplayNode else {
+      assertionFailure("Class inheriting ASPlayground must be an ASDisplayNode")
+      return
+    }
+
+    let constrainedSize = ASSizeRange(min: rect.size, max: rect.size)
+    _ = ASCalculateRootLayout(nodeSelf, constrainedSize)
+    nodeSelf.frame = rect
+    PlaygroundPage.current.needsIndefiniteExecution = true
+    PlaygroundPage.current.liveView = nodeSelf.view
+  }
+}

--- a/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Sources/HorizontalStackWithSpacer.swift
+++ b/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Sources/HorizontalStackWithSpacer.swift
@@ -15,7 +15,7 @@ public class HorizontalStackWithSpacer: ASDisplayNode, ASPlayground {
     setupNodes()
   }
 
-  func setupNodes() {
+  private func setupNodes() {
     usernameNode.backgroundColor = .yellow
     usernameNode.attributedText = NSAttributedString.attributedString(string: "hannahmbanana", fontSize: fontSize, color: .darkBlueColor(), firstWordColor: nil)
 

--- a/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Sources/HorizontalStackWithSpacer.swift
+++ b/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Sources/HorizontalStackWithSpacer.swift
@@ -1,0 +1,38 @@
+import AsyncDisplayKit
+
+let fontSize: CGFloat = 20
+
+public class HorizontalStackWithSpacer: ASDisplayNode, ASPlayground {
+  public let usernameNode     = ASTextNode()
+  public let postLocationNode = ASTextNode()
+  public let postTimeNode     = ASTextNode()
+
+  override public init() {
+    super.init()
+    backgroundColor = .white
+
+    automaticallyManagesSubnodes = true
+    setupNodes()
+  }
+
+  func setupNodes() {
+    usernameNode.backgroundColor = .yellow
+    usernameNode.attributedText = NSAttributedString.attributedString(string: "hannahmbanana", fontSize: fontSize, color: .darkBlueColor(), firstWordColor: nil)
+
+    postLocationNode.backgroundColor = .lightGray
+    postLocationNode.maximumNumberOfLines = 1;
+    postLocationNode.attributedText = NSAttributedString.attributedString(string: "San Fransisco, CA", fontSize: fontSize, color: .lightBlueColor(), firstWordColor: nil)
+
+    postTimeNode.backgroundColor = .brown
+    postTimeNode.attributedText = NSAttributedString.attributedString(string: "30m", fontSize: fontSize, color: .lightGray, firstWordColor: nil)
+  }
+
+  // This is used to expose this function for overriding in extensions
+  override public func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
+    return ASLayoutSpec()
+  }
+
+  public func show() {
+    display(inRect: CGRect(x: 0, y: 0, width: 450, height: 100))
+  }
+}

--- a/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Sources/HorizontalStackWithSpacer.swift
+++ b/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Sources/HorizontalStackWithSpacer.swift
@@ -1,6 +1,6 @@
 import AsyncDisplayKit
 
-let fontSize: CGFloat = 20
+fileprivate let fontSize: CGFloat = 20
 
 public class HorizontalStackWithSpacer: ASDisplayNode, ASPlayground {
   public let usernameNode     = ASTextNode()

--- a/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Sources/PhotoWithInsetTextOverlay.swift
+++ b/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Sources/PhotoWithInsetTextOverlay.swift
@@ -1,0 +1,37 @@
+import AsyncDisplayKit
+
+public class PhotoWithInsetTextOverlay: ASDisplayNode, ASPlayground {
+  public let photoNode = ASNetworkImageNode()
+  public let titleNode = ASTextNode()
+
+  override public init() {
+    super.init()
+    backgroundColor = .white
+
+    automaticallyManagesSubnodes = true
+    setupNodes()
+  }
+
+  func setupNodes() {
+    photoNode.url = URL(string: "http://asyncdisplaykit.org/static/images/layout-examples-photo-with-inset-text-overlay-photo.png")
+    photoNode.backgroundColor = .black
+
+    let attributes = [NSFontAttributeName: UIFont.boldSystemFont(ofSize: 16),
+                      NSForegroundColorAttributeName: UIColor.white]
+
+    titleNode.backgroundColor = .blue
+    titleNode.maximumNumberOfLines = 2
+    titleNode.truncationAttributedText = NSAttributedString(string: "...", attributes: attributes)
+    titleNode.attributedText = NSAttributedString(string: "family fall hikes", attributes: attributes)
+
+  }
+
+  override public func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
+    // This is to expose this function for overriding in extensions
+    return ASLayoutSpec()
+  }
+
+  public func show() {
+    display(inRect: CGRect(x: 0, y: 0, width: 120, height: 120))
+  }
+}

--- a/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Sources/PhotoWithInsetTextOverlay.swift
+++ b/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Sources/PhotoWithInsetTextOverlay.swift
@@ -16,18 +16,14 @@ public class PhotoWithInsetTextOverlay: ASDisplayNode, ASPlayground {
     photoNode.url = URL(string: "http://asyncdisplaykit.org/static/images/layout-examples-photo-with-inset-text-overlay-photo.png")
     photoNode.backgroundColor = .black
 
-    let attributes = [NSFontAttributeName: UIFont.boldSystemFont(ofSize: 16),
-                      NSForegroundColorAttributeName: UIColor.white]
-
     titleNode.backgroundColor = .blue
     titleNode.maximumNumberOfLines = 2
-    titleNode.truncationAttributedText = NSAttributedString(string: "...", attributes: attributes)
-    titleNode.attributedText = NSAttributedString(string: "family fall hikes", attributes: attributes)
-
+    titleNode.truncationAttributedText = NSAttributedString.attributedString(string: "...", fontSize: 16, color: .white, firstWordColor: nil)
+    titleNode.attributedText = NSAttributedString.attributedString(string: "family fall hikes", fontSize: 16, color: .white, firstWordColor: nil)
   }
 
+  // This is used to expose this function for overriding in extensions
   override public func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
-    // This is to expose this function for overriding in extensions
     return ASLayoutSpec()
   }
 

--- a/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Sources/PhotoWithInsetTextOverlay.swift
+++ b/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Sources/PhotoWithInsetTextOverlay.swift
@@ -12,7 +12,7 @@ public class PhotoWithInsetTextOverlay: ASDisplayNode, ASPlayground {
     setupNodes()
   }
 
-  func setupNodes() {
+  private func setupNodes() {
     photoNode.url = URL(string: "http://asyncdisplaykit.org/static/images/layout-examples-photo-with-inset-text-overlay-photo.png")
     photoNode.backgroundColor = .black
 

--- a/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Sources/PhotoWithOutsetIconOverlay.swift
+++ b/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Sources/PhotoWithOutsetIconOverlay.swift
@@ -1,6 +1,6 @@
 import AsyncDisplayKit
 
-let userImageHeight = 60
+fileprivate let userImageHeight = 60
 
 public class PhotoWithOutsetIconOverlay: ASDisplayNode, ASPlayground {
   public let photoNode = ASNetworkImageNode()

--- a/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Sources/PhotoWithOutsetIconOverlay.swift
+++ b/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Sources/PhotoWithOutsetIconOverlay.swift
@@ -1,0 +1,33 @@
+import AsyncDisplayKit
+
+let userImageHeight = 60
+
+public class PhotoWithOutsetIconOverlay: ASDisplayNode, ASPlayground {
+  public let photoNode = ASNetworkImageNode()
+  public let iconNode = ASNetworkImageNode()
+
+  override public init() {
+    super.init()
+    backgroundColor = .white
+
+    automaticallyManagesSubnodes = true
+    setupNodes()
+  }
+
+  func setupNodes() {
+    photoNode.url = URL(string: "http://asyncdisplaykit.org/static/images/layout-examples-photo-with-outset-icon-overlay-photo.png")
+    photoNode.backgroundColor = .black
+
+    iconNode.url = URL(string: "http://asyncdisplaykit.org/static/images/layout-examples-photo-with-outset-icon-overlay-icon.png")
+    iconNode.imageModificationBlock = ASImageNodeRoundBorderModificationBlock(10, .white)
+  }
+
+  override public func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
+    // This is to expose this function for overriding in extensions
+    return ASLayoutSpec()
+  }
+
+  public func show() {
+    display(inRect: CGRect(x: 0, y: 0, width: 190, height: 190))
+  }
+}

--- a/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Sources/PhotoWithOutsetIconOverlay.swift
+++ b/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Sources/PhotoWithOutsetIconOverlay.swift
@@ -14,7 +14,7 @@ public class PhotoWithOutsetIconOverlay: ASDisplayNode, ASPlayground {
     setupNodes()
   }
 
-  func setupNodes() {
+  private func setupNodes() {
     photoNode.url = URL(string: "http://asyncdisplaykit.org/static/images/layout-examples-photo-with-outset-icon-overlay-photo.png")
     photoNode.backgroundColor = .black
 

--- a/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Sources/PhotoWithOutsetIconOverlay.swift
+++ b/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Sources/PhotoWithOutsetIconOverlay.swift
@@ -4,7 +4,7 @@ let userImageHeight = 60
 
 public class PhotoWithOutsetIconOverlay: ASDisplayNode, ASPlayground {
   public let photoNode = ASNetworkImageNode()
-  public let iconNode = ASNetworkImageNode()
+  public let iconNode  = ASNetworkImageNode()
 
   override public init() {
     super.init()
@@ -22,8 +22,8 @@ public class PhotoWithOutsetIconOverlay: ASDisplayNode, ASPlayground {
     iconNode.imageModificationBlock = ASImageNodeRoundBorderModificationBlock(10, .white)
   }
 
+  // This is used to expose this function for overriding in extensions
   override public func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
-    // This is to expose this function for overriding in extensions
     return ASLayoutSpec()
   }
 

--- a/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Sources/StackLayout.swift
+++ b/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Sources/StackLayout.swift
@@ -14,14 +14,14 @@ public class StackLayout: ASDisplayNode, ASPlayground {
 
   func setupNodes() {
     titleNode.backgroundColor = .blue
-    titleNode.attributedText = NSAttributedString(string: "Headline!", attributes: [NSForegroundColorAttributeName: UIColor.white, NSFontAttributeName: UIFont.boldSystemFont(ofSize: 14)])
+    titleNode.attributedText = NSAttributedString.attributedString(string: "Headline!", fontSize: 14, color: .white, firstWordColor: nil)
 
     subtitleNode.backgroundColor = .yellow
     subtitleNode.attributedText = NSAttributedString(string: "Lorem ipsum dolor sit amet, sed ex laudem utroque meliore, at cum lucilius vituperata. Ludus mollis consulatu mei eu, esse vocent epicurei sed at. Ut cum recusabo prodesset. Ut cetero periculis sed, mundi senserit est ut. Nam ut sonet mandamus intellegebat, summo voluptaria vim ad.")
   }
 
+  // This is used to expose this function for overriding in extensions
   override public func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
-    // This is to expose this function for overriding in extensions
     return ASLayoutSpec()
   }
 

--- a/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Sources/StackLayout.swift
+++ b/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Sources/StackLayout.swift
@@ -1,0 +1,31 @@
+import AsyncDisplayKit
+
+public class StackLayout: ASDisplayNode, ASPlayground {
+  public let titleNode    = ASTextNode()
+  public let subtitleNode = ASTextNode()
+
+  override public init() {
+    super.init()
+    backgroundColor = .white
+
+    automaticallyManagesSubnodes = true
+    setupNodes()
+  }
+
+  func setupNodes() {
+    titleNode.backgroundColor = .blue
+    titleNode.attributedText = NSAttributedString(string: "Headline!", attributes: [NSForegroundColorAttributeName: UIColor.white, NSFontAttributeName: UIFont.boldSystemFont(ofSize: 14)])
+
+    subtitleNode.backgroundColor = .yellow
+    subtitleNode.attributedText = NSAttributedString(string: "Lorem ipsum dolor sit amet, sed ex laudem utroque meliore, at cum lucilius vituperata. Ludus mollis consulatu mei eu, esse vocent epicurei sed at. Ut cum recusabo prodesset. Ut cetero periculis sed, mundi senserit est ut. Nam ut sonet mandamus intellegebat, summo voluptaria vim ad.")
+  }
+
+  override public func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
+    // This is to expose this function for overriding in extensions
+    return ASLayoutSpec()
+  }
+
+  public func show() {
+    display(inRect: .zero)
+  }
+}

--- a/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Sources/StackLayout.swift
+++ b/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Sources/StackLayout.swift
@@ -12,7 +12,7 @@ public class StackLayout: ASDisplayNode, ASPlayground {
     setupNodes()
   }
 
-  func setupNodes() {
+  private func setupNodes() {
     titleNode.backgroundColor = .blue
     titleNode.attributedText = NSAttributedString.attributedString(string: "Headline!", fontSize: 14, color: .white, firstWordColor: nil)
 

--- a/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Sources/Utilities.swift
+++ b/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Sources/Utilities.swift
@@ -1,0 +1,43 @@
+import UIKit
+import Foundation
+
+extension UIColor {
+
+  static func darkBlueColor() -> UIColor {
+    return UIColor(red: 18.0/255.0, green: 86.0/255.0, blue: 136.0/255.0, alpha: 1.0)
+  }
+
+
+  static func lightBlueColor() -> UIColor {
+    return UIColor(red: 0.0, green: 122.0/255.0, blue: 1.0, alpha: 1.0)
+  }
+
+  static func duskColor() -> UIColor {
+    return UIColor(red: 255/255.0, green: 181/255.0, blue: 68/255.0, alpha: 1.0)
+  }
+
+  static func customOrangeColor() -> UIColor {
+    return UIColor(red: 40/255.0, green: 43/255.0, blue: 53/255.0, alpha: 1.0)
+  }
+
+}
+
+extension NSAttributedString {
+
+  static func attributedString(string: String, fontSize size: CGFloat, color: UIColor?, firstWordColor: UIColor?) -> NSAttributedString {
+    let attributes = [NSForegroundColorAttributeName: color ?? UIColor.black,
+                      NSFontAttributeName: UIFont.boldSystemFont(ofSize: size)]
+
+    let attributedString = NSMutableAttributedString(string: string, attributes: attributes)
+
+    if let firstWordColor = firstWordColor {
+      let nsString = string as NSString
+      let firstSpaceRange = nsString.rangeOfCharacter(from: NSCharacterSet.whitespaces)
+      let firstWordRange  = NSMakeRange(0, firstSpaceRange.location)
+      attributedString.addAttribute(NSForegroundColorAttributeName, value: firstWordColor, range: firstWordRange)
+    }
+
+    return attributedString
+  }
+
+}

--- a/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/contents.xcplayground
+++ b/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/contents.xcplayground
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<playground version='6.0' target-platform='ios' display-mode='raw' timelineScrubberEnabled='true'/>

--- a/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/contents.xcplayground
+++ b/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/contents.xcplayground
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='6.0' target-platform='ios' display-mode='rendered' executeOnSourceChanges='false' timelineScrubberEnabled='true'>
+<playground version='6.0' target-platform='ios' display-mode='rendered' timelineScrubberEnabled='true'>
     <pages>
         <page name='Index'/>
-        <page name='PhotoWithInsetTextOverlay'/>
         <page name='StackLayout'/>
+        <page name='PhotoWithInsetTextOverlay'/>
         <page name='PhotoWithOutsetIconOverlay'/>
+        <page name='HorizontalStackWithSpacer'/>
     </pages>
 </playground>

--- a/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/contents.xcplayground
+++ b/examples/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/contents.xcplayground
@@ -1,2 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='6.0' target-platform='ios' display-mode='raw' timelineScrubberEnabled='true'/>
+<playground version='6.0' target-platform='ios' display-mode='rendered' executeOnSourceChanges='false' timelineScrubberEnabled='true'>
+    <pages>
+        <page name='Index'/>
+        <page name='PhotoWithInsetTextOverlay'/>
+        <page name='StackLayout'/>
+        <page name='PhotoWithOutsetIconOverlay'/>
+    </pages>
+</playground>


### PR DESCRIPTION
Added Swift playground with the following example layouts:
- StackLayout (Simplified stack layout example with an easy way to demonstrate the effects of flexShrink)
- PhotoWithInsetTextOverlay (Same as the online docs + ObjectiveC playground)
- PhotoWithOutsetIconOverlay (Same as the online docs + ObjectiveC playground)
- HorizontalStackWithSpacer (Same as the online docs + ObjectiveC playground)
