### PR TITLE
Improve deprecation situation for 2.0

### DIFF
--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -171,7 +171,7 @@
 		636EA1A41C7FF4EC00EE152F /* NSArray+Diffing.m in Sources */ = {isa = PBXBuildFile; fileRef = DBC452DA1C5BF64600B16017 /* NSArray+Diffing.m */; };
 		636EA1A51C7FF4EF00EE152F /* ASDefaultPlayButton.m in Sources */ = {isa = PBXBuildFile; fileRef = AEB7B0191C5962EA00662EF4 /* ASDefaultPlayButton.m */; };
 		680346941CE4052A0009FEB4 /* ASNavigationController.h in Headers */ = {isa = PBXBuildFile; fileRef = 68FC85DC1CE29AB700EDD713 /* ASNavigationController.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		683489281D70DE3400327501 /* ASDisplayNode+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 683489271D70DE3400327501 /* ASDisplayNode+Deprecated.h */; };
+		683489281D70DE3400327501 /* ASDisplayNode+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 683489271D70DE3400327501 /* ASDisplayNode+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		68355B311CB5799E001D4E68 /* ASImageNode+AnimatedImage.mm in Sources */ = {isa = PBXBuildFile; fileRef = 68355B2E1CB5799E001D4E68 /* ASImageNode+AnimatedImage.mm */; };
 		68355B341CB579B9001D4E68 /* ASImageNode+AnimatedImage.mm in Sources */ = {isa = PBXBuildFile; fileRef = 68355B2E1CB5799E001D4E68 /* ASImageNode+AnimatedImage.mm */; };
 		68355B3A1CB57A5A001D4E68 /* ASPINRemoteImageDownloader.m in Sources */ = {isa = PBXBuildFile; fileRef = 68355B361CB57A5A001D4E68 /* ASPINRemoteImageDownloader.m */; };
@@ -1759,6 +1759,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				683489281D70DE3400327501 /* ASDisplayNode+Deprecated.h in Headers */,
 				69E0E8A71D356C9400627613 /* ASEqualityHelpers.h in Headers */,
 				698C8B621CAB49FC0052DC3F /* ASLayoutElementExtensibility.h in Headers */,
 				698548641CA9E025008A345F /* ASEnvironment.h in Headers */,
@@ -1886,7 +1887,6 @@
 				69708BA61D76386D005C3CF9 /* ASEqualityHashHelpers.h in Headers */,
 				B350622D1B010EFD0018CF92 /* ASScrollDirection.h in Headers */,
 				254C6B751BF94DF4003EC431 /* ASTextKitComponents.h in Headers */,
-				683489281D70DE3400327501 /* ASDisplayNode+Deprecated.h in Headers */,
 				B35062081B010EFD0018CF92 /* ASScrollNode.h in Headers */,
 				25E327571C16819500A2170C /* ASPagerNode.h in Headers */,
 				9C8221961BA237B80037F19A /* ASStackBaselinePositionedLayout.h in Headers */,

--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -196,6 +196,7 @@
 		68FC85EA1CE29C7D00EDD713 /* ASVisibilityProtocols.h in Headers */ = {isa = PBXBuildFile; fileRef = 68FC85E71CE29C7D00EDD713 /* ASVisibilityProtocols.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		68FC85EB1CE29C7D00EDD713 /* ASVisibilityProtocols.m in Sources */ = {isa = PBXBuildFile; fileRef = 68FC85E81CE29C7D00EDD713 /* ASVisibilityProtocols.m */; };
 		68FC85EC1CE29C7D00EDD713 /* ASVisibilityProtocols.m in Sources */ = {isa = PBXBuildFile; fileRef = 68FC85E81CE29C7D00EDD713 /* ASVisibilityProtocols.m */; };
+		693117CE1DC7C72700DE4784 /* ASDisplayNode+Deprecated.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 683489271D70DE3400327501 /* ASDisplayNode+Deprecated.h */; };
 		6959433E1D70815300B0EE1F /* ASDisplayNodeLayout.mm in Sources */ = {isa = PBXBuildFile; fileRef = 6959433C1D70815300B0EE1F /* ASDisplayNodeLayout.mm */; };
 		6959433F1D70815300B0EE1F /* ASDisplayNodeLayout.mm in Sources */ = {isa = PBXBuildFile; fileRef = 6959433C1D70815300B0EE1F /* ASDisplayNodeLayout.mm */; };
 		695943401D70815300B0EE1F /* ASDisplayNodeLayout.h in Headers */ = {isa = PBXBuildFile; fileRef = 6959433D1D70815300B0EE1F /* ASDisplayNodeLayout.h */; };
