### PR TITLE
Disable ASTraceEvent Backtraces by Default

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode+Beta.h
+++ b/AsyncDisplayKit/ASDisplayNode+Beta.h
@@ -20,7 +20,7 @@ void ASPerformBlockOnBackgroundThread(void (^block)()); // DISPATCH_QUEUE_PRIORI
 ASDISPLAYNODE_EXTERN_C_END
 
 #if ASEVENTLOG_ENABLE
-#define ASDisplayNodeLogEvent(node, ...) [node.eventLog logEventWithBacktrace:[NSThread callStackSymbols] format:__VA_ARGS__]
+#define ASDisplayNodeLogEvent(node, ...) [node.eventLog logEventWithBacktrace:(AS_SAVE_EVENT_BACKTRACES ? [NSThread callStackSymbols] : nil) format:__VA_ARGS__]
 #else
 #define ASDisplayNodeLogEvent(node, ...)
 #endif

--- a/AsyncDisplayKit/Details/ASDataController.h
+++ b/AsyncDisplayKit/Details/ASDataController.h
@@ -19,7 +19,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 #if ASEVENTLOG_ENABLE
-#define ASDataControllerLogEvent(dataController, ...) [dataController.eventLog logEventWithBacktrace:[NSThread callStackSymbols] format:__VA_ARGS__]
+#define ASDataControllerLogEvent(dataController, ...) [dataController.eventLog logEventWithBacktrace:(AS_SAVE_EVENT_BACKTRACES ? [NSThread callStackSymbols] : nil) format:__VA_ARGS__]
 #else
 #define ASDataControllerLogEvent(dataController, ...)
 #endif

--- a/AsyncDisplayKit/Details/ASEventLog.h
+++ b/AsyncDisplayKit/Details/ASEventLog.h
@@ -18,8 +18,12 @@
 #define ASEVENTLOG_ENABLE 1
 #endif
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface ASEventLog : NSObject
 
-- (void)logEventWithBacktrace:(NSArray<NSString *> *)backtrace format:(NSString *)format, ... NS_FORMAT_FUNCTION(2, 3);
+- (void)logEventWithBacktrace:(nullable NSArray<NSString *> *)backtrace format:(NSString *)format, ... NS_FORMAT_FUNCTION(2, 3);
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/AsyncDisplayKit/Details/ASTraceEvent.h
+++ b/AsyncDisplayKit/Details/ASTraceEvent.h
@@ -8,18 +8,23 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface ASTraceEvent : NSObject
 
 /**
  * This method is dealloc safe.
  */
 - (instancetype)initWithObject:(id)object
-                     backtrace:(NSArray<NSString *> *)backtrace
+                     backtrace:(nullable NSArray<NSString *> *)backtrace
                         format:(NSString *)format
                      arguments:(va_list)arguments NS_FORMAT_FUNCTION(3,0);
 
-@property (nonatomic, readonly) NSArray<NSString *> *backtrace;
+// Will be nil unless AS_SAVE_EVENT_BACKTRACES=1 (default=0)
+@property (nonatomic, nullable, readonly) NSArray<NSString *> *backtrace;
 @property (nonatomic, strong, readonly) NSString *message;
 @property (nonatomic, readonly) NSTimeInterval timestamp;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/AsyncDisplayKit/Details/ASTraceEvent.m
+++ b/AsyncDisplayKit/Details/ASTraceEvent.m
@@ -46,9 +46,7 @@
     }
     _threadDescription = threadDescription;
 
-    // The backtrace will be an _NSCallStackArray which is actually pretty
-    // huge and retains other objects. Create an immutable NSArray<NSString *> from it.
-    _backtrace = [[NSArray alloc] initWithArray:backtrace];
+    _backtrace = backtrace;
     _timestamp = CACurrentMediaTime() - refTime;
   }
   return self;

--- a/Base/ASBaseDefines.h
+++ b/Base/ASBaseDefines.h
@@ -96,6 +96,17 @@
 # define ASDISPLAYNODE_NOTHROW
 #endif
 
+/**
+ * The event backtraces take a static 2KB of memory
+ * and retain all objects present in all the registers
+ * of the stack frames. The memory consumption impact
+ * is too significant even to be enabled during general
+ * development.
+ */
+#ifndef AS_SAVE_EVENT_BACKTRACES
+# define AS_SAVE_EVENT_BACKTRACES 0
+#endif
+
 #define ARRAY_COUNT(x) sizeof(x) / sizeof(x[0])
 
 #ifndef __has_feature      // Optional.


### PR DESCRIPTION
While #2570 fixed the memory consumption caused by backtrace recording, it added significant CPU cost for debug builds.

This diff adds a new macro `AS_SAVE_EVENT_BACKTRACES`, which defaults to `0`. If the user defines it otherwise, then we use the pre-2570 behavior.