### PR TITLE
[Layout API] Manual Layout API Changes

### DIFF
--- a/AsyncDisplayKit/ASButtonNode.mm
+++ b/AsyncDisplayKit/ASButtonNode.mm
@@ -524,9 +524,10 @@
   return spec;
 }
 
-- (void)layout
+- (void)layoutSubnodes
 {
-  [super layout];
+  [super layoutSubnodes];
+    
   _backgroundImageNode.hidden = (_backgroundImageNode.image == nil);
   _imageNode.hidden = (_imageNode.image == nil);
   _titleNode.hidden = (_titleNode.attributedText.length == 0);

--- a/AsyncDisplayKit/ASCellNode.mm
+++ b/AsyncDisplayKit/ASCellNode.mm
@@ -103,16 +103,16 @@ static NSMutableSet *__cellClassesForVisibilityNotifications = nil; // See +init
   }
 }
 
-- (void)layout
+- (void)layoutSubnodes
 {
-  [super layout];
+  [super layoutSubnodes];
   
   _viewControllerNode.frame = self.bounds;
 }
 
-- (void)layoutDidFinish
+- (void)nodeDidLayoutSubnodes
 {
-  [super layoutDidFinish];
+  [super nodeDidLayoutSubnodes];
 
   _viewControllerNode.frame = self.bounds;
 }

--- a/AsyncDisplayKit/ASDisplayNode+Subclasses.h
+++ b/AsyncDisplayKit/ASDisplayNode+Subclasses.h
@@ -51,14 +51,14 @@ NS_ASSUME_NONNULL_BEGIN
  * calculatedLayout may be accessed on subnodes to retrieved cached information about their size.  
  * This allows -layout to be very fast, saving time on the main thread.  
  * Note: .calculatedLayout will only be set for nodes that have had -measure: called on them.  
- * For manual layout, make sure you call -measure: in your implementation of -calculateSizeThatFits:.
+ * For manual layout, make sure you call -measure: in your implementation of -sizeThatFits:.
  *
  * For node subclasses that use automatic layout (e.g., they implement -layoutSpecThatFits:), 
  * it is typically not necessary to use .calculatedLayout at any point.  For these nodes, 
  * the ASLayoutSpec implementation will automatically call -measureWithSizeRange: on all of the subnodes,
  * and the ASDisplayNode base class implementation of -layout will automatically make use of .calculatedLayout on the subnodes.
  *
- * @return Layout that wraps calculated size returned by -calculateSizeThatFits: (in manual layout mode),
+ * @return Layout that wraps calculated size returned by -sizeThatFits: (in manual layout mode),
  * or layout already calculated from layout spec returned by -layoutSpecThatFits: (in automatic layout mode).
  *
  * @warning Subclasses must not override this; it returns the last cached layout and is never expensive.
@@ -84,15 +84,30 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @discussion Subclasses override this method to layout all subnodes or subviews.
  */
-- (void)layout ASDISPLAYNODE_REQUIRES_SUPER;
+- (void)layout ASDISPLAYNODE_REQUIRES_SUPER ASDISPLAYNODE_DEPRECATED_MSG("Override layoutSubnodes: method instead.");
 
 /**
- * @abstract Called on the main thread by the view's -layoutSubviews, after -layout.
+ * @abstract Called on the main thread by the view's -layoutSubviews.
+ *
+ * @discussion Subclasses override this method to layout all subnodes or subviews.
+ */
+- (void)layoutSubnodes ASDISPLAYNODE_REQUIRES_SUPER;
+
+/**
+ * @abstract Called on the main thread by the view's -layoutSubviews, after -layoutSubnodes.
  *
  * @discussion Gives a chance for subclasses to perform actions after the subclass and superclass have finished laying
  * out.
  */
