### PR TITLE
[Layout] Coalescing setNeedsLayout calls

### DIFF
--- a/AsyncDisplayKit/ASCellNode.mm
+++ b/AsyncDisplayKit/ASCellNode.mm
@@ -121,9 +121,6 @@ static NSMutableSet *__cellClassesForVisibilityNotifications = nil; // See +init
 {
   CGSize oldSize = self.bounds.size;
   [super __setNeedsLayout];
-    
-  // TODO: coalayout: We have to get rid of that
-  [super __layoutIfNeeded];
   
   //Adding this lock because lock used to be held when this method was called. Not sure if it's necessary for
   //didRelayoutFromOldSize:toNewSize:

--- a/AsyncDisplayKit/ASCellNode.mm
+++ b/AsyncDisplayKit/ASCellNode.mm
@@ -119,8 +119,11 @@ static NSMutableSet *__cellClassesForVisibilityNotifications = nil; // See +init
 
 - (void)__setNeedsLayout
 {
-  CGSize oldSize = self.calculatedSize;
+  CGSize oldSize = self.bounds.size;
   [super __setNeedsLayout];
+    
+  // TODO: coalayout: We have to get rid of that
+  [super __layoutIfNeeded];
   
   //Adding this lock because lock used to be held when this method was called. Not sure if it's necessary for
   //didRelayoutFromOldSize:toNewSize:

--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -639,12 +639,19 @@ extern NSInteger const ASDefaultDrawingPriority;
  * Marks the node as needing layout. Convenience for use whether the view / layer is loaded or not. Safe to call from a background thread.
  * 
  * If this node was measured, calling this method triggers an internal relayout: the calculated layout is invalidated,
- * and the supernode is notified or (if this node is the root one) a full measurement pass is executed using the old constrained size.
+ * and the supernode is notified or (if this node is the root one).
  *
  * Note: ASCellNode has special behavior in that calling this method will automatically notify 
  * the containing ASTableView / ASCollectionView that the cell should be resized, if necessary.
  */
 - (void)setNeedsLayout;
+
+/**
+ * Recalculate the receiver’s layout, if required.
+ *
+ * When this message is received, the layer’s super layers are traversed until a ancestor layer is found that does not require layout. Then layout is performed on the entire layer-tree beneath that ancestor.
+ */
+- (void)layoutIfNeeded;
 
 @property (nonatomic, strong, nullable) id contents;                           // default=nil
 @property (nonatomic, assign)           BOOL clipsToBounds;                    // default==NO

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -1501,17 +1501,29 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
   if (node == nil || _asyncDataSource == nil) {
     return;
   }
-  
+
   CGFloat contentViewWidth = tableViewCell.contentView.bounds.size.width;
-  ASSizeRange constrainedSize = node.constrainedSizeForCalculatedLayout;
+  CGSize oldSize = node.bounds.size;
+  const CGSize calculatedSize = [node layoutThatFits:ASSizeRangeMake(CGSizeMake(contentViewWidth, 0),
+                                                                     CGSizeMake(contentViewWidth, CGFLOAT_MAX))].size;
+  node.frame = { .size = calculatedSize };
+
+    // If the node height changed, trigger a height requery.
+  if (oldSize.height != calculatedSize.height) {
+    [self beginUpdates];
+    [self endUpdates];
+  }
+  //CGFloat contentViewWidth = tableViewCell.contentView.bounds.size.width;
+  //CGSize contentViewSize = tableViewCell.contentView.bounds.size;
+  //ASSizeRange constrainedSize = node.constrainedSizeForCalculatedLayout;
   
   // Table view cells should always fill its content view width.
   // Normally the content view width equals to the constrained size width (which equals to the table view width).
   // If there is a mismatch between these values, for example after the table view entered or left editing mode,
   // content view width is preferred and used to re-measure the cell node.
-  if (contentViewWidth != constrainedSize.max.width) {
-    constrainedSize.min.width = contentViewWidth;
-    constrainedSize.max.width = contentViewWidth;
+  //if (contentViewWidth != constrainedSize.max.width) {
+    //constrainedSize.min.width = contentViewWidth;
+    //constrainedSize.max.width = contentViewWidth;
 
     // Re-measurement is done on main to ensure thread affinity. In the worst case, this is as fast as UIKit's implementation.
     //
@@ -1519,16 +1531,22 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     // is the same for all cells (because there is no easy way to get that individual value before the node being assigned to a _ASTableViewCell).
     // Also, in many cases, some nodes may not need to be re-measured at all, such as when user enters and then immediately leaves editing mode.
     // To avoid premature optimization and making such assumption, as well as to keep ASTableView simple, re-measurement is strictly done on main.
-    CGSize oldSize = node.bounds.size;
-    const CGSize calculatedSize = [node layoutThatFits:constrainedSize].size;
-    node.frame = { .size = calculatedSize };
-
+    //CGSize oldSize = node.bounds.size;
+    //const CGSize calculatedSize = [node layoutThatFits:constrainedSize].size;
+    //node.frame = { .size = calculatedSize };
+    
+    // Adjust the node too the calculated size
+    /*const CGSize calculatedSize = node.calculatedSize;
+    if (CGSizeEqualToSize(calculatedSize, node.bounds.size) == NO) {
+      node.frame = { .size = calculatedSize };
+    }*/
+    
     // If the node height changed, trigger a height requery.
-    if (oldSize.height != calculatedSize.height) {
+    /*if (oldSize.height != calculatedSize.height) {
       [self beginUpdates];
       [self endUpdates];
-    }
-  }
+    }*/
+  //}
 }
 
 #pragma mark - ASCellNodeDelegate

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -1501,29 +1501,17 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
   if (node == nil || _asyncDataSource == nil) {
     return;
   }
-
+  
   CGFloat contentViewWidth = tableViewCell.contentView.bounds.size.width;
-  CGSize oldSize = node.bounds.size;
-  const CGSize calculatedSize = [node layoutThatFits:ASSizeRangeMake(CGSizeMake(contentViewWidth, 0),
-                                                                     CGSizeMake(contentViewWidth, CGFLOAT_MAX))].size;
-  node.frame = { .size = calculatedSize };
-
-    // If the node height changed, trigger a height requery.
-  if (oldSize.height != calculatedSize.height) {
-    [self beginUpdates];
-    [self endUpdates];
-  }
-  //CGFloat contentViewWidth = tableViewCell.contentView.bounds.size.width;
-  //CGSize contentViewSize = tableViewCell.contentView.bounds.size;
-  //ASSizeRange constrainedSize = node.constrainedSizeForCalculatedLayout;
+  ASSizeRange constrainedSize = node.constrainedSizeForCalculatedLayout;
   
   // Table view cells should always fill its content view width.
   // Normally the content view width equals to the constrained size width (which equals to the table view width).
   // If there is a mismatch between these values, for example after the table view entered or left editing mode,
   // content view width is preferred and used to re-measure the cell node.
   //if (contentViewWidth != constrainedSize.max.width) {
-    //constrainedSize.min.width = contentViewWidth;
-    //constrainedSize.max.width = contentViewWidth;
+    constrainedSize.min.width = contentViewWidth;
+    constrainedSize.max.width = contentViewWidth;
 
     // Re-measurement is done on main to ensure thread affinity. In the worst case, this is as fast as UIKit's implementation.
     //
@@ -1531,21 +1519,16 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     // is the same for all cells (because there is no easy way to get that individual value before the node being assigned to a _ASTableViewCell).
     // Also, in many cases, some nodes may not need to be re-measured at all, such as when user enters and then immediately leaves editing mode.
     // To avoid premature optimization and making such assumption, as well as to keep ASTableView simple, re-measurement is strictly done on main.
-    //CGSize oldSize = node.bounds.size;
-    //const CGSize calculatedSize = [node layoutThatFits:constrainedSize].size;
-    //node.frame = { .size = calculatedSize };
-    
-    // Adjust the node too the calculated size
-    /*const CGSize calculatedSize = node.calculatedSize;
-    if (CGSizeEqualToSize(calculatedSize, node.bounds.size) == NO) {
-      node.frame = { .size = calculatedSize };
-    }*/
-    
+    CGSize oldSize = node.bounds.size;
+    constrainedSize  = ASSizeRangeMake(CGSizeMake(contentViewWidth, 0), CGSizeMake(contentViewWidth, CGFLOAT_MAX));
+    const CGSize calculatedSize = [node layoutThatFits:constrainedSize].size;
+    node.frame = { .size = calculatedSize };
+
     // If the node height changed, trigger a height requery.
-    /*if (oldSize.height != calculatedSize.height) {
+    if (oldSize.height != calculatedSize.height) {
       [self beginUpdates];
       [self endUpdates];
-    }*/
+    }
   //}
 }
 

--- a/AsyncDisplayKit/ASViewController.mm
+++ b/AsyncDisplayKit/ASViewController.mm
@@ -138,7 +138,9 @@ ASVisibilityDidMoveToParentViewController;
   // We do this early layout because we need to get any ASCollectionNodes etc. into the
   // hierarchy before UIKit applies the scroll view inset adjustments, if you are using
   // automatic subnode management.
-  [_node layoutThatFits:[self nodeConstrainedSize]];
+  ASLayout *l = [_node layoutThatFits:[self nodeConstrainedSize]];
+  _node.frame = (CGRect){.size = l.size};
+  [_node layoutIfNeeded];
 
   [_node recursivelyFetchData];
   

--- a/AsyncDisplayKit/Details/UIView+ASConvenience.h
+++ b/AsyncDisplayKit/Details/UIView+ASConvenience.h
@@ -42,6 +42,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)setNeedsDisplay;
 - (void)setNeedsLayout;
