### PR TITLE
[Operations] Fix Xcode 7 Build Failing Due to Missing Signposts Header

### DIFF
--- a/AsyncDisplayKit/Details/ASDataController.mm
+++ b/AsyncDisplayKit/Details/ASDataController.mm
@@ -23,8 +23,6 @@
 #import "ASInternalHelpers.h"
 #import "ASCellNode+Internal.h"
 
-#import <sys/kdebug_signpost.h>
-
 //#define LOG(...) NSLog(__VA_ARGS__)
 #define LOG(...)
 

--- a/AsyncDisplayKit/Details/ASRangeController.mm
+++ b/AsyncDisplayKit/Details/ASRangeController.mm
@@ -22,8 +22,6 @@
 #import "ASDisplayNode+FrameworkPrivate.h"
 #import "AsyncDisplayKit+Debug.h"
 
-#import <sys/kdebug_signpost.h>
-
 #define AS_RANGECONTROLLER_LOG_UPDATE_FREQ 0
 
 @interface ASRangeController ()

--- a/Base/ASLog.h
+++ b/Base/ASLog.h
@@ -10,7 +10,6 @@
 
 #pragma once
 
-#import <sys/kdebug_signpost.h>
 #import "ASAvailability.h"
 
 #define ASMultiplexImageNodeLogDebug(...)
@@ -19,7 +18,11 @@
 #define ASMultiplexImageNodeLogError(...)
 #define ASMultiplexImageNodeCLogError(...)
 
-#if PROFILE
+// Note: `<sys/kdebug_signpost.h>` only exists in Xcode 8 and later.
+#if PROFILE && __has_include("<sys/kdebug_signpost.h>")
+
+#import <sys/kdebug_signpost.h>
+
 // These definitions are required to build the backward-compatible kdebug trace
 // on the iOS 10 SDK.  The kdebug_trace function crashes if run on iOS 9 and earlier.
 // It's valuable to support trace signposts on iOS 9, because A5 devices don't support iOS 10.


### PR DESCRIPTION
Resolves #2429 . Very simple.