-- (void)layoutDidFinish ASDISPLAYNODE_REQUIRES_SUPER;
+- (void)nodeDidLayoutSubnodes ASDISPLAYNODE_REQUIRES_SUPER;
+
+/**
+ * @abstract Called on the main thread by the view's -layoutSubviews, after -layoutSubnodes.
+ *
+ * @discussion Gives a chance for subclasses to perform actions after the subclass and superclass have finished laying
+ * out.
+ */
+- (void)layoutDidFinish ASDISPLAYNODE_REQUIRES_SUPER ASDISPLAYNODE_DEPRECATED_MSG("Override nodeDidLayoutSubnodes method instead.");;
 
 /**
  * @abstract Called on a background thread if !isNodeLoaded - called on the main thread if isNodeLoaded.
@@ -114,8 +129,8 @@ NS_ASSUME_NONNULL_BEGIN
  * @return An ASLayout instance defining the layout of the receiver (and its children, if the box layout model is used).
  *
  * @discussion This method is called on a non-main thread. The default implementation calls either -layoutSpecThatFits: 
- * or -calculateSizeThatFits:, whichever method is overriden. Subclasses rarely need to override this method,
- * override -layoutSpecThatFits: or -calculateSizeThatFits: instead.
+ * or -sizeThatFits:, whichever method is overriden. Subclasses rarely need to override this method,
+ * override -layoutSpecThatFits: or -sizeThatFits: instead.
  *
  * @note This method should not be called directly outside of ASDisplayNode; use -measure: or -calculatedLayout instead.
  */
@@ -144,11 +159,29 @@ NS_ASSUME_NONNULL_BEGIN
  * be done before display can be performed here, and using ivars to cache any valuable intermediate results is
  * encouraged.
  *
- * @note Subclasses that override are committed to manual layout. Therefore, -layout: must be overriden to layout all subnodes or subviews.
+ * @note Subclasses that override are committed to manual layout. Therefore, -layoutSubnodes: must be overriden to layout all subnodes or subviews.
  *
  * @note This method should not be called directly outside of ASDisplayNode; use -layoutThatFits: or layoutThatFits:parentSize: instead.
  */
-- (CGSize)calculateSizeThatFits:(CGSize)constrainedSize;
+- (CGSize)calculateSizeThatFits:(CGSize)constrainedSize ASDISPLAYNODE_DEPRECATED_MSG("Use calculateSizeThatFits: method instead.");;
+
+/**
+ * @abstract Asks the view to calculate and return the size that best fits the specified size.
+ *
+ * @param constrainedSize The size for which the node should calculate its best-fitting size.
+ *
+ * @discussion The default implementation of this method returns the existing size of the view. Subclasses can
+ * override this method to return a custom value based on the desired layout of any subnodes.
+ * Subclasses that override should expect this method to be called on a non-main thread. The returned size
+ * is wrapped in an ASLayout and cached for quick access during -layout. Other expensive work that needs to
+ * be done before display can be performed here, and using ivars to cache any valuable intermediate results is
+ * encouraged.
+ *
+ * @note Subclasses that override are committed to manual layout. Therefore, -layoutSubnodes: must be overriden to layout all subnodes or subviews.
+ *
+ * @note This method should not be called directly outside of ASDisplayNode; use -layoutThatFits: or layoutThatFits:parentSize: instead.
+ */
+- (CGSize)sizeThatFits:(CGSize)constrainedSize;
 
 /**
  * @abstract Return a layout spec that describes the layout of the receiver and its children.

--- a/AsyncDisplayKit/ASEditableTextNode.mm
+++ b/AsyncDisplayKit/ASEditableTextNode.mm
@@ -235,7 +235,7 @@
   _textInputTraits = nil;
 }
 
-- (CGSize)calculateSizeThatFits:(CGSize)constrainedSize
+- (CGSize)sizeThatFits:(CGSize)constrainedSize
 {
   ASTextKitComponents *displayedComponents = [self isDisplayingPlaceholder] ? _placeholderTextKitComponents : _textKitComponents;
   CGSize textSize = [displayedComponents sizeForConstrainedWidth:constrainedSize.width];
@@ -244,11 +244,11 @@
   return CGSizeMake(std::fmin(width, constrainedSize.width), std::fmin(height, constrainedSize.height));
 }
 
-- (void)layout
+- (void)layoutSubnodes
 {
   ASDisplayNodeAssertMainThread();
 
-  [super layout];
+  [super layoutSubnodes];
   [self _layoutTextView];
 }
 

--- a/AsyncDisplayKit/ASImageNode.mm
+++ b/AsyncDisplayKit/ASImageNode.mm
@@ -185,12 +185,12 @@ struct ASImageNodeDrawParameters {
 
 #pragma mark - Layout and Sizing
 
-- (CGSize)calculateSizeThatFits:(CGSize)constrainedSize
+- (CGSize)sizeThatFits:(CGSize)constrainedSize
 {
   ASDN::MutexLocker l(__instanceLock__);
 
   if (_image == nil) {
-    return [super calculateSizeThatFits:constrainedSize];
+    return [super sizeThatFits:constrainedSize];
   }
 
   return _image.size;
@@ -640,9 +640,9 @@ static ASDN::Mutex cacheLock;
 
 #pragma mark - Debug
 
-- (void)layout
+- (void)layoutSubnodes
 {
-  [super layout];
+  [super layoutSubnodes];
   
   if (_debugLabelNode) {
     CGSize boundsSize        = self.bounds.size;

--- a/AsyncDisplayKit/ASMapNode.mm
+++ b/AsyncDisplayKit/ASMapNode.mm
@@ -390,7 +390,7 @@
   }
 }
 
-- (CGSize)calculateSizeThatFits:(CGSize)constrainedSize
+- (CGSize)sizeThatFits:(CGSize)constrainedSize
 {
   // FIXME: Need a better way to allow maps to take up the right amount of space in a layout (sizeRange, etc)
   // These fallbacks protect against inheriting a constrainedSize that contains a CGFLOAT_MAX value.
@@ -412,9 +412,10 @@
 }
 
 // -layout isn't usually needed over -layoutSpecThatFits, but this way we can avoid a needless node wrapper for MKMapView.
-- (void)layout
+- (void)layoutSubnodes
 {
-  [super layout];
+  [super layoutSubnodes];
+
   if (self.isLiveMap) {
     _mapView.frame = CGRectMake(0.0f, 0.0f, self.calculatedSize.width, self.calculatedSize.height);
   } else {

--- a/AsyncDisplayKit/ASTableNode.h
+++ b/AsyncDisplayKit/ASTableNode.h
@@ -504,7 +504,7 @@ NS_ASSUME_NONNULL_BEGIN
  * This is a node-based UITableViewDelegate.
  *
  * Note that -tableView:heightForRowAtIndexPath: has been removed; instead, your custom ASCellNode subclasses are
- * responsible for deciding their preferred onscreen height in -calculateSizeThatFits:.
+ * responsible for deciding their preferred onscreen height in -sizeThatFits:.
  */
 @protocol ASTableDelegate <ASCommonTableViewDelegate, NSObject>
 