+- (void)layoutIfNeeded;
 
 @end
 

--- a/AsyncDisplayKit/Details/_ASDisplayLayer.mm
+++ b/AsyncDisplayKit/Details/_ASDisplayLayer.mm
@@ -119,14 +119,16 @@
 
 - (void)setNeedsLayout
 {
-  ASDisplayNodeAssertMainThread();
-  [super setNeedsLayout];
+  ASPerformBlockOnMainThread(^{
+    [super setNeedsLayout];
+  });
 }
 
 - (void)layoutIfNeeded
 {
-  ASDisplayNodeAssertMainThread();
-  [super layoutIfNeeded];
+  ASPerformBlockOnMainThread(^{
+    [super layoutIfNeeded];
+  });
 }
 #endif
 

--- a/AsyncDisplayKit/Details/_ASDisplayLayer.mm
+++ b/AsyncDisplayKit/Details/_ASDisplayLayer.mm
@@ -122,6 +122,12 @@
   ASDisplayNodeAssertMainThread();
   [super setNeedsLayout];
 }
+
+- (void)layoutIfNeeded
+{
+  ASDisplayNodeAssertMainThread();
+  [super layoutIfNeeded];
+}
 #endif
 
 - (void)layoutSublayers

--- a/AsyncDisplayKit/Details/_ASDisplayView.mm
+++ b/AsyncDisplayKit/Details/_ASDisplayView.mm
@@ -209,6 +209,13 @@
   [self.layer setNeedsDisplay];
 }
 
