### PR TITLE
[ASCollectionNode] Modify Initialization API

### DIFF
--- a/AsyncDisplayKit/ASCollectionNode.h
+++ b/AsyncDisplayKit/ASCollectionNode.h
@@ -33,19 +33,19 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @discussion Initializes and returns a newly allocated collection node object with the specified layout.
  *
- * @param layout The layout object to use for organizing items. The collection view stores a strong reference to the specified object. Must not be nil.
+ * @param layout The layout object to use for organizing items. The collection node stores a strong reference to the specified object. Must not be nil.
  */
 - (instancetype)initWithCollectionViewLayout:(UICollectionViewLayout *)layout;
 
 /**
  * Initializes an ASCollectionNode
  *
- * @discussion Initializes and returns a newly allocated collection node object with the specified frame and layout.
+ * @discussion Initializes and returns a newly allocated collection node object with the specified layout.
  *
- * @param frame The frame rectangle for the collection view, measured in points. The origin of the frame is relative to the superview in which you plan to add it. This frame is passed to the superclass during initialization.
- * @param layout The layout object to use for organizing items. The collection view stores a strong reference to the specified object. Must not be nil.
+ * @param layout The layout object to use for organizing items. The collection node stores a strong reference to the specified object. Must not be nil.
+ * @param layoutInspector The layout inspector to use, or nil to use the ASDK default layout inspector.
  */
-- (instancetype)initWithFrame:(CGRect)frame collectionViewLayout:(UICollectionViewLayout *)layout;
+- (instancetype)initWithCollectionViewLayout:(UICollectionViewLayout *)layout layoutInspector:(nullable id<ASCollectionViewLayoutInspecting>)layoutInspector;
 
 /**
  * Returns the corresponding ASCollectionView
@@ -415,6 +415,16 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @interface ASCollectionNode (Deprecated)
+
+/**
+ * Initializes an ASCollectionNode
+ *
+ * @discussion Initializes and returns a newly allocated collection node object with the specified frame and layout.
+ *
+ * @param frame The frame rectangle for the collection view, measured in points. The origin of the frame is relative to the superview in which you plan to add it. This frame is passed to the superclass during initialization.
+ * @param layout The layout object to use for organizing items. The collection view stores a strong reference to the specified object. Must not be nil.
+ */
+- (instancetype)initWithFrame:(CGRect)frame collectionViewLayout:(UICollectionViewLayout *)layout ASDISPLAYNODE_DEPRECATED_MSG("Use -initWithCollectionViewLayout: instead.");
 
 /**
  * Reload everything from scratch, destroying the working range and all cached nodes.

--- a/AsyncDisplayKit/ASCollectionNode.mm
+++ b/AsyncDisplayKit/ASCollectionNode.mm
@@ -111,20 +111,22 @@
 
 - (instancetype)initWithCollectionViewLayout:(UICollectionViewLayout *)layout
 {
-  return [self initWithFrame:CGRectZero collectionViewLayout:layout];
+  return [self initWithCollectionViewLayout:layout layoutInspector:nil];
 }
 
-- (instancetype)initWithFrame:(CGRect)frame collectionViewLayout:(UICollectionViewLayout *)layout
+- (instancetype)initWithCollectionViewLayout:(UICollectionViewLayout *)layout layoutInspector:(id<ASCollectionViewLayoutInspecting>)layoutInspector
 {
-  return [self initWithFrame:frame collectionViewLayout:layout layoutFacilitator:nil];
+  return [self initWithCollectionViewLayout:layout layoutInspector:layoutInspector layoutFacilitator:nil];
 }
 
-- (instancetype)initWithFrame:(CGRect)frame collectionViewLayout:(UICollectionViewLayout *)layout layoutFacilitator:(id<ASCollectionViewLayoutFacilitatorProtocol>)layoutFacilitator
+- (instancetype)initWithCollectionViewLayout:(UICollectionViewLayout *)layout layoutInspector:(id<ASCollectionViewLayoutInspecting>)layoutInspector layoutFacilitator:(id<ASCollectionViewLayoutFacilitatorProtocol>)layoutFacilitator
 {
   __weak __typeof__(self) weakSelf = self;
   ASDisplayNodeViewBlock collectionViewBlock = ^UIView *{
     __typeof__(self) strongSelf = weakSelf;
-    return [[ASCollectionView alloc] _initWithFrame:frame collectionViewLayout:layout layoutFacilitator:layoutFacilitator eventLog:ASDisplayNodeGetEventLog(strongSelf)];
+    ASCollectionView *collectionView = [[ASCollectionView alloc] _initWithFrame:CGRectZero collectionViewLayout:layout layoutFacilitator:layoutFacilitator eventLog:ASDisplayNodeGetEventLog(strongSelf)];
+    collectionView.layoutInspector = layoutInspector;
+    return collectionView;
   };
 
   if (self = [super initWithViewBlock:collectionViewBlock]) {

--- a/AsyncDisplayKitTests/ASCollectionViewTests.mm
+++ b/AsyncDisplayKitTests/ASCollectionViewTests.mm
@@ -148,7 +148,7 @@
     self.asyncDelegate = [[ASCollectionViewTestDelegate alloc] initWithNumberOfSections:10 numberOfItemsInSection:10];
     id realLayout = [UICollectionViewFlowLayout new];
     id mockLayout = [OCMockObject partialMockForObject:realLayout];
-    self.collectionNode = [[ASCollectionNode alloc] initWithFrame:self.view.bounds collectionViewLayout:mockLayout];
+    self.collectionNode = [[ASCollectionNode alloc] initWithCollectionViewLayout:mockLayout];
     self.collectionView = self.collectionNode.view;
     self.collectionView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     self.collectionNode.dataSource = self.asyncDelegate;
@@ -366,7 +366,7 @@
  */
 - (void)testThatCollectionNodeConformsToExpectedProtocols
 {
-  ASCollectionNode *node = [[ASCollectionNode alloc] initWithFrame:CGRectZero collectionViewLayout:[[UICollectionViewFlowLayout alloc] init]];
+  ASCollectionNode *node = [[ASCollectionNode alloc] initWithCollectionViewLayout:[[UICollectionViewFlowLayout alloc] init]];
   XCTAssert([node conformsToProtocol:@protocol(ASRangeControllerUpdateRangeProtocol)]);
 }
 