--- a/AsyncDisplayKit/ASTextNode.mm
+++ b/AsyncDisplayKit/ASTextNode.mm
@@ -382,7 +382,7 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
   }
 }
 
-- (CGSize)calculateSizeThatFits:(CGSize)constrainedSize
+- (CGSize)sizeThatFits:(CGSize)constrainedSize
 {
   ASDN::MutexLocker l(__instanceLock__);
   

--- a/AsyncDisplayKit/ASVideoNode.mm
+++ b/AsyncDisplayKit/ASVideoNode.mm
@@ -231,14 +231,15 @@ static NSString * const kRate = @"rate";
   }
 }
 
-- (void)layout
+- (void)layoutSubnodes
 {
-  [super layout];
+  [super layoutSubnodes];
+
   // The _playerNode wraps AVPlayerLayer, and therefore should extend across the entire bounds.
   _playerNode.frame = self.bounds;
 }
 
-- (CGSize)calculateSizeThatFits:(CGSize)constrainedSize
+- (CGSize)sizeThatFits:(CGSize)constrainedSize
 {
   ASDN::MutexLocker l(__instanceLock__);
   CGSize calculatedSize = constrainedSize;

--- a/AsyncDisplayKit/AsyncDisplayKit+Debug.m
+++ b/AsyncDisplayKit/AsyncDisplayKit+Debug.m
@@ -64,9 +64,9 @@ static BOOL __enableHitTestDebug = NO;
 }
 
 // layout method required ONLY when hitTestDebug is enabled
