### PR TITLE
Make a Public Function for Main Thread Deallocation

### DIFF
--- a/AsyncDisplayKit/ASDisplayNodeExtras.h
+++ b/AsyncDisplayKit/ASDisplayNodeExtras.h
@@ -14,6 +14,9 @@
 #import <AsyncDisplayKit/ASBaseDefines.h>
 #import <AsyncDisplayKit/ASDisplayNode.h>
 
+/// For deallocation of objects on the main thread across multiple run loops.
+extern void ASPerformMainThreadDeallocation(_Nullable id object);
+
 // Because inline methods can't be extern'd and need to be part of the translation unit of code
 // that compiles with them to actually inline, we both declare and define these in the header.
 ASDISPLAYNODE_INLINE BOOL ASInterfaceStateIncludesVisible(ASInterfaceState interfaceState)

--- a/AsyncDisplayKit/ASDisplayNodeExtras.mm
+++ b/AsyncDisplayKit/ASDisplayNodeExtras.mm
@@ -13,6 +13,24 @@
 #import "ASDisplayNode+FrameworkPrivate.h"
 
 #import <queue>
+#import "ASRunLoopQueue.h"
+
+extern void ASPerformMainThreadDeallocation(_Nullable id object)
+{
+  /**
+   * UIKit components must be deallocated on the main thread. We use this shared
+   * run loop queue to gradually deallocate them across many turns of the main run loop.
+   */
+  static ASRunLoopQueue *queue;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    queue = [[ASRunLoopQueue alloc] initWithRunLoop:CFRunLoopGetMain() andHandler:nil];
+    queue.batchSize = 10;
+  });
+  if (object != nil) {
+  	[queue enqueue:object];
+  }
+}
 
 extern ASInterfaceState ASInterfaceStateForDisplayNode(ASDisplayNode *displayNode, UIWindow *window)
 {


### PR DESCRIPTION
If you want to manually deallocate something on the main thread, you can now call `ASPerformMainThreadDeallocation`. It might be worth publicizing `ASPerfomBackgroundDeallocation` but this is very urgent so I'm going to minimize the change and land after CI passes.