### PR TITLE
Expose internal singleton method as a class method vs instance method in ASPINRemoteImageDownloader

### DIFF
--- a/AsyncDisplayKit/Details/ASPINRemoteImageDownloader.m
+++ b/AsyncDisplayKit/Details/ASPINRemoteImageDownloader.m
@@ -103,15 +103,10 @@ static ASPINRemoteImageDownloader *sharedDownloader = nil;
 + (void)setSharedImageManagerWithConfiguration:(nullable NSURLSessionConfiguration *)configuration
 {
   NSAssert(sharedDownloader == nil, @"Singleton has been created and session can no longer be configured.");
-  __unused PINRemoteImageManager *sharedManager = [[self class] sharedPINRemoteImageManagerWithConfiguration:configuration];
+  __unused PINRemoteImageManager *sharedManager = [self sharedPINRemoteImageManagerWithConfiguration:configuration];
 }
 
-- (PINRemoteImageManager *)sharedPINRemoteImageManager
-{
-  return [self sharedPINRemoteImageManagerWithConfiguration:nil];
-}
-
-- (PINRemoteImageManager *)sharedPINRemoteImageManagerWithConfiguration:(NSURLSessionConfiguration *)configuration
++ (PINRemoteImageManager *)sharedPINRemoteImageManagerWithConfiguration:(NSURLSessionConfiguration *)configuration
 {
   static ASPINRemoteImageManager *sharedPINRemoteImageManager;
   static dispatch_once_t onceToken;
@@ -139,6 +134,11 @@ static ASPINRemoteImageDownloader *sharedDownloader = nil;
 #endif
   });
   return sharedPINRemoteImageManager;
+}
+
+- (PINRemoteImageManager *)sharedPINRemoteImageManager
+{
+  return [ASPINRemoteImageDownloader sharedPINRemoteImageManagerWithConfiguration:nil];
 }
 
 - (BOOL)sharedImageManagerSupportsMemoryRemoval


### PR DESCRIPTION
Currently setting an NSURLSessionConfiguration through ASPINRemoteImageManager
will crash. 

- PINRemoteImage is not linked with ASDK so it makes it difficult to make changes in this file without adding it manually into the Podfile.  
- Also I noticed the compiler will yell at you for `unrecognized selector` calls if you use the actual class name (`ASPINRemoteImageDownloader`) vs `[self class]`. I expected the build should fail since we should create the build in configurations where PINRemoteImage is available or unavailable.