@@ -656,6 +657,7 @@
 			dstPath = "include/$(PRODUCT_NAME)";
 			dstSubfolderSpec = 16;
 			files = (
+				693117CE1DC7C72700DE4784 /* ASDisplayNode+Deprecated.h in CopyFiles */,
 				69F381A51DA4630D00CF2278 /* NSArray+Diffing.h in CopyFiles */,
 				CC4C2A7A1D8902350039ACAB /* ASTraceEvent.h in CopyFiles */,
 				CC88F7AE1D80AF5E000D6D4E /* ASObjectDescriptionHelpers.h in CopyFiles */,

--- a/AsyncDisplayKit/ASDisplayNode+Deprecated.h
+++ b/AsyncDisplayKit/ASDisplayNode+Deprecated.h
@@ -23,36 +23,16 @@
 @property (nullable, nonatomic, copy) NSString *name ASDISPLAYNODE_DEPRECATED_MSG("Use .debugName instead.");
 
 /**
- * @abstract Asks the node to measure and return the size that best fits its subnodes.
+ * @abstract Provides a default intrinsic content size for calculateSizeThatFits:. This is useful when laying out
+ * a node that either has no intrinsic content size or should be laid out at a different size than its intrinsic content
+ * size. For example, this property could be set on an ASImageNode to display at a size different from the underlying
+ * image size.
  *
- * @param constrainedSize The maximum size the receiver should fit in.
+ * @return Try to create a CGSize for preferredFrameSize of this node from the width and height property of this node. It will return CGSizeZero if widht and height dimensions are not of type ASDimensionUnitPoints.
  *
- * @return A new size that fits the receiver's subviews.
- *
- * @discussion Though this method does not set the bounds of the view, it does have side effects--caching both the
- * constraint and the result.
- *
- * @warning Subclasses must not override this; it calls -measureWithSizeRange: with zero min size.
- * -measureWithSizeRange: caches results from -calculateLayoutThatFits:.  Calling this method may
- * be expensive if result is not cached.
- *
- * @see measureWithSizeRange:
- * @see [ASDisplayNode(Subclassing) calculateLayoutThatFits:]
- *
- * @deprecated Deprecated in version 2.0: Use layoutThatFits: with a constrained size of (CGSizeZero, constrainedSize) and call size on the returned ASLayout
+ * @deprecated Deprecated in version 2.0: Just calls through to set the height and width property of the node. Convert to use sizing properties instead: height, minHeight, maxHeight, width, minWidth, maxWidth.
  */
-- (CGSize)measure:(CGSize)constrainedSize ASDISPLAYNODE_DEPRECATED_MSG("Use layoutThatFits: with a constrained size of (CGSizeZero, constrainedSize) and call size on the returned ASLayout.");
-
-/**
- * @abstract Calculate a layout based on given size range.
- *
- * @param constrainedSize The minimum and maximum sizes the receiver should fit in.
- *
- * @return An ASLayout instance defining the layout of the receiver and its children.
- *
- * @deprecated Deprecated in version 2.0: Use ASCalculateRootLayout() or ASCalculateLayout() instead
- */
-- (nonnull ASLayout *)measureWithSizeRange:(ASSizeRange)constrainedSize ASDISPLAYNODE_DEPRECATED_MSG("Use layoutThatFits: instead.");
+@property (nonatomic, assign, readwrite) CGSize preferredFrameSize ASDISPLAYNODE_DEPRECATED_MSG("Use .style.preferredSize instead OR set individual values with .style.height and .style.width.");
 
 /**
  * @abstract Called whenever the visiblity of the node changed.

--- a/AsyncDisplayKit/ASDisplayNode+Deprecated.h
+++ b/AsyncDisplayKit/ASDisplayNode+Deprecated.h
@@ -35,6 +35,29 @@
 @property (nonatomic, assign, readwrite) CGSize preferredFrameSize ASDISPLAYNODE_DEPRECATED_MSG("Use .style.preferredSize instead OR set individual values with .style.height and .style.width.");
 
 /**
+ * @abstract Asks the node to measure and return the size that best fits its subnodes.
+ *
+ * @param constrainedSize The maximum size the receiver should fit in.
+ *
+ * @return A new size that fits the receiver's subviews.
+ *
+ * @discussion Though this method does not set the bounds of the view, it does have side effects--caching both the
+ * constraint and the result.
+ *
+ * @warning Subclasses must not override this; it calls -measureWithSizeRange: with zero min size.
+ * -measureWithSizeRange: caches results from -calculateLayoutThatFits:.  Calling this method may
+ * be expensive if result is not cached.
+ *
+ * @see measureWithSizeRange:
+ * @see [ASDisplayNode(Subclassing) calculateLayoutThatFits:]
+ *
+ * @deprecated Deprecated in version 2.0: Use layoutThatFits: with a constrained size of (CGSizeZero, constrainedSize) and call size on the returned ASLayout
+ */
+- (CGSize)measure:(CGSize)constrainedSize ASDISPLAYNODE_DEPRECATED_MSG("Use layoutThatFits: with a constrained size of (CGSizeZero, constrainedSize) and call size on the returned ASLayout.");
+
+ASLayoutElementStyleForwardingDeclaration
+
+/**
  * @abstract Called whenever the visiblity of the node changed.
  *
  * @discussion Subclasses may use this to monitor when they become visible.

--- a/AsyncDisplayKit/ASDisplayNode+Deprecated.h
+++ b/AsyncDisplayKit/ASDisplayNode+Deprecated.h
@@ -28,7 +28,7 @@
  * size. For example, this property could be set on an ASImageNode to display at a size different from the underlying
  * image size.
  *
- * @return Try to create a CGSize for preferredFrameSize of this node from the width and height property of this node. It will return CGSizeZero if widht and height dimensions are not of type ASDimensionUnitPoints.
+ * @return Try to create a CGSize for preferredFrameSize of this node from the width and height property of this node. It will return CGSizeZero if width and height dimensions are not of type ASDimensionUnitPoints.
  *
  * @deprecated Deprecated in version 2.0: Just calls through to set the height and width property of the node. Convert to use sizing properties instead: height, minHeight, maxHeight, width, minWidth, maxWidth.
  */

--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -814,7 +814,7 @@ extern NSInteger const ASDefaultDrawingPriority;
 
 @end
 
-@interface ASDisplayNode (DeprecatedProtocolMethods) <ASStackLayoutElement, ASAbsoluteLayoutElement>
+@interface ASDisplayNode (DeprecatedProtocolMethods)
 
 #pragma mark - Deprecated
 
@@ -837,19 +837,9 @@ extern NSInteger const ASDefaultDrawingPriority;
  *
  * @deprecated Deprecated in version 2.0: Use layoutThatFits: with a constrained size of (CGSizeZero, constrainedSize) and call size on the returned ASLayout
  */
-- (CGSize)measure:(CGSize)constrainedSize ASDISPLAYNODE_DEPRECATED;
+- (CGSize)measure:(CGSize)constrainedSize ASDISPLAYNODE_DEPRECATED_MSG("Use layoutThatFits: with a constrained size of (CGSizeZero, constrainedSize) and call size on the returned ASLayout.");
 
-/**
- * @abstract Provides a default intrinsic content size for calculateSizeThatFits:. This is useful when laying out
- * a node that either has no intrinsic content size or should be laid out at a different size than its intrinsic content
- * size. For example, this property could be set on an ASImageNode to display at a size different from the underlying
- * image size.
- *
- * @return Try to create a CGSize for preferredFrameSize of this node from the width and height property of this node. It will return CGSizeZero if widht and height dimensions are not of type ASDimensionUnitPoints.
- *
- * @deprecated Deprecated in version 2.0: Just calls through to set the height and width property of the node. Convert to use sizing properties instead: height, minHeight, maxHeight, width, minWidth, maxWidth.
- */
-@property (nonatomic, assign, readwrite) CGSize preferredFrameSize ASDISPLAYNODE_DEPRECATED_MSG("Use .style.preferredSize instead OR set individual values with .style.height and .style.width.");
+ASLayoutElementStyleForwardingDeclaration
 
 @end
 

--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -814,35 +814,6 @@ extern NSInteger const ASDefaultDrawingPriority;
 
 @end
 
-@interface ASDisplayNode (DeprecatedProtocolMethods)
-
-#pragma mark - Deprecated
-
-/**
- * @abstract Asks the node to measure and return the size that best fits its subnodes.
- *
- * @param constrainedSize The maximum size the receiver should fit in.
- *
- * @return A new size that fits the receiver's subviews.
- *
- * @discussion Though this method does not set the bounds of the view, it does have side effects--caching both the
- * constraint and the result.
- *
- * @warning Subclasses must not override this; it calls -measureWithSizeRange: with zero min size.
- * -measureWithSizeRange: caches results from -calculateLayoutThatFits:.  Calling this method may
- * be expensive if result is not cached.
- *
- * @see measureWithSizeRange:
- * @see [ASDisplayNode(Subclassing) calculateLayoutThatFits:]
- *
- * @deprecated Deprecated in version 2.0: Use layoutThatFits: with a constrained size of (CGSizeZero, constrainedSize) and call size on the returned ASLayout
- */
-- (CGSize)measure:(CGSize)constrainedSize ASDISPLAYNODE_DEPRECATED_MSG("Use layoutThatFits: with a constrained size of (CGSizeZero, constrainedSize) and call size on the returned ASLayout.");
-
-ASLayoutElementStyleForwardingDeclaration
-
-@end
-
 /*
  * ASDisplayNode support for automatic subnode management.
  */

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -3654,6 +3654,13 @@ static const char *ASDisplayNodeAssociatedNodeKey = "ASAssociatedNode";
   return isPoints ? CGSizeMake(size.width.value, size.height.value) : CGSizeZero;
 }
 
