### PR TITLE
[ASDisplayNode Fix using UIActivityIndicatorView provided via view block

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -495,7 +495,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   }
   
   // Update flags related to special handling of UIImageView layers. More details on the flags
-  if (_flags.synchronous && [_viewClass isSubclassOfClass:[UIImageView class]]) {
+  if (_flags.synchronous && ([_viewClass isSubclassOfClass:[UIImageView class]] || [_viewClass isSubclassOfClass:[UIActivityIndicatorView class]])) {
     _flags.canClearContentsOfLayer = NO;
     _flags.canCallSetNeedsDisplayOfLayer = NO;
   }

--- a/examples/Swift/Sample/TailLoadingCellNode.swift
+++ b/examples/Swift/Sample/TailLoadingCellNode.swift
@@ -40,8 +40,6 @@ final class TailLoadingCellNode: ASCellNode {
 
   override func layoutSpecThatFits(constrainedSize: ASSizeRange) -> ASLayoutSpec {
     
-    spinner.style.flexBasis = ASDimensionMakeWithPoints(0.0)
-    
     return ASStackLayoutSpec(
       direction: .Horizontal,
       spacing: 16,
@@ -59,12 +57,13 @@ final class SpinnerNode: ASDisplayNode {
   override init() {
     super.init(viewBlock: { UIActivityIndicatorView(activityIndicatorStyle: .Gray) }, didLoadBlock: nil)
     
-    
-    self.style.height = ASDimensionMakeWithPoints(44.0)
+    // Set spinner node to default size of the activitiy indicator view
+    self.style.preferredSize = CGSizeMake(20.0, 20.0)
   }
 
   override func didLoad() {
     super.didLoad()
+    
     activityIndicatorView.startAnimating()
   }
 }

--- a/examples/Swift/Sample/ViewController.swift
+++ b/examples/Swift/Sample/ViewController.swift
@@ -55,7 +55,9 @@ final class ViewController: ASViewController, ASTableDataSource, ASTableDelegate
     let rowCount = self.tableNode(tableNode, numberOfRowsInSection: 0)
 
     if state.fetchingMore && indexPath.row == rowCount - 1 {
-      return TailLoadingCellNode()
+      let node = TailLoadingCellNode()
+      node.style.height = ASDimensionMake(44.0)
+      return node;
     }
 
     let node = ASTextCellNode()


### PR DESCRIPTION
While going through our Swift example I discovered some strange behavior if a UIActivityIndicatorView is wrapped in a node via a view block. If the node is get a specific size via `style.preferredSize` it will just show up as a black box.
After looking into it a bit more it seems it has the same problems as an `UIImageView` and it’s not safe to clear the contents of the layer of the view and recreate it by calling `setNeedsDisplay`.

@appleguy @garrettmoon  @Adlai-Holler  Ready for review