### PR TITLE
Re-add NSURLSessionConfiguration support and fix crashes

### DIFF
--- a/AsyncDisplayKit/Details/ASPINRemoteImageDownloader.m
+++ b/AsyncDisplayKit/Details/ASPINRemoteImageDownloader.m
@@ -103,15 +103,10 @@ static ASPINRemoteImageDownloader *sharedDownloader = nil;
 + (void)setSharedImageManagerWithConfiguration:(nullable NSURLSessionConfiguration *)configuration
 {
   NSAssert(sharedDownloader == nil, @"Singleton has been created and session can no longer be configured.");
-  __unused PINRemoteImageManager *sharedManager = [[self class] sharedPINRemoteImageManagerWithConfiguration:configuration];
+  __unused PINRemoteImageManager *sharedManager = [self sharedPINRemoteImageManagerWithConfiguration:configuration];
 }
 
-- (PINRemoteImageManager *)sharedPINRemoteImageManager
-{
-  return [self sharedPINRemoteImageManagerWithConfiguration:nil];
-}
-
-- (PINRemoteImageManager *)sharedPINRemoteImageManagerWithConfiguration:(NSURLSessionConfiguration *)configuration
++ (PINRemoteImageManager *)sharedPINRemoteImageManagerWithConfiguration:(NSURLSessionConfiguration *)configuration
 {
   static ASPINRemoteImageManager *sharedPINRemoteImageManager;
   static dispatch_once_t onceToken;
@@ -133,12 +128,18 @@ static ASPINRemoteImageDownloader *sharedDownloader = nil;
                         userInfo:nil];
       @throw e;
     }
-    sharedPINRemoteImageManager = [[ASPINRemoteImageManager alloc] initWithSessionConfiguration:configuration alternativeRepresentationProvider:self];
+    sharedPINRemoteImageManager = [[ASPINRemoteImageManager alloc] initWithSessionConfiguration:configuration
+                                                              alternativeRepresentationProvider:[self sharedDownloader]];
 #else
     sharedPINRemoteImageManager = [[ASPINRemoteImageManager alloc] initWithSessionConfiguration:configuration];
 #endif
   });
   return sharedPINRemoteImageManager;
+}
+
+- (PINRemoteImageManager *)sharedPINRemoteImageManager
+{
+  return [ASPINRemoteImageDownloader sharedPINRemoteImageManagerWithConfiguration:nil];
 }
 
 - (BOOL)sharedImageManagerSupportsMemoryRemoval


### PR DESCRIPTION
Tested locally with the Pinterest app. 

The issue that caused this to be revered in the first place was the value for `alternativeRepresentationProvider` was set to the `ASPINRemoteImageDownloader` class instead of an instance. This slipped when converting the singleton method to a class method.

Included in this PR:
- Revert "Revert "Expose internal singleton method as a class method vs instance method.""
- Fix assignment of alternativeRepresentationProvider to be the singleton
  instance of ASPINRemoteImageDownloader.