### PR TITLE
[ASCollectionNode] add -indexPathsForVisibleItems

### DIFF
--- a/AsyncDisplayKit/ASCollectionNode.h
+++ b/AsyncDisplayKit/ASCollectionNode.h
@@ -313,6 +313,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (nullable NSIndexPath *)indexPathForNode:(ASCellNode *)cellNode AS_WARN_UNUSED_RESULT;
 
+/**
+ * Retrieve the index paths of all visible items.
+ *
+ * @return an array containing the index paths of all visible items. This must be called on the main thread.
+ */
+- (NSArray<__kindof NSIndexPath *> *)indexPathsForVisibleItems AS_WARN_UNUSED_RESULT;
 
 /**
  * Retrieves the context object for the given section, as provided by the data source in

--- a/AsyncDisplayKit/ASCollectionNode.mm
+++ b/AsyncDisplayKit/ASCollectionNode.mm
@@ -295,6 +295,19 @@
   return [self.dataController indexPathForNode:cellNode];
 }
 
+- (NSArray<__kindof NSIndexPath *> *)indexPathsForVisibleItems
+{
+  NSMutableArray *indexPathsArray = [NSMutableArray new];
+  for (ASCellNode *cell in [self visibleNodes]) {
+    NSIndexPath *indexPath = [self indexPathForNode:cell];
+    if (indexPath) {
+      [indexPathsArray addObject:indexPath];
+    }
+  }
+  return indexPathsArray;
+}
+
+
 - (ASCellNode *)nodeForItemAtIndexPath:(NSIndexPath *)indexPath
 {
   return [self.dataController nodeAtIndexPath:indexPath];


### PR DESCRIPTION
Any reason we don't want to expose this on ASCollectionView and pass to the ASCollectionNode?