### PR TITLE
[ASControlNode] Implementation needs to match decleration.

### DIFF
--- a/AsyncDisplayKit/Private/ASControlTargetAction.m
+++ b/AsyncDisplayKit/Private/ASControlTargetAction.m
@@ -12,7 +12,7 @@
 
 @implementation ASControlTargetAction
 {
-  id _target;
+  __weak id _target;
   BOOL _createdWithNoTarget;
 }
 


### PR DESCRIPTION
This could have been… bad. It's amazing that Xcode doesn't get angry about this :(