+- (void)layoutIfNeeded
+{
+  ASPerformBlockOnMainThread(^{
+    [super layoutIfNeeded];
+  });
+}
+
 - (UIViewContentMode)contentMode
 {
   return ASDisplayNodeUIContentModeFromCAContentsGravity(self.layer.contentsGravity);

--- a/AsyncDisplayKit/Details/_ASDisplayView.mm
+++ b/AsyncDisplayKit/Details/_ASDisplayView.mm
@@ -209,6 +209,13 @@
   [self.layer setNeedsDisplay];
 }
 
+- (void)setNeedsLayout
+{
+  ASPerformBlockOnMainThread(^{
+    [super setNeedsLayout];
+  });
+}
+
 - (void)layoutIfNeeded
 {
   ASPerformBlockOnMainThread(^{

--- a/AsyncDisplayKit/Layout/ASLayoutElement.h
+++ b/AsyncDisplayKit/Layout/ASLayoutElement.h
@@ -83,11 +83,10 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return An ASLayout instance defining the layout of the receiver (and its children, if the box layout model is used).
  *
- * @discussion Though this method does not set the bounds of the view, it does have side effects--caching both the
- * constraint and the result.
+ * @discussion Though this method does not set the bounds of the view it reuses the calculated layout if constrainedSize
+ * or parentSize didn't change.
  *
- * @warning Subclasses must not override this; it caches results from -calculateLayoutThatFits:.  Calling this method may
- * be expensive if result is not cached.
+ * @warning Subclasses must not override this. Calling this method may be expensive if result is not cached.
  *
  * @see [ASDisplayNode(Subclassing) calculateLayoutThatFits:]
  */
@@ -104,8 +103,8 @@ NS_ASSUME_NONNULL_BEGIN
  *                  then it should be passed as ASLayoutElementParentDimensionUndefined (for example, if the parent's width
  *                  depends on the child's size).
  *
- * @discussion Though this method does not set the bounds of the view, it does have side effects--caching both the
- * constraint and the result.
+ * @discussion Though this method does not set the bounds of the view it reuses the calculated layout if constrainedSize
+ * or parentSize didn't change.
  *
  * @return An ASLayout instance defining the layout of the receiver (and its children, if the box layout model is used).
  */

--- a/AsyncDisplayKit/Private/ASDisplayNode+UIViewBridge.mm
+++ b/AsyncDisplayKit/Private/ASDisplayNode+UIViewBridge.mm
@@ -332,7 +332,7 @@ if (shouldApply) { _layer.layerProperty = (layerValueExpr); } else { ASDisplayNo
   BOOL shouldApply = ASDisplayNodeShouldApplyBridgedWriteToView(self);
   if (shouldApply) {
     // The node is loaded and we're on main.
-    // Quite the opposite of setNeedsDisplay, we must call __setNeedsLayout before messaging
+    // Quite the opposite of setNeedsLayout, we must call __setNeedsLayout before messaging
     // the view or layer to ensure that measurement and implicitly added subnodes have been handled.
     
     // Calling __setNeedsLayout while holding the property lock can cause deadlocks

--- a/AsyncDisplayKit/Private/ASDisplayNode+UIViewBridge.mm
+++ b/AsyncDisplayKit/Private/ASDisplayNode+UIViewBridge.mm
@@ -354,6 +354,34 @@ if (shouldApply) { _layer.layerProperty = (layerValueExpr); } else { ASDisplayNo
   }
 }
 
+- (void)layoutIfNeeded
+{
+  _bridge_prologue_write;
+  BOOL shouldApply = ASDisplayNodeShouldApplyBridgedWriteToView(self);
+  if (shouldApply) {
+    // The node is loaded and we're on main.
+    // Quite the opposite of setNeedsDisplay, we must call __setNeedsLayout before messaging
+    // the view or layer to ensure that measurement and implicitly added subnodes have been handled.
+    
+    // Calling __layoutIfNeeded while holding the property lock can cause deadlocks
+    _bridge_prologue_write_unlock;
+    [self __layoutIfNeeded];
+    _bridge_prologue_write;
+    _messageToViewOrLayer(layoutIfNeeded);
+  } else if (__loaded(self)) {
+    // The node is loaded but we're not on main.
+    // We will call [self __setNeedsLayout] when we apply
+    // the pending state. We need to call it on main if the node is loaded
+    // to support implicit hierarchy management.
+    [ASDisplayNodeGetPendingState(self) layoutIfNeeded];
+  } else {
+    // The node is not loaded and we're not on main.
+    _bridge_prologue_write_unlock;
+    [self __layoutIfNeeded];
+    _bridge_prologue_write;
+  }
+}
+
 - (BOOL)isOpaque
 {
   _bridge_prologue_read;

--- a/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
+++ b/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
@@ -206,6 +206,11 @@ FOUNDATION_EXPORT NSString * const ASRenderingEngineDidDisplayNodesScheduledBefo
 - (void)__setNeedsLayout;
 
 /**
+ 
+ */
+- (void)__layoutIfNeeded;
+
+/**
  Invoked after a call to setNeedsDisplay to the underlying view
  */
 - (void)__setNeedsDisplay;

--- a/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
+++ b/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
@@ -137,6 +137,7 @@ FOUNDATION_EXPORT NSString * const ASRenderingEngineDidDisplayNodesScheduledBefo
   int32_t _pendingTransitionID;
   ASLayoutTransition *_pendingLayoutTransition;
   std::shared_ptr<ASDisplayNodeLayout> _calculatedDisplayNodeLayout;
+  std::shared_ptr<ASDisplayNodeLayout> _pendingDisplayNodeLayout;
   
   ASDisplayNodeViewBlock _viewBlock;
   ASDisplayNodeLayerBlock _layerBlock;
@@ -188,12 +189,13 @@ FOUNDATION_EXPORT NSString * const ASRenderingEngineDidDisplayNodesScheduledBefo
 
 + (void)scheduleNodeForRecursiveDisplay:(ASDisplayNode *)node;
 
-// The _ASDisplayLayer backing the node, if any.
+/// The _ASDisplayLayer backing the node, if any.
 @property (nonatomic, readonly, strong) _ASDisplayLayer *asyncLayer;
 
-// Bitmask to check which methods an object overrides.
+/// Bitmask to check which methods an object overrides.
 @property (nonatomic, assign, readonly) ASDisplayNodeMethodOverrides methodOverrides;
 
+/// Thread safe way to access the bounds of the node
 @property (nonatomic, assign) CGRect threadSafeBounds;
 
 
@@ -201,26 +203,39 @@ FOUNDATION_EXPORT NSString * const ASRenderingEngineDidDisplayNodesScheduledBefo
 - (BOOL)__shouldLoadViewOrLayer;
 
 /**
- Invoked before a call to setNeedsLayout to the underlying view
+ * Invoked before a call to setNeedsLayout to the underlying view
  */
 - (void)__setNeedsLayout;
 
 /**
- 
+ * Returns a BOOL indicating whether the layer has been marked as needing a layout update.
+ */
+- (BOOL)__needsLayout;
+
+/**
+ * The node's supernodes are traversed until a ancestor node is found that does not require layout. Then layout
+ * is performed on the entire node-tree beneath that ancestor
  */
 - (void)__layoutIfNeeded;
 
 /**
- Invoked after a call to setNeedsDisplay to the underlying view
+ * Invoked after a call to setNeedsDisplay to the underlying view
  */
 - (void)__setNeedsDisplay;
 
+/**
+ * Called from [CALayer layoutSublayers:]. Executes the layout pass for the node
+ */
 - (void)__layout;
+
+/*
+ *
+ */
 - (void)__setSupernode:(ASDisplayNode *)supernode;
 
 /**
- Internal method to add / replace / insert subnode and remove from supernode without checking if
- node has automaticallyManagesSubnodes set to YES. 
+ * Internal method to add / replace / insert subnode and remove from supernode without checking if
+ * node has automaticallyManagesSubnodes set to YES.
  */
 - (void)_addSubnode:(ASDisplayNode *)subnode;
 - (void)_replaceSubnode:(ASDisplayNode *)oldSubnode withSubnode:(ASDisplayNode *)replacementSubnode;
@@ -235,16 +250,16 @@ FOUNDATION_EXPORT NSString * const ASRenderingEngineDidDisplayNodesScheduledBefo
 - (void)__incrementVisibilityNotificationsDisabled;
 - (void)__decrementVisibilityNotificationsDisabled;
 
-// Helper method to summarize whether or not the node run through the display process
+/// Helper method to summarize whether or not the node run through the display process
 - (BOOL)__implementsDisplay;
 
-// Display the node's view/layer immediately on the current thread, bypassing the background thread rendering. Will be deprecated.
+/// Display the node's view/layer immediately on the current thread, bypassing the background thread rendering. Will be deprecated.
 - (void)displayImmediately;
 
-// Alternative initialiser for backing with a custom view class.  Supports asynchronous display with _ASDisplayView subclasses.
+/// Alternative initialiser for backing with a custom view class.  Supports asynchronous display with _ASDisplayView subclasses.
 - (instancetype)initWithViewClass:(Class)viewClass;
 
-// Alternative initialiser for backing with a custom layer class.  Supports asynchronous display with _ASDisplayLayer subclasses.
+/// Alternative initialiser for backing with a custom layer class.  Supports asynchronous display with _ASDisplayLayer subclasses.
 - (instancetype)initWithLayerClass:(Class)layerClass;
 
 @property (nonatomic, assign) CGFloat contentsScaleForDisplay;

--- a/AsyncDisplayKit/Private/_ASPendingState.mm
+++ b/AsyncDisplayKit/Private/_ASPendingState.mm
@@ -24,6 +24,7 @@ typedef struct {
   // Properties
   int needsDisplay:1;
   int needsLayout:1;
+  int layoutIfNeeded:1;
 
   // Flags indicating that a given property should be applied to the view at creation
   int setClipsToBounds:1;
@@ -270,6 +271,11 @@ static BOOL defaultAllowsEdgeAntialiasing = NO;
 - (void)setNeedsLayout
 {
   _flags.needsLayout = YES;
+}
+
+- (void)layoutIfNeeded
+{
+  _flags.layoutIfNeeded = YES;
 }
 
 - (void)setClipsToBounds:(BOOL)flag
@@ -763,6 +769,9 @@ static BOOL defaultAllowsEdgeAntialiasing = NO;
 
   if (flags.needsLayout)
     [layer setNeedsLayout];
+  
+  if (flags.layoutIfNeeded)
+    [layer layoutIfNeeded];
 
   if (flags.setAsyncTransactionContainer)
     layer.asyncdisplaykit_asyncTransactionContainer = asyncTransactionContainer;
@@ -891,6 +900,9 @@ static BOOL defaultAllowsEdgeAntialiasing = NO;
 
   if (flags.needsLayout)
     [view setNeedsLayout];
+  
+  if (flags.layoutIfNeeded)
+    [view layoutIfNeeded];
 
   if (flags.setAsyncTransactionContainer)
     view.asyncdisplaykit_asyncTransactionContainer = asyncTransactionContainer;
@@ -1105,6 +1117,7 @@ static BOOL defaultAllowsEdgeAntialiasing = NO;
   || flags.setEdgeAntialiasingMask
   || flags.needsDisplay
   || flags.needsLayout
+  || flags.layoutIfNeeded
   || flags.setAsyncTransactionContainer
   || flags.setOpaque
   || flags.setIsAccessibilityElement

--- a/AsyncDisplayKitTests/ASDisplayNodeImplicitHierarchyTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeImplicitHierarchyTests.m
@@ -16,6 +16,8 @@
 #import "ASDisplayNode+Beta.h"
 #import "ASDisplayNode+Subclasses.h"
 
+#import "ASLayout.h"
+
 #import "ASAbsoluteLayoutSpec.h"
 #import "ASStackLayoutSpec.h"
 #import "ASInsetLayoutSpec.h"
@@ -88,7 +90,10 @@
     
     return [ASAbsoluteLayoutSpec absoluteLayoutSpecWithChildren:@[stack1, stack2, node5]];
   };
-  [node layoutThatFits:ASSizeRangeMake(CGSizeZero)];
+  ASLayout *l = [node layoutThatFits:ASSizeRangeMake(CGSizeZero, CGSizeMake(INFINITY, INFINITY))];
+  node.frame = (CGRect){.size = l.size};
+  [node layoutIfNeeded];
+  
   XCTAssertEqual(node.subnodes[0], node5);
   XCTAssertEqual(node.subnodes[1], node1);
   XCTAssertEqual(node.subnodes[2], node2);
@@ -122,13 +127,17 @@
     }
   };
   
-  [node layoutThatFits:ASSizeRangeMake(CGSizeZero)];
+  ASLayout *l = [node layoutThatFits:ASSizeRangeMake(CGSizeZero, CGSizeMake(INFINITY, INFINITY))];
+  node.frame = (CGRect){.size = l.size};
+  [node layoutIfNeeded];
   XCTAssertEqual(node.subnodes[0], node1);
   XCTAssertEqual(node.subnodes[1], node2);
   
   node.layoutState = @2;
-  [node invalidateCalculatedLayout];
-  [node layoutThatFits:ASSizeRangeMake(CGSizeZero)];
+  l = [node layoutThatFits:ASSizeRangeMake(CGSizeZero, CGSizeMake(INFINITY, INFINITY))];
+  node.frame = (CGRect){.size = l.size};
+  [node setNeedsLayout];
+  [node layoutIfNeeded];
 
   XCTAssertEqual(node.subnodes[0], node1);
   XCTAssertEqual(node.subnodes[1], node3);
@@ -191,12 +200,15 @@
   
   dispatch_async(dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
     
-    [node layoutThatFits:ASSizeRangeMake(CGSizeZero)];
+    ASLayout *l = [node layoutThatFits:ASSizeRangeMake(CGSizeZero, CGSizeMake(INFINITY, INFINITY))];
+    node.frame = (CGRect){.size = l.size};
     XCTAssertEqual(node.subnodes[0], node1);
     
     node.layoutState = @2;
-    [node invalidateCalculatedLayout];
-    [node layoutThatFits:ASSizeRangeMake(CGSizeZero)];
+    l = [node layoutThatFits:ASSizeRangeMake(CGSizeZero, CGSizeMake(INFINITY, INFINITY))];
+    node.frame = (CGRect){.size = l.size};
+    [node setNeedsLayout];
+    [node layoutIfNeeded];
     
     // Dispatch back to the main thread to let the insertion / deletion of subnodes happening
     dispatch_async(dispatch_get_main_queue(), ^{

--- a/AsyncDisplayKitTests/ASDisplayNodeSnapshotTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeSnapshotTests.m
@@ -28,7 +28,8 @@
   node.layoutSpecBlock = ^(ASDisplayNode * _Nonnull node, ASSizeRange constrainedSize) {
     return [ASInsetLayoutSpec insetLayoutSpecWithInsets:UIEdgeInsetsMake(5, 5, 5, 5) child:subnode];
   };
-  [node layoutThatFits:ASSizeRangeMake(CGSizeZero, CGSizeMake(100, 100))];
+  ASLayout *l = [node layoutThatFits:ASSizeRangeMake(CGSizeZero, CGSizeMake(100, 100))];
+  node.frame = (CGRect){.size = l.size};
 
   ASSnapshotVerifyNode(node, nil);
 }

--- a/AsyncDisplayKitTests/ASImageNodeSnapshotTests.m
+++ b/AsyncDisplayKitTests/ASImageNodeSnapshotTests.m
@@ -30,7 +30,9 @@
   // trivial test case to ensure ASSnapshotTestCase works
   ASImageNode *imageNode = [[ASImageNode alloc] init];
   imageNode.image = [self testImage];
-  [imageNode layoutThatFits:ASSizeRangeMake(CGSizeZero, CGSizeMake(100, 100))];
+  ASLayout *l = [imageNode layoutThatFits:ASSizeRangeMake(CGSizeZero, CGSizeMake(100, 100))];
+  imageNode.frame = (CGRect){.size = l.size};
+  [imageNode layoutIfNeeded];
 
   ASSnapshotVerifyNode(imageNode, nil);
 }
@@ -46,12 +48,16 @@
   // Snapshot testing requires that node is formally laid out.
   imageNode.style.width = ASDimensionMake(forcedImageSize.width);
   imageNode.style.height = ASDimensionMake(forcedImageSize.height);
-  [imageNode layoutThatFits:ASSizeRangeMake(CGSizeZero, forcedImageSize)];
+  ASLayout *l = [imageNode layoutThatFits:ASSizeRangeMake(CGSizeZero, forcedImageSize)];
+  imageNode.frame = (CGRect){.size = l.size};
+  [imageNode layoutIfNeeded];
   ASSnapshotVerifyNode(imageNode, @"first");
   
   imageNode.style.width = ASDimensionMake(200);
   imageNode.style.height = ASDimensionMake(200);
-  [imageNode layoutThatFits:ASSizeRangeMake(CGSizeZero, CGSizeMake(200, 200))];
+  l = [imageNode layoutThatFits:ASSizeRangeMake(CGSizeZero, CGSizeMake(200, 200))];
+  imageNode.frame = (CGRect){.size = l.size};
+  [imageNode layoutIfNeeded];
   
   ASSnapshotVerifyNode(imageNode, @"second");
   
@@ -66,7 +72,9 @@
   UIImage *tinted = ASImageNodeTintColorModificationBlock([UIColor redColor])(test);
   ASImageNode *node = [[ASImageNode alloc] init];
   node.image = tinted;
-  [node layoutThatFits:ASSizeRangeMake(test.size)];
+  ASLayout *l = [node layoutThatFits:ASSizeRangeMake(test.size)];
+  node.frame = (CGRect){.size = l.size};
+  [node layoutIfNeeded];
   
   ASSnapshotVerifyNode(node, nil);
 }
@@ -81,7 +89,9 @@
   UIImage *rounded = ASImageNodeRoundBorderModificationBlock(2, [UIColor redColor])(result);
   ASImageNode *node = [[ASImageNode alloc] init];
   node.image = rounded;
-  [node layoutThatFits:ASSizeRangeMake(rounded.size)];
+  ASLayout *l = [node layoutThatFits:ASSizeRangeMake(rounded.size)];
+  node.frame = (CGRect){.size = l.size};
+  [node layoutIfNeeded];
   
   ASSnapshotVerifyNode(node, nil);
 }

--- a/AsyncDisplayKitTests/ASLayoutSpecSnapshotTestsHelper.m
+++ b/AsyncDisplayKitTests/ASLayoutSpecSnapshotTestsHelper.m
@@ -39,7 +39,8 @@
   
   node.layoutSpecUnderTest = layoutSpec;
   
-  [node layoutThatFits:sizeRange];
+  ASLayout *layout = [node layoutThatFits:sizeRange];
+  node.bounds = CGRectMake(0, 0, layout.size.width, layout.size.height);
   ASSnapshotVerifyNode(node, identifier);
 }
 

--- a/AsyncDisplayKitTests/ASSnapshotTestCase.m
+++ b/AsyncDisplayKitTests/ASSnapshotTestCase.m
@@ -37,8 +37,10 @@ NSOrderedSet *ASSnapshotTestCaseDefaultSuffixes(void)
 
 + (void)hackilySynchronouslyRecursivelyRenderNode:(ASDisplayNode *)node
 {
-  ASDisplayNodeAssertNotNil(node.calculatedLayout, @"Node %@ must be measured before it is rendered.", node);
-  node.bounds = (CGRect) { .size = node.calculatedSize };
+  //[node layoutIfNeeded];
+  //ASDisplayNodeAssertNotNil(node.calculatedLayout, @"Node %@ must be measured before it is rendered.", node);
+  
+  //node.bounds = (CGRect) { .size = node.calculatedSize };
   ASDisplayNodePerformBlockOnEveryNode(nil, node, YES, ^(ASDisplayNode * _Nonnull node) {
     [node.layer setNeedsDisplay];
   });

--- a/AsyncDisplayKitTests/ASTextNodeSnapshotTests.m
+++ b/AsyncDisplayKitTests/ASTextNodeSnapshotTests.m
@@ -25,8 +25,10 @@
   ASTextNode *textNode = [[ASTextNode alloc] init];
   textNode.attributedText = [[NSAttributedString alloc] initWithString:@"judar"
                                                             attributes:@{NSFontAttributeName : [UIFont italicSystemFontOfSize:24]}];
-  [textNode layoutThatFits:ASSizeRangeMake(CGSizeZero, CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX))];
   textNode.textContainerInset = UIEdgeInsetsMake(0, 2, 0, 2);
+  
+  ASLayout *l = [textNode layoutThatFits:ASSizeRangeMake(CGSizeZero, CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX))];
+  textNode.frame = (CGRect){.origin = {0, 0}, .size = l.size};
   
   ASSnapshotVerifyNode(textNode, nil);
 }
