### PR TITLE
[ASLayoutTransition isSynchronous] Don't use a shared lock for layout transitions

### DIFF
--- a/AsyncDisplayKit/Private/ASLayoutTransition.mm
+++ b/AsyncDisplayKit/Private/ASLayoutTransition.mm
@@ -16,7 +16,6 @@
 #import "ASLayout.h"
 
 #import <queue>
-#import <memory>
 
 #import "NSArray+Diffing.h"
 #import "ASEqualityHelpers.h"
@@ -48,8 +47,7 @@ static inline BOOL ASLayoutCanTransitionAsynchronous(ASLayout *layout) {
 }
 
 @implementation ASLayoutTransition {
-  std::shared_ptr<ASDN::RecursiveMutex> __instanceLock__;
-  
+  ASDN::RecursiveMutex __instanceLock__;
   BOOL _calculatedSubnodeOperations;
   NSArray<ASDisplayNode *> *_insertedSubnodes;
   NSArray<ASDisplayNode *> *_removedSubnodes;
@@ -63,8 +61,6 @@ static inline BOOL ASLayoutCanTransitionAsynchronous(ASLayout *layout) {
 {
   self = [super init];
   if (self) {
-    __instanceLock__ = std::make_shared<ASDN::RecursiveMutex>();
-      
     _node = node;
     _pendingLayout = pendingLayout;
     _previousLayout = previousLayout;
@@ -80,7 +76,7 @@ static inline BOOL ASLayoutCanTransitionAsynchronous(ASLayout *layout) {
 
 - (BOOL)isSynchronous
 {
-  ASDN::MutexSharedLocker l(__instanceLock__);
+  ASDN::MutexLocker l(__instanceLock__);
   return !ASLayoutCanTransitionAsynchronous(_pendingLayout->layout);
 }
 
@@ -92,7 +88,7 @@ static inline BOOL ASLayoutCanTransitionAsynchronous(ASLayout *layout) {
 
 - (void)applySubnodeInsertions
 {
-  ASDN::MutexSharedLocker l(__instanceLock__);
+  ASDN::MutexLocker l(__instanceLock__);
   [self calculateSubnodeOperationsIfNeeded];
   
   if (_insertedSubnodes.count == 0) {
@@ -110,7 +106,7 @@ static inline BOOL ASLayoutCanTransitionAsynchronous(ASLayout *layout) {
 
 - (void)applySubnodeRemovals
 {
-  ASDN::MutexSharedLocker l(__instanceLock__);
+  ASDN::MutexLocker l(__instanceLock__);
   [self calculateSubnodeOperationsIfNeeded];
 
   if (_removedSubnodes.count == 0) {
@@ -125,7 +121,7 @@ static inline BOOL ASLayoutCanTransitionAsynchronous(ASLayout *layout) {
 
 - (void)calculateSubnodeOperationsIfNeeded
 {
-  ASDN::MutexSharedLocker l(__instanceLock__);
+  ASDN::MutexLocker l(__instanceLock__);
   if (_calculatedSubnodeOperations) {
     return;
   }
@@ -159,27 +155,27 @@ static inline BOOL ASLayoutCanTransitionAsynchronous(ASLayout *layout) {
 
 - (NSArray<ASDisplayNode *> *)currentSubnodesWithTransitionContext:(_ASTransitionContext *)context
 {
-  ASDN::MutexSharedLocker l(__instanceLock__);
+  ASDN::MutexLocker l(__instanceLock__);
   return _node.subnodes;
 }
 
 - (NSArray<ASDisplayNode *> *)insertedSubnodesWithTransitionContext:(_ASTransitionContext *)context
 {
-  ASDN::MutexSharedLocker l(__instanceLock__);
+  ASDN::MutexLocker l(__instanceLock__);
   [self calculateSubnodeOperationsIfNeeded];
   return _insertedSubnodes;
 }
 
 - (NSArray<ASDisplayNode *> *)removedSubnodesWithTransitionContext:(_ASTransitionContext *)context
 {
-  ASDN::MutexSharedLocker l(__instanceLock__);
+  ASDN::MutexLocker l(__instanceLock__);
   [self calculateSubnodeOperationsIfNeeded];
   return _removedSubnodes;
 }
 
 - (ASLayout *)transitionContext:(_ASTransitionContext *)context layoutForKey:(NSString *)key
 {
-  ASDN::MutexSharedLocker l(__instanceLock__);
+  ASDN::MutexLocker l(__instanceLock__);
   if ([key isEqualToString:ASTransitionContextFromLayoutKey]) {
     return _previousLayout->layout;
   } else if ([key isEqualToString:ASTransitionContextToLayoutKey]) {
@@ -191,7 +187,7 @@ static inline BOOL ASLayoutCanTransitionAsynchronous(ASLayout *layout) {
 
 - (ASSizeRange)transitionContext:(_ASTransitionContext *)context constrainedSizeForKey:(NSString *)key
 {
-  ASDN::MutexSharedLocker l(__instanceLock__);
+  ASDN::MutexLocker l(__instanceLock__);
   if ([key isEqualToString:ASTransitionContextFromLayoutKey]) {
     return _previousLayout->constrainedSize;
   } else if ([key isEqualToString:ASTransitionContextToLayoutKey]) {


### PR DESCRIPTION
- The shared lock was used to fix a crash in which applying a pending layout transition can cause another new transition to be created and stored on the same ivar, causing the existing one to be deallocated while being used (#2038, #2047).
- However, using a shared lock across all layout transitions can easily cause deadlocks.
  - Consider a situation in which a node is trying to apply its pending transition on main thread, and as part of this process some subnodes need to be inserted. Main thread is holding the shared layout transition lock and now needs to grab the node's instance lock.
  - Meanwhile, on a background thread, another async transition on the same node has been executed and now it's time to determine if the transition can be applied synchronously or not. The thread is holding instance lock of the node and calls `isSynchronous` on the new transition, thus tries to acquire the lock shared across all transitions (#2641).
- Luckily, the recent layout coalescing mechanism (#2597) fixes the above crash because calling `-setNeedsLayout` no longer results in a new pending layout transition immediately but much later. I ran the sample project provided in #2038 with ASDK updated to HEAD (60756a1) and could not reproduce the crash.
- So now we can use a unique instance lock for each layout transition object. This commit reverts changes in ASLayoutTransition.mm of commit aba05a747c9222de91de2a65e601393a7a284943 to do just that. This should fix #2641.