### PR TITLE
Add a Declarative API for Collection Node (standard dataSource still available).

### DIFF
--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -200,11 +200,10 @@
 		68FC85EA1CE29C7D00EDD713 /* ASVisibilityProtocols.h in Headers */ = {isa = PBXBuildFile; fileRef = 68FC85E71CE29C7D00EDD713 /* ASVisibilityProtocols.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		68FC85EB1CE29C7D00EDD713 /* ASVisibilityProtocols.m in Sources */ = {isa = PBXBuildFile; fileRef = 68FC85E81CE29C7D00EDD713 /* ASVisibilityProtocols.m */; };
 		68FC85EC1CE29C7D00EDD713 /* ASVisibilityProtocols.m in Sources */ = {isa = PBXBuildFile; fileRef = 68FC85E81CE29C7D00EDD713 /* ASVisibilityProtocols.m */; };
+		693117CE1DC7C72700DE4784 /* ASDisplayNode+Deprecated.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 683489271D70DE3400327501 /* ASDisplayNode+Deprecated.h */; };
 		6907C2581DC4ECFE00374C66 /* ASObjectDescriptionHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 6907C2561DC4ECFE00374C66 /* ASObjectDescriptionHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6907C2591DC4ECFE00374C66 /* ASObjectDescriptionHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 6907C2571DC4ECFE00374C66 /* ASObjectDescriptionHelpers.m */; };
 		6907C25A1DC4ECFE00374C66 /* ASObjectDescriptionHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 6907C2571DC4ECFE00374C66 /* ASObjectDescriptionHelpers.m */; };
-		69127CFE1DD2B387004BF6E2 /* ASEventLog.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 696F01EA1DD2AF450049FBD5 /* ASEventLog.h */; };
-		693117CE1DC7C72700DE4784 /* ASDisplayNode+Deprecated.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 683489271D70DE3400327501 /* ASDisplayNode+Deprecated.h */; };
 		69527B121DC84292004785FB /* ASLayoutElementStylePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 69527B111DC84292004785FB /* ASLayoutElementStylePrivate.h */; };
 		6959433E1D70815300B0EE1F /* ASDisplayNodeLayout.mm in Sources */ = {isa = PBXBuildFile; fileRef = 6959433C1D70815300B0EE1F /* ASDisplayNodeLayout.mm */; };
 		6959433F1D70815300B0EE1F /* ASDisplayNodeLayout.mm in Sources */ = {isa = PBXBuildFile; fileRef = 6959433C1D70815300B0EE1F /* ASDisplayNodeLayout.mm */; };
@@ -434,6 +433,9 @@
 		CC051F1F1D7A286A006434CB /* ASCALayerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CC051F1E1D7A286A006434CB /* ASCALayerTests.m */; };
 		CC0AEEA41D66316E005D1C78 /* ASUICollectionViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CC0AEEA31D66316E005D1C78 /* ASUICollectionViewTests.m */; };
 		CC11F97A1DB181180024D77B /* ASNetworkImageNodeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CC11F9791DB181180024D77B /* ASNetworkImageNodeTests.m */; };
+		CC17AB851DD2DE6D009E7EE7 /* ASCollectionDataInternal.mm in Sources */ = {isa = PBXBuildFile; fileRef = CCA845531DCE67A600FC50C5 /* ASCollectionDataInternal.mm */; };
+		CC17AB861DD2DEF2009E7EE7 /* ASCollectionDataInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = CCA845521DCE67A600FC50C5 /* ASCollectionDataInternal.h */; };
+		CC17AB871DD2DF1D009E7EE7 /* ASCollectionDataInternal.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = CCA845521DCE67A600FC50C5 /* ASCollectionDataInternal.h */; };
 		CC3B20841C3F76D600798563 /* ASPendingStateController.h in Headers */ = {isa = PBXBuildFile; fileRef = CC3B20811C3F76D600798563 /* ASPendingStateController.h */; };
 		CC3B20851C3F76D600798563 /* ASPendingStateController.mm in Sources */ = {isa = PBXBuildFile; fileRef = CC3B20821C3F76D600798563 /* ASPendingStateController.mm */; };
 		CC3B20861C3F76D600798563 /* ASPendingStateController.mm in Sources */ = {isa = PBXBuildFile; fileRef = CC3B20821C3F76D600798563 /* ASPendingStateController.mm */; };
@@ -457,6 +459,9 @@
 		CC8B05D61D73836400F54286 /* ASPerformanceTestContext.m in Sources */ = {isa = PBXBuildFile; fileRef = CC8B05D51D73836400F54286 /* ASPerformanceTestContext.m */; };
 		CC8B05D81D73979700F54286 /* ASTextNodePerformanceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CC8B05D71D73979700F54286 /* ASTextNodePerformanceTests.m */; };
 		CCA221D31D6FA7EF00AF6A0F /* ASViewControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CCA221D21D6FA7EF00AF6A0F /* ASViewControllerTests.m */; };
+		CCA845541DCE67A600FC50C5 /* ASCollectionDataInternal.mm in Sources */ = {isa = PBXBuildFile; fileRef = CCA845531DCE67A600FC50C5 /* ASCollectionDataInternal.mm */; };
+		CCA845551DCE67F200FC50C5 /* ASCollectionData.h in Headers */ = {isa = PBXBuildFile; fileRef = CC2821361DCD035A006A2377 /* ASCollectionData.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CCA845561DCE680600FC50C5 /* ASCollectionData.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = CC2821361DCD035A006A2377 /* ASCollectionData.h */; };
 		CCB2F34D1D63CCC6004E6DE9 /* ASDisplayNodeSnapshotTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CCB2F34C1D63CCC6004E6DE9 /* ASDisplayNodeSnapshotTests.m */; };
 		CCF18FF41D2575E300DF5895 /* NSIndexSet+ASHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = CC4981BA1D1C7F65004E13CC /* NSIndexSet+ASHelpers.h */; };
 		D785F6631A74327E00291744 /* ASScrollNode.m in Sources */ = {isa = PBXBuildFile; fileRef = D785F6611A74327E00291744 /* ASScrollNode.m */; };
@@ -676,6 +681,8 @@
 				68C2155B1DE11A790019C4BC /* ASCollectionViewLayoutInspector.h in CopyFiles */,
 				DEB8ED7E1DD007F400DBDE55 /* ASLayoutElementInspectorNode.h in CopyFiles */,
 				69127CFE1DD2B387004BF6E2 /* ASEventLog.h in CopyFiles */,
+				CC17AB871DD2DF1D009E7EE7 /* ASCollectionDataInternal.h in CopyFiles */,
+				CCA845561DCE680600FC50C5 /* ASCollectionData.h in CopyFiles */,
 				693117CE1DC7C72700DE4784 /* ASDisplayNode+Deprecated.h in CopyFiles */,
 				69F381A51DA4630D00CF2278 /* NSArray+Diffing.h in CopyFiles */,
 				CC4C2A7A1D8902350039ACAB /* ASTraceEvent.h in CopyFiles */,