@@ -39,10 +41,10 @@
   ASTextNode *textNode = [[ASTextNode alloc] init];
   textNode.attributedText = [[NSAttributedString alloc] initWithString:@"judar judar judar judar judar judar"
                                                             attributes:@{ NSFontAttributeName : [UIFont systemFontOfSize:30] }];
-  
-  [textNode layoutThatFits:ASSizeRangeMake(CGSizeZero, CGSizeMake(100, 80))];
-  textNode.frame = CGRectMake(50, 50, textNode.calculatedSize.width, textNode.calculatedSize.height);
   textNode.textContainerInset = UIEdgeInsetsMake(10, 10, 10, 10);
+  
+  ASLayout *l = [textNode layoutThatFits:ASSizeRangeMake(CGSizeZero, CGSizeMake(100, 80))];
+  textNode.frame = CGRectMake(50, 50, l.size.width, l.size.height);
 
   [backgroundView addSubview:textNode.view];
   backgroundView.frame = UIEdgeInsetsInsetRect(textNode.bounds, UIEdgeInsetsMake(-50, -50, -50, -50));
@@ -61,10 +63,10 @@
   ASTextNode *textNode = [[ASTextNode alloc] init];
   textNode.attributedText = [[NSAttributedString alloc] initWithString:@"yolo"
                                                             attributes:@{ NSFontAttributeName : [UIFont systemFontOfSize:30] }];
