### PR TITLE
[ASVideoNode] Prevent premature placeholder image clear when setting the video asset

### DIFF
--- a/AsyncDisplayKit/ASVideoNode.mm
+++ b/AsyncDisplayKit/ASVideoNode.mm
@@ -405,17 +405,20 @@ static NSString * const kRate = @"rate";
   }
 }
 
+- (void)_clearPlayer
+{
+  ASDN::MutexLocker l(__instanceLock__);
+  
+  self.player = nil;
+  self.currentItem = nil;
+  self.playerState = ASVideoNodePlayerStateUnknown;
+}
+
 - (void)clearFetchedData
 {
   [super clearFetchedData];
   
-  {
-    ASDN::MutexLocker l(__instanceLock__);
-
-    self.player = nil;
-    self.currentItem = nil;
-    self.playerState = ASVideoNodePlayerStateUnknown;
-  }
+  [self _clearPlayer];
 }
 
 - (void)didEnterVisibleState
@@ -505,7 +508,7 @@ static NSString * const kRate = @"rate";
 
 - (void)_setAndFetchAsset:(AVAsset *)asset url:(NSURL *)assetURL
 {
-  [self clearFetchedData];
+  [self _clearPlayer]; // Clear the player but not the underlying ASNetworkImageNode to avoid clearing the placeholder image and showing the background before the video starts.
   _asset = asset;
   _assetURL = assetURL;
   [self setNeedsDataFetch];

--- a/examples/Videos/Sample/ViewController.m
+++ b/examples/Videos/Sample/ViewController.m
@@ -69,6 +69,12 @@
     return [ASAbsoluteLayoutSpec absoluteLayoutSpecWithChildren:@[guitarVideoNode, nicCageVideoNode, simonVideoNode, hlsVideoNode]];
   };
   
+  // Delay setting video asset for testing that the transition between the placeholder and setting/playing the asset is seamless.
+  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(3 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+    hlsVideoNode.asset = [AVAsset assetWithURL:[NSURL URLWithString:@"http://devimages.apple.com/iphone/samples/bipbop/gear1/prog_index.m3u8"]];
+    [hlsVideoNode play];
+  });
+  
   [self.view addSubnode:_rootNode];
 }
 
@@ -124,9 +130,8 @@
   ASVideoNode *hlsVideoNode = [[ASVideoNode alloc] init];
   
   hlsVideoNode.delegate = self;
-  hlsVideoNode.asset = [AVAsset assetWithURL:[NSURL URLWithString:@"http://devimages.apple.com/iphone/samples/bipbop/gear1/prog_index.m3u8"]];
   hlsVideoNode.gravity = AVLayerVideoGravityResize;
-  hlsVideoNode.backgroundColor = [UIColor lightGrayColor];
+  hlsVideoNode.backgroundColor = [UIColor redColor]; // Should not be seen after placeholder image is loaded
   hlsVideoNode.shouldAutorepeat = YES;
   hlsVideoNode.shouldAutoplay = YES;
   hlsVideoNode.muted = YES;


### PR DESCRIPTION
Prevents flashing the background color in between the placeholder and the first frame of the video.

For more info refer to issue: https://github.com/facebook/AsyncDisplayKit/issues/2329