### PR TITLE
Fix memory leaks in ASCollectionNode and ASTableNode

### DIFF
--- a/AsyncDisplayKit/ASCollectionNode.mm
+++ b/AsyncDisplayKit/ASCollectionNode.mm
@@ -121,8 +121,9 @@
 
 - (instancetype)initWithFrame:(CGRect)frame collectionViewLayout:(UICollectionViewLayout *)layout layoutFacilitator:(id<ASCollectionViewLayoutFacilitatorProtocol>)layoutFacilitator
 {
+  ASEventLog *eventLog = ASDisplayNodeGetEventLog(self);
   ASDisplayNodeViewBlock collectionViewBlock = ^UIView *{
-    return [[ASCollectionView alloc] _initWithFrame:frame collectionViewLayout:layout layoutFacilitator:layoutFacilitator eventLog:ASDisplayNodeGetEventLog(self)];
+    return [[ASCollectionView alloc] _initWithFrame:frame collectionViewLayout:layout layoutFacilitator:layoutFacilitator eventLog:eventLog];
   };
 
   if (self = [super initWithViewBlock:collectionViewBlock]) {

--- a/AsyncDisplayKit/ASTableNode.mm
+++ b/AsyncDisplayKit/ASTableNode.mm
@@ -79,8 +79,9 @@
 
 - (instancetype)_initWithFrame:(CGRect)frame style:(UITableViewStyle)style dataControllerClass:(Class)dataControllerClass
 {
+  ASEventLog *eventLog = ASDisplayNodeGetEventLog(self);
   ASDisplayNodeViewBlock tableViewBlock = ^UIView *{
-    return [[ASTableView alloc] _initWithFrame:frame style:style dataControllerClass:dataControllerClass eventLog:ASDisplayNodeGetEventLog(self)];
+    return [[ASTableView alloc] _initWithFrame:frame style:style dataControllerClass:dataControllerClass eventLog:eventLog];
   };
 
   if (self = [super initWithViewBlock:tableViewBlock]) {


### PR DESCRIPTION
- Don't capture the nodes in their view blocks just for getting their event logs
- Get the logs outside and pass them into the blocks instead