### PR TITLE
Remove Explicit Calls to -copy on Blocks

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -2505,7 +2505,7 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
   ASDisplayNodeAssert(!(_methodOverrides & ASDisplayNodeMethodOverrideLayoutSpecThatFits), @"Overwriting layoutSpecThatFits: and providing a layoutSpecBlock block is currently not supported");
 
   ASDN::MutexLocker l(__instanceLock__);
-  _layoutSpecBlock = [layoutSpecBlock copy];
+  _layoutSpecBlock = layoutSpecBlock;
 }
 
 - (ASLayoutSpecBlock)layoutSpecBlock

--- a/AsyncDisplayKit/ASImageNode.mm
+++ b/AsyncDisplayKit/ASImageNode.mm
@@ -526,7 +526,7 @@ static ASDN::Mutex cacheLock;
   // Stash the block and call-site queue. We'll invoke it in -displayDidFinish.
   ASDN::MutexLocker l(__instanceLock__);
   if (_displayCompletionBlock != displayCompletionBlock) {
-    _displayCompletionBlock = [displayCompletionBlock copy];
+    _displayCompletionBlock = displayCompletionBlock;
   }
 
   [self setNeedsDisplay];

--- a/AsyncDisplayKit/ASRunLoopQueue.mm
+++ b/AsyncDisplayKit/ASRunLoopQueue.mm
@@ -164,7 +164,7 @@ static void runLoopSourceCallback(void *info) {
   if (self = [super init]) {
     _runLoop = runloop;
     _internalQueue = std::deque<id>();
-    _queueConsumer = [handlerBlock copy];
+    _queueConsumer = handlerBlock;
     _batchSize = 1;
     _ensureExclusiveMembership = YES;
     

--- a/AsyncDisplayKit/Details/Transactions/_ASAsyncTransaction.mm
+++ b/AsyncDisplayKit/Details/Transactions/_ASAsyncTransaction.mm
@@ -36,7 +36,7 @@ NSInteger const ASDefaultTransactionPriority = 0;
 - (instancetype)initWithOperationCompletionBlock:(asyncdisplaykit_async_transaction_operation_completion_block_t)operationCompletionBlock
 {
   if ((self = [super init])) {
-    _operationCompletionBlock = [operationCompletionBlock copy];
+    _operationCompletionBlock = operationCompletionBlock;
   }
   return self;
 }
@@ -339,7 +339,7 @@ ASAsyncTransactionQueue & ASAsyncTransactionQueue::instance()
       callbackQueue = dispatch_get_main_queue();
     }
     _callbackQueue = callbackQueue;
-    _completionBlock = [completionBlock copy];
+    _completionBlock = completionBlock;
 
     _state = ATOMIC_VAR_INIT(ASAsyncTransactionStateOpen);
   }


### PR DESCRIPTION
I've confirmed that the optimizer does not remove these calls automatically, even though they're unnecessary.

Under ARC, block copying is done automatically when required. So calling `-copy` is purely wasted resources.

http://clang.llvm.org/docs/AutomaticReferenceCounting.html#id50

> With the exception of retains done as part of initializing a `__strong` parameter variable or reading a `__weak` variable, whenever these semantics call for retaining a value of block-pointer type, it has the effect of a `Block_copy`. The optimizer may remove such copies when it sees that the result is used only as an argument to a call.

Details at http://stackoverflow.com/a/23352604

I was also able to make the display completion block static, since it's pure. Not huge, but hey it's a freebie!