### PR TITLE
Revert "We need to ensure point dimensions are valid for sizing. (#25…

### DIFF
--- a/AsyncDisplayKit/Layout/ASDimension.h
+++ b/AsyncDisplayKit/Layout/ASDimension.h
@@ -102,7 +102,7 @@ ASOVERLOADABLE ASDISPLAYNODE_INLINE ASDimension ASDimensionMake(ASDimensionUnit 
   if (unit == ASDimensionUnitAuto ) {
     ASDisplayNodeCAssert(value == 0, @"ASDimension auto value must be 0.");
   } else if (unit == ASDimensionUnitPoints) {
-    ASDisplayNodeCAssert(ASPointsValidForSize(value), @"ASDimension points value (%f) must be valid for size.", value);
+    ASDisplayNodeCAssertPositiveReal(@"Points", value);
   } else if (unit == ASDimensionUnitFraction) {
     ASDisplayNodeCAssert( 0 <= value && value <= 1.0, @"ASDimension fraction value (%f) must be between 0 and 1.", value);
   }
@@ -132,7 +132,7 @@ ASOVERLOADABLE AS_WARN_UNUSED_RESULT extern ASDimension ASDimensionMake(NSString
  */
 ASDISPLAYNODE_INLINE AS_WARN_UNUSED_RESULT ASDimension ASDimensionMakeWithPoints(CGFloat points)
 {
-  ASDisplayNodeCAssert(ASPointsValidForSize(points), @"ASDimension points value (%f) must be valid for size.", points);
+  ASDisplayNodeCAssertPositiveReal(@"Points", points);
   return ASDimensionMake(ASDimensionUnitPoints, points);
 }
 


### PR DESCRIPTION
…03)"

This reverts commit 1165628905f92aa00c1605230f32953f5d7f0670.

I wanted to catch dimension issues early, we should move the assert to setting
width and height. The former was correct for here.
