### PR TITLE
[ASViewController] Improve ASViewController view behavior

### DIFF
--- a/AsyncDisplayKit/ASViewController.h
+++ b/AsyncDisplayKit/ASViewController.h
@@ -64,16 +64,6 @@ typedef ASTraitCollection * _Nonnull (^ASDisplayTraitsForTraitWindowSizeBlock)(C
 // Refer to examples/SynchronousConcurrency, AsyncViewController.m
 @property (nonatomic, assign) BOOL neverShowPlaceholders;
 
-
-/**
- * The constrained size used to measure the backing node.
- *
- * @discussion Defaults to providing a size range that uses the view controller view's bounds as
- * both the min and max definitions. Override this method to provide a custom size range to the
- * backing node.
- */
-- (ASSizeRange)nodeConstrainedSize AS_WARN_UNUSED_RESULT;
-
 @end
 
 @interface ASViewController (ASRangeControllerUpdateRangeProtocol)
@@ -85,6 +75,19 @@ typedef ASTraitCollection * _Nonnull (^ASDisplayTraitsForTraitWindowSizeBlock)(C
  * Default value is YES *if* node or view controller conform to ASRangeControllerUpdateRangeProtocol otherwise it is NO.
  */
 @property (nonatomic, assign) BOOL automaticallyAdjustRangeModeBasedOnViewEvents;
+
+@end
+
+@interface ASViewController (Deprecated)
+
+/**
+ * The constrained size used to measure the backing node.
+ *
+ * @discussion Defaults to providing a size range that uses the view controller view's bounds as
+ * both the min and max definitions. Override this method to provide a custom size range to the
+ * backing node.
+ */
+- (ASSizeRange)nodeConstrainedSize AS_WARN_UNUSED_RESULT ASDISPLAYNODE_DEPRECATED_MSG("Set the size directly to the view's frame");
 
 @end
 

--- a/AsyncDisplayKit/ASViewController.mm
+++ b/AsyncDisplayKit/ASViewController.mm
@@ -132,11 +132,12 @@
       [self progagateNewEnvironmentTraitCollection:environmentTraitCollection];
     }];
   } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    // Call layoutThatFits: to let the node prepare for a layout that will happen shortly in the layout pass of the view.
+    // If the node's constrained size didn't change between the last layout pass it's a no-op
     [_node layoutThatFits:[self nodeConstrainedSize]];
-  }
-  
-  if (!AS_AT_LEAST_IOS9) {
-    [self _legacyHandleViewDidLayoutSubviews];
+#pragma clang diagnostic pop
   }
 }
 
@@ -156,10 +157,9 @@ ASVisibilityDidMoveToParentViewController;
   [super viewWillAppear:animated];
   _ensureDisplayed = YES;
 
-  // A measure as well as layout pass is forced this early to get nodes like ASCollectionNode, ASTableNode etc.
+  // A layout pass is forced this early to get nodes like ASCollectionNode, ASTableNode etc.
   // into the hierarchy before UIKit applies the scroll view inset adjustments, if automatic subnode management
   // is enabled. Otherwise the insets would not be applied.
-  [_node layoutThatFits:[self nodeConstrainedSize]];
   [_node.view layoutIfNeeded];
 
   [_node recursivelyFetchData];
@@ -241,62 +241,12 @@ ASVisibilityDepthImplementation;
 
 - (ASSizeRange)nodeConstrainedSize
 {
-  if (AS_AT_LEAST_IOS9) {
-    CGSize viewSize = self.view.bounds.size;
-    return ASSizeRangeMake(viewSize);
-  } else {
-    return [self _legacyConstrainedSize];
-  }
+  return ASSizeRangeMake(self.view.bounds.size);
 }
 
 - (ASInterfaceState)interfaceState
 {
   return _node.interfaceState;
-}
-
-#pragma mark - Legacy Layout Handling
-
-- (BOOL)_shouldLayoutTheLegacyWay
-{
-  BOOL isModalViewController = (self.presentingViewController != nil && self.presentedViewController == nil);
-  BOOL hasNavigationController = (self.navigationController != nil);
-  BOOL hasParentViewController = (self.parentViewController != nil);
-  if (isModalViewController && !hasNavigationController && !hasParentViewController) {
-    return YES;
-  }
-  
-  // Check if the view controller is a root view controller
-  BOOL isRootViewController = self.view.window.rootViewController == self;
-  if (isRootViewController) {
-    return YES;
-  }
-  
-  return NO;
-}
-
-- (ASSizeRange)_legacyConstrainedSize
-{
-  // In modal presentation the view does not have the right bounds in iOS7 and iOS8. As workaround using the superviews
-  // view bounds
-  UIView *view = self.view;
-  CGSize viewSize = view.bounds.size;
-  if ([self _shouldLayoutTheLegacyWay]) {
-    UIView *superview = view.superview;
-    if (superview != nil) {
-      viewSize = superview.bounds.size;
-    }
-  }
-  return ASSizeRangeMake(viewSize, viewSize);
-}
-
-- (void)_legacyHandleViewDidLayoutSubviews
-{
-  // In modal presentation or as root viw controller the view does not automatic resize in iOS7 and iOS8.
-  // As workaround we adjust the frame of the view manually
-  if ([self _shouldLayoutTheLegacyWay]) {
-    CGSize maxConstrainedSize = [self nodeConstrainedSize].max;
-    _node.frame = (CGRect){.origin = CGPointZero, .size = maxConstrainedSize};
-  }
 }
 
 #pragma mark - ASEnvironmentTraitCollection
@@ -327,10 +277,12 @@ ASVisibilityDepthImplementation;
     for (id<ASEnvironment> child in children) {
       ASEnvironmentStatePropagateDown(child, environmentState.environmentTraitCollection);
     }
-    
-    // once we've propagated all the traits, layout this node.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    // Once we've propagated all the traits, layout this node.
     // Remeasure the node with the latest constrained size – old constrained size may be incorrect.
     [self.node layoutThatFits:[self nodeConstrainedSize]];
+#pragma clang diagnostic pop
   }
 }
 


### PR DESCRIPTION
Replaces: #2636

### Changes
- Remove `layoutThatFit:` call in `viewWillAppear:` and only force a layout pass to execute automatic subnode management
- Deprecate `-[ASViewController nodeConstrainedSize]`
- Use the view’s bounds to layout the node

### Related issues
- ASViewController/ASPagerNode layout bug since version 1.9.81 https://github.com/facebook/AsyncDisplayKit/issues/1949 (fixed)
- ASViewController does not resize when contained in a Container View https://github.com/facebook/AsyncDisplayKit/issues/2085 (fixed)
- Accepts edgesForExtendedLayout without any hacks (fixed without special code) https://github.com/facebook/AsyncDisplayKit/pull/2123
- [ASViewController] Regression causing layout issues when presenting a portrait-only view controller while in landscape (fixed without special code) https://github.com/facebook/AsyncDisplayKit/issues/2213
- [ASViewController] iOS 8 + UIWindow rotation problem (fixed without special code) https://github.com/facebook/AsyncDisplayKit/issues/1905
- [ASViewController] Modal presented ASViewController don't rotate on iOS 8.3 (fixed without special code) https://github.com/facebook/AsyncDisplayKit/issues/1810

### Note Resolved
- [ASViewController] Accessing vc.node.view doesn't go through ViewController's -loadView. https://github.com/facebook/AsyncDisplayKit/issues/2350