-
-  [textNode layoutThatFits:ASSizeRangeMake(CGSizeZero, CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX))];
-  textNode.frame = CGRectMake(50, 50, textNode.calculatedSize.width, textNode.calculatedSize.height);
   textNode.textContainerInset = UIEdgeInsetsMake(5, 10, 10, 5);
+
+  ASLayout *l = [textNode layoutThatFits:ASSizeRangeMake(CGSizeZero, CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX))];
+  textNode.frame = CGRectMake(50, 50, l.size.width, l.size.height);
 
   [backgroundView addSubview:textNode.view];
   backgroundView.frame = UIEdgeInsetsInsetRect(textNode.bounds, UIEdgeInsetsMake(-50, -50, -50, -50));
@@ -80,7 +82,9 @@
 {
   ASTextNode *textNode = [[ASTextNode alloc] init];
   textNode.attributedText = [[NSAttributedString alloc] initWithString:@"Quality is Important" attributes:@{ NSForegroundColorAttributeName: [UIColor blueColor], NSFontAttributeName: [UIFont italicSystemFontOfSize:24] }];
-  [textNode layoutThatFits:ASSizeRangeMake(CGSizeZero, CGSizeMake(100, 50))];
+  ASLayout *l = [textNode layoutThatFits:ASSizeRangeMake(CGSizeZero, CGSizeMake(100, 50))];
+  textNode.frame = CGRectMake(0, 0, l.size.width, l.size.height);
+  
   ASSnapshotVerifyNode(textNode, nil);
 }
 
