### PR TITLE
[Layout] Only throw if width or height are fractions in preferredSize getter

### DIFF
--- a/AsyncDisplayKit/Layout/ASLayoutElement.mm
+++ b/AsyncDisplayKit/Layout/ASLayoutElement.mm
@@ -257,12 +257,12 @@ do {\
 - (CGSize)preferredSize
 {
   ASDN::MutexLocker l(__instanceLock__);
-  if (_size.width.unit != ASDimensionUnitPoints) {
+  if (_size.width.unit == ASDimensionUnitFraction) {
     NSCAssert(NO, @"Cannot get preferredSize of element with fractional width. Width: %@.", NSStringFromASDimension(_size.width));
     return CGSizeZero;
   }
   
-  if (_size.height.unit != ASDimensionUnitPoints) {
+  if (_size.height.unit == ASDimensionUnitFraction) {
     NSCAssert(NO, @"Cannot get preferredSize of element with fractional height. Height: %@.", NSStringFromASDimension(_size.height));
     return CGSizeZero;
   }

--- a/AsyncDisplayKitTests/ASLayoutElementStyleTests.m
+++ b/AsyncDisplayKitTests/ASLayoutElementStyleTests.m
@@ -58,6 +58,8 @@
 {
   ASLayoutElementStyle *style = [ASLayoutElementStyle new];
   
+  ASXCTAssertEqualSizes(style.preferredSize, CGSizeZero);
+  
   CGSize size = CGSizeMake(100, 100);
   
   style.preferredSize = size;
@@ -78,7 +80,7 @@
 {
   ASLayoutElementStyle *style = [ASLayoutElementStyle new];
   
-  XCTAssertThrows(style.preferredSize);
+  XCTAssertNoThrow(style.preferredSize);
   
   style.width = ASDimensionMake(ASDimensionUnitFraction, 0.5);
   XCTAssertThrows(style.preferredSize);


### PR DESCRIPTION
If width and height of an `ASLayoutElement` is not of unit type `ASDimensionUnitPoints` we throw an assertion for accessing the `style.preferredSize`.

Instead of throwing an assertion if the unit type is not `ASDimensionUnitPoints` we will throw an assertion if the unit type is `ASDimensionUnitFraction`. If the unit type is `ASDimensionUnitPoints` or `ASDimensionUnitAuto` we will use the value of the `width` and `height` dimension to create the size to return.

Addresses: #2483 