### PR TITLE
[ASLayoutSpec] Add ASStaticLayoutSpec back without deprecation warning

### DIFF
--- a/AsyncDisplayKit/Layout/ASAbsoluteLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASAbsoluteLayoutSpec.h
@@ -43,4 +43,16 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+#pragma mark - Deprecated
+
+@interface ASStaticLayoutSpec : ASAbsoluteLayoutSpec
+
++ (instancetype)staticLayoutSpecWithChildren:(NSArray<id<ASLayoutElement>> *)children AS_WARN_UNUSED_RESULT ASDISPLAYNODE_DEPRECATED;
+
+
++ (instancetype)absoluteLayoutSpecWithSizing:(ASAbsoluteLayoutSpecSizing)sizing children:(NSArray<id<ASLayoutElement>> *)children AS_WARN_UNUSED_RESULT __unavailable;
++ (instancetype)absoluteLayoutSpecWithChildren:(NSArray<id<ASLayoutElement>> *)children AS_WARN_UNUSED_RESULT __unavailable;
+
+@end
+
 NS_ASSUME_NONNULL_END

--- a/AsyncDisplayKit/Layout/ASAbsoluteLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASAbsoluteLayoutSpec.mm
@@ -119,3 +119,20 @@
 }
 
 @end
+
+
+#pragma mark - ASStaticLayoutSpec
+
+@implementation ASStaticLayoutSpec : ASAbsoluteLayoutSpec
+
++ (instancetype)staticLayoutSpecWithChildren:(NSArray<id<ASLayoutElement>> *)children
+{
+  return [[self alloc] initWithChildren:children];
+}
+
+- (instancetype)initWithChildren:(NSArray *)children
+{
+  return [super initWithSizing:ASAbsoluteLayoutSpecSizingSizeToFit children:children];
+}
+
+@end


### PR DESCRIPTION
For the transition phase let's add `ASStaticLayoutSpec` back without deprecation warnings.