@@ -88,6 +92,10 @@
 {
   ASTextNode *textNode = [[ASTextNode alloc] init];
   textNode.attributedText = [[NSAttributedString alloc] initWithString:@"Quality is Important" attributes:@{ NSForegroundColorAttributeName: [UIColor blueColor], NSFontAttributeName: [UIFont italicSystemFontOfSize:24] }];
+
+  ASLayout *l = [textNode layoutThatFits:ASSizeRangeMake(CGSizeZero, CGSizeMake(100, 50))];
+  textNode.frame = CGRectMake(0, 0, l.size.width, l.size.height);
+  
   // Set exclusion paths to trigger slow path
   textNode.exclusionPaths = @[ [UIBezierPath bezierPath] ];
   [textNode layoutThatFits:ASSizeRangeMake(CGSizeZero, CGSizeMake(100, 50))];
@@ -102,7 +110,10 @@
   textNode.shadowOpacity = 0.3;
   textNode.shadowRadius = 3;
   textNode.shadowOffset = CGSizeMake(0, 1);
-  [textNode layoutThatFits:ASSizeRangeMake(CGSizeZero, CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX))];
+  ASLayout *l = [textNode layoutThatFits:ASSizeRangeMake(CGSizeZero, CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX))];
+  textNode.frame = CGRectMake(0, 0, l.size.width, l.size.height);
+  
+  
   ASSnapshotVerifyNode(textNode, nil);
 }
 

