### PR TITLE
[ASViewController] Trigger load view in ASViewController if node did load but not the view of the view controller

### DIFF
--- a/AsyncDisplayKit/ASViewController.mm
+++ b/AsyncDisplayKit/ASViewController.mm
@@ -58,6 +58,21 @@
   _selfConformsToRangeModeProtocol = [self conformsToProtocol:@protocol(ASRangeControllerUpdateRangeProtocol)];
   _nodeConformsToRangeModeProtocol = [_node conformsToProtocol:@protocol(ASRangeControllerUpdateRangeProtocol)];
   _automaticallyAdjustRangeModeBasedOnViewEvents = _selfConformsToRangeModeProtocol || _nodeConformsToRangeModeProtocol;
+  
+  // In case the node will get loaded
+  if (_node.nodeLoaded) {
+    // Node already loaded the view
+    [self view];
+  } else {
+    // If the node didn't load yet add ourselves as on did load observer to laod the view in case the node get's loaded
+    // before the view controller
+    __weak __typeof__(self) weakSelf = self;
+    [_node onDidLoad:^(__kindof ASDisplayNode * _Nonnull node) {
+      if (weakSelf.viewLoaded == NO) {
+        [weakSelf view];
+      }
+    }];
+  }
 
   return self;
 }

--- a/AsyncDisplayKit/ASViewController.mm
+++ b/AsyncDisplayKit/ASViewController.mm
@@ -64,7 +64,7 @@
     // Node already loaded the view
     [self view];
   } else {
-    // If the node didn't load yet add ourselves as on did load observer to laod the view in case the node get's loaded
+    // If the node didn't load yet add ourselves as on did load observer to laod the view in case the node gets loaded
     // before the view controller
     __weak __typeof__(self) weakSelf = self;
     [_node onDidLoad:^(__kindof ASDisplayNode * _Nonnull node) {


### PR DESCRIPTION
Calling `viewController.node.view` or passing in a already loaded view will not automatically trigger a `loadView` on the view controller. This PR should address this issue by either triggering a `loadView` if the node is already loaded or observing the node loaded state and trigger a `loadView` in case the view controller's view is not already loaded

Addresses: #2350