### PR TITLE
Use CACurrentMediaTime Instead of CFAbsoluteTime

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -284,7 +284,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
                                                                 andHandler:^(ASDisplayNode * _Nonnull dequeuedItem, BOOL isQueueDrained) {
       [dequeuedItem _recursivelyTriggerDisplayAndBlock:NO];
       if (isQueueDrained) {
-        CFAbsoluteTime timestamp = CFAbsoluteTimeGetCurrent();
+        CFTimeInterval timestamp = CACurrentMediaTime();
         [[NSNotificationCenter defaultCenter] postNotificationName:ASRenderingEngineDidDisplayScheduledNodesNotification
                                                             object:nil
                                                           userInfo:@{ASRenderingEngineDidDisplayNodesScheduledBeforeTimestamp: @(timestamp)}];

--- a/AsyncDisplayKit/Details/ASRangeController.mm
+++ b/AsyncDisplayKit/Details/ASRangeController.mm
@@ -34,7 +34,7 @@
   ASLayoutRangeMode _currentRangeMode;
   BOOL _didUpdateCurrentRange;
   BOOL _didRegisterForNodeDisplayNotifications;
-  CFAbsoluteTime _pendingDisplayNodesTimestamp;
+  CFTimeInterval _pendingDisplayNodesTimestamp;
   
 #if AS_RANGECONTROLLER_LOG_UPDATE_FREQ
   NSUInteger _updateCountThisFrame;
@@ -335,7 +335,7 @@ static UIApplicationState __ApplicationState = UIApplicationStateActive;
           if (nodeShouldScheduleDisplay) {
             [self registerForNodeDisplayNotificationsForInterfaceStateIfNeeded:selfInterfaceState];
             if (_didRegisterForNodeDisplayNotifications) {
-              _pendingDisplayNodesTimestamp = CFAbsoluteTimeGetCurrent();
+              _pendingDisplayNodesTimestamp = CACurrentMediaTime();
             }
           }
         }


### PR DESCRIPTION
`CFAbsoluteTime` is the time as displayed to the user, which can be changed e.g. as the device syncs with the server. `CACurrentMediaTime` is the time since machine booted, which is what we should use for these kinds of internal purposes. See http://nshipster.com/benchmarking/ for info. It might also be faster but I'm not sure.