### PR TITLE
Improve Table Performance, Especially When Using Section Index Bar

### DIFF
--- a/AsyncDisplayKit/ASTableNode.mm
+++ b/AsyncDisplayKit/ASTableNode.mm
@@ -389,18 +389,22 @@ ASEnvironmentCollectionTableSetEnvironmentState(_environmentStateLock)
 - (void)reloadDataInitiallyIfNeeded
 {
   if (!self.dataController.initialReloadDataHasBeenCalled) {
-    [self reloadData];
+    // Note: Just calling reloadData isn't enough here – we need to
+    // ensure that _nodesConstrainedWidth is updated first.
+    [self.view layoutIfNeeded];
   }
 }
 
 - (NSInteger)numberOfRowsInSection:(NSInteger)section
 {
+  ASDisplayNodeAssertMainThread();
   [self reloadDataInitiallyIfNeeded];
   return [self.dataController numberOfRowsInSection:section];
 }
 
 - (NSInteger)numberOfSections
 {
+  ASDisplayNodeAssertMainThread();
   [self reloadDataInitiallyIfNeeded];
   return [self.dataController numberOfSections];
 }

--- a/AsyncDisplayKit/ASTableNode.mm
+++ b/AsyncDisplayKit/ASTableNode.mm
@@ -388,6 +388,7 @@ ASEnvironmentCollectionTableSetEnvironmentState(_environmentStateLock)
 
 - (void)reloadDataInitiallyIfNeeded
 {
+  ASDisplayNodeAssertMainThread();
   if (!self.dataController.initialReloadDataHasBeenCalled) {
     // Note: Just calling reloadData isn't enough here – we need to
     // ensure that _nodesConstrainedWidth is updated first.

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -1512,10 +1512,15 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     // is the same for all cells (because there is no easy way to get that individual value before the node being assigned to a _ASTableViewCell).
     // Also, in many cases, some nodes may not need to be re-measured at all, such as when user enters and then immediately leaves editing mode.
     // To avoid premature optimization and making such assumption, as well as to keep ASTableView simple, re-measurement is strictly done on main.
-    [self beginUpdates];
+    CGSize oldSize = node.bounds.size;
     const CGSize calculatedSize = [node layoutThatFits:constrainedSize].size;
-    node.frame = CGRectMake(0, 0, calculatedSize.width, calculatedSize.height);
-    [self endUpdates];
+    node.frame = { .size = calculatedSize };
+
+    // If the node height changed, trigger a height requery.
+    if (oldSize.height != calculatedSize.height) {
+      [self beginUpdates];
+      [self endUpdates];
+    }
   }
 }
 

--- a/AsyncDisplayKit/ASTableViewInternal.h
+++ b/AsyncDisplayKit/ASTableViewInternal.h
@@ -59,4 +59,7 @@
  */
 - (NSArray<NSIndexPath *> *)convertIndexPathsToTableNode:(NSArray<NSIndexPath *> *)indexPaths;
 
+/// Returns the width of the section index view on the right-hand side of the table, if one is present.
+- (CGFloat)sectionIndexWidth;
+
 @end

--- a/AsyncDisplayKitTests/ASTableViewTests.m
+++ b/AsyncDisplayKitTests/ASTableViewTests.m
@@ -638,9 +638,6 @@
 /**
  * This tests an issue where, if the table is loaded before the first layout pass,
  * the nodes are first measured with a constrained width of 0 which isn't ideal.
- *
- * The implementation fix might be, in reloadDataInitiallyIfNeeded, to call
- * [self layoutIfNeeded] if the initial reload hasn't happened.
  */
 - (void)testThatNodeConstrainedSizesAreCorrectIfReloadIsPreempted
 {

--- a/AsyncDisplayKitTests/ASXCTExtensions.h
+++ b/AsyncDisplayKitTests/ASXCTExtensions.h
@@ -31,3 +31,6 @@
 
 #define ASXCTAssertNotEqualDimensions(r0, r1, ...) \
   _XCTPrimitiveAssertNotEqualObjects(self, NSStringFromASDimension(r0), @#r0, NSStringFromASDimension(r1), @#r1, __VA_ARGS__)
+
+#define ASXCTAssertEqualSizeRanges(r0, r1, ...) \
+  _XCTPrimitiveAssertEqualObjects(self, NSStringFromASSizeRange(r0), @#r0, NSStringFromASSizeRange(r1), @#r1, __VA_ARGS__)


### PR DESCRIPTION
This is a diff that I developed with @chrisdanford – it resolves #2501.

- Only call `beginUpdates/endUpdates` if the node's height changed as a result of remeasuring against content view.
- Subtract section index frame from bounds-width when determining the row width. Otherwise, when the cell comes on screen, it's going to have to synchronously remeasure.
- Fix an unrelated issue where if you call `ASTableNode.numberOfSections` before the first layout, it'll reload data with `_nodesConstrainedWidth = 0` and all the rows will get measured against 0 which is less than ideal.

@chrisdanford Would you be willing to download this as a patch and try it against Pinterest to make sure that I haven't regressed anything since the last profiling?