### PR TITLE
Improve Automatic Subnode Management Node Ordering

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -2184,7 +2184,7 @@ ASDISPLAYNODE_INLINE BOOL nodeIsInRasterizedTree(ASDisplayNode *node) {
 - (NSArray *)subnodes
 {
   ASDN::MutexLocker l(__instanceLock__);
-  return [_subnodes copy];
+  return ([_subnodes copy] ?: @[]);
 }
 
 - (ASDisplayNode *)supernode

--- a/AsyncDisplayKit/Layout/ASLayout.mm
+++ b/AsyncDisplayKit/Layout/ASLayout.mm
@@ -148,13 +148,13 @@ static inline NSString * descriptionIndents(NSUInteger indents)
     CGPoint absolutePosition;
   };
   
-  // Queue used to keep track of sublayouts while traversing this layout in a BFS fashion.
-  std::queue<Context> queue;
-  queue.push({self, CGPointMake(0, 0)});
+  // Queue used to keep track of sublayouts while traversing this layout in a DFS fashion.
+  std::deque<Context> queue;
+  queue.push_front({self, CGPointZero});
   
   while (!queue.empty()) {
     Context context = queue.front();
-    queue.pop();
+    queue.pop_front();
 
     if (self != context.layout && context.layout.type == ASLayoutElementTypeDisplayNode) {
       ASLayout *layout = [ASLayout layoutWithLayout:context.layout position:context.absolutePosition];
@@ -162,11 +162,13 @@ static inline NSString * descriptionIndents(NSUInteger indents)
       [flattenedSublayouts addObject:layout];
     }
     
+    std::vector<Context> sublayoutContexts;
     for (ASLayout *sublayout in context.layout.sublayouts) {
       if (sublayout.isFlattened == NO) {
-        queue.push({sublayout, context.absolutePosition + sublayout.position});
+        sublayoutContexts.push_back({sublayout, context.absolutePosition + sublayout.position});
       }
     }
+    queue.insert(queue.cbegin(), sublayoutContexts.begin(), sublayoutContexts.end());
   }
 
   return [ASLayout layoutWithLayoutElement:_layoutElement size:_size sublayouts:flattenedSublayouts];

--- a/AsyncDisplayKitTests/ASDisplayNodeImplicitHierarchyTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeImplicitHierarchyTests.m
@@ -89,11 +89,11 @@
     return [ASAbsoluteLayoutSpec absoluteLayoutSpecWithChildren:@[stack1, stack2, node5]];
   };
   [node layoutThatFits:ASSizeRangeMake(CGSizeZero)];
-  XCTAssertEqual(node.subnodes[0], node5);
-  XCTAssertEqual(node.subnodes[1], node1);
-  XCTAssertEqual(node.subnodes[2], node2);
-  XCTAssertEqual(node.subnodes[3], node3);
-  XCTAssertEqual(node.subnodes[4], node4);
+  XCTAssertEqual(node.subnodes[0], node1);
+  XCTAssertEqual(node.subnodes[1], node2);
+  XCTAssertEqual(node.subnodes[2], node3);
+  XCTAssertEqual(node.subnodes[3], node4);
+  XCTAssertEqual(node.subnodes[4], node5);
 }
 
 - (void)testCalculatedLayoutHierarchyTransitions

--- a/AsyncDisplayKitTests/ASDisplayNodeTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeTests.m
@@ -2159,7 +2159,9 @@ static bool stringContainsPointer(NSString *description, id p) {
   ASDisplayNode *node = [[ASDisplayNode alloc] init];
   node.automaticallyManagesSubnodes = YES;
   ASDisplayNode *underlay = [[ASDisplayNode alloc] init];
+  underlay.debugName = @"underlay";
   ASDisplayNode *overlay = [[ASDisplayNode alloc] init];
+  overlay.debugName = @"overlay";
   node.layoutSpecBlock = ^(ASDisplayNode *node, ASSizeRange size) {
     // The inset spec here is crucial. If the nodes themselves are children, it passed before the fix.
     return [ASOverlayLayoutSpec overlayLayoutSpecWithChild:[ASInsetLayoutSpec insetLayoutSpecWithInsets:UIEdgeInsetsZero child:underlay] overlay:overlay];
@@ -2176,7 +2178,9 @@ static bool stringContainsPointer(NSString *description, id p) {
   ASDisplayNode *node = [[ASDisplayNode alloc] init];
   node.automaticallyManagesSubnodes = YES;
   ASDisplayNode *underlay = [[ASDisplayNode alloc] init];
+  underlay.debugName = @"underlay";
   ASDisplayNode *overlay = [[ASDisplayNode alloc] init];
+  overlay.debugName = @"overlay";
   node.layoutSpecBlock = ^(ASDisplayNode *node, ASSizeRange size) {
     // The inset spec here is crucial. If the nodes themselves are children, it passed before the fix.
     return [ASBackgroundLayoutSpec backgroundLayoutSpecWithChild:overlay background:[ASInsetLayoutSpec insetLayoutSpecWithInsets:UIEdgeInsetsZero child:underlay]];


### PR DESCRIPTION
Resolves #2549 

This diff changes the flattening traversal from breadth-first to depth-first, so that the resulting node array will have an ordering that matches the user's expectations, and adds some unit tests which failed before the change.