### PR TITLE
[ASCollectionViewLayoutInspecting] make -scrollableDirections  required

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -1115,27 +1115,6 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   return direction;
 }
 
-- (ASScrollDirection)scrollableDirections
-{
-  //Cache results of layoutInspector to ensure flags are up to date if getter lazily loads a new one.
-  id<ASCollectionViewLayoutInspecting> layoutInspector = self.layoutInspector;
-  if (_layoutInspectorFlags.scrollableDirections) {
-    return [layoutInspector scrollableDirections];
-  } else {
-    ASScrollDirection scrollableDirection = ASScrollDirectionNone;
-    CGFloat totalContentWidth = self.contentSize.width + self.contentInset.left + self.contentInset.right;
-    CGFloat totalContentHeight = self.contentSize.height + self.contentInset.top + self.contentInset.bottom;
-    
-    if (self.alwaysBounceHorizontal || totalContentWidth > self.bounds.size.width) { // Can scroll horizontally.
-      scrollableDirection |= ASScrollDirectionHorizontalDirections;
-    }
-    if (self.alwaysBounceVertical || totalContentHeight > self.bounds.size.height) { // Can scroll vertically.
-      scrollableDirection |= ASScrollDirectionVerticalDirections;
-    }
-    return scrollableDirection;
-  }
-}
-
 - (ASScrollDirection)flowLayoutScrollableDirections:(UICollectionViewFlowLayout *)flowLayout {
   return (flowLayout.scrollDirection == UICollectionViewScrollDirectionHorizontal) ? ASScrollDirectionHorizontalDirections : ASScrollDirectionVerticalDirections;
 }

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -212,7 +212,6 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   struct {
     unsigned int didChangeCollectionViewDataSource:1;
     unsigned int didChangeCollectionViewDelegate:1;
-	unsigned int scrollableDirections:1;
   } _layoutInspectorFlags;
 }
 
@@ -515,7 +514,6 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   
   _layoutInspectorFlags.didChangeCollectionViewDataSource = [_layoutInspector respondsToSelector:@selector(didChangeCollectionViewDataSource:)];
   _layoutInspectorFlags.didChangeCollectionViewDelegate = [_layoutInspector respondsToSelector:@selector(didChangeCollectionViewDelegate:)];
-  _layoutInspectorFlags.scrollableDirections = [_layoutInspector respondsToSelector:@selector(scrollableDirections)];
 }
 
 - (void)setTuningParameters:(ASRangeTuningParameters)tuningParameters forRangeType:(ASLayoutRangeType)rangeType
@@ -1113,6 +1111,11 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   }
   
   return direction;
