### PR TITLE
[ASViewController] Don’t use the view of the root node for the view of the ASViewController

### DIFF
--- a/AsyncDisplayKit/ASViewController.h
+++ b/AsyncDisplayKit/ASViewController.h
@@ -64,16 +64,6 @@ typedef ASTraitCollection * _Nonnull (^ASDisplayTraitsForTraitWindowSizeBlock)(C
 // Refer to examples/SynchronousConcurrency, AsyncViewController.m
 @property (nonatomic, assign) BOOL neverShowPlaceholders;
 
-
-/**
- * The constrained size used to measure the backing node.
- *
- * @discussion Defaults to providing a size range that uses the view controller view's bounds as
- * both the min and max definitions. Override this method to provide a custom size range to the
- * backing node.
- */
-- (ASSizeRange)nodeConstrainedSize AS_WARN_UNUSED_RESULT;
-
 @end
 
 @interface ASViewController (ASRangeControllerUpdateRangeProtocol)
@@ -85,6 +75,19 @@ typedef ASTraitCollection * _Nonnull (^ASDisplayTraitsForTraitWindowSizeBlock)(C
  * Default value is YES *if* node or view controller conform to ASRangeControllerUpdateRangeProtocol otherwise it is NO.
  */
 @property (nonatomic, assign) BOOL automaticallyAdjustRangeModeBasedOnViewEvents;
+
+@end
+
+@interface ASViewController (Deprecated)
+
+/**
+ * The constrained size used to measure the backing node.
+ *
+ * @discussion Defaults to providing a size range that uses the view controller view's bounds as
+ * both the min and max definitions. Override this method to provide a custom size range to the
+ * backing node.
+ */
+- (ASSizeRange)nodeConstrainedSize AS_WARN_UNUSED_RESULT ASDISPLAYNODE_DEPRECATED_MSG("Set the size directly to the view's frame");
 
 @end
 

--- a/AsyncDisplayKit/ASViewController.mm
+++ b/AsyncDisplayKit/ASViewController.mm
@@ -67,26 +67,15 @@
   ASPerformBackgroundDeallocation(_node);
 }
 
-- (void)loadView
+- (void)viewDidLoad
 {
-  ASDisplayNodeAssertTrue(!_node.layerBacked);
+  [super viewDidLoad];
   
-  // Apple applies a frame and autoresizing masks we need.  Allocating a view is not
-  // nearly as expensive as adding and removing it from a hierarchy, and fortunately
-  // we can avoid that here.  Enabling layerBacking on a single node in the hierarchy
-  // will have a greater performance benefit than the impact of this transient view.
-  [super loadView];
-  UIView *view = self.view;
-  CGRect frame = view.frame;
-  UIViewAutoresizing autoresizingMask = view.autoresizingMask;
+  // Add the root node to the view
+  _node.view.frame = self.view.bounds;
+  [self.view addSubnode:_node];
   
-  // We have what we need, so now create and assign the view we actually want.
-  view = _node.view;
-  _node.frame = frame;
-  _node.autoresizingMask = autoresizingMask;
-  self.view = view;
-  
-  // ensure that self.node has a valid trait collection before a subclass's implementation of viewDidLoad.
+  // Ensure that self.node has a valid trait collection before a subclass's implementation of viewDidLoad.
   // Any subnodes added in viewDidLoad will then inherit the proper environment.
   if (AS_AT_LEAST_IOS8) {
     ASEnvironmentTraitCollection traitCollection = [self environmentTraitCollectionForUITraitCollection:self.traitCollection];
@@ -117,11 +106,8 @@
       [self progagateNewEnvironmentTraitCollection:environmentTraitCollection];
     }];
   } else {
-    [_node layoutThatFits:[self nodeConstrainedSize]];
-  }
-  
-  if (!AS_AT_LEAST_IOS9) {
-    [self _legacyHandleViewDidLayoutSubviews];
+    CGSize size = [_node layoutThatFits:[self nodeConstrainedSize]].size;
+    _node.frame = (CGRect){.origin = CGPointZero, .size = size};
   }
 }
 
@@ -141,12 +127,11 @@ ASVisibilityDidMoveToParentViewController;
   [super viewWillAppear:animated];
   _ensureDisplayed = YES;
 
-  // A measure as well as layout pass is forced this early to get nodes like ASCollectionNode, ASTableNode etc.
+  // A layout pass is forced this early to get nodes like ASCollectionNode, ASTableNode etc.
   // into the hierarchy before UIKit applies the scroll view inset adjustments, if automatic subnode management
   // is enabled. Otherwise the insets would not be applied.
-  [_node layoutThatFits:[self nodeConstrainedSize]];
   [_node.view layoutIfNeeded];