@@ -552,7 +552,7 @@
 {
   UIWindow *window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
   UICollectionViewLayout *layout = [[UICollectionViewFlowLayout alloc] init];
-  ASCollectionNode *cn = [[ASCollectionNode alloc] initWithFrame:window.bounds collectionViewLayout:layout];
+  ASCollectionNode *cn = [[ASCollectionNode alloc] initWithCollectionViewLayout:layout];
   ASCollectionView *cv = cn.view;
 
 

--- a/AsyncDisplayKitTests/ASCollectionViewTests.mm
+++ b/AsyncDisplayKitTests/ASCollectionViewTests.mm
@@ -149,10 +149,11 @@
     id realLayout = [UICollectionViewFlowLayout new];
     id mockLayout = [OCMockObject partialMockForObject:realLayout];
     self.collectionNode = [[ASCollectionNode alloc] initWithCollectionViewLayout:mockLayout];
-    self.collectionView = self.collectionNode.view;
-    self.collectionView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    self.collectionNode.frame = self.view.bounds;
+    self.collectionNode.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     self.collectionNode.dataSource = self.asyncDelegate;
     self.collectionNode.delegate = self.asyncDelegate;
+    self.collectionView = self.collectionNode.view;
     
     [self.collectionNode registerSupplementaryNodeOfKind:UICollectionElementKindSectionHeader];
     [self.view addSubview:self.collectionView];


### PR DESCRIPTION
- Remove `initWithFrame:collectionViewLayout:` and replace with `initWithCollectionViewLayout:`. This is more inline with `ASTableNode` and `ASDisplayNode`, rather than `UIView`.
- Add `initWithCollectionViewLayout:layoutInspector:` for when they have a layout inspector to provide. It is still acceptable to set the layout inspector later.

Note that the layout inspector API is likely to be replaced by a single asynchronous layout object, that serves as both our equivalent to `UICollectionViewLayout` and the layout inspector.