### PR TITLE
[ASCollectionView] Caching scrollable directions is not safe

### DIFF
--- a/AsyncDisplayKit/Details/ASCollectionViewLayoutController.mm
+++ b/AsyncDisplayKit/Details/ASCollectionViewLayoutController.mm
@@ -30,7 +30,6 @@ typedef struct ASRangeGeometry ASRangeGeometry;
   @package
   ASCollectionView * __weak _collectionView;
   UICollectionViewLayout * __strong _collectionViewLayout;
-  ASScrollDirection _scrollableDirections;
 }
 @end
 
@@ -42,7 +41,6 @@ typedef struct ASRangeGeometry ASRangeGeometry;
     return nil;
   }
   
-  _scrollableDirections = [collectionView scrollableDirections];
   _collectionView = collectionView;
   _collectionViewLayout = [collectionView collectionViewLayout];
   return self;
@@ -74,12 +72,7 @@ typedef struct ASRangeGeometry ASRangeGeometry;
 {
   CGRect rect = _collectionView.bounds;
   
-  // Scrollable directions can change for non-flow layouts
-  if ([_collectionViewLayout asdk_isFlowLayout] == NO) {
-    _scrollableDirections = [_collectionView scrollableDirections];
-  }
-  
-  return CGRectExpandToRangeWithScrollableDirections(rect, tuningParameters, _scrollableDirections, scrollDirection);
+  return CGRectExpandToRangeWithScrollableDirections(rect, tuningParameters, [_collectionView scrollableDirections], scrollDirection);
 }
 
 @end


### PR DESCRIPTION
I'm not sure if there's a different way to optimize this instead.