### PR TITLE
[ASTableView] Not animated for end updates if animation is already going on within ASTableView

### DIFF
--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -21,6 +21,7 @@
 #import "ASInternalHelpers.h"
 #import "ASLayout.h"
 #import "_ASDisplayLayer.h"
+#import "_ASCoreAnimationExtras.h"
 #import "ASTableNode.h"
 #import "ASEqualityHelpers.h"
 #import "ASTableView+Undeprecated.h"
@@ -610,7 +611,7 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     } else {
       [self beginUpdates];
       [_dataController relayoutAllNodes];
-      [self endUpdates];
+      [self endUpdatesAnimated:(ASDisplayNodeLayerHasAnimations(self.layer) == NO) completion:nil];
     }
   }
   
@@ -1583,7 +1584,7 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     // If the node height changed, trigger a height requery.
     if (oldSize.height != calculatedSize.height) {
       [self beginUpdates];
-      [self endUpdates];
+      [self endUpdatesAnimated:(ASDisplayNodeLayerHasAnimations(self.layer) == NO) completion:nil];
     }
   }
 }

--- a/AsyncDisplayKit/Private/_ASCoreAnimationExtras.h
+++ b/AsyncDisplayKit/Private/_ASCoreAnimationExtras.h
@@ -53,4 +53,11 @@ extern UIViewContentMode ASDisplayNodeUIContentModeFromCAContentsGravity(NSStrin
  */
 extern UIImage *ASDisplayNodeStretchableBoxContentsWithColor(UIColor *color, CGSize innerSize);
 
+/**
+ Checks whether a layer has ongoing animations
+ @param layer A layer to check if animations are ongoing
+ @return YES if the layer has ongoing animations, otherwise NO
+ */
+extern BOOL ASDisplayNodeLayerHasAnimations(CALayer *layer);
+
 ASDISPLAYNODE_EXTERN_C_END

--- a/AsyncDisplayKit/Private/_ASCoreAnimationExtras.mm
+++ b/AsyncDisplayKit/Private/_ASCoreAnimationExtras.mm
@@ -154,3 +154,8 @@ UIViewContentMode ASDisplayNodeUIContentModeFromCAContentsGravity(NSString *cons
   // If asserts disabled, fall back to this
   return UIViewContentModeScaleToFill;
 }
+
+BOOL ASDisplayNodeLayerHasAnimations(CALayer *layer)
+{
+  return (layer.animationKeys.count != 0);
+}


### PR DESCRIPTION
Fix strange artifacts in ASTableView are visible when changing the device orientation or other animations are going on while calling endUpdates

Resolves #1361