### PR TITLE
[Project Config] switch ios-snapshot-test-case back to main repo

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -4,6 +4,5 @@ platform :ios, '7.0'
 
 target :'AsyncDisplayKitTests' do
   pod 'OCMock', '~> 2.2'
-  # this is identical to FBSnapshotTestCase 2.1.3 except that the deployment was changed from 8.0 -> 7.0
-  pod 'FBSnapshotTestCase/Core', :git => "https://github.com/hannahmbanana/ios-snapshot-test-case.git"
+  pod 'FBSnapshotTestCase/Core', '~> 2.1'
 end


### PR DESCRIPTION
The latest version of ios-snapshot-test-case (v2.1.4) brought back the "old" deployment target
`s.ios.deployment_target  = '7.0'`.