### PR TITLE
Fix to beta 5 of PINRemoteImage

### DIFF
--- a/AsyncDisplayKit.podspec
+++ b/AsyncDisplayKit.podspec
@@ -59,8 +59,7 @@ Pod::Spec.new do |spec|
   
   spec.subspec 'PINRemoteImage' do |pin|
       pin.xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) PIN_REMOTE_IMAGE=1' }
-      pin.dependency 'PINRemoteImage/iOS', '>= 3.0.0-beta.4'
-      pin.dependency 'PINRemoteImage/PINCache'
+      pin.dependency 'PINRemoteImage/iOS', '= 3.0.0-beta.5'
       pin.dependency 'AsyncDisplayKit/Core'
   end
   


### PR DESCRIPTION
Beta 4 added a PINCache subspec which was required for ASDK. However,
Beta 5 reverted this in an attempt to fix automatically updated versions
of ASDK. So this patch sets the specific version to beta 5 until we're
ready to launch.