### PR TITLE
[ASWrapperLayoutSpec] Add support  for multiple children

### DIFF
--- a/AsyncDisplayKit/Layout/ASLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASLayoutSpec.h
@@ -63,19 +63,31 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 /**
- * An ASLayoutSpec subclass that can wrap a ASLayoutElement and calculates the layout of the child.
+ * An ASLayoutSpec subclass that can wrap one or more ASLayoutElement and calculates the layout based on the
+ * sizes of the children. If multiple children are provided the size of the biggest child will be used to for
+ * size of this layout spec.
  */
 @interface ASWrapperLayoutSpec : ASLayoutSpec
 
 /*
- * Returns an ASWrapperLayoutSpec object with the given layoutElement as child
+ * Returns an ASWrapperLayoutSpec object with the given layoutElement as child.
  */
 + (instancetype)wrapperWithLayoutElement:(id<ASLayoutElement>)layoutElement AS_WARN_UNUSED_RESULT;
 
 /*
- * Returns an ASWrapperLayoutSpec object initialized with the given layoutElement as child
+ * Returns an ASWrapperLayoutSpec object with the given layoutElements as children.
  */
-- (instancetype)initWithLayoutElement:(id<ASLayoutElement>)layoutElement NS_DESIGNATED_INITIALIZER;
++ (instancetype)wrapperWithLayoutElements:(NSArray<id<ASLayoutElement>> *)layoutElements AS_WARN_UNUSED_RESULT;
+
+/*
+ * Returns an ASWrapperLayoutSpec object initialized with the given layoutElement as child.
+ */
+- (instancetype)initWithLayoutElement:(id<ASLayoutElement>)layoutElement AS_WARN_UNUSED_RESULT;
+
+/*
+ * Returns an ASWrapperLayoutSpec object initialized with the given layoutElements as children.
+ */
+- (instancetype)initWithLayoutElements:(NSArray<id<ASLayoutElement>> *)layoutElements AS_WARN_UNUSED_RESULT;
 
 /*
  * Init not available for ASWrapperLayoutSpec

--- a/AsyncDisplayKit/Layout/ASLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASLayoutSpec.mm
@@ -315,11 +315,36 @@ ASLayoutElementStyleForwarding
   return self;
 }
 
++ (instancetype)wrapperWithLayoutElements:(NSArray<id<ASLayoutElement>> *)layoutElements
+{
+  return [[self alloc] initWithLayoutElements:layoutElements];
+}
+
+- (instancetype)initWithLayoutElements:(NSArray<id<ASLayoutElement>> *)layoutElements
+{
+  self = [super init];
+  if (self) {
+    self.children = layoutElements;
+  }
+  return self;
+}
+
 - (ASLayout *)calculateLayoutThatFits:(ASSizeRange)constrainedSize
 {
-  ASLayout *sublayout = [self.child layoutThatFits:constrainedSize parentSize:constrainedSize.max];
-  sublayout.position = CGPointZero;
-  return [ASLayout layoutWithLayoutElement:self size:sublayout.size sublayouts:@[sublayout]];
+  NSArray *children = self.children;
+  NSMutableArray *sublayouts = [NSMutableArray arrayWithCapacity:children.count];
+  
+  CGSize size = constrainedSize.min;
+  for (id<ASLayoutElement> child in children) {
+    ASLayout *sublayout = [child layoutThatFits:constrainedSize parentSize:constrainedSize.max];
+    
+    size.width = MAX(size.width,  sublayout.size.width);
+    size.height = MAX(size.height, sublayout.size.height);
+    
+    [sublayouts addObject:sublayout];
+  }
+  
+  return [ASLayout layoutWithLayoutElement:self size:size sublayouts:sublayouts];
 }
 
 @end


### PR DESCRIPTION
Currently there is no good way to return multiple children from `layoutSpecThatFits:`. The workaround is to use an `ASAbsoluteLayoutSpec` and set the sizing option to `ASAbsoluteLayoutSpecSizingSizeToFit`.

Let's add the capability to the wrapper layout spec to have multiple children so multiple children can be returned in `layoutSpecThatFits:` without using `ASAbsoluteLayoutSpec` as hack around it.

This almost completely removes the case for using an `ASAbsoluteLayoutSpec ` with `ASAbsoluteLayoutSpecSizingSizeToFit` and we have a default way to use or return multiple children within a layout spec.