### PR TITLE
[ASDisplayNode] Convert assertion to log so developer can see layout issues onscreen.

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -2517,9 +2517,13 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
 {
   __ASDisplayNodeCheckForLayoutMethodOverrides;
   
-  ASDisplayNodeAssert(ASIsCGSizeValidForSize(constrainedSize), @"Cannot calculate size of node because constrained size is infinite and node does not override -calculateSizeThatFits:. Try setting style.preferredSize on the node. Node: %@", self);
+#if ASDISPLAYNODE_ASSERTIONS_ENABLED
+  if (ASIsCGSizeValidForSize(constrainedSize) == NO) {
+    NSLog(@"Cannot calculate size of node: constrainedSize is infinite and node does not override -calculateSizeThatFits: or specify a preferredSize. Try setting style.preferredSize. Node: %@", [self displayNodeRecursiveDescription]);
+  }
+#endif
 
-  return constrainedSize;
+  return ASIsCGSizeValidForSize(constrainedSize) ? constrainedSize : CGSizeZero;
 }
 
 - (id<ASLayoutElement>)_layoutElementThatFits:(ASSizeRange)constrainedSize

--- a/AsyncDisplayKitTests/ASDisplayNodeLayoutTests.mm
+++ b/AsyncDisplayKitTests/ASDisplayNodeLayoutTests.mm
@@ -111,12 +111,6 @@
   };
   
   XCTAssertThrows([node layoutThatFits:ASSizeRangeMake(CGSizeMake(0, FLT_MAX))]);
-  
-  // This dance is necessary as we would assert in case we create an ASDimension that is not real numbers
-  ASDimension width = displayNode.style.width;
-  width.value = INFINITY;
-  displayNode.style.width = width;
-  XCTAssertThrows([node layoutThatFits:ASSizeRangeMake(CGSizeMake(0, 0), CGSizeMake(INFINITY, INFINITY))]);
 }
 
 - (void)testThatLayoutCreatedWithInvalidSizeCausesException


### PR DESCRIPTION
In this case, the user hasn't specified enough about the layout of a node.  We default to
0, 0 - but ideally the case should not occur at all.  So it's important to help developers
detect these cases and fix them quickly.

An assertion causes developers several problems:
- They can't see important information unless an exception breakpoint is manually added.
- They can't see their layout onscreen and so visually understanding the problem is impossible.
- They can't proceed with testing to trigger other faults in the layout and are blocked fixing one at a time.

A log fixes every one of those problems:
- They can set a breakpoint on the log line very easily if desired.
- They can see their layout display and recognize the 0,0 node even more quickly than the log text information.
- They can see if multiple logs print out, or if the log only occurs for one item in a feed, or certain types --
    This helps them debug faster by knowing if the layout is always broken or certain conditions break it.

Since developing with ASLayoutSpecs is an iterative process, it's crucial that we let developers have the
freedom to experiment and test without hitting too many assertions.  Fortunately it will be impossible to ignore
these huge logs (full recursive description) and their nodes will be 0, 0 size, so they will get fixed.