### PR TITLE
[Swift] Addressed two warnings when building for swift.

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode+Deprecated.h
+++ b/AsyncDisplayKit/ASDisplayNode+Deprecated.h
@@ -52,7 +52,7 @@
  *
  * @deprecated Deprecated in version 2.0: Use ASCalculateRootLayout() or ASCalculateLayout() instead
  */
-- (ASLayout *)measureWithSizeRange:(ASSizeRange)constrainedSize ASDISPLAYNODE_DEPRECATED_MSG("Use layoutThatFits: instead.");
+- (nonnull ASLayout *)measureWithSizeRange:(ASSizeRange)constrainedSize ASDISPLAYNODE_DEPRECATED_MSG("Use layoutThatFits: instead.");
 
 /**
  * @abstract Called whenever the visiblity of the node changed.

--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -814,7 +814,7 @@ extern NSInteger const ASDefaultDrawingPriority;
 
 @end
 
-@interface ASDisplayNode (Deprecated) <ASStackLayoutElement, ASAbsoluteLayoutElement>
+@interface ASDisplayNode (DeprecatedProtocolMethods) <ASStackLayoutElement, ASAbsoluteLayoutElement>
 
 #pragma mark - Deprecated
 


### PR DESCRIPTION
Solves the following warnings (posted on Slack by emeskhi):
```
ASDisplayNode+Deprecated.h:15:27: Duplicate definition of category 'Deprecated' on interface 'ASDisplayNode'
```
```
ASDisplayNode+Deprecated.h:55:13: Pointer is missing a nullability type specifier (_Nonnull, _Nullable, or _Null_unspecified)
```
