### PR TITLE
[ASDisplayNode] Re-add layout transition check for invalid constrained size

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -845,6 +845,12 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
                 measurementCompletion:(void(^)())completion
 {
   ASDisplayNodeAssertMainThread();
+  
+  if (constrainedSize.max.width <= 0.0 || constrainedSize.max.height <= 0.0) {
+    // Using CGSizeZero for the sizeRange can cause negative values in client layout code.
+    // Most likely called transitionLayout: without providing a size, before first layout pass.
+    return;
+  }
     
   // Check if we are a subnode in a layout transition.
   // In this case no measurement is needed as we're part of the layout transition.

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -832,6 +832,11 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
                    shouldMeasureAsync:(BOOL)shouldMeasureAsync
                 measurementCompletion:(void(^)())completion
 {
+  ASDisplayNodeAssertMainThread();
+
+  [self setNeedsLayout];
+  [self.view layoutIfNeeded];
+    
   [self transitionLayoutWithSizeRange:[self _locked_constrainedSizeForLayoutPass]
                              animated:animated
                    shouldMeasureAsync:shouldMeasureAsync
@@ -862,9 +867,6 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
     ASDN::MutexLocker l(__instanceLock__);
     ASDisplayNodeAssert(ASHierarchyStateIncludesLayoutPending(_hierarchyState) == NO, @"Can't start a transition when one of the supernodes is performing one.");
   }
-
-  // Invalidate the current layout to be able to measure a new layout based onthe given constrained size
-  [self setNeedsLayout];
   
   // Every new layout transition has a transition id associated to check in subsequent transitions for cancelling
   int32_t transitionID = [self _startNewTransition];


### PR DESCRIPTION
Using CGSizeZero for the sizeRange can cause negative values in client layout code. Most likely called transitionLayout: without providing a size, before first layout pass.