-
+    
   [_node recursivelyFetchData];
   
   if (_parentManagesVisibilityDepth == NO) {
@@ -226,62 +211,12 @@ ASVisibilityDepthImplementation;
 
 - (ASSizeRange)nodeConstrainedSize
 {
-  if (AS_AT_LEAST_IOS9) {
-    CGSize viewSize = self.view.bounds.size;
-    return ASSizeRangeMake(viewSize);
-  } else {
-    return [self _legacyConstrainedSize];
-  }
+    return ASSizeRangeMake(self.view.bounds.size);
 }
 
 - (ASInterfaceState)interfaceState
 {
   return _node.interfaceState;
-}
-
-#pragma mark - Legacy Layout Handling
-
-- (BOOL)_shouldLayoutTheLegacyWay
-{
-  BOOL isModalViewController = (self.presentingViewController != nil && self.presentedViewController == nil);
-  BOOL hasNavigationController = (self.navigationController != nil);
-  BOOL hasParentViewController = (self.parentViewController != nil);
-  if (isModalViewController && !hasNavigationController && !hasParentViewController) {
-    return YES;
-  }
-  
-  // Check if the view controller is a root view controller
-  BOOL isRootViewController = self.view.window.rootViewController == self;
-  if (isRootViewController) {
-    return YES;
-  }
-  
-  return NO;
-}
-
-- (ASSizeRange)_legacyConstrainedSize
-{
-  // In modal presentation the view does not have the right bounds in iOS7 and iOS8. As workaround using the superviews
-  // view bounds
-  UIView *view = self.view;
-  CGSize viewSize = view.bounds.size;
-  if ([self _shouldLayoutTheLegacyWay]) {
-    UIView *superview = view.superview;
-    if (superview != nil) {
-      viewSize = superview.bounds.size;
-    }
-  }
-  return ASSizeRangeMake(viewSize, viewSize);
-}
-
-- (void)_legacyHandleViewDidLayoutSubviews
-{
-  // In modal presentation or as root viw controller the view does not automatic resize in iOS7 and iOS8.
-  // As workaround we adjust the frame of the view manually
-  if ([self _shouldLayoutTheLegacyWay]) {
-    CGSize maxConstrainedSize = [self nodeConstrainedSize].max;
-    _node.frame = (CGRect){.origin = CGPointZero, .size = maxConstrainedSize};
-  }
 }
 
 #pragma mark - ASEnvironmentTraitCollection

--- a/AsyncDisplayKit/ASViewController.mm
+++ b/AsyncDisplayKit/ASViewController.mm
@@ -72,6 +72,7 @@
   [super viewDidLoad];
   
   // Add the root node to the view
+  _node.view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
   _node.view.frame = self.view.bounds;
   [self.view addSubnode:_node];
   
@@ -105,10 +106,14 @@
       // this method will call measure
       [self progagateNewEnvironmentTraitCollection:environmentTraitCollection];
     }];
-  } else {
-    CGSize size = [_node layoutThatFits:[self nodeConstrainedSize]].size;
-    _node.frame = (CGRect){.origin = CGPointZero, .size = size};
   }
+  
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  // Call layoutThatFits: to let the node prepare for a layout that will happen shortly in the layout pass of the view.
+  // If the node's constrained size didn't change between the last layout pass it's a no-op
+  [_node layoutThatFits:[self nodeConstrainedSize]];
+#pragma clang diagnostic pop
 }
 
 - (void)viewDidLayoutSubviews
@@ -247,10 +252,6 @@ ASVisibilityDepthImplementation;
     for (id<ASEnvironment> child in children) {
       ASEnvironmentStatePropagateDown(child, environmentState.environmentTraitCollection);
     }
-    
-    // once we've propagated all the traits, layout this node.
-    // Remeasure the node with the latest constrained size – old constrained size may be incorrect.
-    [self.node layoutThatFits:[self nodeConstrainedSize]];
   }
 }
 

--- a/AsyncDisplayKitTests/ASViewControllerTests.m
+++ b/AsyncDisplayKitTests/ASViewControllerTests.m
@@ -76,7 +76,7 @@
   CGFloat navHeight = CGRectGetMaxY([nav.navigationBar convertRect:nav.navigationBar.bounds toView:window]);
   CGRect expectedRect, slice;
   CGRectDivide(window.bounds, &slice, &expectedRect, navHeight, CGRectMinYEdge);
-  XCTAssertEqualObjects(NSStringFromCGRect(expectedRect), NSStringFromCGRect(node.frame));
+  XCTAssertEqualObjects(NSStringFromCGRect(expectedRect), NSStringFromCGRect([node.view.superview convertRect:node.frame toView:nil]));
   [navDelegate verify];
   [animator verify];
 }


### PR DESCRIPTION
Due to the fact we use an `ASDisplayNode`’s view as view of the `ASViewController` we ran into a couple of problems in the past as well as we have a couple of open issues (see issues below). Especially around sizing and layout, we work against UIKit instead of working with UIKit.

### Changes
- We should change from having the view of the display node as ASViewController.view to add the node as subview to the ASViewController.view
- Stretch the node always the full size of the ASViewController.view in the layout pass
- Remove `nodeConstrainedSize`

### Open Questions
- `ASViewController` containment: Big question mark and that's the reason why we have this PR still in development stage is the handling of view controller containment. A good example is within here: https://gist.github.com/maicki/45a33341af35d6a04dbb8df7db13f42e . The problem within here is that the node hierarchy will not reflect the view hierarchy anymore. @Adlai-Holler, @appleguy any thoughts on it?

### Related issues
- ASViewController/ASPagerNode layout bug since version 1.9.81 https://github.com/facebook/AsyncDisplayKit/issues/1949 (fixed)
- ASViewController does not resize when contained in a Container View https://github.com/facebook/AsyncDisplayKit/issues/2085 (fixed)
- [ASViewController] Accessing vc.node.view doesn't go through ViewController's -loadView. (fixed) https://github.com/facebook/AsyncDisplayKit/issues/2350
- Accepts edgesForExtendedLayout without any hacks (fixed without special code) https://github.com/facebook/AsyncDisplayKit/pull/2123
- [ASViewController] Regression causing layout issues when presenting a portrait-only view controller while in landscape (fixed without special code) https://github.com/facebook/AsyncDisplayKit/issues/2213
- [ASViewController] iOS 8 + UIWindow rotation problem (fixed without special code) https://github.com/facebook/AsyncDisplayKit/issues/1905
- [ASViewController] Modal presented ASViewController don't rotate on iOS 8.3 (fixed without special code) https://github.com/facebook/AsyncDisplayKit/issues/1810