### PR TITLE
[Layout Transition] Layout Transition Fixes

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -933,7 +933,6 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   ASDisplayNodeAssertMainThread();
 
   [self setNeedsLayout];
-  [self.view layoutIfNeeded];
     
   [self transitionLayoutWithSizeRange:[self _locked_constrainedSizeForLayoutPass]
                              animated:animated


### PR DESCRIPTION
Calling `layoutIfNeeded` before actually starting the layout transition pcoess can cause a measurement pass with the already new layout description to happen. This means instead of animating the nodes in and out as well as the position of nodes, it will just apply the new layout immediately without any animation.