--- a/examples/ASDKLayoutTransition/Sample/ViewController.m
+++ b/examples/ASDKLayoutTransition/Sample/ViewController.m
@@ -61,11 +61,7 @@
   
   _buttonNode = [[ASButtonNode alloc] init];
   [_buttonNode setTitle:buttonTitle withFont:buttonFont withColor:buttonColor forState:ASControlStateNormal];
-  
-  // Note: Currently we have to set all the button properties to the same one as for ASControlStateNormal. Otherwise
-  //       if the button is involved in the layout transition it would break the transition as it does a layout pass
-  //       while changing the title. This needs and will be fixed in the future!
-  [_buttonNode setTitle:buttonTitle withFont:buttonFont withColor:buttonColor forState:ASControlStateHighlighted];
+  [_buttonNode setTitle:buttonTitle withFont:buttonFont withColor:[buttonColor colorWithAlphaComponent:0.5] forState:ASControlStateHighlighted];
   
   
   // Some debug colors
@@ -80,7 +76,7 @@
 {
   [super didLoad];
   
-  [self.buttonNode addTarget:self action:@selector(buttonPressed:) forControlEvents:ASControlNodeEventTouchDown];
+  [self.buttonNode addTarget:self action:@selector(buttonPressed:) forControlEvents:ASControlNodeEventTouchUpInside];
 }
 
 #pragma mark - Actions
