### PR TITLE
Fix Issue in ASPagerNode Flags Handling, Restore Disabled Test

### DIFF
--- a/AsyncDisplayKit/ASPagerNode.m
+++ b/AsyncDisplayKit/ASPagerNode.m
@@ -21,11 +21,15 @@
 
   __weak id <ASPagerDataSource> _pagerDataSource;
   ASPagerNodeProxy *_proxyDataSource;
-  BOOL _pagerDataSourceImplementsNodeBlockAtIndex;
+  struct {
+    unsigned nodeBlockAtIndex:1;
+  } _pagerDataSourceFlags;
 
   __weak id <ASPagerDelegate> _pagerDelegate;
+  struct {
+    unsigned constrainedSizeForNode:1;
+  } _pagerDelegateFlags;
   ASPagerNodeProxy *_proxyDelegate;
-  BOOL _pagerDelegateImplementsConstrainedSizeForNode;
 }
 
 @end
@@ -123,7 +127,7 @@
 - (ASCellNodeBlock)collectionNode:(ASCollectionNode *)collectionNode nodeBlockForItemAtIndexPath:(NSIndexPath *)indexPath
 {
   ASDisplayNodeAssert(_pagerDataSource != nil, @"ASPagerNode must have a data source to load nodes to display");
-  if (!_pagerDataSourceImplementsNodeBlockAtIndex) {
+  if (_pagerDataSourceFlags.nodeBlockAtIndex == NO) {
     ASCellNode *node = [_pagerDataSource pagerNode:self nodeAtIndex:indexPath.item];
     return ^{ return node; };
   }
@@ -140,7 +144,7 @@
 
 - (ASSizeRange)collectionNode:(ASCollectionNode *)collectionNode constrainedSizeForItemAtIndexPath:(NSIndexPath *)indexPath
 {
-  if (_pagerDelegateImplementsConstrainedSizeForNode) {
+  if (_pagerDelegateFlags.constrainedSizeForNode) {
     return [_pagerDelegate pagerNode:self constrainedSizeForNodeAtIndex:indexPath.item];
   }
 
@@ -159,9 +163,13 @@
   if (dataSource != _pagerDataSource) {
     _pagerDataSource = dataSource;
     
-    _pagerDataSourceImplementsNodeBlockAtIndex = [_pagerDataSource respondsToSelector:@selector(pagerNode:nodeBlockAtIndex:)];
-    // Data source must implement pagerNode:nodeBlockAtIndex: or pagerNode:nodeAtIndex:
-    ASDisplayNodeAssertTrue(_pagerDataSourceImplementsNodeBlockAtIndex || [_pagerDataSource respondsToSelector:@selector(pagerNode:nodeAtIndex:)]);
+    if (dataSource == nil) {
+      memset(&_pagerDataSourceFlags, 0, sizeof(_pagerDataSourceFlags));
+    } else {
+      _pagerDataSourceFlags.nodeBlockAtIndex = [_pagerDataSource respondsToSelector:@selector(pagerNode:nodeBlockAtIndex:)];
+      // Data source must implement pagerNode:nodeBlockAtIndex: or pagerNode:nodeAtIndex:
+      ASDisplayNodeAssertTrue(_pagerDataSourceFlags.nodeBlockAtIndex || [_pagerDataSource respondsToSelector:@selector(pagerNode:nodeAtIndex:)]);
+    }
     
     _proxyDataSource = dataSource ? [[ASPagerNodeProxy alloc] initWithTarget:dataSource interceptor:self] : nil;
     
@@ -174,7 +182,11 @@
   if (delegate != _pagerDelegate) {
     _pagerDelegate = delegate;
     
-    _pagerDelegateImplementsConstrainedSizeForNode = [_pagerDelegate respondsToSelector:@selector(pagerNode:constrainedSizeForNodeAtIndex:)];
+    if (delegate == nil) {
+      memset(&_pagerDelegateFlags, 0, sizeof(_pagerDelegateFlags));
+    } else {
+    	_pagerDelegateFlags.constrainedSizeForNode = [_pagerDelegate respondsToSelector:@selector(pagerNode:constrainedSizeForNodeAtIndex:)];
+    }
     
     _proxyDelegate = delegate ? [[ASPagerNodeProxy alloc] initWithTarget:delegate interceptor:self] : nil;
     

--- a/AsyncDisplayKitTests/ASViewControllerTests.m
+++ b/AsyncDisplayKitTests/ASViewControllerTests.m
@@ -34,7 +34,7 @@
   XCTAssertNotEqual(scrollNode.view.contentInset.top, 0);
 }
 
-- (void)DISABLED_testThatViewControllerFrameIsRightAfterCustomTransitionWithNonextendedEdges
+- (void)testThatViewControllerFrameIsRightAfterCustomTransitionWithNonextendedEdges
 {
   UIWindow *window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
   ASDisplayNode *node = [[ASDisplayNode alloc] init];


### PR DESCRIPTION
We disabled an ASViewController test because it was failing after #2561 landed.

It turns out the cause of the failure is that the pager node tests set the application's key window and when the ASViewController test updated the key window, the previous one would be released and torn down. The pager node would have its data source set to `nil`, and would throw an exception because `nil` doesn't implement either `nodeBlockAtIndex:` or `nodeAtIndex:`.

This diff updates the flags handling for `ASPagerNode` pretty holistically, handling the `nil` case, and restores the affected view controller test. 