### PR TITLE
fix macro

### DIFF
--- a/Base/ASBaseDefines.h
+++ b/Base/ASBaseDefines.h
@@ -74,8 +74,18 @@
 # define ASDISPLAYNODE_WARN_DEPRECATED 1
 #endif
 
+#ifndef ASDISPLAYNODE_DEPRECATED
+# if ASDISPLAYNODE_GNUC (3, 0) && ASDISPLAYNODE_WARN_DEPRECATED
+#  define ASDISPLAYNODE_DEPRECATED __attribute__ ((deprecated))
+# else
+#  define ASDISPLAYNODE_DEPRECATED
+# endif
+#endif
+
 #ifndef ASDISPLAYNODE_DEPRECATED_MSG
-# define  ASDISPLAYNODE_DEPRECATED_MSG(msg) __deprecated_msg(msg)
+# if ASDISPLAYNODE_GNUC (3, 0) && ASDISPLAYNODE_WARN_DEPRECATED
+#   define  ASDISPLAYNODE_DEPRECATED_MSG(msg) __deprecated_msg(msg)
+# endif
 #endif
 
 #if defined (__cplusplus) && defined (__GNUC__)


### PR DESCRIPTION
- releaseses/p6.14 still uses ASDISPLAYNODE_DEPRECATED
- need the warn deprecated flag 