-- (void)layout
+- (void)layoutSubnodes
 {
-  [super layout];
+  [super layoutSubnodes];
   
   if ([ASControlNode enableHitTestDebug]) {
     

--- a/AsyncDisplayKit/Details/_ASDisplayLayer.mm
+++ b/AsyncDisplayKit/Details/_ASDisplayLayer.mm
@@ -129,7 +129,7 @@
   ASDisplayNodeAssertMainThread();
   [super layoutSublayers];
 
-  [self.asyncdisplaykit_node __layout];
+  [self.asyncdisplaykit_node __layoutSubnodes];
 }
 
 - (void)setNeedsDisplay

--- a/AsyncDisplayKit/Layout/ASLayoutElement.h
+++ b/AsyncDisplayKit/Layout/ASLayoutElement.h
@@ -250,7 +250,7 @@ extern NSString * const ASLayoutElementStyleLayoutPositionProperty;
 /**
  * @abstract Provides a suggested size for a layout element. If the optional minSize or maxSize are provided, 
  * and the preferredSize exceeds these, the minSize or maxSize will be enforced. If this optional value is not 
- * provided, the layout element’s size will default to it’s intrinsic content size provided calculateSizeThatFits:
+ * provided, the layout element’s size will default to it’s intrinsic content size provided sizeThatFits:
  * 
  * @discussion This method is optional, but one of either preferredSize or preferredLayoutSize is required
  * for nodes that either have no intrinsic content size or 
@@ -290,7 +290,7 @@ extern NSString * const ASLayoutElementStyleLayoutPositionProperty;
  * than points to specify layout. E.g. width should be 50% of the parent’s width. If the optional minLayoutSize or
  * maxLayoutSize are provided, and the preferredLayoutSize exceeds these, the minLayoutSize or maxLayoutSize 
  * will be enforced. If this optional value is not provided, the layout element’s size will default to its intrinsic content size 
- * provided calculateSizeThatFits:
+ * provided sizeThatFits:
  */
 @property (nonatomic, assign, readwrite) ASLayoutSize preferredLayoutSize;
 

--- a/AsyncDisplayKit/Private/ASDisplayNode+AsyncDisplay.mm
+++ b/AsyncDisplayKit/Private/ASDisplayNode+AsyncDisplay.mm
@@ -52,7 +52,7 @@
 
   // if super node is rasterizing descendants, subnodes will not have had layout calls because they don't have layers
   if (rasterizingFromAscendent) {
-    [self __layout];
+    [self __layoutSubnodes];
   }
 
   // Capture these outside the display block so they are retained.

--- a/AsyncDisplayKit/Private/ASDisplayNode+UIViewBridge.mm
+++ b/AsyncDisplayKit/Private/ASDisplayNode+UIViewBridge.mm
@@ -83,7 +83,7 @@ if (shouldApply) { _layer.layerProperty = (layerValueExpr); } else { ASDisplayNo
 /**
  * This category implements certain frequently-used properties and methods of UIView and CALayer so that ASDisplayNode clients can just call the view/layer methods on the node,
  * with minimal loss in performance.  Unlike UIView and CALayer methods, these can be called from a non-main thread until the view or layer is created.
- * This allows text sizing in -calculateSizeThatFits: (essentially a simplified layout) to happen off the main thread
+ * This allows text sizing in -sizeThatFits: (essentially a simplified layout) to happen off the main thread
  * without any CALayer or UIView actually existing while still being able to set and read properties from ASDisplayNode instances.
  */
 @implementation ASDisplayNode (UIViewBridge)

--- a/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
+++ b/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
@@ -210,7 +210,8 @@ FOUNDATION_EXPORT NSString * const ASRenderingEngineDidDisplayNodesScheduledBefo
  */
 - (void)__setNeedsDisplay;
 
-- (void)__layout;
+- (void)__layoutSubnodes;
+
 - (void)__setSupernode:(ASDisplayNode *)supernode;
 
 /**

--- a/AsyncDisplayKitTests/ASDisplayNodeTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeTests.m
@@ -100,7 +100,7 @@ for (ASDisplayNode *n in @[ nodes ]) {\
 
 @implementation ASTestDisplayNode
 
-- (CGSize)calculateSizeThatFits:(CGSize)constrainedSize
+- (CGSize)sizeThatFits:(CGSize)constrainedSize
 {
   return _calculateSizeBlock ? _calculateSizeBlock(self, constrainedSize) : CGSizeZero;
 }


### PR DESCRIPTION
**Changes:**
* `-[ASDisplayNode __layout]` to `-[ASDisplayNode __layoutSubnodes]`
* `-[ASDisplayNode layout]` to `-[ASDisplayNode layoutSubnodes]`
* `-[ASDisplayNode layoutDidFinish]` to `-[ASDisplayNode nodeDidLayoutSubnodes]`
* `-[ASDisplayNode calculateSizeThatFits:]` to `-[ASDisplayNode sizeThatFits:]`

**Deprecations:**
* `-[ASDisplayNode layout]`
* `-[ASDisplayNode layoutDidFinish]`
* `-[ASDisplayNode calculateSizeThatFits:]`

Goes in hand with #2538 