### PR TITLE
Reduce Flashing & Optimize ASTableNode/ASCollectionNode Data Loading

### DIFF
--- a/AsyncDisplayKit/Details/ASDataController.mm
+++ b/AsyncDisplayKit/Details/ASDataController.mm
@@ -431,6 +431,15 @@ NSString * const ASDataControllerRowNodeKind = @"_ASDataControllerRowNodeKind";
   dispatch_group_async(_editingTransactionGroup, _editingTransactionQueue, ^{
     LOG(@"Edit Transaction - reloadData");
     
+    /**
+     * Leave the current data in the collection view until the first batch of nodes are laid out.
+     * Once the first batch is laid out, in one operation, replace all the sections and insert
+     * the first batch of items.
+     *
+     * We previously would replace all the sections immediately, and then start adding items as they
+     * were laid out. This resulted in more traffic to the UICollectionView and it also caused all the
+     * section headers to bunch up until the items come and fill out the sections.
+     */
     __block BOOL isFirstBatch = YES;
     [self batchLayoutNodesFromContexts:newContexts batchCompletion:^(NSArray<ASCellNode *> *nodes, NSArray<NSIndexPath *> *indexPaths) {
       if (isFirstBatch) {

--- a/AsyncDisplayKit/Details/ASDataController.mm
+++ b/AsyncDisplayKit/Details/ASDataController.mm
@@ -140,6 +140,11 @@ NSString * const ASDataControllerRowNodeKind = @"_ASDataControllerRowNodeKind";
 #if AS_MEASURE_AVOIDED_DATACONTROLLER_WORK
     [ASDataController _expectToInsertNodes:contexts.count];
 #endif
+  
+  if (contexts.count == 0) {
+    batchCompletionHandler(@[], @[]);
+    return;
+  }
 
   ASProfilingSignpostStart(2, _dataSource);
   
@@ -426,38 +431,44 @@ NSString * const ASDataControllerRowNodeKind = @"_ASDataControllerRowNodeKind";
   dispatch_group_async(_editingTransactionGroup, _editingTransactionQueue, ^{
     LOG(@"Edit Transaction - reloadData");
     
-    // Remove everything that existed before the reload, now that we're ready to insert replacements
-    NSUInteger oldSectionCount = [_editingNodes[ASDataControllerRowNodeKind] count];
-
-    // If we have old sections, we should delete them inside beginUpdates/endUpdates with inserting the new ones.
-    if (oldSectionCount) {
-      // -beginUpdates
-      [_mainSerialQueue performBlockOnMainThread:^{
-        [_delegate dataControllerBeginUpdates:self];
-      }];
-
-      NSIndexSet *indexSet = [[NSIndexSet alloc] initWithIndexesInRange:NSMakeRange(0, oldSectionCount)];
-      [self _deleteSectionsAtIndexSet:indexSet withAnimationOptions:animationOptions];
-    }
+    __block BOOL isFirstBatch = YES;
+    [self batchLayoutNodesFromContexts:newContexts batchCompletion:^(NSArray<ASCellNode *> *nodes, NSArray<NSIndexPath *> *indexPaths) {
+      if (isFirstBatch) {
+        // -beginUpdates
+        [_mainSerialQueue performBlockOnMainThread:^{
+          [_delegate dataControllerBeginUpdates:self];
+        }];
+        
+        // deleteSections:
+        // Remove everything that existed before the reload, now that we're ready to insert replacements
+        NSUInteger oldSectionCount = [_editingNodes[ASDataControllerRowNodeKind] count];
+        if (oldSectionCount) {
+          NSIndexSet *indexSet = [[NSIndexSet alloc] initWithIndexesInRange:NSMakeRange(0, oldSectionCount)];
+          [self _deleteSectionsAtIndexSet:indexSet withAnimationOptions:animationOptions];
+        }
+        
+        [self willReloadDataWithSectionCount:sectionCount];
+        
+        // insertSections:
+        NSMutableArray *sections = [NSMutableArray arrayWithCapacity:sectionCount];
+        for (int i = 0; i < sectionCount; i++) {
+          [sections addObject:[[NSMutableArray alloc] init]];
+        }
+        [self _insertSections:sections atIndexSet:sectionIndexes withAnimationOptions:animationOptions];
+      }
+      
+      // insertItemsAtIndexPaths:
+      [self _insertNodes:nodes atIndexPaths:indexPaths withAnimationOptions:animationOptions];
+      
+      if (isFirstBatch) {
+        // -endUpdates
+        [_mainSerialQueue performBlockOnMainThread:^{
+          [_delegate dataController:self endUpdatesAnimated:NO completion:nil];
+        }];
+        isFirstBatch = NO;
+      }
+    }];
     
-    [self willReloadDataWithSectionCount:sectionCount];
-    
-    // Insert empty sections
-    NSMutableArray *sections = [NSMutableArray arrayWithCapacity:sectionCount];
-    for (int i = 0; i < sectionCount; i++) {
-      [sections addObject:[[NSMutableArray alloc] init]];
-    }
-    [self _insertSections:sections atIndexSet:sectionIndexes withAnimationOptions:animationOptions];
-
-    if (oldSectionCount) {
-      // -endUpdates
-      [_mainSerialQueue performBlockOnMainThread:^{
-        [_delegate dataController:self endUpdatesAnimated:NO completion:nil];
-      }];
-    }
-    
-    [self _batchLayoutAndInsertNodesFromContexts:newContexts withAnimationOptions:animationOptions];
-
     if (completion) {
       [_mainSerialQueue performBlockOnMainThread:completion];
     }

--- a/AsyncDisplayKitTests/ASTableViewTests.m
+++ b/AsyncDisplayKitTests/ASTableViewTests.m
@@ -592,8 +592,10 @@
   // Assert that the beginning of the call pattern is correct.
   // There is currently noise that comes after that we will allow for this test.
   NSArray *expectedSelectors = @[ NSStringFromSelector(@selector(reloadData)),
+                                  NSStringFromSelector(@selector(beginUpdates)),
                                   NSStringFromSelector(@selector(insertSections:withRowAnimation:)),
-                                  NSStringFromSelector(@selector(insertRowsAtIndexPaths:withRowAnimation:))];
+                                  NSStringFromSelector(@selector(insertRowsAtIndexPaths:withRowAnimation:)),
+                                  NSStringFromSelector(@selector(endUpdates))];
   NSArray *firstSelectors = [selectors subarrayWithRange:NSMakeRange(0, expectedSelectors.count)];
   XCTAssertEqualObjects(firstSelectors, expectedSelectors);
 
@@ -627,8 +629,8 @@
                                  NSStringFromSelector(@selector(beginUpdates)),
                                  NSStringFromSelector(@selector(deleteSections:withRowAnimation:)),
                                  NSStringFromSelector(@selector(insertSections:withRowAnimation:)),
-                                 NSStringFromSelector(@selector(endUpdates)),
-                                 NSStringFromSelector(@selector(insertRowsAtIndexPaths:withRowAnimation:))];
+                                 NSStringFromSelector(@selector(insertRowsAtIndexPaths:withRowAnimation:)),
+                                 NSStringFromSelector(@selector(endUpdates))];
   NSArray *firstSelectors = [selectors subarrayWithRange:NSMakeRange(0, expectedSelectors.count)];
   XCTAssertEqualObjects(firstSelectors, expectedSelectors);
 


### PR DESCRIPTION
Issuing updates to `UICollectionView` is one of the most expensive operations we perform.

This diff combines the section-delete, section-insert, and first-batch-of-rows-insert operations during initial data load & reload data. This will fix flashing in cases where the first batch of items covers the visible area, and it will reduce the total number of UIKit update operations we perform.