### PR TITLE
Update AsyncDisplayKit.podspec for 2.0-beta.2

### DIFF
--- a/AsyncDisplayKit.podspec
+++ b/AsyncDisplayKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = 'AsyncDisplayKit'
-  spec.version      = '2.0-beta.1'
+  spec.version      = '2.0-beta.2'
   spec.license      =  { :type => 'BSD' }
   spec.homepage     = 'http://asyncdisplaykit.org'
   spec.authors      = { 'Scott Goodson' => 'scottgoodson@gmail.com' }


### PR DESCRIPTION
Just updating ASDK within Buffer, noticed the podspec wasn't including beta 2 yet.