+}
+
+- (ASScrollDirection)scrollableDirections
+{
+  return [self.layoutInspector scrollableDirections];
 }
 
 - (ASScrollDirection)flowLayoutScrollableDirections:(UICollectionViewFlowLayout *)flowLayout {

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -1115,7 +1115,8 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
 
 - (ASScrollDirection)scrollableDirections
 {
-  return [self.layoutInspector scrollableDirections];
+  ASDisplayNodeAssertNotNil(_layoutInspector, @"Layout inspector should be assigned.");
+  return [_layoutInspector scrollableDirections];
 }
 
 - (ASScrollDirection)flowLayoutScrollableDirections:(UICollectionViewFlowLayout *)flowLayout {

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -1115,8 +1115,8 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
 
 - (ASScrollDirection)scrollableDirections
 {
-  ASDisplayNodeAssertNotNil(_layoutInspector, @"Layout inspector should be assigned.");
-  return [_layoutInspector scrollableDirections];
+  ASDisplayNodeAssertNotNil(self.layoutInspector, @"Layout inspector should be assigned.");
+  return [self.layoutInspector scrollableDirections];
 }
 
 - (ASScrollDirection)flowLayoutScrollableDirections:(UICollectionViewFlowLayout *)flowLayout {
@@ -1655,6 +1655,9 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
  */
 - (void)layer:(CALayer *)layer didChangeBoundsWithOldValue:(CGRect)oldBounds newValue:(CGRect)newBounds
 {
+  if (self.collectionViewLayout == nil) {
+    return;
+  }
   CGSize lastUsedSize = _lastBoundsSizeUsedForMeasuringNodes;
   if (CGSizeEqualToSize(lastUsedSize, newBounds.size)) {
     return;

--- a/AsyncDisplayKit/Details/ASCollectionViewFlowLayoutInspector.h
+++ b/AsyncDisplayKit/Details/ASCollectionViewFlowLayoutInspector.h
@@ -27,6 +27,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (ASSizeRange)collectionView:(ASCollectionView *)collectionView constrainedSizeForNodeAtIndexPath:(NSIndexPath *)indexPath;
 
+/**
+ * Return the directions in which your collection view can scroll
+ */
+- (ASScrollDirection)scrollableDirections;
+
 @optional
 
 /**
@@ -52,11 +57,6 @@ NS_ASSUME_NONNULL_BEGIN
  * @discussion A great time to update perform selector caches!
  */
 - (void)didChangeCollectionViewDataSource:(nullable id<ASCollectionDataSource>)dataSource;
-
-/**
- * Return the directions in which your collection view can scroll
- */
-- (ASScrollDirection)scrollableDirections;
 
 #pragma mark Deprecated Methods
 

--- a/AsyncDisplayKit/Details/ASCollectionViewFlowLayoutInspector.m
+++ b/AsyncDisplayKit/Details/ASCollectionViewFlowLayoutInspector.m
@@ -36,6 +36,7 @@ static inline ASSizeRange NodeConstrainedSizeForScrollDirection(ASCollectionView
   struct {
     unsigned int implementsConstrainedSizeForNodeAtIndexPathDeprecated:1;
     unsigned int implementsConstrainedSizeForNodeAtIndexPath:1;
+    unsigned int implementsScrollableDirections:1;
   } _delegateFlags;
 }
 
@@ -59,6 +60,7 @@ static inline ASSizeRange NodeConstrainedSizeForScrollDirection(ASCollectionView
   } else {
     _delegateFlags.implementsConstrainedSizeForNodeAtIndexPathDeprecated = [delegate respondsToSelector:@selector(collectionView:constrainedSizeForNodeAtIndexPath:)];
     _delegateFlags.implementsConstrainedSizeForNodeAtIndexPath = [delegate respondsToSelector:@selector(collectionNode:constrainedSizeForItemAtIndexPath:)];
+    _delegateFlags.implementsScrollableDirections = [delegate respondsToSelector:@selector(scrollableDirections)];
   }
 }
 
@@ -77,6 +79,16 @@ static inline ASSizeRange NodeConstrainedSizeForScrollDirection(ASCollectionView
   }
   
   return NodeConstrainedSizeForScrollDirection(collectionView);
+}
+
+- (ASScrollDirection)scrollableDirections
+{
+  if (_delegateFlags.implementsScrollableDirections) {
+    return [self scrollableDirections];
+  } else {
+    ASDisplayNodeAssert([self respondsToSelector:@selector(scrollableDirections)] == NO, @"As of the 2.0 release, -scrollableDirections is a required method for the layoutInspector.");
+  }
+  return ASScrollDirectionVerticalDirections;
 }
 
 - (ASSizeRange)collectionView:(ASCollectionView *)collectionView constrainedSizeForSupplementaryNodeOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath
@@ -106,6 +118,7 @@ static inline ASSizeRange NodeConstrainedSizeForScrollDirection(ASCollectionView
     unsigned int implementsReferenceSizeForFooter:1;
     unsigned int implementsConstrainedSizeForNodeAtIndexPathDeprecated:1;
     unsigned int implementsConstrainedSizeForItemAtIndexPath:1;
+    unsigned int implementsScrollableDirections:1;
   } _delegateFlags;
   
   struct {
@@ -140,6 +153,7 @@ static inline ASSizeRange NodeConstrainedSizeForScrollDirection(ASCollectionView
     _delegateFlags.implementsReferenceSizeForFooter = [delegate respondsToSelector:@selector(collectionView:layout:referenceSizeForFooterInSection:)];
     _delegateFlags.implementsConstrainedSizeForNodeAtIndexPathDeprecated = [delegate respondsToSelector:@selector(collectionView:constrainedSizeForNodeAtIndexPath:)];
     _delegateFlags.implementsConstrainedSizeForItemAtIndexPath = [delegate respondsToSelector:@selector(collectionNode:constrainedSizeForItemAtIndexPath:)];
+    _delegateFlags.implementsScrollableDirections = [delegate respondsToSelector:@selector(scrollableDirections)];
   }
 }
 
@@ -174,6 +188,16 @@ static inline ASSizeRange NodeConstrainedSizeForScrollDirection(ASCollectionView
   return NodeConstrainedSizeForScrollDirection(collectionView);
 }
 
+- (ASScrollDirection)scrollableDirections
+{
+  if (_delegateFlags.implementsScrollableDirections) {
+    return [self scrollableDirections];
+  } else {
+    ASDisplayNodeAssert([self respondsToSelector:@selector(scrollableDirections)] == NO, @"As of the 2.0 release, -scrollableDirections is a required method for the layoutInspector.");
+  }
+  return ASScrollDirectionVerticalDirections;
+}
+
 - (ASSizeRange)collectionView:(ASCollectionView *)collectionView constrainedSizeForSupplementaryNodeOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath
 {
   CGSize constrainedSize;
@@ -189,11 +213,6 @@ static inline ASSizeRange NodeConstrainedSizeForScrollDirection(ASCollectionView
 - (NSUInteger)collectionView:(ASCollectionView *)collectionView supplementaryNodesOfKind:(NSString *)kind inSection:(NSUInteger)section
 {
   return [self layoutHasSupplementaryViewOfKind:kind inSection:section collectionView:collectionView] ? 1 : 0;
-}
-
-- (ASScrollDirection)scrollableDirections
-{
-  return (self.layout.scrollDirection == UICollectionViewScrollDirectionHorizontal) ? ASScrollDirectionHorizontalDirections : ASScrollDirectionVerticalDirections;
 }
 
 #pragma mark - Private helpers

--- a/AsyncDisplayKit/Details/ASCollectionViewFlowLayoutInspector.m
+++ b/AsyncDisplayKit/Details/ASCollectionViewFlowLayoutInspector.m
@@ -36,7 +36,6 @@ static inline ASSizeRange NodeConstrainedSizeForScrollDirection(ASCollectionView
   struct {
     unsigned int implementsConstrainedSizeForNodeAtIndexPathDeprecated:1;
     unsigned int implementsConstrainedSizeForNodeAtIndexPath:1;
-    unsigned int implementsScrollableDirections:1;
   } _delegateFlags;
 }
 
@@ -60,7 +59,6 @@ static inline ASSizeRange NodeConstrainedSizeForScrollDirection(ASCollectionView
   } else {
     _delegateFlags.implementsConstrainedSizeForNodeAtIndexPathDeprecated = [delegate respondsToSelector:@selector(collectionView:constrainedSizeForNodeAtIndexPath:)];
     _delegateFlags.implementsConstrainedSizeForNodeAtIndexPath = [delegate respondsToSelector:@selector(collectionNode:constrainedSizeForItemAtIndexPath:)];
-    _delegateFlags.implementsScrollableDirections = [delegate respondsToSelector:@selector(scrollableDirections)];
   }
 }
 
@@ -83,12 +81,8 @@ static inline ASSizeRange NodeConstrainedSizeForScrollDirection(ASCollectionView
 
 - (ASScrollDirection)scrollableDirections
 {
-  if (_delegateFlags.implementsScrollableDirections) {
-    return [self scrollableDirections];
-  } else {
-    ASDisplayNodeAssert([self respondsToSelector:@selector(scrollableDirections)] == NO, @"As of the 2.0 release, -scrollableDirections is a required method for the layoutInspector.");
-  }
-  return ASScrollDirectionVerticalDirections;
+  ASDisplayNodeAssert(NO, @"layoutInspector object must implement -scrollableDirections %@", self);
+  return ASScrollDirectionNone;
 }
 
 - (ASSizeRange)collectionView:(ASCollectionView *)collectionView constrainedSizeForSupplementaryNodeOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath
@@ -118,7 +112,6 @@ static inline ASSizeRange NodeConstrainedSizeForScrollDirection(ASCollectionView
     unsigned int implementsReferenceSizeForFooter:1;
     unsigned int implementsConstrainedSizeForNodeAtIndexPathDeprecated:1;
     unsigned int implementsConstrainedSizeForItemAtIndexPath:1;
-    unsigned int implementsScrollableDirections:1;
   } _delegateFlags;
   
   struct {
@@ -153,7 +146,6 @@ static inline ASSizeRange NodeConstrainedSizeForScrollDirection(ASCollectionView
     _delegateFlags.implementsReferenceSizeForFooter = [delegate respondsToSelector:@selector(collectionView:layout:referenceSizeForFooterInSection:)];
     _delegateFlags.implementsConstrainedSizeForNodeAtIndexPathDeprecated = [delegate respondsToSelector:@selector(collectionView:constrainedSizeForNodeAtIndexPath:)];
     _delegateFlags.implementsConstrainedSizeForItemAtIndexPath = [delegate respondsToSelector:@selector(collectionNode:constrainedSizeForItemAtIndexPath:)];
-    _delegateFlags.implementsScrollableDirections = [delegate respondsToSelector:@selector(scrollableDirections)];
   }
 }
 
@@ -188,16 +180,6 @@ static inline ASSizeRange NodeConstrainedSizeForScrollDirection(ASCollectionView
   return NodeConstrainedSizeForScrollDirection(collectionView);
 }
 
-- (ASScrollDirection)scrollableDirections
-{
-  if (_delegateFlags.implementsScrollableDirections) {
-    return [self scrollableDirections];
-  } else {
-    ASDisplayNodeAssert([self respondsToSelector:@selector(scrollableDirections)] == NO, @"As of the 2.0 release, -scrollableDirections is a required method for the layoutInspector.");
-  }
-  return ASScrollDirectionVerticalDirections;
-}
-
 - (ASSizeRange)collectionView:(ASCollectionView *)collectionView constrainedSizeForSupplementaryNodeOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath
 {
   CGSize constrainedSize;
@@ -213,6 +195,11 @@ static inline ASSizeRange NodeConstrainedSizeForScrollDirection(ASCollectionView
 - (NSUInteger)collectionView:(ASCollectionView *)collectionView supplementaryNodesOfKind:(NSString *)kind inSection:(NSUInteger)section
 {
   return [self layoutHasSupplementaryViewOfKind:kind inSection:section collectionView:collectionView] ? 1 : 0;
+}
+
+- (ASScrollDirection)scrollableDirections
+{
+  return (self.layout.scrollDirection == UICollectionViewScrollDirectionHorizontal) ? ASScrollDirectionHorizontalDirections : ASScrollDirectionVerticalDirections;
 }
 
 #pragma mark - Private helpers

--- a/examples/CustomCollectionView/Sample/MosaicCollectionViewLayout.m
+++ b/examples/CustomCollectionView/Sample/MosaicCollectionViewLayout.m
@@ -214,6 +214,11 @@
   return ASSizeRangeMake(CGSizeZero, [layout _headerSizeForSection:indexPath.section]);
 }
 
+- (ASScrollDirection)scrollableDirections
+{
+  return ASScrollDirectionVerticalDirections;
+}
+
 /**
  * Asks the inspector for the number of supplementary views for the given kind in the specified section.
  */


### PR DESCRIPTION
Thanks to @Baevra for catching this (#2540) and @Adlai-Holler for debugging this with me!

**Issue:**
Rotation from Portrait to Landscape in CustomCollectionView example does not trigger the layout inspector's `-constrainedSizeForNodeAtIndexPath` method. 

**Explanation:**
The collectionView's `scrollableDirections` was getting set to all directions because the bounds size changed before the content size changed. Going from portrait to landscape, the bounds size changed from a smaller width to a larger width, triggering a relayout of all nodes. Going from landscape to portrait, the bounds size changed from a larger width to a smaller width, causing the data controller to think that it was scrollable in the horizontal direction as well. 

Since laying out all nodes is expensive, we only do this if the bounds changes in the non-scrollable direction.  If, for example, a vertical flow layout has its height changed due to a status bar appearance update, we do not need to relayout all nodes. 

**Solution:**
make `-scrollableDirections` a required method for ASCollectionViewLayoutInspecting

- [x] update CustomCollectionView example
- [x] make scrollableDirections required for ASCollectionViewLayoutInspecting object
- [x] remove ASCollectionView's implementation