### PR TITLE
[ASCollectionView] Allow Decoration Views

### DIFF
--- a/AsyncDisplayKit/Details/ASCollectionViewLayoutController.mm
+++ b/AsyncDisplayKit/Details/ASCollectionViewLayoutController.mm
@@ -60,7 +60,6 @@ typedef struct ASRangeGeometry ASRangeGeometry;
   
   for (UICollectionViewLayoutAttributes *la in layoutAttributes) {
     //ASDisplayNodeAssert(![indexPathSet containsObject:la.indexPath], @"Shouldn't already contain indexPath");
-    ASDisplayNodeAssert(la.representedElementCategory != UICollectionElementCategoryDecorationView, @"UICollectionView decoration views are not supported by ASCollectionView");
     [indexPathSet addObject:la.indexPath];
   }
 


### PR DESCRIPTION
Removed assert which prevents decoration views from being displayed in `ASCollectionView` as discussed in issue https://github.com/facebook/AsyncDisplayKit/issues/1829. I confirmed that decoration views are displayed properly in our project using ASDK when this assert is disabled.