### PR TITLE
[ASTextNode] Set flexShrink to 1.0 on Text Nodes by Default

### DIFF
--- a/AsyncDisplayKit/ASTextNode.mm
+++ b/AsyncDisplayKit/ASTextNode.mm
@@ -117,6 +117,10 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
     self.opaque = NO;
     self.backgroundColor = [UIColor clearColor];
 
+    // Enable flexShrink by default on text nodes. Text is naturally reflowable and
+    // the vast majority of use cases prefer this behavior.
+    self.style.flexShrink = 1.0;
+
     self.linkAttributeNames = DefaultLinkAttributeNames;
 
     // Accessibility

--- a/AsyncDisplayKit/Layout/ASStackLayoutElement.h
+++ b/AsyncDisplayKit/Layout/ASStackLayoutElement.h
@@ -40,7 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * @abstract If the sum of childrens' stack dimensions is greater than the maximum size, how much should this component shrink?
  * This value represents the "flex shrink factor" and determines how much this component should shink in relation to
- * other flexible children.
+ * other flexible children. Defaults to @c 0.0 except for @c ASTextNode which defaults to @c 1.0.
  */
 @property (nonatomic, readwrite) CGFloat flexShrink;
 

--- a/examples_extra/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Pages/StackLayout.xcplaygroundpage/Contents.swift
+++ b/examples_extra/ASLayoutSpecPlayground-Swift/Sample/Sample.playground/Pages/StackLayout.xcplaygroundpage/Contents.swift
@@ -7,8 +7,9 @@ import AsyncDisplayKit
 extension StackLayout {
 
   override public func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
-    // Try commenting out the flexShrink to see its consequences.
-    subtitleNode.style.flexShrink = 1.0
+//    Text nodes have flexShrink = 1.0 by default.
+//    Try uncommenting this line to see its consequences:
+//    subtitleNode.style.flexShrink = 0.0
 
     let stackSpec = ASStackLayoutSpec(direction: .horizontal,
                                       spacing: 5,


### PR DESCRIPTION
The vast majority of use cases prefer this behavior. We previously held off on doing this for the sake of consistency across the framework. When the impact is this low, user convenience should precede consistency of that kind. See `UIImageView` changing the default value for `userInteractionEnabled`.

It's unfortunate that we create the style object for all text nodes in this diff. We could do something more elaborate in the future, by creating a "default style object" system where we share singleton style objects instead of using `nil`. The cost is acceptably small for this diff.