### PR TITLE
Invalidate TextNode Renderer Instead of Changing constrainedSize

### DIFF
--- a/AsyncDisplayKit/ASTextNode.mm
+++ b/AsyncDisplayKit/ASTextNode.mm
@@ -398,7 +398,9 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
   
   _constrainedSize = constrainedSize;
   
-  [self _invalidateRenderer];
+  if (_renderer != nil && CGSizeEqualToSize(constrainedSize, _renderer.constrainedSize) == NO) {
+    [self _invalidateRenderer];
+  }
 
   [self setNeedsDisplay];
   

--- a/AsyncDisplayKit/ASTextNode.mm
+++ b/AsyncDisplayKit/ASTextNode.mm
@@ -354,12 +354,7 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
     // as this would essentially serve to set its constrainedSize to be its calculatedSize (unnecessary).
     ASLayout *layout = self.calculatedLayout;
     if (layout != nil && CGSizeEqualToSize(boundsSize, layout.size)) {
-      if (boundsSize.width != rendererConstrainedSize.width) {
-        // Don't bother changing _constrainedSize, as ASDisplayNode's -measure: method would have a cache miss
-        // and ask us to recalculate layout if it were called with the same calculatedSize that got us to this point!
-        _renderer.constrainedSize = boundsSize;
-      }
-      return NO;
+      return (boundsSize.width != rendererConstrainedSize.width);
     } else {
       return YES;
     }
@@ -382,7 +377,7 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
     
     if (CGSizeEqualToSize(_constrainedSize, layoutSize) == NO) {
       _constrainedSize = layoutSize;
-      _renderer.constrainedSize = layoutSize;
+      [self _invalidateRenderer];
     }
   }
 }
@@ -403,9 +398,7 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
   
   _constrainedSize = constrainedSize;
   
-  // Instead of invalidating the renderer, in case this is a new call with a different constrained size,
-  // just update the size of the NSTextContainer that is owned by the renderer's internal context object.
-  [self _renderer].constrainedSize = _constrainedSize;
+  [self _invalidateRenderer];
 
   [self setNeedsDisplay];
   

--- a/AsyncDisplayKit/TextKit/ASTextKitRenderer.h
+++ b/AsyncDisplayKit/TextKit/ASTextKitRenderer.h
@@ -53,7 +53,7 @@
 
 @property (nonatomic, assign, readonly) ASTextKitAttributes attributes;
 
-@property (nonatomic, assign, readwrite) CGSize constrainedSize;
+@property (nonatomic, assign, readonly) CGSize constrainedSize;
 
 @property (nonatomic, assign, readonly) CGFloat currentScaleFactor;
 

--- a/AsyncDisplayKit/TextKit/ASTextKitRenderer.mm
+++ b/AsyncDisplayKit/TextKit/ASTextKitRenderer.mm
@@ -140,27 +140,6 @@ static NSCharacterSet *_defaultAvoidTruncationCharacterSet()
   return _calculatedSize;
 }
 
-- (void)setConstrainedSize:(CGSize)constrainedSize
-{
-  if (!CGSizeEqualToSize(constrainedSize, _constrainedSize)) {
-    _sizeIsCalculated = NO;
-    _constrainedSize = constrainedSize;
-    _calculatedSize = CGSizeZero;
-    
-    // Throw away the all subcomponents to create them with the new constrained size new as well as let the
-    // truncater do it's job again for the new constrained size. This is necessary as after a truncation did happen
-    // the context would use the truncated string and not the original string to truncate based on the new
-    // constrained size
-
-    ASPerformBackgroundDeallocation(_context);
-    ASPerformBackgroundDeallocation(_truncater);
-    ASPerformBackgroundDeallocation(_fontSizeAdjuster);
-    _context = nil;
-    _truncater = nil;
-    _fontSizeAdjuster = nil;
-  }
-}
-
 - (void)_calculateSize
 {
   // if we have no scale factors or an unconstrained width, there is no reason to try to adjust the font size


### PR DESCRIPTION
Resolves #2515 

Instead of fixing the immediate issue, I decided to make a more substantial change and remove `setConstrainedSize:` from the renderer.

The renderer is meant to be one-shot, and this bug would never have cropped up if we had stuck to that. Changing the constrained size basically gutted the entire renderer anyway, so this change hardly matters.

I've tested this with Pinterest and it resolves the issue nicely.