### PR TITLE
[ASTextNode] Ensure that isTruncated computes the correct value when sizing fast-path is used.

### DIFF
--- a/AsyncDisplayKit/ASTextNode.mm
+++ b/AsyncDisplayKit/ASTextNode.mm
@@ -1243,7 +1243,7 @@ static NSAttributedString *DefaultTruncationAttributedString()
   ASDN::MutexLocker l(__instanceLock__);
   
   ASTextKitRenderer *renderer = [self _renderer];
-  return renderer.firstVisibleRange.length < _attributedText.length;
+  return renderer.isTruncated;
 }
 
 - (void)setPointSizeScaleFactors:(NSArray *)pointSizeScaleFactors

--- a/AsyncDisplayKit/TextKit/ASTextKitRenderer.h
+++ b/AsyncDisplayKit/TextKit/ASTextKitRenderer.h
@@ -85,6 +85,11 @@
  */
 - (NSUInteger)lineCount;
 
+/**
+ Whether or not the text is truncated.
+ */
+- (BOOL)isTruncated;
+
 @end
 
 @interface ASTextKitRenderer (ASTextKitRendererConvenience)

--- a/AsyncDisplayKit/TextKit/ASTextKitRenderer.mm
+++ b/AsyncDisplayKit/TextKit/ASTextKitRenderer.mm
@@ -299,6 +299,16 @@ static NSCharacterSet *_defaultAvoidTruncationCharacterSet()
   return lineCount;
 }
 
+- (BOOL)isTruncated
+{
+  if (self.canUseFastPath) {
+    CGRect boundedRect = [_attributes.attributedString boundingRectWithSize:CGSizeMake(_constrainedSize.width, CGFLOAT_MAX) options:NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingTruncatesLastVisibleLine context:nil];
+    return boundedRect.size.height > _constrainedSize.height;
+  } else {
+    return self.firstVisibleRange.length < _attributes.attributedString.length;
+  t }
+}
+
 - (std::vector<NSRange>)visibleRanges
 {
   ASTextKitTailTruncater *truncater = [self truncater];

--- a/AsyncDisplayKit/TextKit/ASTextKitRenderer.mm
+++ b/AsyncDisplayKit/TextKit/ASTextKitRenderer.mm
@@ -302,11 +302,13 @@ static NSCharacterSet *_defaultAvoidTruncationCharacterSet()
 - (BOOL)isTruncated
 {
   if (self.canUseFastPath) {
-    CGRect boundedRect = [_attributes.attributedString boundingRectWithSize:CGSizeMake(_constrainedSize.width, CGFLOAT_MAX) options:NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingTruncatesLastVisibleLine context:nil];
+    CGRect boundedRect = [_attributes.attributedString boundingRectWithSize:CGSizeMake(_constrainedSize.width, CGFLOAT_MAX)
+                                                                    options:NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingTruncatesLastVisibleLine
+                                                                    context:nil];
     return boundedRect.size.height > _constrainedSize.height;
   } else {
     return self.firstVisibleRange.length < _attributes.attributedString.length;
-  t }
+  }
 }
 
 - (std::vector<NSRange>)visibleRanges


### PR DESCRIPTION
This is an attempt to fix #2504.

@Adlai-Holler what do you think?

@garrettmoon I tried setting the context to be `self.stringDrawingContext` but that didn't work – it only worked as expected when the context is `nil`.