### PR TITLE
[ASStackLayoutSpec] Performance improvements

### DIFF
--- a/AsyncDisplayKit/Layout/ASStackLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASStackLayoutSpec.h
@@ -13,7 +13,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-
 /**
  A simple layout spec that stacks a list of children vertically or horizontally.
 

--- a/AsyncDisplayKit/Layout/ASStackLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASStackLayoutSpec.h
@@ -13,6 +13,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+
 /**
  A simple layout spec that stacks a list of children vertically or horizontally.
 

--- a/AsyncDisplayKit/Layout/ASStackLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASStackLayoutSpec.mm
@@ -134,7 +134,6 @@
     return {child, style, style.size};
   });
   
-  // TOOD: Does this needs locking?
   const ASStackLayoutSpecStyle style = {.direction = _direction, .spacing = _spacing, .justifyContent = _justifyContent, .alignItems = _alignItems, .baselineRelativeArrangement = _baselineRelativeArrangement};
   
   // First pass is to get the children into a positioned state
@@ -149,8 +148,12 @@
   NSMutableArray *sublayouts = [NSMutableArray array];
   CGSize finalSize = CGSizeZero;
   if (needsBaselinePositioning) {
-    // Regardless of whether or not this stack aligns to baseline, we need to let ASStackBaselinePositionedLayout::compute find the max ascender
-    // and min descender in case this spec is a child in another spec that wants to align to a baseline.
+    // All horizontal stacks, regardless of whether or not they are baseline aligned, should go through a baseline
+    // computation. They could be used in another horizontal stack that is baseline aligned and will need to have
+    // computed the proper ascender/descender.
+    
+    // Vertical stacks do not need to go through this computation since we can easily compute ascender/descender by
+    // looking at their first/last child's ascender/descender.
     const auto baselinePositionedLayout = ASStackBaselinePositionedLayout::compute(positionedLayout, style, constrainedSize);
 
     if (directionIsVertical == NO) {

--- a/AsyncDisplayKit/Private/ASStackBaselinePositionedLayout.h
+++ b/AsyncDisplayKit/Private/ASStackBaselinePositionedLayout.h
@@ -12,16 +12,8 @@
 #import "ASDimension.h"
 #import "ASStackPositionedLayout.h"
 
-struct ASStackBaselinePositionedLayoutItem {
-  /** The original source child. */
-  ASStackLayoutSpecChild child;
-  /** The proposed layout. */
-  ASLayout *layout;
-};
-
 struct ASStackBaselinePositionedLayout {
-  const std::vector<ASStackBaselinePositionedLayoutItem> items;
-  //const std::vector<ASLayout *> sublayouts;
+  const std::vector<ASStackLayoutSpecItem> items;
   const CGFloat crossSize;
   const CGFloat ascender;
   const CGFloat descender;
@@ -30,4 +22,6 @@ struct ASStackBaselinePositionedLayout {
   static ASStackBaselinePositionedLayout compute(const ASStackPositionedLayout &positionedLayout,
                                                  const ASStackLayoutSpecStyle &style,
                                                  const ASSizeRange &constrainedSize);
+    
+  static BOOL needsBaselineAlignment(const ASStackLayoutSpecStyle &style);
 };

--- a/AsyncDisplayKit/Private/ASStackBaselinePositionedLayout.h
+++ b/AsyncDisplayKit/Private/ASStackBaselinePositionedLayout.h
@@ -12,12 +12,20 @@
 #import "ASDimension.h"
 #import "ASStackPositionedLayout.h"
 
+struct ASStackBaselinePositionedLayoutItem {
+  /** The original source child. */
+  ASStackLayoutSpecChild child;
+  /** The proposed layout. */
+  ASLayout *layout;
+};
+
 struct ASStackBaselinePositionedLayout {
-    const std::vector<ASLayout *> sublayouts;
-    const CGFloat crossSize;
-    const CGFloat ascender;
-    const CGFloat descender;
-    
+  const std::vector<ASStackBaselinePositionedLayoutItem> items;
+  //const std::vector<ASLayout *> sublayouts;
+  const CGFloat crossSize;
+  const CGFloat ascender;
+  const CGFloat descender;
+  
     /** Given a positioned layout, computes each child position using baseline alignment. */
   static ASStackBaselinePositionedLayout compute(const ASStackPositionedLayout &positionedLayout,
                                                  const ASStackLayoutSpecStyle &style,

--- a/AsyncDisplayKit/Private/ASStackBaselinePositionedLayout.mm
+++ b/AsyncDisplayKit/Private/ASStackBaselinePositionedLayout.mm
@@ -69,7 +69,7 @@ ASStackBaselinePositionedLayout ASStackBaselinePositionedLayout::compute(const A
 {
   const auto stackedChildren = positionedLayout.items;
   
-  /* Step 1: Look at each child and determine the distance from the top of the child node it's baseline.
+  /* Step 1: Look at each child and determine the distance from the top of the child node to its baseline.
      For  example, let's say we have the following two text nodes and want to align them to the first baseline:
    
      Hello!    Why, hello there! How

--- a/AsyncDisplayKit/Private/ASStackBaselinePositionedLayout.mm
+++ b/AsyncDisplayKit/Private/ASStackBaselinePositionedLayout.mm
@@ -13,31 +13,31 @@
 #import "ASLayoutSpecUtilities.h"
 #import "ASLayoutSpec+Subclasses.h"
 
+#import "ASLayoutElement.h"
+#import "ASLayoutElementStylePrivate.h"
+
 static CGFloat baselineForItem(const ASStackLayoutSpecStyle &style,
-                               const ASLayout *layout) {
-  
-  __weak id<ASLayoutElement> child = layout.layoutElement;
+                               const ASStackPositionedItem &l)
+{
   switch (style.alignItems) {
     case ASStackLayoutAlignItemsBaselineFirst:
-      return child.style.ascender;
+      return l.child.style.ascender;
     case ASStackLayoutAlignItemsBaselineLast:
-      return layout.size.height + child.style.descender;
+      return l.layout.size.height + l.child.style.descender;
     default:
       return 0;
   }
-  
 }
 
 static CGFloat baselineOffset(const ASStackLayoutSpecStyle &style,
-                              const ASLayout *l,
+                              const ASStackPositionedItem &l,
                               const CGFloat maxAscender,
                               const CGFloat maxBaseline)
 {
   if (style.direction == ASStackLayoutDirectionHorizontal) {
-    __weak id<ASLayoutElement> child = l.layoutElement;
     switch (style.alignItems) {
       case ASStackLayoutAlignItemsBaselineFirst:
-        return maxAscender - child.style.ascender;
+        return maxAscender - l.child.style.ascender;
       case ASStackLayoutAlignItemsBaselineLast:
         return maxBaseline - baselineForItem(style, l);
         
@@ -48,11 +48,11 @@ static CGFloat baselineOffset(const ASStackLayoutSpecStyle &style,
   return 0;
 }
 
-static CGFloat maxDimensionForLayout(const ASLayout *l,
-                                     const ASStackLayoutSpecStyle &style)
+static CGFloat maxDimensionForItem(const ASStackBaselinePositionedLayoutItem &l,
+                                   const ASStackLayoutSpecStyle &style)
 {
-  CGFloat maxDimension = crossDimension(style.direction, l.size);
-  style.direction == ASStackLayoutDirectionVertical ? maxDimension += l.position.x : maxDimension += l.position.y;
+  CGFloat maxDimension = crossDimension(style.direction, l.layout.size);
+  style.direction == ASStackLayoutDirectionVertical ? maxDimension += l.layout.position.x : maxDimension += l.layout.position.y;
   return maxDimension;
 }
 
@@ -74,10 +74,10 @@ ASStackBaselinePositionedLayout ASStackBaselinePositionedLayout::compute(const A
      the font's descender (it's negative). In the case of the first node, which is only 1 line, this should be the same value as the ascender.
      The second node, however, has a larger height and there will have a larger baseline offset.
    */
-  const auto baselineIt = std::max_element(positionedLayout.sublayouts.begin(), positionedLayout.sublayouts.end(), [&](const ASLayout *a, const ASLayout *b){
+  const auto baselineIt = std::max_element(positionedLayout.items.begin(), positionedLayout.items.end(), [&](const ASStackPositionedItem &a, const ASStackPositionedItem &b){
     return baselineForItem(style, a) < baselineForItem(style, b);
   });
-  const CGFloat maxBaseline = baselineIt == positionedLayout.sublayouts.end() ? 0 : baselineForItem(style, *baselineIt);
+  const CGFloat maxBaseline = baselineIt == positionedLayout.items.end() ? 0 : baselineForItem(style, *baselineIt);
   
   /*
     Step 2: Find the max ascender for all of the children.
@@ -89,10 +89,10 @@ ASStackBaselinePositionedLayout ASStackBaselinePositionedLayout::compute(const A
     Note: if we are aligning to the last baseline, then we don't need this value in our computation. However, we do want
     our layoutSpec to have it so that it can be baseline aligned with another text node or baseline layout spec.
    */
-  const auto ascenderIt = std::max_element(positionedLayout.sublayouts.begin(), positionedLayout.sublayouts.end(), [&](const ASLayout *a, const ASLayout *b){
-    return a.layoutElement.style.ascender < b.layoutElement.style.ascender;
+  const auto ascenderIt = std::max_element(positionedLayout.items.begin(), positionedLayout.items.end(), [&](const ASStackPositionedItem &a, const ASStackPositionedItem &b){
+    return a.child.style.ascender < b.child.style.ascender;
   });
-  const CGFloat maxAscender = ascenderIt == positionedLayout.sublayouts.end() ? 0 : (*ascenderIt).layoutElement.style.ascender;
+  const CGFloat maxAscender = ascenderIt == positionedLayout.items.end() ? 0 : (*ascenderIt).child.style.ascender;
   
   /*
     Step 3: Take each child and update its layout position based on the baseline offset.
@@ -102,18 +102,25 @@ ASStackBaselinePositionedLayout ASStackBaselinePositionedLayout::compute(const A
     spacing between the two nodes is from the baseline, not the bounding box.
    
   */
-  std::vector<ASLayout *> stackedChildren;
   // Only change positions of layouts this stackSpec is aligning to a baseline. Otherwise we are only here to
   // compute the min/max descender/ascender for this stack spec.
-  if (style.baselineRelativeArrangement || style.alignItems == ASStackLayoutAlignItemsBaselineFirst || style.alignItems == ASStackLayoutAlignItemsBaselineLast) {
-    CGPoint p = CGPointZero;
-    BOOL first = YES;
-    stackedChildren = AS::map(positionedLayout.sublayouts, [&](ASLayout *l) -> ASLayout *{
-      __weak id<ASLayoutElement> child = l.layoutElement;
-      p = p + directionPoint(style.direction, child.style.spacingBefore, 0);
+  const BOOL aligningToBaseline = style.baselineRelativeArrangement ||
+                                  style.alignItems == ASStackLayoutAlignItemsBaselineFirst ||
+                                  style.alignItems == ASStackLayoutAlignItemsBaselineLast;
+  
+  CGPoint p = CGPointZero;
+  BOOL first = YES;
+  const auto stackedChildren = AS::map(positionedLayout.items, [&](const ASStackPositionedItem &l) -> ASStackBaselinePositionedLayoutItem {
+    
+    // Align item to baseline
+    if (aligningToBaseline) {
+      ASLayout *layout = l.layout;
+      ASLayoutElementStyle *layoutElementStyle = l.child.style;
+      
+      p = p + directionPoint(style.direction, layoutElementStyle.spacingBefore, 0);
       if (first) {
         // if this is the first item use the previously computed start point
-        p = l.position;
+        p = layout.position;
       } else {
         // otherwise add the stack spacing
         p = p + directionPoint(style.direction, style.spacing, 0);
@@ -121,21 +128,19 @@ ASStackBaselinePositionedLayout ASStackBaselinePositionedLayout::compute(const A
       first = NO;
       
       // Find the difference between this node's baseline and the max baseline of all the children. Add this difference to the child's y position.
-      l.position = p + CGPointMake(0, baselineOffset(style, l, maxAscender, maxBaseline));
+      layout.position = p + CGPointMake(0, baselineOffset(style, l, maxAscender, maxBaseline));
       
       // If we are a vertical stack, add the item's descender (it is negative) to the offset for the next node. This will ensure we are spacing
       // node from baselines and not bounding boxes.
       CGFloat spacingAfterBaseline = 0;
       if (style.direction == ASStackLayoutDirectionVertical) {
-        spacingAfterBaseline = child.style.descender;
+        spacingAfterBaseline = layoutElementStyle.descender;
       }
-      p = p + directionPoint(style.direction, stackDimension(style.direction, l.size) + child.style.spacingAfter + spacingAfterBaseline, 0);
-      
-      return l;
-    });
-  } else {
-    stackedChildren = positionedLayout.sublayouts;
-  }
+      p = p + directionPoint(style.direction, stackDimension(style.direction, layout.size) + layoutElementStyle.spacingAfter + spacingAfterBaseline, 0);
+    }
+
+    return {l.child, l.layout};
+  });
   
   /*
     Step 4: Since we have been mucking with positions, there is a chance that our cross size has changed. Imagine a node with a font size of 40
@@ -147,10 +152,10 @@ ASStackBaselinePositionedLayout ASStackBaselinePositionedLayout::compute(const A
    
    */
   const auto it = std::max_element(stackedChildren.begin(), stackedChildren.end(),
-                                   [&](ASLayout *a, ASLayout *b) {
-                                     return maxDimensionForLayout(a, style) < maxDimensionForLayout(b, style);
+                                   [&](const ASStackBaselinePositionedLayoutItem &a, const ASStackBaselinePositionedLayoutItem &b) {
+                                     return maxDimensionForItem(a, style) < maxDimensionForItem(b, style);
                                    });
-  const auto largestChildCrossSize = it == stackedChildren.end() ? 0 : maxDimensionForLayout(*it, style);
+  const auto largestChildCrossSize = it == stackedChildren.end() ? 0 : maxDimensionForItem(*it, style);
   const auto minCrossSize = crossDimension(style.direction, constrainedSize.min);
   const auto maxCrossSize = crossDimension(style.direction, constrainedSize.max);
   const CGFloat crossSize = MIN(MAX(minCrossSize, largestChildCrossSize), maxCrossSize);
@@ -159,10 +164,10 @@ ASStackBaselinePositionedLayout ASStackBaselinePositionedLayout::compute(const A
      Step 5: finally, we must find the smallest descender (descender is negative). This is since ASBaselineLayoutSpec implements
      ASLayoutElement and needs an ascender and descender to lay itself out properly.
    */
-  const auto descenderIt = std::max_element(stackedChildren.begin(), stackedChildren.end(), [&](const ASLayout *a, const ASLayout *b){
-    return  a.position.y + a.size.height <  b.position.y + b.size.height;
+  const auto descenderIt = std::max_element(stackedChildren.begin(), stackedChildren.end(), [&](const ASStackBaselinePositionedLayoutItem &a, const ASStackBaselinePositionedLayoutItem &b){
+    return  a.layout.position.y + a.layout.size.height <  b.layout.position.y + b.layout.size.height;
   });
-  const CGFloat minDescender = descenderIt == stackedChildren.end() ? 0 : (*descenderIt).layoutElement.style.descender;
+  const CGFloat minDescender = descenderIt == stackedChildren.end() ? 0 : (*descenderIt).child.style.descender;
 
-  return {stackedChildren, crossSize, maxAscender, minDescender};
+  return {std::move(stackedChildren), crossSize, maxAscender, minDescender};
 }

--- a/AsyncDisplayKit/Private/ASStackPositionedLayout.h
+++ b/AsyncDisplayKit/Private/ASStackPositionedLayout.h
@@ -12,9 +12,16 @@
 #import "ASDimension.h"
 #import "ASStackUnpositionedLayout.h"
 
+struct ASStackPositionedItem {
+  /** The original source child. */
+  ASStackLayoutSpecChild child;
+  /** The proposed layout. */
+  ASLayout *layout;
+};
+
 /** Represents a set of laid out and positioned stack layout children. */
 struct ASStackPositionedLayout {
-  const std::vector<ASLayout *> sublayouts;
+  const std::vector<ASStackPositionedItem> items;
   const CGFloat crossSize;
 
   /** Given an unpositioned layout, computes the positions each child should be placed at. */

--- a/AsyncDisplayKit/Private/ASStackPositionedLayout.h
+++ b/AsyncDisplayKit/Private/ASStackPositionedLayout.h
@@ -12,16 +12,9 @@
 #import "ASDimension.h"
 #import "ASStackUnpositionedLayout.h"
 
-struct ASStackPositionedItem {
-  /** The original source child. */
-  ASStackLayoutSpecChild child;
-  /** The proposed layout. */
-  ASLayout *layout;
-};
-
 /** Represents a set of laid out and positioned stack layout children. */
 struct ASStackPositionedLayout {
-  const std::vector<ASStackPositionedItem> items;
+  const std::vector<ASStackLayoutSpecItem> items;
   const CGFloat crossSize;
 
   /** Given an unpositioned layout, computes the positions each child should be placed at. */

--- a/AsyncDisplayKit/Private/ASStackUnpositionedLayout.h
+++ b/AsyncDisplayKit/Private/ASStackUnpositionedLayout.h
@@ -14,12 +14,22 @@
 #import "ASStackLayoutSpecUtilities.h"
 #import "ASStackLayoutSpec.h"
 
+struct ASStackLayoutSpecChild {
+  /** The original source child. */
+  id<ASLayoutElement> element;
+  /** Style object of element. */
+  ASLayoutElementStyle *style;
+  /** Size object of the element */
+  ASLayoutElementSize size;
+};
+
 struct ASStackUnpositionedItem {
   /** The original source child. */
-  id<ASLayoutElement> child;
+  ASStackLayoutSpecChild child;
   /** The proposed layout. */
   ASLayout *layout;
 };
+
 
 /** Represents a set of stack layout children that have their final layout computed, but are not yet positioned. */
 struct ASStackUnpositionedLayout {
@@ -31,7 +41,7 @@ struct ASStackUnpositionedLayout {
   const CGFloat violation;
 
   /** Given a set of children, computes the unpositioned layouts for those children. */
-  static ASStackUnpositionedLayout compute(const std::vector<id<ASLayoutElement>> &children,
+  static ASStackUnpositionedLayout compute(const std::vector<ASStackLayoutSpecChild> &children,
                                            const ASStackLayoutSpecStyle &style,
                                            const ASSizeRange &sizeRange);
 };

--- a/AsyncDisplayKit/Private/ASStackUnpositionedLayout.h
+++ b/AsyncDisplayKit/Private/ASStackUnpositionedLayout.h
@@ -23,10 +23,10 @@ struct ASStackLayoutSpecChild {
   ASLayoutElementSize size;
 };
 
-struct ASStackUnpositionedItem {
+struct ASStackLayoutSpecItem {
   /** The original source child. */
   ASStackLayoutSpecChild child;
-  /** The proposed layout. */
+  /** The proposed layout or nil if no is calculated yet. */
   ASLayout *layout;
 };
 
@@ -34,7 +34,7 @@ struct ASStackUnpositionedItem {
 /** Represents a set of stack layout children that have their final layout computed, but are not yet positioned. */
 struct ASStackUnpositionedLayout {
   /** A set of proposed child layouts, not yet positioned. */
-  const std::vector<ASStackUnpositionedItem> items;
+  const std::vector<ASStackLayoutSpecItem> items;
   /** The total size of the children in the stack dimension, including all spacing. */
   const CGFloat stackDimensionSum;
   /** The amount by which stackDimensionSum violates constraints. If positive, less than min; negative, greater than max. */

--- a/AsyncDisplayKit/Private/ASStackUnpositionedLayout.mm
+++ b/AsyncDisplayKit/Private/ASStackUnpositionedLayout.mm
@@ -97,13 +97,13 @@ static ASLayout *crossChildLayout(const ASStackLayoutSpecChild &child,
  @param layouts pre-computed child layouts; modified in-place as needed
  @param style the layout style of the overall stack layout
  */
-static void stretchChildrenAlongCrossDimension(std::vector<ASStackUnpositionedItem> &layouts,
+static void stretchChildrenAlongCrossDimension(std::vector<ASStackLayoutSpecItem> &layouts,
                                                const ASStackLayoutSpecStyle &style,
                                                const CGSize size)
 {
   // Find the maximum cross dimension size among child layouts
   const auto it = std::max_element(layouts.begin(), layouts.end(),
-                                   [&](const ASStackUnpositionedItem &a, const ASStackUnpositionedItem &b) {
+                                   [&](const ASStackLayoutSpecItem &a, const ASStackLayoutSpecItem &b) {
                                      return compareCrossDimension(style.direction, a.layout.size, b.layout.size);
                                    });
 
@@ -130,18 +130,18 @@ static const CGFloat kViolationEpsilon = 0.01;
  Returns a lambda that computes the relevant flex factor based on the given violation.
  @param violation The amount that the stack layout violates its size range.  See header for sign interpretation.
  */
-static std::function<CGFloat(const ASStackUnpositionedItem &)> flexFactorInViolationDirection(const CGFloat violation)
+static std::function<CGFloat(const ASStackLayoutSpecItem &)> flexFactorInViolationDirection(const CGFloat violation)
 {
   if (std::fabs(violation) < kViolationEpsilon) {
-    return [](const ASStackUnpositionedItem &item) { return 0.0; };
+    return [](const ASStackLayoutSpecItem &item) { return 0.0; };
   } else if (violation > 0) {
-    return [](const ASStackUnpositionedItem &item) { return item.child.style.flexGrow; };
+    return [](const ASStackLayoutSpecItem &item) { return item.child.style.flexGrow; };
   } else {
-    return [](const ASStackUnpositionedItem &item) { return item.child.style.flexShrink; };
+    return [](const ASStackLayoutSpecItem &item) { return item.child.style.flexShrink; };
   }
 }
 
-static inline CGFloat scaledFlexShrinkFactor(const ASStackUnpositionedItem &item,
+static inline CGFloat scaledFlexShrinkFactor(const ASStackLayoutSpecItem &item,
                                              const ASStackLayoutSpecStyle &style,
                                              const CGFloat flexFactorSum)
 {
@@ -156,15 +156,15 @@ static inline CGFloat scaledFlexShrinkFactor(const ASStackUnpositionedItem &item
  @param flexFactorSum The sum of each item's flex factor as determined by the provided violation.
  @return A lambda capable of computing the flex shrink adjustment, if any, for a particular item.
  */
-static std::function<CGFloat(const ASStackUnpositionedItem &)> flexShrinkAdjustment(const std::vector<ASStackUnpositionedItem> &items,
+static std::function<CGFloat(const ASStackLayoutSpecItem &)> flexShrinkAdjustment(const std::vector<ASStackLayoutSpecItem> &items,
                                                                                     const ASStackLayoutSpecStyle &style,
                                                                                     const CGFloat violation,
                                                                                     const CGFloat flexFactorSum)
 {
-  const CGFloat scaledFlexShrinkFactorSum = std::accumulate(items.begin(), items.end(), 0.0, [&](CGFloat x, const ASStackUnpositionedItem &item) {
+  const CGFloat scaledFlexShrinkFactorSum = std::accumulate(items.begin(), items.end(), 0.0, [&](CGFloat x, const ASStackLayoutSpecItem &item) {
     return x + scaledFlexShrinkFactor(item, style, flexFactorSum);
   });
-  return [style, scaledFlexShrinkFactorSum, violation, flexFactorSum](const ASStackUnpositionedItem &item) {
+  return [style, scaledFlexShrinkFactorSum, violation, flexFactorSum](const ASStackLayoutSpecItem &item) {
     const CGFloat scaledFlexShrinkFactorRatio = scaledFlexShrinkFactor(item, style, flexFactorSum) / scaledFlexShrinkFactorSum;
     // The item should shrink proportionally to the scaled flex shrink factor ratio computed above.
     // Unlike the flex grow adjustment the flex shrink adjustment needs to take the size of each item into account.
@@ -179,12 +179,12 @@ static std::function<CGFloat(const ASStackUnpositionedItem &)> flexShrinkAdjustm
  @param flexFactorSum The sum of each item's flex factor as determined by the provided violation.
  @return A lambda capable of computing the flex grow adjustment, if any, for a particular item.
  */
-static std::function<CGFloat(const ASStackUnpositionedItem &)> flexGrowAdjustment(const std::vector<ASStackUnpositionedItem> &items,
+static std::function<CGFloat(const ASStackLayoutSpecItem &)> flexGrowAdjustment(const std::vector<ASStackLayoutSpecItem> &items,
                                                                                   const CGFloat violation,
                                                                                   const CGFloat flexFactorSum)
 {
   // To compute the flex grow adjustment distribute the violation proportionally based on each item's flex grow factor.
-  return [violation, flexFactorSum](const ASStackUnpositionedItem &item) {
+  return [violation, flexFactorSum](const ASStackLayoutSpecItem &item) {
     return std::floor(violation * (item.child.style.flexGrow / flexFactorSum));
   };
 }
@@ -197,7 +197,7 @@ static std::function<CGFloat(const ASStackUnpositionedItem &)> flexGrowAdjustmen
  @param flexFactorSum The sum of each item's flex factor as determined by the provided violation.
  @return A lambda capable of computing the flex adjustment for a particular item.
  */
-static std::function<CGFloat(const ASStackUnpositionedItem &)> flexAdjustmentInViolationDirection(const std::vector<ASStackUnpositionedItem> &items,
+static std::function<CGFloat(const ASStackLayoutSpecItem &)> flexAdjustmentInViolationDirection(const std::vector<ASStackLayoutSpecItem> &items,
                                                                                                   const ASStackLayoutSpecStyle &style,
                                                                                                   const CGFloat violation,
                                                                                                   const CGFloat flexFactorSum)
@@ -218,12 +218,12 @@ ASDISPLAYNODE_INLINE BOOL isFlexibleInBothDirections(const ASStackLayoutSpecChil
  The flexible children may have been left not laid out in the initial layout pass, so we may have to go through and size
  these children at zero size so that the children layouts are at least present.
  */
-static void layoutFlexibleChildrenAtZeroSize(std::vector<ASStackUnpositionedItem> &items,
+static void layoutFlexibleChildrenAtZeroSize(std::vector<ASStackLayoutSpecItem> &items,
                                              const ASStackLayoutSpecStyle &style,
                                              const ASSizeRange &sizeRange,
                                              const CGSize size)
 {
-  for (ASStackUnpositionedItem &item : items) {
+  for (ASStackLayoutSpecItem &item : items) {
     if (isFlexibleInBothDirections(item.child)) {
       item.layout = crossChildLayout(item.child,
                                      style,
@@ -250,20 +250,20 @@ static void layoutFlexibleChildrenAtZeroSize(std::vector<ASStackUnpositionedItem
  @param children unpositioned layouts for the children of the stack spec
  @param style the layout style of the overall stack layout
  */
-static CGFloat computeStackDimensionSum(const std::vector<ASStackUnpositionedItem> &children,
+static CGFloat computeStackDimensionSum(const std::vector<ASStackLayoutSpecItem> &children,
                                         const ASStackLayoutSpecStyle &style)
 {
   // Sum up the childrens' spacing
   const CGFloat childSpacingSum = std::accumulate(children.begin(), children.end(),
                                                   // Start from default spacing between each child:
                                                   children.empty() ? 0 : style.spacing * (children.size() - 1),
-                                                  [&](CGFloat x, const ASStackUnpositionedItem &l) {
+                                                  [&](CGFloat x, const ASStackLayoutSpecItem &l) {
                                                     return x + l.child.style.spacingBefore + l.child.style.spacingAfter;
                                                   });
 
   // Sum up the childrens' dimensions (including spacing) in the stack direction.
   const CGFloat childStackDimensionSum = std::accumulate(children.begin(), children.end(), childSpacingSum,
-                                                         [&](CGFloat x, const ASStackUnpositionedItem &l) {
+                                                         [&](CGFloat x, const ASStackLayoutSpecItem &l) {
                                                            return x + stackDimension(style.direction, l.layout.size);
                                                          });
   return childStackDimensionSum;
@@ -341,17 +341,17 @@ ASDISPLAYNODE_INLINE BOOL useOptimizedFlexing(const std::vector<ASStackLayoutSpe
  @param sizeRange the range of allowable sizes for the stack layout component
  @param size Size of the stack layout component. May be undefined in either or both directions.
  */
-static void flexChildrenAlongStackDimension(std::vector<ASStackUnpositionedItem> &items,
+static void flexChildrenAlongStackDimension(std::vector<ASStackLayoutSpecItem> &items,
                                             const ASStackLayoutSpecStyle &style,
                                             const ASSizeRange &sizeRange,
                                             const CGSize size,
                                             const BOOL useOptimizedFlexing)
 {
   const CGFloat violation = computeViolation(computeStackDimensionSum(items, style), style, sizeRange);
-  std::function<CGFloat(const ASStackUnpositionedItem &)> flexFactor = flexFactorInViolationDirection(violation);
+  std::function<CGFloat(const ASStackLayoutSpecItem &)> flexFactor = flexFactorInViolationDirection(violation);
   // The flex factor sum is needed to determine if flexing is necessary.
   // This value is also needed if the violation is positive and flexible children need to grow, so keep it around.
-  const CGFloat flexFactorSum = std::accumulate(items.begin(), items.end(), 0.0, [&](CGFloat x, const ASStackUnpositionedItem &item) {
+  const CGFloat flexFactorSum = std::accumulate(items.begin(), items.end(), 0.0, [&](CGFloat x, const ASStackLayoutSpecItem &item) {
     return x + flexFactor(item);
   });
   // If no children are able to flex then there is nothing left to do. Bail.
@@ -362,17 +362,17 @@ static void flexChildrenAlongStackDimension(std::vector<ASStackUnpositionedItem>
     }
     return;
   }
-  std::function<CGFloat(const ASStackUnpositionedItem &)> flexAdjustment = flexAdjustmentInViolationDirection(items,
+  std::function<CGFloat(const ASStackLayoutSpecItem &)> flexAdjustment = flexAdjustmentInViolationDirection(items,
                                                                                                               style,
                                                                                                               violation,
                                                                                                               flexFactorSum);
 
   // Compute any remaining violation to the first flexible child.
-  const CGFloat remainingViolation = std::accumulate(items.begin(), items.end(), violation, [&](CGFloat x, const ASStackUnpositionedItem &item) {
+  const CGFloat remainingViolation = std::accumulate(items.begin(), items.end(), violation, [&](CGFloat x, const ASStackLayoutSpecItem &item) {
     return x - flexAdjustment(item);
   });
   BOOL isFirstFlex = YES;
-  for (ASStackUnpositionedItem &item : items) {
+  for (ASStackLayoutSpecItem &item : items) {
     const CGFloat currentFlexAdjustment = flexAdjustment(item);
     // Children are consider inflexible if they do not need to make a flex adjustment.
     if (currentFlexAdjustment != 0) {
@@ -395,7 +395,7 @@ static void flexChildrenAlongStackDimension(std::vector<ASStackUnpositionedItem>
  Performs the first unconstrained layout of the children, generating the unpositioned items that are then flexed and
  stretched.
  */
-static std::vector<ASStackUnpositionedItem> layoutChildrenAlongUnconstrainedStackDimension(const std::vector<ASStackLayoutSpecChild> &children,
+static std::vector<ASStackLayoutSpecItem> layoutChildrenAlongUnconstrainedStackDimension(const std::vector<ASStackLayoutSpecChild> &children,
                                                                                            const ASStackLayoutSpecStyle &style,
                                                                                            const ASSizeRange &sizeRange,
                                                                                            const CGSize size,
@@ -403,7 +403,7 @@ static std::vector<ASStackUnpositionedItem> layoutChildrenAlongUnconstrainedStac
 {
   const CGFloat minCrossDimension = crossDimension(style.direction, sizeRange.min);
   const CGFloat maxCrossDimension = crossDimension(style.direction, sizeRange.max);
-  return AS::map(children, [&](const ASStackLayoutSpecChild &child) -> ASStackUnpositionedItem {
+  return AS::map(children, [&](const ASStackLayoutSpecChild &child) -> ASStackLayoutSpecItem {
     if (useOptimizedFlexing && isFlexibleInBothDirections(child)) {
       return {child, [ASLayout layoutWithLayoutElement:child.element size:{0, 0}]};
     } else {
@@ -438,7 +438,7 @@ ASStackUnpositionedLayout ASStackUnpositionedLayout::compute(const std::vector<A
   // We do a first pass of all the children, generating an unpositioned layout for each with an unbounded range along
   // the stack dimension.  This allows us to compute the "intrinsic" size of each child and find the available violation
   // which determines whether we must grow or shrink the flexible children.
-  std::vector<ASStackUnpositionedItem> items = layoutChildrenAlongUnconstrainedStackDimension(children,
+  std::vector<ASStackLayoutSpecItem> items = layoutChildrenAlongUnconstrainedStackDimension(children,
                                                                                               style,
                                                                                               sizeRange,
                                                                                               size,
@@ -448,5 +448,5 @@ ASStackUnpositionedLayout ASStackUnpositionedLayout::compute(const std::vector<A
   stretchChildrenAlongCrossDimension(items, style, size);
 
   const CGFloat stackDimensionSum = computeStackDimensionSum(items, style);
-  return {items, stackDimensionSum, computeViolation(stackDimensionSum, style, sizeRange)};
+  return {std::move(items), stackDimensionSum, computeViolation(stackDimensionSum, style, sizeRange)};
 }


### PR DESCRIPTION
Moves layout calculations of the stack layout spec in the C++ layer of the layout spec implementation. Previously we used references of `ASLayout` to as for specific properties like `layoutElement` and `style` or `size` on the `ASLlayoutElement`.

Now we create a C++ wrapper around the `ASLayout` before the actual layout calculations happening and use this to access the common components to reduce the overhead of Objc message calling.

- Add `ASStackLayoutSpecItem ` and don't separate between unpositioned and positioned items anymore. This didn't work properly previously in the first place as the `ASLayout` that was included was basically shared, so on ASDK side having them was basically nonsense. It would have make sense if we would have create specific `ASLayout` objects for unpositioned and positioned items by copying the old one. In that case the immutability of the `ASLayout` would have make sense.
- Reduce overhead of calling `.style` `.style.size` on `ASLayoutElement`s
- Bypass baseline calculation if not needed