@@ -1140,6 +1147,7 @@
 		CC051F1E1D7A286A006434CB /* ASCALayerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASCALayerTests.m; sourceTree = "<group>"; };
 		CC0AEEA31D66316E005D1C78 /* ASUICollectionViewTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASUICollectionViewTests.m; sourceTree = "<group>"; };
 		CC11F9791DB181180024D77B /* ASNetworkImageNodeTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASNetworkImageNodeTests.m; sourceTree = "<group>"; };
+		CC2821361DCD035A006A2377 /* ASCollectionData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASCollectionData.h; sourceTree = "<group>"; };
 		CC2E317F1DAC353700EEE891 /* ASCollectionView+Undeprecated.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ASCollectionView+Undeprecated.h"; sourceTree = "<group>"; };
 		CC3B20811C3F76D600798563 /* ASPendingStateController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASPendingStateController.h; sourceTree = "<group>"; };
 		CC3B20821C3F76D600798563 /* ASPendingStateController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASPendingStateController.mm; sourceTree = "<group>"; };
@@ -1163,6 +1171,8 @@
 		CC8B05D51D73836400F54286 /* ASPerformanceTestContext.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASPerformanceTestContext.m; sourceTree = "<group>"; };
 		CC8B05D71D73979700F54286 /* ASTextNodePerformanceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASTextNodePerformanceTests.m; sourceTree = "<group>"; };
 		CCA221D21D6FA7EF00AF6A0F /* ASViewControllerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASViewControllerTests.m; sourceTree = "<group>"; };
+		CCA845521DCE67A600FC50C5 /* ASCollectionDataInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASCollectionDataInternal.h; sourceTree = "<group>"; };
+		CCA845531DCE67A600FC50C5 /* ASCollectionDataInternal.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASCollectionDataInternal.mm; sourceTree = "<group>"; };
 		CCB2F34C1D63CCC6004E6DE9 /* ASDisplayNodeSnapshotTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASDisplayNodeSnapshotTests.m; sourceTree = "<group>"; };
 		D3779BCFF841AD3EB56537ED /* Pods-AsyncDisplayKitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AsyncDisplayKitTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-AsyncDisplayKitTests/Pods-AsyncDisplayKitTests.release.xcconfig"; sourceTree = "<group>"; };
 		D785F6601A74327E00291744 /* ASScrollNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASScrollNode.h; sourceTree = "<group>"; };
@@ -1312,6 +1322,7 @@
 		058D09B1195D04C000B7D73C /* AsyncDisplayKit */ = {
 			isa = PBXGroup;
 			children = (
+				CC2821361DCD035A006A2377 /* ASCollectionData.h */,
 				DBDB83921C6E879900D0098C /* ASPagerFlowLayout.h */,
 				DBDB83931C6E879900D0098C /* ASPagerFlowLayout.m */,
 				92DD2FE11BF4B97E0074C9DD /* ASMapNode.h */,
@@ -1572,6 +1583,10 @@
 		058D0A01195D050800B7D73C /* Private */ = {
 			isa = PBXGroup;
 			children = (
+				9F98C0231DBDF2A300476D92 /* ASControlTargetAction.h */,
+				9F98C0241DBDF2A300476D92 /* ASControlTargetAction.m */,
+				CCA845521DCE67A600FC50C5 /* ASCollectionDataInternal.h */,
+				CCA845531DCE67A600FC50C5 /* ASCollectionDataInternal.mm */,
 				058D0A03195D050800B7D73C /* _ASCoreAnimationExtras.h */,
 				058D0A04195D050800B7D73C /* _ASCoreAnimationExtras.mm */,
 				AC026B6D1BD57DBF00BBC17E /* _ASHierarchyChangeSet.h */,
@@ -1901,6 +1916,7 @@
 				34EFC75D1B701BE900AD841F /* ASInternalHelpers.h in Headers */,
 				34EFC7671B701CD900AD841F /* ASLayout.h in Headers */,
 				DEC146B71C37A16A004A0EE7 /* ASCollectionInternal.h in Headers */,
+				CCA845551DCE67F200FC50C5 /* ASCollectionData.h in Headers */,
 				DBDB83951C6E879900D0098C /* ASPagerFlowLayout.h in Headers */,
 				34EFC7691B701CE100AD841F /* ASLayoutElement.h in Headers */,
 				9CDC18CD1B910E12004965E2 /* ASLayoutElementPrivate.h in Headers */,
@@ -1969,6 +1985,7 @@
 				509E68651B3AEDC5009B9150 /* CoreGraphics+ASConvenience.h in Headers */,
 				B350623A1B010EFD0018CF92 /* NSMutableAttributedString+TextKitAdditions.h in Headers */,
 				044284FF1BAA3BD600D16268 /* UICollectionViewLayout+ASConvenience.h in Headers */,
+				CC17AB861DD2DEF2009E7EE7 /* ASCollectionDataInternal.h in Headers */,
 				B35062431B010EFD0018CF92 /* UIView+ASConvenience.h in Headers */,
 				8BDA5FC71CDBDF91007D13B2 /* ASVideoPlayerNode.h in Headers */,
 			);
@@ -2294,6 +2311,7 @@
 				AC026B6B1BD57D6F00BBC17E /* ASChangeSetDataController.mm in Sources */,
 				68355B311CB5799E001D4E68 /* ASImageNode+AnimatedImage.mm in Sources */,
 				68C215591DE10D330019C4BC /* ASCollectionViewLayoutInspector.m in Sources */,
+				CCA845541DCE67A600FC50C5 /* ASCollectionDataInternal.mm in Sources */,
 				9CFFC6C01CCAC73C006A6476 /* ASViewController.mm in Sources */,
 				055F1A3519ABD3E3004DAFF1 /* ASTableView.mm in Sources */,
 				6959433E1D70815300B0EE1F /* ASDisplayNodeLayout.mm in Sources */,
@@ -2382,6 +2400,7 @@
 				92DD2FE71BF4D0850074C9DD /* ASMapNode.mm in Sources */,
 				636EA1A51C7FF4EF00EE152F /* ASDefaultPlayButton.m in Sources */,
 				9B92C8861BC2EB7600EE46B2 /* ASCollectionViewFlowLayoutInspector.m in Sources */,
+				CC17AB851DD2DE6D009E7EE7 /* ASCollectionDataInternal.mm in Sources */,
 				9B92C8851BC2EB6E00EE46B2 /* ASCollectionDataController.mm in Sources */,
 				B350623D1B010EFD0018CF92 /* _ASAsyncTransaction.mm in Sources */,
 				B35062401B010EFD0018CF92 /* _ASAsyncTransactionContainer.m in Sources */,

--- a/AsyncDisplayKit/ASCollectionData.h
+++ b/AsyncDisplayKit/ASCollectionData.h
@@ -1,0 +1,131 @@
+//
+//  ASCollectionItem.h
+//  AsyncDisplayKit
+//
+//  Created by Adlai Holler on 11/4/16.
+//  Copyright © 2016 Facebook. All rights reserved.
+//
+
+#pragma once
+#import <Foundation/Foundation.h>
+#import <AsyncDisplayKit/ASDimension.h>
+
+@class ASCellNode;
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NSString * ASSectionIdentifier;
+typedef NSString * ASItemIdentifier;
+typedef NSString * ASSupplementaryElementKind;
+
+/**
+ * ASCellNode creation block. Used to lazily create the ASCellNode instance for an item.
+ */
+typedef ASCellNode * _Nonnull(^ASCellNodeBlock)();
+
+@protocol ASCollectionItem <NSObject>
+
+/**
+ * The identifier for the item.
+ */
+@property (nonatomic, strong, readonly) ASItemIdentifier identifier;
+
+@end
+
+@protocol ASCollectionSection <NSObject>
+
+/**
+ * The identifier for the section.
+ */
+@property (nonatomic, strong, readonly) ASSectionIdentifier identifier;
+
+/**
+ * The items in the section. You can use this property to get fine-grained control over the collection data.
+ */
+@property (nonatomic, strong, readonly) NSMutableArray<id<ASCollectionItem>> *mutableItems;
+
+@end
+
+/**
+ * An object used to construct the data set for a collection
+ * or table node. 
+ * When the collection needs to update its data, it calls @c dataForCollectionNode:
+ * on the data source. The data source calls @c createNewData on the collection node,
+ * configures the data object, and returns it.
+ */
+@interface ASCollectionData : NSObject
+
+/**
+ * Appends a section to the collection.
+ *
+ * @param identifier The identifier for the section.
+ * @param block A block in which to configure the section.
+ *
+ * @warning It is an error to call this method with an identifier that is associated with another section.
+ */
+- (void)addSectionWithIdentifier:(ASSectionIdentifier)identifier
+                           block:(__attribute((noescape)) void(^)(ASCollectionData * data))block;
+
+/**
+ * Adds an item to the current section. If this method is called outside of an addSectionWithIdentifier:
+ * block, a default section will be created and used.
+ *
+ * @param identifier The identifier for the new item.
+ * @param nodeBlock A block that will be used to construct the node for the item.
+ *
+ * @note If an item already exists with this identifier, the node block will be ignored.
+ * @note It is more performant to specify the node block inline here, rather than calling a method that generates it, but the difference is not prohibitive.
+ */
+- (void)addItemWithIdentifier:(ASItemIdentifier)identifier
+                    nodeBlock:(ASCellNodeBlock)nodeBlock;
+
+/**
+ * Adds a supplementary element to the current section. If this method is called outside of an addSectionWithIdentifier:
+ * block, a default section will be created and used.
+ *
+ * @param elementKind The kind of supplementary element to add.
+ * @param identifier The identifier for the new item.
+ * @param index The index for the supplementary element. This can be @c NSNotFound.
+ * @param nodeBlock A block that will be used to construct the node for the supplementary element.
+ *
+ * @note If an element already exists with this identifier, the node block will be ignored.
+ * @note It is more performant to specify the node block inline here, rather than calling a method that generates it, but the difference is not prohibitive.
+ */
+- (void)addSupplementaryElementOfKind:(NSString *)elementKind
+                       withIdentifier:(ASItemIdentifier)identifier
+                                index:(NSInteger)index
+                            nodeBlock:(ASCellNodeBlock)nodeBlock;
+
+/**
+ * Finds or creates an item with the given identifier.
+ *
+ * @param identifier The identifier for the item.
+ * @param nodeBlock A block that will be used to construct the node for the item.
+ *
+ * You can use this method to get more fine-grained control over the collection data.
+ * The returned item can be inserted into the @c mutableItems of an @c ASCollectionSection.
+ *
+ * Note that if an item already exists with this identifier, the node block will be ignored.
+ * @note It is more performant to specify the node block inline here, rather than calling a method that generates it, but the difference is not prohibitive.
+ */
+- (id<ASCollectionItem>)itemWithIdentifier:(ASItemIdentifier)identifier
+                                 nodeBlock:(ASCellNodeBlock)nodeBlock;
+
+/**
+ * Finds or creates a section with the given identifier.
+ *
+ * @param identifier The identifier for the section.
+ *
+ * You can use this method to get more fine-grained control over the collection data.
+ * The returned section can be inserted into @c mutableSections.
+ */
+- (id<ASCollectionSection>)sectionWithIdentifier:(ASSectionIdentifier)identifier;
+
+/**
+ * The sections in the collection. You can use this property to get fine-grained control over the collection data.
+ */
+@property (nonatomic, strong, readonly) NSMutableArray<id<ASCollectionSection>> *mutableSections;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/AsyncDisplayKit/ASCollectionNode.h
+++ b/AsyncDisplayKit/ASCollectionNode.h
@@ -18,6 +18,7 @@
 @protocol ASCollectionViewLayoutFacilitatorProtocol;
 @protocol ASCollectionDelegate;
 @protocol ASCollectionDataSource;
+@protocol ASCollectionData;
 @class ASCollectionView;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -158,6 +159,8 @@ NS_ASSUME_NONNULL_BEGIN
  * `registerClass:forSupplementaryViewOfKind:withReuseIdentifier:` and `registerNib:forSupplementaryViewOfKind:withReuseIdentifier:`
  * methods. This method will register an internal backing view that will host the contents of the supplementary nodes
  * returned from the data source.
+ *
+ * @note If the data source implements @c dataForCollectionNode: you do not need to call this method.
  */
 - (void)registerSupplementaryNodeOfKind:(NSString *)elementKind;
 
@@ -412,6 +415,15 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (nullable id<ASSectionContext>)contextForSection:(NSInteger)section AS_WARN_UNUSED_RESULT;
 
+/**
+ * Creates a new data object for this collection node.
+ *
+ * You call this method in your implementation of @c dataForCollectionNode:. 
+ * You should not store or reuse the returned object.
+ * You should not call this method outside of @c dataForCollectionNode: .
+ */
+- (ASCollectionData *)createNewData;
+
 @end
 
 @interface ASCollectionNode (Deprecated)
@@ -434,6 +446,17 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol ASCollectionDataSource <ASCommonCollectionDataSource>
 
 @optional
+
+/**
+ * Asks the data source to provide the new data.
+ *
+ * @param collectionNode The sender.
+ *
+ * The data source should call @c -createNewData , configure the data object
+ * and then return it. You should not store or reuse the data object.
+ * This method will be called on the main thread.
+ */
+- (ASCollectionData *)dataForCollectionNode:(ASCollectionNode *)collectionNode;
 
 /**
  * Asks the data source for the number of items in the given section of the collection node.

--- a/AsyncDisplayKit/ASCollectionNode.mm
+++ b/AsyncDisplayKit/ASCollectionNode.mm
@@ -22,6 +22,9 @@
 #import "ASSectionContext.h"
 #import "ASCollectionDataController.h"
 #import "ASCollectionView+Undeprecated.h"
+#import "ASDisplayNodeInternal.h"
+#import "NSArray+Diffing.h"
+#import "ASCollectionDataInternal.h"
 
 #pragma mark - _ASCollectionPendingState
 
@@ -457,6 +460,16 @@
 {
   ASDisplayNodeAssertMainThread();
   return [self.dataController contextForSection:section];
+}
+
+- (ASCollectionData *)createNewData
+{
+  ASCollectionData *data = [[ASCollectionData alloc] initWithReusableContentFromCompletedData:self.dataController.previousData];
+  __weak __typeof(self) weakSelf = self;
+  data.postNodeBlock = ^(ASCellNode *node) {
+    [weakSelf.view didCreateNode:node];
+  };
+  return data;
 }
 
 #pragma mark - Editing

--- a/AsyncDisplayKit/AsyncDisplayKit.h
+++ b/AsyncDisplayKit/AsyncDisplayKit.h
@@ -68,6 +68,7 @@
 #import <AsyncDisplayKit/ASTextNode+Beta.h>
 #import <AsyncDisplayKit/ASTextNodeTypes.h>
 #import <AsyncDisplayKit/ASAvailability.h>
+#import <AsyncDisplayKit/ASCollectionData.h>
 #import <AsyncDisplayKit/ASCollectionViewLayoutController.h>
 #import <AsyncDisplayKit/ASContextTransitioning.h>
 #import <AsyncDisplayKit/ASControlNode+Subclasses.h>

--- a/AsyncDisplayKit/Details/ASCollectionInternal.h
+++ b/AsyncDisplayKit/Details/ASCollectionInternal.h
@@ -20,7 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class ASRangeController;
 
 @interface ASCollectionView ()
-- (instancetype)_initWithFrame:(CGRect)frame collectionViewLayout:(UICollectionViewLayout *)layout layoutFacilitator:(nullable id<ASCollectionViewLayoutFacilitatorProtocol>)layoutFacilitator eventLog:(ASEventLog*)eventLog;
+- (instancetype)_initWithFrame:(CGRect)frame collectionViewLayout:(UICollectionViewLayout *)layout layoutFacilitator:(nullable id<ASCollectionViewLayoutFacilitatorProtocol>)layoutFacilitator eventLog:(nullable ASEventLog *)eventLog;
 
 @property (nonatomic, weak, readwrite) ASCollectionNode *collectionNode;
 @property (nonatomic, strong, readonly) ASDataController *dataController;
@@ -47,6 +47,18 @@ NS_ASSUME_NONNULL_BEGIN
  * @param indexPaths An array of index paths in the view space
  */
 - (nullable NSArray<NSIndexPath *> *)convertIndexPathsToCollectionNode:(nullable NSArray<NSIndexPath *> *)indexPaths;
+
+// Called after running each node block, to update the
+// hierarchy state and set the interaction delegate.
+- (void)didCreateNode:(ASCellNode *)node;
+
+/**
+ * Prevent this collection view from making assertions about what methods its delegate/data source implement.
+ *
+ * This isn't pretty, but unfortunately OCMock always responds to all selectors, so
+ * removing it will require pretty significant resources that aren't currently worth it.
+ */
+@property (nonatomic, assign) BOOL test_suppressCallbackImplementationAssertions;
 
 @end
 

--- a/AsyncDisplayKit/Details/ASDataController.h
+++ b/AsyncDisplayKit/Details/ASDataController.h
@@ -14,6 +14,7 @@
 #import <AsyncDisplayKit/ASDimension.h>
 #import <AsyncDisplayKit/ASFlowLayoutController.h>
 #import <AsyncDisplayKit/ASEventLog.h>
+#import <AsyncDisplayKit/ASCollectionData.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -28,11 +29,6 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol ASEnvironment;
 
 typedef NSUInteger ASDataControllerAnimationOptions;
-
-/**
- * ASCellNode creation block. Used to lazily create the ASCellNode instance for a specified indexPath.
- */
-typedef ASCellNode * _Nonnull(^ASCellNodeBlock)();
 
 FOUNDATION_EXPORT NSString * const ASDataControllerRowNodeKind;
 
@@ -62,6 +58,13 @@ FOUNDATION_EXPORT NSString * const ASDataControllerRowNodeKind;
  Fetch the number of sections.
  */
 - (NSUInteger)numberOfSectionsInDataController:(ASDataController *)dataController;
+
+@optional
+
+/**
+ * Fetch the new data set. This is called in endUpdates.
+ */
+- (ASCollectionData *)dataForDataController:(ASDataController *)dataController;
 
 @end
 
@@ -116,6 +119,29 @@ FOUNDATION_EXPORT NSString * const ASDataControllerRowNodeKind;
 @interface ASDataController : NSObject <ASFlowLayoutControllerDataSource>
 
 - (instancetype)initWithDataSource:(id<ASDataControllerSource>)dataSource eventLog:(nullable ASEventLog *)eventLog NS_DESIGNATED_INITIALIZER;
+
+/**
+ * Whether or not our upstream data source supports dataForCollectionNode:. 
+ * If YES, then we read the new data and perform a diff after each update.
+ * Otherwise we rely on them calling insertItemsAtIndexPaths: etc.
+ */
+@property (assign) BOOL supportsDeclarativeData;
+
+/**
+ * The valid ASCollectionData most recently fetched from the data source, if functional data
+ * updating is active.
+ * 
+ * If the data has been invalidated, this property will request new data from the data source before returning.
+ */
+@property (nonatomic, readonly, strong, nullable) ASCollectionData * currentData;
+
+/**
+ * The ASCollectionData most recently fetched from the data source, if functional data
+ * updating is active.
+ *
+ * This method will return a data, even if it has been invalidated.
+ */
+@property (nonatomic, readonly, strong, nullable) ASCollectionData * previousData;
 
 /**
  Data source for fetching data info.

--- a/AsyncDisplayKit/Details/ASObjectDescriptionHelpers.m
+++ b/AsyncDisplayKit/Details/ASObjectDescriptionHelpers.m
@@ -34,6 +34,16 @@ NSString *ASGetDescriptionValueString(id object)
       [strings addObject:[NSString stringWithFormat:@"%lu", (unsigned long)[indexPath indexAtPosition:i]]];
     }
     return [NSString stringWithFormat:@"(%@)", [strings componentsJoinedByString:@", "]];
+  } else if ([object isKindOfClass:[NSArray class]]) {
+    NSArray *array = (NSArray *)object;
+    NSMutableString *str = [NSMutableString stringWithString:@"(\n"];
+    NSInteger i = 0;
+    for (id obj in array) {
+      [str appendFormat:@"\t[%ld]: \"%@\",\n", (long)i, obj];
+      i += 1;
+    }
+    [str appendString:@")"];
+    return str;
   }
   return [object description];
 }

--- a/AsyncDisplayKit/Details/NSArray+Diffing.h
+++ b/AsyncDisplayKit/Details/NSArray+Diffing.h
@@ -12,7 +12,7 @@
 
 #import <Foundation/Foundation.h>
 
-@interface NSArray (Diffing)
+@interface NSArray<__covariant ObjectType> (Diffing)
 
 /**
  * @abstract Compares two arrays, providing the insertion and deletion indexes needed to transform into the target array.
@@ -20,14 +20,26 @@
  * This diffing algorithm uses a bottom-up memoized longest common subsequence solution to identify differences.
  * It runs in O(mn) complexity.
  */
-- (void)asdk_diffWithArray:(NSArray *)array insertions:(NSIndexSet **)insertions deletions:(NSIndexSet **)deletions;
+- (void)asdk_diffWithArray:(NSArray<ObjectType> *)array insertions:(NSIndexSet **)insertions deletions:(NSIndexSet **)deletions;
 
 /**
  * @abstract Compares two arrays, providing the insertion and deletion indexes needed to transform into the target array.
  * @discussion The `compareBlock` is used to identify the equality of the objects within the arrays.
  * This diffing algorithm uses a bottom-up memoized longest common subsequence solution to identify differences.
- * It runs in O(mn) complexity.
+ * It runs in O(mn) complexity. If no compare block is provided, the isEqual: method is used.
+ *
+ * @warning Providing a comparison block makes this operation tremendously slower. For any array that isn't extremely small,
+ *   consider creating new arrays using @c valueForKey: and performing the diff on those with the default comparison.
  */
 - (void)asdk_diffWithArray:(NSArray *)array insertions:(NSIndexSet **)insertions deletions:(NSIndexSet **)deletions compareBlock:(BOOL (^)(id lhs, id rhs))comparison;
 
+/**
+ * @abstract A two-dimensional variant of @c asdk_diffWithArray that computes diffs at both the outer (section) and inner (item) levels.
+ */
+- (void)asdk_nestedDiffWithArray:(NSArray<ObjectType> *)nestedArray
+                insertedSections:(NSIndexSet **)insertedSections
+                 deletedSections:(NSIndexSet **)deletedSections
+                   insertedItems:(NSArray<NSIndexPath *> **)insertedItems
+                    deletedItems:(NSArray<NSIndexPath *> **)deletedItems
+										nestingBlock:(__attribute((noescape)) NSArray *(^)(ObjectType object))nestingBlock;
 @end

--- a/AsyncDisplayKit/Details/NSArray+Diffing.m
+++ b/AsyncDisplayKit/Details/NSArray+Diffing.m
@@ -12,26 +12,72 @@
 
 #import "NSArray+Diffing.h"
 #import "ASAssert.h"
+#import "NSIndexSet+ASHelpers.h"
+#import "ASEqualityHelpers.h"
+
+// This is required to get +indexPathForItem:inSection: which uses tagged pointers for performance.
+#import <UIKit/UICollectionView.h>
+
+/**
+ * If a comparison block exists, calls that.
+ * Otherwise, checks if the precomputed hashes are equal.
+ * If they are equal, uses @c ASObjectIsEqual
+ */
+#define FAST_EQUAL(selfIndex, otherIndex) (comparison ? comparison(self[selfIndex], array[otherIndex]) : (selfHashes[selfIndex] == arrayHashes[otherIndex] && ASObjectIsEqual(self[selfIndex], array[otherIndex])))
+
+#define FAST_EQUAL_NOHASH(array, index, otherArray, otherIndex) (comparison ? comparison(array[index], otherArray[otherIndex]) : ASObjectIsEqual(array[index], otherArray[otherIndex]))
 
 @implementation NSArray (Diffing)
 
 - (void)asdk_diffWithArray:(NSArray *)array insertions:(NSIndexSet **)insertions deletions:(NSIndexSet **)deletions
 {
-  [self asdk_diffWithArray:array insertions:insertions deletions:deletions compareBlock:^BOOL(id lhs, id rhs) {
-    return [lhs isEqual:rhs];
-  }];
+  [self asdk_diffWithArray:array insertions:insertions deletions:deletions compareBlock:nil];
 }
 
 - (void)asdk_diffWithArray:(NSArray *)array insertions:(NSIndexSet **)insertions deletions:(NSIndexSet **)deletions compareBlock:(BOOL (^)(id lhs, id rhs))comparison
 {
-  NSAssert(comparison != nil, @"Comparison block is required");
-  NSIndexSet *commonIndexes = [self _asdk_commonIndexesWithArray:array compareBlock:comparison];
-  
+  [self asdk_diffWithArray:array insertions:insertions deletions:deletions commons:nil compareBlock:comparison];
+}
+
+- (void)asdk_diffWithArray:(NSArray *)array insertions:(NSIndexSet **)insertions deletions:(NSIndexSet **)deletions commons:(NSIndexSet **)commons compareBlock:(BOOL (^)(id lhs, id rhs))comparison
+{
+  NSUInteger selfCount = self.count;
+  NSUInteger arrayCount = array.count;
+
+  // If they didn't provide a comparison block, we are going to use isEqual:
+  // We precompute the hashes of all our elements because for non-trivial
+  // counts, even extremely fast isEqual: implementations will be far too slow.
+  NSUInteger selfHashes[selfCount];
+  NSUInteger arrayHashes[arrayCount];
+  if (comparison == nil) {
+    NSUInteger i = 0;
+    for (id object in self) {
+      selfHashes[i] = [object hash];
+      i += 1;
+    }
+    i = 0;
+    for (id object in array) {
+      arrayHashes[i] = [object hash];
+      i += 1;
+    }
+  }
+
+  NSIndexSet *commonIndexes = [self _asdk_commonIndexesWithArray:array selfHashes:selfHashes arrayHashes:arrayHashes compareBlock:comparison];
+  NSUInteger commonCount = commonIndexes.count;
+
+  if (commons) {
+    *commons = commonIndexes;
+  }
+
+  if (selfCount == arrayCount && commonCount == selfCount) {
+    return;
+  }
+
   if (insertions) {
     NSArray *commonObjects = [self objectsAtIndexes:commonIndexes];
     NSMutableIndexSet *insertionIndexes = [NSMutableIndexSet indexSet];
-    for (NSInteger i = 0, j = 0; i < commonObjects.count || j < array.count;) {
-      if (i < commonObjects.count && j < array.count && comparison(commonObjects[i], array[j])) {
+    for (NSInteger i = 0, j = 0; i < commonCount || j < arrayCount;) {
+      if (i < commonCount && j < arrayCount && FAST_EQUAL_NOHASH(commonObjects, i, array, j)) {
         i++; j++;
       } else {
         [insertionIndexes addIndex:j];
@@ -42,20 +88,14 @@
   }
   
   if (deletions) {
-    NSMutableIndexSet *deletionIndexes = [NSMutableIndexSet indexSet];
-    for (NSInteger i = 0; i < self.count; i++) {
-      if (![commonIndexes containsIndex:i]) {
-        [deletionIndexes addIndex:i];
-      }
-    }
+    NSMutableIndexSet *deletionIndexes = [NSMutableIndexSet indexSetWithIndexesInRange:NSMakeRange(0, self.count)];
+    [deletionIndexes removeIndexes:commonIndexes];
     *deletions = deletionIndexes;
   }
 }
 
-- (NSIndexSet *)_asdk_commonIndexesWithArray:(NSArray *)array compareBlock:(BOOL (^)(id lhs, id rhs))comparison
+- (NSIndexSet *)_asdk_commonIndexesWithArray:(NSArray *)array selfHashes:(NSUInteger *)selfHashes arrayHashes:(NSUInteger *)arrayHashes compareBlock:(BOOL (^)(id lhs, id rhs))comparison
 {
-  NSAssert(comparison != nil, @"Comparison block is required");
-  
   NSInteger selfCount = self.count;
   NSInteger arrayCount = array.count;
   
@@ -72,11 +112,10 @@
   }
   
   for (NSInteger i = 0; i <= selfCount; i++) {
-    id selfObj = i > 0 ? self[i-1] : nil;
     for (NSInteger j = 0; j <= arrayCount; j++) {
       if (i == 0 || j == 0) {
         lengths[i][j] = 0;
-      } else if (comparison(selfObj, array[j-1])) {
+      } else if (FAST_EQUAL(i-1, j-1)) {
         lengths[i][j] = 1 + lengths[i-1][j-1];
       } else {
         lengths[i][j] = MAX(lengths[i-1][j], lengths[i][j-1]);
@@ -87,7 +126,7 @@
   NSMutableIndexSet *common = [NSMutableIndexSet indexSet];
   NSInteger i = selfCount, j = arrayCount;
   while(i > 0 && j > 0) {
-    if (comparison(self[i-1], array[j-1])) {
+    if (FAST_EQUAL(i-1, j-1)) {
       [common addIndex:(i-1)];
       i--; j--;
     } else if (lengths[i-1][j] > lengths[i][j-1]) {
@@ -98,6 +137,52 @@
   }
   
   return common;
+}
+
+- (void)asdk_nestedDiffWithArray:(NSArray *)nestedArray
+                insertedSections:(NSIndexSet **)insertedSections
+                 deletedSections:(NSIndexSet **)deletedSections
+                   insertedItems:(NSArray<NSIndexPath *> **)insertedItems
+                    deletedItems:(NSArray<NSIndexPath *> **)deletedItems
+                    nestingBlock:(__attribute((noescape)) NSArray *(^)(id object))nestingBlock;
+{
+  NSIndexSet *survivingSections = nil;
+  NSMutableArray<NSIndexPath *> *mutableInsertedItems = [NSMutableArray array];
+  NSMutableArray<NSIndexPath *> *mutableDeletedItems = [NSMutableArray array];
+
+  [self asdk_diffWithArray:nestedArray insertions:insertedSections deletions:deletedSections commons:&survivingSections compareBlock:^BOOL(id lhs, id rhs) {
+    return [lhs isEqual:rhs];
+  }];
+  // Would prefer to use ASDN::Mutex but:
+  // 1. It doesn't play well with __block
+  // 2. This file contains code that won't build under C++ (lengths = lengthsData.mutableBytes;)
+  __block pthread_mutex_t lock;
+  ASDisplayNodeAssert(pthread_mutex_init(&lock, NULL) == 0, @"Failed to init lock.");
+  [self enumerateObjectsAtIndexes:survivingSections options:NSEnumerationConcurrent usingBlock:^(id  _Nonnull oldSection, NSUInteger oldSectionIndex, BOOL * _Nonnull stop) {
+    NSUInteger newSectionIndex = oldSectionIndex;
+    newSectionIndex -= [*deletedSections countOfIndexesInRange:NSMakeRange(0, oldSectionIndex)];
+    newSectionIndex += [*insertedSections as_indexChangeByInsertingItemsBelowIndex:oldSectionIndex];
+
+    id newSection = nestedArray[newSectionIndex];
+    NSArray *oldItems = nestingBlock(oldSection);
+    NSArray *newItems = nestingBlock(newSection);
+    NSIndexSet *deletedItemsInSection = nil, *insertedItemsInSection = nil;
+    [oldItems asdk_diffWithArray:newItems insertions:&insertedItemsInSection deletions:&deletedItemsInSection];
+
+    // Technically we could just lock around the -addObject call but this is simpler and
+    // the performance difference would probably be a wash.
+    ASDisplayNodeAssert(pthread_mutex_lock(&lock) == 0, @"Failed to acquire lock");
+    [deletedItemsInSection enumerateIndexesUsingBlock:^(NSUInteger idx, BOOL * _Nonnull stop) {
+      [mutableDeletedItems addObject:[NSIndexPath indexPathForItem:idx inSection:oldSectionIndex]];
+    }];
+    [insertedItemsInSection enumerateIndexesUsingBlock:^(NSUInteger idx, BOOL * _Nonnull stop) {
+      [mutableInsertedItems addObject:[NSIndexPath indexPathForItem:idx inSection:newSectionIndex]];
+    }];
+    ASDisplayNodeAssert(pthread_mutex_unlock(&lock) == 0, @"Failed to release lock");
+  }];
+  ASDisplayNodeAssert(pthread_mutex_destroy(&lock) == 0, @"Failed to destroy lock.");
+  *insertedItems = mutableInsertedItems;
+  *deletedItems = mutableDeletedItems;
 }
 
 @end

--- a/AsyncDisplayKit/Private/ASCollectionDataInternal.h
+++ b/AsyncDisplayKit/Private/ASCollectionDataInternal.h
@@ -1,0 +1,76 @@
+//
+//  ASCollectionDataInternal.h
+//  AsyncDisplayKit
+//
+//  Created by Adlai Holler on 11/5/16.
+//  Copyright © 2016 Facebook. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <vector>
+#import <AsyncDisplayKit/ASBaseDefines.h>
+#import <AsyncDisplayKit/ASCollectionData.h>
+#import "ASSection.h"
+#import "ASIndexedNodeContext.h"
+#import "ASObjectDescriptionHelpers.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * An item (or supplementary element) in a collection.
+ * 
+ * NOTE: Hashing and equality are based on identifier.
+ */
+@interface ASCollectionItemImpl : NSObject <ASCollectionItem, ASDescriptionProvider>
+
+// NOTE: This property is nilled out after it is read.
+@property (nonatomic, readonly, strong, nullable) ASCellNodeBlock nodeBlock;
+
+- (instancetype)initWithIdentifier:(ASItemIdentifier)identifier
+                         nodeBlock:(ASCellNodeBlock)nodeBlock;
+@end
+
+/**
+ * In the future we could unify this with ASSection, but right now they're
+ * used in somewhat different ways, and have different lifetimes.
+ *
+ * NOTE: When a section is copied, its items array is reset to empty.
+ * NOTE: Hashing and equality are based on identifier AND supplementary element set.
+ *   - This is because currently the only way we can reconfigure the supplementary elements
+ *     in a given section is by reloading the section. This doesn't discard the items in that 
+ *     section, so changing this should not be very high priority.
+ */
+@interface ASCollectionSectionImpl : NSObject <ASCollectionSection, ASDescriptionProvider, NSCopying>
+
+- (instancetype)initWithIdentifier:(ASSectionIdentifier)identifier;
+
+// Private properties
+@property (nonatomic, strong, readonly) NSArray<ASCollectionItemImpl *> *itemsInternal;
+@property (nonatomic, strong, readonly) NSMutableDictionary<NSString *, NSMutableDictionary<NSNumber *, ASCollectionItemImpl *> *> *supplementaryElements;
+@end
+
+@interface ASCollectionData () <ASDescriptionProvider>
+
+/**
+ * Creates a new data that can reuse elements from the given data object, or a blank one if none is provided.
+ */
+- (instancetype)initWithReusableContentFromCompletedData:(nullable ASCollectionData *)data NS_DESIGNATED_INITIALIZER;
+
+@property (nonatomic, copy, nullable) void(^postNodeBlock)(ASCellNode *);
+
+@property (nonatomic, strong, readonly) NSArray<ASCollectionSectionImpl *> *sectionsInternal;
+
+/// Retrieve the number of items in each section. Must be completed.
+@property (nonatomic, readonly) std::vector<NSInteger> itemCounts;
+
+/// Retrieve the item at the given index path. Must be completed.
+- (ASCollectionItemImpl *)elementOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath;
+
+// Call this when editing the data is done.
+- (void)markCompleted;
+
+@property (nonatomic, copy, readonly) NSMutableSet<ASSupplementaryElementKind> *allSupplementaryKinds;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/AsyncDisplayKit/Private/ASCollectionDataInternal.mm
+++ b/AsyncDisplayKit/Private/ASCollectionDataInternal.mm
@@ -1,0 +1,320 @@
+//
+//  ASCollectionDataInternal.m
+//  AsyncDisplayKit
+//
+//  Created by Adlai Holler on 11/5/16.
+//  Copyright © 2016 Facebook. All rights reserved.
+//
+
+#import "ASCollectionDataInternal.h"
+#import "ASDimension.h"
+#import "ASEqualityHashHelpers.h"
+
+static ASSectionIdentifier const ASDefaultSectionIdentifier = @"ASDefaultSectionIdentifier";
+
+std::vector<NSInteger> ASItemCountsFromData(ASCollectionData * data)
+{
+  std::vector<NSInteger> result;
+  for (id<ASCollectionSection> s in data.mutableSections) {
+    result.push_back(s.mutableItems.count);
+  }
+	return result;
+}
+
+@implementation ASCollectionItemImpl
+@synthesize identifier = _identifier;
+@synthesize nodeBlock = _nodeBlock;
+
+- (instancetype)initWithIdentifier:(ASItemIdentifier)identifier nodeBlock:(ASCellNodeBlock)nodeBlock
+{
+  self = [super init];
+  if (self != nil) {
+    _identifier = identifier;
+    _nodeBlock = nodeBlock;
+  }
+  return self;
+}
+
+- (ASCellNodeBlock)nodeBlock
+{
+  ASCellNodeBlock result = _nodeBlock;
+  _nodeBlock = nil;
+  return result;
+}
+
+- (BOOL)isEqual:(id)object
+{
+  if ([object isKindOfClass:[ASCollectionItemImpl class]] == NO) {
+    return NO;
+  }
+  return [_identifier isEqualToString:[object identifier]];
+}
+
+- (NSUInteger)hash
+{
+  return _identifier.hash;
+}
+
+- (NSString *)description
+{
+  return ASObjectDescriptionMake(self, [self propertiesForDescription]);
+}
+
+- (NSMutableArray <NSDictionary *> *)propertiesForDescription
+{
+  NSMutableArray *array = [NSMutableArray array];
+  [array addObject:@{ @"identifier" : _identifier }];
+  return array;
+}
+
+@end
+
+@implementation ASCollectionSectionImpl
+@synthesize mutableItems = _mutableItems;
+@synthesize identifier = _identifier;
+
+- (instancetype)initWithIdentifier:(ASSectionIdentifier)identifier
+{
+  self = [super init];
+  if (self != nil) {
+    _identifier = identifier;
+    _mutableItems = [NSMutableArray array];
+    _supplementaryElements = [NSMutableDictionary dictionary];
+  }
+  return self;
+}
+
+- (NSArray *)itemsInternal
+{
+  return _mutableItems;
+}
+
+- (BOOL)isEqual:(id)object
+{
+  if ([object isKindOfClass:[ASCollectionSectionImpl class]] == NO) {
+    return NO;
+  }
+  ASCollectionSectionImpl *otherSection = (ASCollectionSectionImpl *)object;
+  return [_identifier isEqualToString:otherSection.identifier]
+    && [_supplementaryElements isEqualToDictionary:otherSection.supplementaryElements];
+}
+
+- (NSUInteger)hash
+{
+  return ASHashCombine((uint64_t)_identifier.hash, (uint64_t)_supplementaryElements.hash);
+}
+
+- (id)copyWithZone:(NSZone *)zone
+{
+  return [[self.class alloc] initWithIdentifier:_identifier];
+}
+
+- (void)setSupplementaryElement:(ASCollectionItemImpl *)item ofKind:(ASSupplementaryElementKind)kind atIndex:(NSInteger)index
+{
+  NSMutableDictionary<NSNumber *, ASCollectionItemImpl *> *dict = _supplementaryElements[kind];
+  if (dict == nil) {
+    dict = [NSMutableDictionary dictionary];
+    _supplementaryElements[kind] = dict;
+  }
+  ASDisplayNodeAssertNil(dict[@(index)], @"Supplementary element of kind %@ already exists at index %td. Identifier: %@", kind, index, dict[@(index)].identifier);
+  dict[@(index)] = item;
+}
+
+- (NSString *)description
+{
+  return ASObjectDescriptionMake(self, [self propertiesForDescription]);
+}
+
+- (NSMutableArray <NSDictionary *> *)propertiesForDescription
+{
+  NSMutableArray *array = [NSMutableArray array];
+  [array addObject:@{ @"identifier" : _identifier }];
+  [array addObject:@{ @"items" : _mutableItems }];
+  if (_supplementaryElements.count > 0) {
+    [array addObject:@{ @"supplementaries" : _supplementaryElements }];
+  }
+  return array;
+}
+
+@end
+
+@implementation ASCollectionData {
+  ASCollectionSectionImpl *_currentSection;
+
+  NSMutableDictionary<ASItemIdentifier, ASCollectionItemImpl *> *_itemsDict;
+  NSMutableDictionary<ASSectionIdentifier, ASCollectionSectionImpl *> *_sectionsDict;
+
+  // We could have used NSMutableSet for these, but copying the dictionary is probably faster than
+  // creating an array of all keys, then creating a set of those, and then creating an array from the set
+  // during the copy.
+  NSMutableDictionary<ASItemIdentifier, ASCollectionItemImpl *> *_usedItems;
+  NSMutableDictionary<ASSectionIdentifier, ASCollectionSectionImpl *> *_usedSections;
+
+  NSMutableSet *_supplementaryElementKinds;
+  BOOL _completed;
+}
+
+- (instancetype)initWithReusableContentFromCompletedData:(ASCollectionData *)data
+{
+  self = [super init];
+  if (self != nil) {
+    _usedItems = [NSMutableDictionary dictionary];
+    _usedSections = [NSMutableDictionary dictionary];
+    _mutableSections = [NSMutableArray array];
+    _supplementaryElementKinds = [NSMutableSet set];
+    
+    if (data != nil) {
+      ASDisplayNodeAssert(data->_completed, @"You must pass a completed collection data.");
+      _itemsDict = data->_usedItems;
+      _sectionsDict = [[NSMutableDictionary alloc] initWithDictionary:data->_usedSections copyItems:YES];
+    } else {
+      _itemsDict = [NSMutableDictionary dictionary];
+      _sectionsDict = [NSMutableDictionary dictionary];
+    }
+  }
+  return self;
+}
+
+- (instancetype)init
+{
+  return [self initWithReusableContentFromCompletedData:nil];
+}
+
+#pragma mark - Convenience Builders (Public)
+
+- (void)addSectionWithIdentifier:(ASSectionIdentifier)identifier block:(void (^)(ASCollectionData * _Nonnull))block
+{
+  if (_currentSection != nil) {
+    ASDisplayNodeFailAssert(@"Call to %@ must not be inside an addSection: block.", NSStringFromSelector(_cmd));
+    return;
+  }
+
+  _currentSection = (ASCollectionSectionImpl *)[self sectionWithIdentifier:identifier];
+  [_mutableSections addObject:_currentSection];
+  block(self);
+  _currentSection = nil;
+}
+
+- (void)addItemWithIdentifier:(ASItemIdentifier)identifier nodeBlock:(ASCellNodeBlock)nodeBlock
+{
+  id<ASCollectionSection> section = _currentSection;
+  if (section == nil) {
+    section = [self _sectionWithIdentifier:identifier appendingIfCreated:YES];
+  }
+
+  ASCollectionItemImpl *item = [self _itemWithIdentifier:identifier nodeBlock:nodeBlock];
+  [section.mutableItems addObject:item];
+  _usedItems[identifier] = item;
+}
+
+- (void)addSupplementaryElementOfKind:(ASSupplementaryElementKind)elementKind
+                       withIdentifier:(ASItemIdentifier)identifier
+                                index:(NSInteger)index
+                            nodeBlock:(ASCellNodeBlock)nodeBlock
+{
+  ASCollectionSectionImpl *section = _currentSection;
+  if (section == nil) {
+    section = [self _sectionWithIdentifier:identifier appendingIfCreated:YES];
+  }
+  ASCollectionItemImpl *item = [self _itemWithIdentifier:identifier nodeBlock:nodeBlock];
+  [_supplementaryElementKinds addObject:elementKind];
+  [section setSupplementaryElement:item ofKind:elementKind atIndex:index];
+  _usedItems[identifier] = item;
+}
+
+#pragma mark - Item / Section Access (Public)
+
+- (id<ASCollectionItem>)itemWithIdentifier:(ASItemIdentifier)identifier nodeBlock:(nonnull ASCellNodeBlock)nodeBlock
+{
+  ASDisplayNodeAssertNil(_usedItems[identifier], @"Attempt to use the same item twice. Identifier: %@", identifier);
+  ASCollectionItemImpl *item = [self _itemWithIdentifier:identifier nodeBlock:nodeBlock];
+  _usedItems[identifier] = item;
+  return item;
+}
+
+- (id<ASCollectionSection>)sectionWithIdentifier:(ASSectionIdentifier)identifier
+{
+  ASDisplayNodeAssertNil(_usedSections[identifier], @"Attempt to use the same section twice. Identifier: %@", identifier);
+  return [self _sectionWithIdentifier:identifier appendingIfCreated:NO];
+}
+
+#pragma mark - Framework Accessors
+
+- (NSMutableSet *)supplementaryElementKinds
+{
+  return [_supplementaryElementKinds mutableCopy];
+}
+
+- (NSArray *)sectionsInternal
+{
+  return _mutableSections;
+}
+
+- (ASCollectionItemImpl *)elementOfKind:(ASSupplementaryElementKind)kind atIndexPath:(NSIndexPath *)indexPath
+{
+  ASCollectionSectionImpl *section = self.sectionsInternal[indexPath.section];
+  if (kind == ASDataControllerRowNodeKind) {
+    return section.itemsInternal[indexPath.item];
+  } else {
+    return section.supplementaryElements[kind][@(indexPath.item)];
+  }
+}
+
+- (void)markCompleted
+{
+  _completed = YES;
+}
+
+- (std::vector<NSInteger>)itemCounts
+{
+  std::vector<NSInteger> result;
+  for (ASCollectionSectionImpl *section in self.sectionsInternal) {
+    result.push_back(section.itemsInternal.count);
+  }
+  return result;
+}
+
+- (NSString *)description
+{
+  return ASObjectDescriptionMake(self, [self propertiesForDescription]);
+}
+
+- (NSMutableArray <NSDictionary *> *)propertiesForDescription
+{
+  NSMutableArray *array = [NSMutableArray array];
+  [array addObject:@{ @"sections" : _mutableSections }];
+  return array;
+}
+
+#pragma mark - Private
+
+- (ASCollectionItemImpl *)_itemWithIdentifier:(ASItemIdentifier)identifier nodeBlock:(nonnull ASCellNodeBlock)nodeBlock
+{
+  ASCollectionItemImpl *item = _itemsDict[identifier];
+  if (item == nil) {
+    void (^postNodeBlock)(ASCellNode *) = _postNodeBlock;
+    item = [[ASCollectionItemImpl alloc] initWithIdentifier:identifier nodeBlock:^{
+      ASCellNode *node = nodeBlock();
+      if (postNodeBlock != nil) {
+        postNodeBlock(node);
+      }
+      return node;
+    }];
+  }
+  return item;
+}
+
+- (ASCollectionSectionImpl *)_sectionWithIdentifier:(ASSectionIdentifier)identifier appendingIfCreated:(BOOL)append
+{
+  ASCollectionSectionImpl *section = _sectionsDict[identifier];
+  if (section == nil) {
+    section = [[ASCollectionSectionImpl alloc] initWithIdentifier:identifier];
+    if (append) {
+      [self.mutableSections addObject:section];
+    }
+  }
+  _usedSections[identifier] = section;
+  return section;
+}
+
+@end

--- a/AsyncDisplayKit/Private/ASDataController+Subclasses.h
+++ b/AsyncDisplayKit/Private/ASDataController+Subclasses.h
@@ -11,6 +11,7 @@
 #pragma once
 #import <vector>
 
+@protocol ASCollectionData;
 @class ASIndexedNodeContext;
 
 typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCellNode *> *nodes, NSArray<NSIndexPath *> *indexPaths);
@@ -39,7 +40,7 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCellNode *> *nodes, NS
  *
  * This must be called on the main thread.
  */
-- (void)invalidateDataSourceItemCounts;
+- (void)invalidateDataSourceData;
 
 /**
  * Returns the most recently gathered item counts from the data source. If the counts

--- a/AsyncDisplayKitTests/ASCollectionViewFlowLayoutInspectorTests.m
+++ b/AsyncDisplayKitTests/ASCollectionViewFlowLayoutInspectorTests.m
@@ -17,6 +17,7 @@
 #import "ASCollectionViewFlowLayoutInspector.h"
 #import "ASCellNode.h"
 #import "ASCollectionView+Undeprecated.h"
+#import "ASCollectionInternal.h"
 
 @interface ASCollectionView (Private)
 
@@ -380,6 +381,7 @@
   UICollectionViewFlowLayout *layout = [[UICollectionViewFlowLayout alloc] init];
   ASCollectionNode *node = [[ASCollectionNode alloc] initWithCollectionViewLayout:layout];
   ASCollectionView *collectionView = node.view;
+  collectionView.test_suppressCallbackImplementationAssertions = YES;
   
   id dataSourceAndDelegate = [OCMockObject mockForProtocol:@protocol(InspectorTestDataSourceDelegateProtocol)];
   ASSizeRange constrainedSize = ASSizeRangeMake(CGSizeZero, CGSizeZero);
@@ -406,6 +408,7 @@
   
   ASCollectionNode *node = [[ASCollectionNode alloc] initWithCollectionViewLayout:layout];
   ASCollectionView *collectionView = node.view;
+  collectionView.test_suppressCallbackImplementationAssertions = YES;
   id dataSourceAndDelegate = [OCMockObject mockForProtocol:@protocol(InspectorTestDataSourceDelegateProtocol)];
   ASSizeRange constrainedSize = ASSizeRangeMake(CGSizeZero, CGSizeZero);
   NSIndexPath *indexPath = [NSIndexPath indexPathForItem:0 inSection:0];

--- a/AsyncDisplayKitTests/ArrayDiffingTests.m
+++ b/AsyncDisplayKitTests/ArrayDiffingTests.m
@@ -15,7 +15,7 @@
 #import "NSArray+Diffing.h"
 
 @interface NSArray (ArrayDiffingTests)
-- (NSIndexSet *)_asdk_commonIndexesWithArray:(NSArray *)array compareBlock:(BOOL (^)(id lhs, id rhs))comparison;
+- (NSIndexSet *)_asdk_commonIndexesWithArray:(NSArray *)array selfHashes:(NSUInteger *)selfHashes arrayHashes:(NSUInteger *)arrayHashes compareBlock:(BOOL (^)(id lhs, id rhs))comparison;
 @end
 
 @interface ArrayDiffingTests : XCTestCase
@@ -55,7 +55,7 @@
   ];
 
   for (NSArray *test in tests) {
-    NSIndexSet *indexSet = [test[0] _asdk_commonIndexesWithArray:test[1] compareBlock:^BOOL(id lhs, id rhs) {
+    NSIndexSet *indexSet = [test[0] _asdk_commonIndexesWithArray:test[1] selfHashes:NULL arrayHashes:NULL compareBlock:^BOOL(id lhs, id rhs) {
       return [lhs isEqual:rhs];
     }];
     

--- a/examples/CatDealsCollectionView/Sample/ItemViewModel.h
+++ b/examples/CatDealsCollectionView/Sample/ItemViewModel.h
@@ -24,6 +24,7 @@
 
 + (instancetype)randomItem;
 
+@property (nonatomic, copy) NSString *uuid;
 @property (nonatomic, copy) NSString *titleText;
 @property (nonatomic, copy) NSString *firstInfoText;
 @property (nonatomic, copy) NSString *secondInfoText;

--- a/examples/CatDealsCollectionView/Sample/ItemViewModel.m
+++ b/examples/CatDealsCollectionView/Sample/ItemViewModel.m
@@ -37,25 +37,25 @@ NSArray *badges;
 }
 
 - (instancetype)init {
-    self = [super init];
-    if (self) {
-        _titleText = [self randomObjectFromArray:titles];
-        _firstInfoText = [self randomObjectFromArray:firstInfos];
-        _secondInfoText = [NSString stringWithFormat:@"%zd+ bought", [self randomNumberInRange:5 to:6000]];
-        _originalPriceText = [NSString stringWithFormat:@"$%zd", [self randomNumberInRange:40 to:90]];
-        _finalPriceText = [NSString stringWithFormat:@"$%zd", [self randomNumberInRange:5 to:30]];
-        BOOL isSoldOut = arc4random() % 5 == 0;
-        _soldOutText = isSoldOut ? @"SOLD OUT" : nil;
-        _distanceLabelText = [NSString stringWithFormat:@"%zd mi", [self randomNumberInRange:1 to:20]];
-        BOOL isBadged = arc4random() % 2 == 0;
-        if (isBadged) {
-            _badgeText = [self randomObjectFromArray:badges];
-        }
-        _catNumber = [self randomNumberInRange:1 to:10];
-        _labelNumber = [self randomNumberInRange:1 to:10000];
-        
+  self = [super init];
+  if (self) {
+    _uuid = [NSUUID UUID].UUIDString;
+    _titleText = [self randomObjectFromArray:titles];
+    _firstInfoText = [self randomObjectFromArray:firstInfos];
+    _secondInfoText = [NSString stringWithFormat:@"%zd+ bought", [self randomNumberInRange:5 to:6000]];
+    _originalPriceText = [NSString stringWithFormat:@"$%zd", [self randomNumberInRange:40 to:90]];
+    _finalPriceText = [NSString stringWithFormat:@"$%zd", [self randomNumberInRange:5 to:30]];
+    BOOL isSoldOut = arc4random() % 5 == 0;
+    _soldOutText = isSoldOut ? @"SOLD OUT" : nil;
+    _distanceLabelText = [NSString stringWithFormat:@"%zd mi", [self randomNumberInRange:1 to:20]];
+    BOOL isBadged = arc4random() % 2 == 0;
+    if (isBadged) {
+      _badgeText = [self randomObjectFromArray:badges];
     }
-    return self;
+    _catNumber = [self randomNumberInRange:1 to:10];
+    _labelNumber = [self randomNumberInRange:1 to:10000];
+  }
+  return self;
 }
 
 - (NSURL *)imageURLWithSize:(CGSize)size {

--- a/examples/CustomCollectionView/Sample/ViewController.m
+++ b/examples/CustomCollectionView/Sample/ViewController.m
@@ -25,7 +25,7 @@ static NSUInteger kNumberOfImages = 14;
 
 @interface ViewController () <ASCollectionDataSource, ASCollectionDelegate>
 {
-  NSMutableArray *_sections;
+  NSMutableArray<NSMutableArray<UIImage *> *> *_sections;
   ASCollectionNode *_collectionNode;
   MosaicCollectionViewLayoutInspector *_layoutInspector;
 }
@@ -76,21 +76,22 @@ static NSUInteger kNumberOfImages = 14;
   _collectionNode.view.layoutInspector = _layoutInspector;
 }
 
-- (void)reloadTapped
-{
-  [_collectionNode reloadData];
-}
-
 #pragma mark - ASCollectionNode data source.
 
-- (ASCellNodeBlock)collectionNode:(ASCollectionNode *)collectionNode nodeBlockForItemAtIndexPath:(NSIndexPath *)indexPath
+- (ASCollectionData *)dataForCollectionNode:(ASCollectionNode *)collectionNode
 {
-  UIImage *image = _sections[indexPath.section][indexPath.item];
-  return ^{
-    return [[ImageCellNode alloc] initWithImage:image];
-  };
+  ASCollectionData *data = [collectionNode createNewData];
+  for (NSArray *section in _sections) {
+    [data addSectionWithIdentifier:[NSString stringWithFormat:@"Section %p", section] block:^(ASCollectionData * _Nonnull data) {
+      for (UIImage *image in section) {
+        [data addItemWithIdentifier:[NSString stringWithFormat:@"Item %p", image] nodeBlock:^ASCellNode * _Nonnull{
+          return [[ImageCellNode alloc] initWithImage:image];
+        }];
+      }
+    }];
+  }
+  return data;
 }
-
 
 - (ASCellNode *)collectionNode:(ASCollectionNode *)collectionNode nodeForSupplementaryElementOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath
 {
@@ -102,16 +103,6 @@ static NSUInteger kNumberOfImages = 14;
   ASTextCellNode *textCellNode = [[ASTextCellNode alloc] initWithAttributes:textAttributes insets:textInsets];
   textCellNode.text = [NSString stringWithFormat:@"Section %zd", indexPath.section + 1];
   return textCellNode;
-}
-
-- (NSInteger)numberOfSectionsInCollectionNode:(ASCollectionNode *)collectionNode
-{
-  return _sections.count;
-}
-
-- (NSInteger)collectionNode:(ASCollectionNode *)collectionNode numberOfItemsInSection:(NSInteger)section
-{
-  return [_sections[section] count];
 }
 
 - (CGSize)collectionView:(ASCollectionNode *)collectionNode layout:(UICollectionViewLayout *)collectionViewLayout originalItemSizeAtIndexPath:(NSIndexPath *)indexPath


### PR DESCRIPTION
UICollectionView/UITableView API is a pain to work with. Does the message `Invalid number of items in section 0. The number of items in an existing section after the update (10) must be equal to the number of items before the update (6), plus or minus the number inserted or deleted (3 inserted, 0 deleted)` look familiar?

### What it Looks Like

#### Before:

```objectivec
- (NSInteger)numberOfSectionsInCollectionNode:(ASCollectionNode *)collectionNode
{
  if (self.showRecentSearches) {
    return 2;
  } else {
    return 1;
  }
}

- (NSInteger)collectionNode:(ASCollectionNode *)collectionNode numberOfItemsInSection:(NSInteger)section
{
  if (self.showRecentSearches && section == 0) {
    return self.recentSearches.count;
  } else {
    return self.searchResults.count + (self.searchIsLoading ? 1 : 0); // Account for loading spinner
  }
}

- (ASCellNodeBlock)collectionNode:(ASCollectionNode *)collectionNode nodeBlockForItemAtIndexPath:(NSIndexPath *)indexPath
{
  if (self.showRecentSearches && indexPath.section == 0) {
    EXRecentSearch *s = self.recentSearches[indexPath.item];
    return ^{
      return [EXRecentSearchNode nodeWithSearch:s];
    };
  } else if (self.searchIsLoading) {
    return ^{
      return [[EXLoadingNode alloc] init];
    }
  } else {
    EXSearchResult *r = self.searchResults[indexPath.item];
    return ^{
      return [EXSearchResultNode nodeWithResult:r];
    }
  } else {
    NSAssert(NO, @"Can't provide node block for item at index path: %@", indexPath);
  }
}

- (void)searchDidReceiveResults:(NSArray *)newResults
{
  NSInteger oldResultCount = self.searchResults.count;
  [self.searchResults addObjectsFromArray:newResults];
  NSInteger newResultCount = self.searchResults.count;
  NSInteger resultsSection = self.showRecentSearches ? 1 : 0;
  [self.collectionNode performBatchUpdates:^{
    // Delete the loading spinner.
    [self.collectionNode deleteItemsAtIndexPaths:@[ [NSIndexPath indexPathForItem:oldResultCount inSection:resultsSection];
    NSMutableArray *indexPaths = [NSMutableArray array];
    for (NSInteger i = oldResultCount; i < newResultCount; i++) {
      [indexPaths addObject:[NSIndexPath indexPathForItem:oldResultCount inSection:resultsSection]];
    }
    [self.collectionNode insertItemsAtIndexPaths:indexPaths];
  } completion:nil];
}
```

#### After:

```objectivec
- (ASCollectionData *)dataForCollectionNode:(ASCollectionNode *)collectionNode
{
  ASCollectionData *data = [collectionNode createNewData];
  if (self.showRecentSearches) {
    [data addSectionWithIdentifier:@"recentSearches" block:^(ASCollectionData *data) {
      for (EXRecentSearch *s in self.recentSearches) {
        // Assume namespacedIdentifier is e.g. "EXRecentSearch.18797555"
        [data addItemWithIdentifier:s.namespacedIdentifier nodeBlock:^{
          return [EXRecentSearchNode nodeWithSearch:s];
        }];
      }
    }];
  }
  [data addSectionWithIdentifier:@"searchResults" block:^(ASCollectionData *data) {
    for (EXSearchResult *r in self.searchResults) {
      [data addItemWithIdentifier:r.namespacedIdentifier nodeBlock:^{
        return [EXSearchResultNode nodeWithResult:r];
      }];
    }
    if (self.searchIsLoading) {
      [data addItemWithIdentifier:@"resultsSpinner" nodeBlock:^{
        return [[EXLoadingNode alloc] init];
      }];
    }
  }];
  // There are also APIs for getting more fine-grained control, i.e.
  // getting an NSMutableArray of items/sections that you can do with as you please.
}

- (void)searchDidReceiveResults:(NSArray *)newResults
{
  [self.searchResults addObjectsFromArray:newResults];
  [self.collectionNode performBatchUpdate:nil completion:nil]; // Could be some new method, or -reloadData.
}
```

#### How it Works

If the data source implements the new method, all imperative updates are ignored. Whenever an update is submitted, the method is called. It retrieves a data object that contains all of the existing items and sections in the collection node, by identifier. It configures the data set how it wants it, we do a nested diff against the old data, and we update if needed.

#### Performance Considerations

- The diffing algorithm in this diff has been vastly optimized. I scrolled down through Pinterest's home feed a long way (30 seconds' worth) on my iPhone 6. Using the original diffing implementation, it spent about 1100ms diffing. After my optimizations, the number was around 33ms, which was small compared to the amount of time spent in UIKit machinery. 
- If the user adds an item with an identifier that already existed, then no allocations occur. If they provide the nodeBlock argument inline, then no `Block_copy` happens either. I've added documentation indicating that you will get somewhat improved performance by specifying the node block inline, rather than calling `[self nodeBlockForItemAtRow:]` or similar.
- Users may generate their identifiers lazily i.e. `[NSString stringWithFormat:@"%@.%@", model.class, model.identifier]`. This is unfortunate, but acceptable – string allocations are crazy fast. For cases with extremely high item counts and extremely common updates, we can advise users to store their identifiers, which really isn't hard.
- In the future, we might do some or all of the diffing asynchronously, but the cost-benefit doesn't justify that at this time.
  - We would have to be sure to wait for the update to complete if the user called `nodeForItemAtIndexPath:` or `numberOfItemsInSection` or `indexPathForNode:` or really any ASCollectionNode API.
  - We should call `dataForCollectionNode:` on the main thread because users are going to use main-thread-affine view controller flags, and their upstream data sources are main-thread-affine as well.

### Further Considerations

- How should a user trigger an update?
  - Option 1: Calling `reloadData` or ending a batch update always triggers the incremental update.
  - Option 2: A new method e.g. `performUpdateWithCompletion:` triggers the incremental update, and `reloadData` always invalidates everything.
  - Advocacy: Option 1.
    - Users are trained to throw `reloadData` when they aren't sure how to commit an update.
    - I can't think of a use case for "throw away all the nodes that exists for all the identifiers and then reload." I'm sure one exists out there, but this could be achieved by another means (see below).
- How should a user indicate they want to invalidate the existing node for a given identifier/section?
  - Consider the use case: a user taps on a pin, and now we want to change that pin to be represented by a different class of node.
  - If this method exists, it should live on the collection node itself, not on the data. They should be able to call it inside of `dataForCollectionNode:` as well as in arbitrary regions of their code , which might be slightly tricky.
  - Option 1: They can't. If you want to get a new node, change the identifier.
  - Option 2: Add a method like `invalidateElementWithIdentifier:` to ASCollectionNode that will pipe the invalidation through to both the current data, and to the data that is currently being configured.
- How should we gather the constrained size? What if they give us a different constrained size for an already-measured node?
  - I believe the correct solution is for the layout inspector (or the asynchronous layout object that will likely replace it) to decide the constrained size on its own.
  - If that object wants to reach out to the data source or delegate (through a separate protocol a la `UICollectionViewDelegateFlowLayout`) to get advisement about the constrained size of an element, then it can. ASDK doesn't need to be involved.
  - For today, I advocate for leaving the constrained-size gathering system as-is. It is sufficient for our purposes, it is likely to change, and in my opinion, it is very unlikely to require ASDK to gather constrained sizes for all items upfront.

#### Wrapping Up

This diff also updates the examples to use the new API. They all run nicely. Once this API is approved, I'll apply it also to ASTableNode. Please be generous with your feedback!
@maicki @garrettmoon @appleguy @nguyenhuy @levi @hannahmbanana @rcancro @Yue-Wang-Google @george-gw 