@@ -89,7 +85,16 @@
 {
   self.enabled = !self.enabled;
   
-  [self transitionLayoutWithAnimation:YES shouldMeasureAsync:NO measurementCompletion:nil];
+  // Example for a layout transition that will use the old constrained size and *not* resize itself
+  // [self transitionLayoutWithAnimation:YES shouldMeasureAsync:NO measurementCompletion:nil];
+  
+  // Example for a layout transition that will also resize the node itself
+  ASSizeRange constrainedSize = ASSizeRangeMake(CGSizeMake(self.bounds.size.width, 0.0),
+                                                CGSizeMake(self.bounds.size.width, CGFLOAT_MAX));
+  [self transitionLayoutWithSizeRange:constrainedSize
+                             animated:YES
+                   shouldMeasureAsync:NO
+                measurementCompletion:nil];
 }
 
 


### PR DESCRIPTION

## Current Problems

1. Currently `-[ASDisplayNode setNeedsLayout]` changes the node's size.  That's very different from the UIKit-equivalent method; UIKit never changes the view's size whose `-[UIView layoutSubviews]` is being invoked (its subviews might change sizes, but never the view itself, unless you do it yourself explicitly in the subclass). 
2. The behavior in 1) is troublesome because sometimes the the root-node should not resize itself to the size that's returned by its `-[ASDisplayNode layoutThatFits:]` (or `-[UIView sizeThatFits:]` in UIKit is just that) that just about fits the content - that's the definition by UIKit anyway; it can be different from the size that actually want the node to be. If the root node is a full-screen node with subnodes, it can happen that the fullscreen node's frames changes based on the content, but as the intention for  this node was to be a full-screen node this should never happen. If a node should resize to just fit its content, there should be a method like `[UIView sizeToFit]` ; it's not expected that `-[ASDisplayNode setNeedsLayout]` to be doing this job.
3. Calling `-[ASDisplayNode layoutThatFits:]` explicitly before calling `-[ASDisplayNode setNeedsLayout]`, then `-[ASDisplayNode setNeedsLayout]` just discards the old layout and calls `-[ASDisplayNode layoutThatFits:]` on its own again.

##  Planned Changes

1. **The size of the node is expected to be handled / updated by the node's owner / supernode.**
2. `-[ASDisplaynode layoutThatFits:]`  Does not cache any layout anymore. It performs a measurement pass and calculates a layout based on the given constrained size. This will be assigned as `pendingLayout` and returned.
3. `-[ASDisplayNode setNeedsLayout]`  marks the receive's layout as invalid. This allows layout to happen in the next layout pass before the drawing cycle happens.
4. Layout of subnodes are happening in the layout pass (`-[ASDisplayNode __layout]`) based on `-[ASDisplayNode bounds]`  as `constrainedSize`.
5. An `-[ASDisplayNode bounds]` change can has multiple routes:
  1. Can trigger a measurement pass (`-[ASDisplayNode layoutThatFits:]`) in the next layout pass (`-[ASDisplayNode __layout]`) in case the node's bounds does not equal the cached layout's constrained size or the layout was marked invalid before.
  2. Should invalidate the layout of itself if the bounds changed  or was explicitly set on, as well as invalidate the layout of the supernode. This is the behavior of UIKit. By changing the `frame` / `boudns` of a UIView, `layoutSublayersOfLayer` and eventually `layoutSubviews`  will be called on the superview and the view.
6. `-[ASDisplayNode layoutIfNeeded]` should be added  lays out the subnodes immediately and does not wait until the next layout pass is happening.
7. `-[ASDisplayNode sizeToFit]` resizes and moves the receiver node so it just encloses its subnodes.
8. `-[ASDisplayNode invalidateCalculatedLayout]` should be removed (deprecated) as it's basically the same as `-[ASDisplayNode setNeedsLayout]` now.

## TODOS:
- [ ] Splitting up measurement and layout pass
- [ ] Automatic cell sizing in `ASTableView`
- [ ] Automatic cell sizing in `ASCollectionView`
- [ ] Search for `TODO: coalayout:` in code base for open tasks left
- [ ] Add / Adjust unit tests
- [ ] Change sample apps
- [ ] Move layout code to a central place like `ASDisplayNode+Layout.mm`