### PR TITLE
Table & Collection Node Should Enqueue Initial Reload If Needed

### DIFF
--- a/AsyncDisplayKit/ASCollectionNode.mm
+++ b/AsyncDisplayKit/ASCollectionNode.mm
@@ -337,13 +337,22 @@
 
 #pragma mark - Querying Data
 
+- (void)reloadDataInitiallyIfNeeded
+{
+  if (!self.dataController.initialReloadDataHasBeenCalled) {
+    [self reloadData];
+  }
+}
+
 - (NSInteger)numberOfItemsInSection:(NSInteger)section
 {
+  [self reloadDataInitiallyIfNeeded];
   return [self.dataController numberOfRowsInSection:section];
 }
 
 - (NSInteger)numberOfSections
 {
+  [self reloadDataInitiallyIfNeeded];
   return [self.dataController numberOfSections];
 }
 
@@ -373,6 +382,7 @@
 
 - (ASCellNode *)nodeForItemAtIndexPath:(NSIndexPath *)indexPath
 {
+  [self reloadDataInitiallyIfNeeded];
   return [self.dataController nodeAtIndexPath:indexPath];
 }
 

--- a/AsyncDisplayKit/ASTableNode.mm
+++ b/AsyncDisplayKit/ASTableNode.mm
@@ -361,13 +361,22 @@ ASEnvironmentCollectionTableSetEnvironmentState(_environmentStateLock)
 
 #pragma mark - Querying Data
 
+- (void)reloadDataInitiallyIfNeeded
+{
+  if (!self.dataController.initialReloadDataHasBeenCalled) {
+    [self reloadData];
+  }
+}
+
 - (NSInteger)numberOfRowsInSection:(NSInteger)section
 {
+  [self reloadDataInitiallyIfNeeded];
   return [self.dataController numberOfRowsInSection:section];
 }
 
 - (NSInteger)numberOfSections
 {
+  [self reloadDataInitiallyIfNeeded];
   return [self.dataController numberOfSections];
 }
 
@@ -384,6 +393,7 @@ ASEnvironmentCollectionTableSetEnvironmentState(_environmentStateLock)
 
 - (ASCellNode *)nodeForRowAtIndexPath:(NSIndexPath *)indexPath
 {
+  [self reloadDataInitiallyIfNeeded];
   return [self.dataController nodeAtIndexPath:indexPath];
 }
 

--- a/AsyncDisplayKitTests/ASCollectionViewTests.mm
+++ b/AsyncDisplayKitTests/ASCollectionViewTests.mm
@@ -210,6 +210,34 @@
   XCTAssertEqualObjects([collectionView supplementaryNodeKindsInDataController:nil], @[UICollectionElementKindSectionHeader]);
 }
 
+- (void)testReloadIfNeeded
+{
+  [ASDisplayNode setSuppressesInvalidCollectionUpdateExceptions:NO];
+
+  __block ASCollectionViewTestController *testController = [[ASCollectionViewTestController alloc] initWithNibName:nil bundle:nil];
+  __block ASCollectionViewTestDelegate *del = testController.asyncDelegate;
+  __block ASCollectionNode *cn = testController.collectionNode;
+
+  void (^reset)() = ^void() {
+    testController = [[ASCollectionViewTestController alloc] initWithNibName:nil bundle:nil];
+    del = testController.asyncDelegate;
+    cn = testController.collectionNode;
+  };
+
+  // Check if the number of sections matches the data source
+  XCTAssertEqual(cn.numberOfSections, del->_itemCounts.size(), @"Section count doesn't match the data source");
+
+  // Reset everything and then check if numberOfItemsInSection matches the data source
+  reset();
+  XCTAssertEqual([cn numberOfItemsInSection:0], del->_itemCounts[0], @"Number of items in Section doesn't match the data source");
+
+  // Reset and check if we can get the node corresponding to a specific indexPath
+  reset();
+  NSIndexPath *indexPath = [NSIndexPath indexPathForItem:0 inSection:0];
+  ASTextCellNodeWithSetSelectedCounter *node = (ASTextCellNodeWithSetSelectedCounter*)[cn nodeForItemAtIndexPath:indexPath];
+  XCTAssertTrue([node.text isEqualToString:indexPath.description], @"Node's text should match the initial text it was created with");
+}
+
 - (void)testSelection
 {
   ASCollectionViewTestController *testController = [[ASCollectionViewTestController alloc] initWithNibName:nil bundle:nil];


### PR DESCRIPTION
refs #2457

- Call reloadData if necessary when accessing specific methods.
- Added test case.

NB: Since the nodes aren't visible at this time, you won't be able to get all the correct information from the node, for instance:

```
NSIndexPath *indexPath = [NSIndexPath indexPathForItem:0 inSection:0];
ASCellNode *node = [cn nodeForItemAtIndexPath:indexPath];
```

In this case `node.indexPath`will actually be `nil` even if the node itself is correct. Take a look at #2468.