+- (CGSize)measure:(CGSize)constrainedSize
+{
+  return [self layoutThatFits:ASSizeRangeMake(CGSizeZero, constrainedSize)].size;
+}
+
+ASLayoutElementStyleForwarding
+
 - (void)visibilityDidChange:(BOOL)isVisible
 {
   if (isVisible) {
@@ -3704,17 +3711,5 @@ static const char *ASDisplayNodeAssociatedNodeKey = "ASAssociatedNode";
 {
   self.automaticallyManagesSubnodes = enabled;
 }
-
-
-@end
-
-@implementation ASDisplayNode (DeprecatedProtocolMethods)
-
-- (CGSize)measure:(CGSize)constrainedSize
-{
-  return [self layoutThatFits:ASSizeRangeMake(CGSizeZero, constrainedSize)].size;
-}
-
-ASLayoutElementStyleForwarding
 
 @end

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -3471,8 +3471,6 @@ static const char *ASDisplayNodeDrawingPriorityKey = "ASDrawingPriority";
 
 #pragma mark - Deprecated
 
-ASLayoutElementStyleForwarding
-
 - (ASLayout *)measureWithSizeRange:(ASSizeRange)constrainedSize
 {
   return [self layoutThatFits:constrainedSize parentSize:constrainedSize.max];
@@ -3642,11 +3640,6 @@ static const char *ASDisplayNodeAssociatedNodeKey = "ASAssociatedNode";
   self.debugName = name;
 }
 
-- (CGSize)measure:(CGSize)constrainedSize
-{
-  return [self layoutThatFits:ASSizeRangeMake(CGSizeZero, constrainedSize)].size;
-}
-
 - (void)setPreferredFrameSize:(CGSize)preferredFrameSize
 {
   // Deprecated preferredFrameSize just calls through to set width and height
@@ -3659,6 +3652,42 @@ static const char *ASDisplayNodeAssociatedNodeKey = "ASAssociatedNode";
   ASLayoutSize size = self.style.preferredLayoutSize;
   BOOL isPoints = (size.width.unit == ASDimensionUnitPoints && size.height.unit == ASDimensionUnitPoints);
   return isPoints ? CGSizeMake(size.width.value, size.height.value) : CGSizeZero;
+}
+
+- (void)visibilityDidChange:(BOOL)isVisible
+{
+  if (isVisible) {
+    [self didEnterVisibleState];
+  } else {
+    [self didExitVisibleState];
+  }
+}
+
+- (void)visibleStateDidChange:(BOOL)isVisible
+{
+  if (isVisible) {
+    [self didEnterVisibleState];
+  } else {
+    [self didExitVisibleState];
+  }
+}
+
+- (void)displayStateDidChange:(BOOL)inDisplayState
+{
+  if (inDisplayState) {
+    [self didEnterVisibleState];
+  } else {
+    [self didExitVisibleState];
+  }
+}
+
+- (void)loadStateDidChange:(BOOL)inLoadState
+{
+  if (inLoadState) {
+    [self didEnterPreloadState];
+  } else {
+    [self didExitPreloadState];
+  }
 }
 
 - (void)cancelLayoutTransitionsInProgress
@@ -3675,5 +3704,17 @@ static const char *ASDisplayNodeAssociatedNodeKey = "ASAssociatedNode";
 {
   self.automaticallyManagesSubnodes = enabled;
 }
+
+
+@end
+
+@implementation ASDisplayNode (DeprecatedProtocolMethods)
+
+- (CGSize)measure:(CGSize)constrainedSize
+{
+  return [self layoutThatFits:ASSizeRangeMake(CGSizeZero, constrainedSize)].size;
+}
+
+ASLayoutElementStyleForwarding
 
 @end

--- a/AsyncDisplayKit/AsyncDisplayKit.h
+++ b/AsyncDisplayKit/AsyncDisplayKit.h
@@ -93,5 +93,6 @@
 #import <AsyncDisplayKit/NSArray+Diffing.h>
 
 #import <AsyncDisplayKit/AsyncDisplayKit+Debug.h>
+#import <AsyncDisplayKit/ASDisplayNode+Deprecated.h>
 
 #import <AsyncDisplayKit/ASCollectionNode+Beta.h>

--- a/AsyncDisplayKit/Layout/ASLayoutElement.h
+++ b/AsyncDisplayKit/Layout/ASLayoutElement.h
@@ -50,7 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
  * access to the options via convenience properties. If you are creating custom layout spec, then you can
  * extend the backing layout options class to accommodate any new layout options.
  */
-@protocol ASLayoutElement <ASEnvironment, ASLayoutElementPrivate, ASLayoutElementExtensibility, ASLayoutElementStylability, NSFastEnumeration, ASStackLayoutElement, ASAbsoluteLayoutElement>
+@protocol ASLayoutElement <ASEnvironment, ASLayoutElementPrivate, ASLayoutElementExtensibility, ASLayoutElementStylability, NSFastEnumeration>
 
 #pragma mark - Getter
 
@@ -151,7 +151,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @deprecated Deprecated in version 2.0: Use ASCalculateRootLayout() or ASCalculateLayout() instead
  */
-- (ASLayout *)measureWithSizeRange:(ASSizeRange)constrainedSize ASDISPLAYNODE_DEPRECATED_MSG("Use layoutThatFits: instead");
+- (nonnull ASLayout *)measureWithSizeRange:(ASSizeRange)constrainedSize ASDISPLAYNODE_DEPRECATED_MSG("Use layoutThatFits: instead.");
 
 @end
 
@@ -319,4 +319,3 @@ extern NSString * const ASLayoutElementStyleLayoutPositionProperty;
 @end
 
 NS_ASSUME_NONNULL_END
-#define ASLayoutable ASLayoutElement

--- a/AsyncDisplayKit/Layout/ASLayoutElement.h
+++ b/AsyncDisplayKit/Layout/ASLayoutElement.h
@@ -149,7 +149,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return An ASLayout instance defining the layout of the receiver and its children.
  *
- * @deprecated Deprecated in version 2.0: Use ASCalculateRootLayout() or ASCalculateLayout() instead
+ * @deprecated Deprecated in version 2.0: Use layoutThatFits: or layoutThatFits:parentSize: if used in
+ * ASLayoutSpec subclasses
  */
 - (nonnull ASLayout *)measureWithSizeRange:(ASSizeRange)constrainedSize ASDISPLAYNODE_DEPRECATED_MSG("Use layoutThatFits: instead.");
 

--- a/AsyncDisplayKit/Layout/ASLayoutElementPrivate.h
+++ b/AsyncDisplayKit/Layout/ASLayoutElementPrivate.h
@@ -95,6 +95,20 @@ extern void ASLayoutElementClearCurrentContext();
 }\
 
 
+#pragma mark ASLayoutElementStyleForwardingDeclaration (Deprecated)
+
+#define ASLayoutElementStyleForwardingDeclaration \
+@property (nonatomic, readwrite) CGFloat spacingBefore ASDISPLAYNODE_DEPRECATED_MSG("Use style.spacingBefore"); \
+@property (nonatomic, readwrite) CGFloat spacingAfter ASDISPLAYNODE_DEPRECATED_MSG("Use style.spacingAfter"); \
+@property (nonatomic, readwrite) CGFloat flexGrow ASDISPLAYNODE_DEPRECATED_MSG("Use style.flexGrow"); \
+@property (nonatomic, readwrite) CGFloat flexShrink ASDISPLAYNODE_DEPRECATED_MSG("Use style.flexShrink"); \
+@property (nonatomic, readwrite) ASDimension flexBasis ASDISPLAYNODE_DEPRECATED_MSG("Use style.flexBasis"); \
+@property (nonatomic, readwrite) ASStackLayoutAlignSelf alignSelf ASDISPLAYNODE_DEPRECATED_MSG("Use style.alignSelf"); \
+@property (nonatomic, readwrite) CGFloat ascender ASDISPLAYNODE_DEPRECATED_MSG("Use style.ascender"); \
+@property (nonatomic, readwrite) CGFloat descender ASDISPLAYNODE_DEPRECATED_MSG("Use style.descender"); \
+@property (nonatomic, assign) ASRelativeSizeRange sizeRange ASDISPLAYNODE_DEPRECATED_MSG("Don't use sizeRange anymore instead set style.width or style.height"); \
+@property (nonatomic, assign) CGPoint layoutPosition ASDISPLAYNODE_DEPRECATED_MSG("Use style.layoutPosition"); \
+
 
 #pragma mark - ASLayoutElementStyleForwarding (Deprecated)
 

--- a/AsyncDisplayKit/Layout/ASLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASLayoutSpec.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * A layout spec is an immutable object that describes a layout, loosely inspired by React.
  */
-@interface ASLayoutSpec : NSObject <ASLayoutElement, ASStackLayoutElement, ASAbsoluteLayoutElement>
+@interface ASLayoutSpec : NSObject <ASLayoutElement>
 
 /** 
  * Creation of a layout spec should only happen by a user in layoutSpecThatFits:. During that method, a
@@ -102,6 +102,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (NSString *)asciiArtStringForChildren:(NSArray *)children parentName:(NSString *)parentName direction:(ASStackLayoutDirection)direction;
 + (NSString *)asciiArtStringForChildren:(NSArray *)children parentName:(NSString *)parentName;
+
+@end
+
+@interface ASLayoutSpec (DeprecatedProtocolMethods)
+
+ASLayoutElementStyleForwardingDeclaration
 
 @end
 

--- a/AsyncDisplayKit/Layout/ASLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASLayoutSpec.h
@@ -105,7 +105,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface ASLayoutSpec (DeprecatedProtocolMethods)
+@interface ASLayoutSpec (Deprecated)
 
 ASLayoutElementStyleForwardingDeclaration
 

--- a/AsyncDisplayKit/Layout/ASLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASLayoutSpec.mm
@@ -262,8 +262,6 @@ ASEnvironmentLayoutExtensibilityForwarding
   return [self layoutThatFits:constrainedSize];
 }
 
-ASLayoutElementStyleForwarding
-
 @end
 
 #pragma mark - ASWrapperLayoutSpec
@@ -359,5 +357,13 @@ ASLayoutElementStyleForwarding
   }
   return string;
 }
+
+@end
+
+#pragma mark - ASLayoutSpec (DeprecatedProtocolMethods)
+
+@implementation ASLayoutSpec (DeprecatedProtocolMethods)
+
+ASLayoutElementStyleForwarding
 
 @end

--- a/AsyncDisplayKit/Layout/ASLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASLayoutSpec.mm
@@ -360,9 +360,9 @@ ASEnvironmentLayoutExtensibilityForwarding
 
 @end
 
-#pragma mark - ASLayoutSpec (DeprecatedProtocolMethods)
+#pragma mark - ASLayoutSpec (Deprecated)
 
-@implementation ASLayoutSpec (DeprecatedProtocolMethods)
+@implementation ASLayoutSpec (Deprecated)
 
 ASLayoutElementStyleForwarding
 

--- a/AsyncDisplayKitTests/ASDisplayNodeTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeTests.m
@@ -17,6 +17,7 @@
 #import "_ASDisplayView.h"
 #import "ASDisplayNode+Subclasses.h"
 #import "ASDisplayNode+FrameworkPrivate.h"
+#import "ASDisplayNode+Deprecated.h"
 #import "ASDisplayNodeTestsHelper.h"
 #import "UIView+ASConvenience.h"
 #import "ASCellNode.h"


### PR DESCRIPTION
- Add deprecations for node / layoutSpec style properties
- Implement missing methods on ASDisplay from deprecation header
- Cleanup all of the deprecation categories