### PR TITLE
Add noescape Attribute to isCancelledBlock Parameters

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode+Subclasses.h
+++ b/AsyncDisplayKit/ASDisplayNode+Subclasses.h
@@ -212,7 +212,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @note Called on the display queue and/or main queue (MUST BE THREAD SAFE)
  */
 + (nullable UIImage *)displayWithParameters:(nullable id<NSObject>)parameters
-                       isCancelled:(__attribute((noescape)) asdisplaynode_iscancelled_block_t)isCancelledBlock;
+                                isCancelled:(__attribute((noescape)) asdisplaynode_iscancelled_block_t)isCancelledBlock;
 
 /**
  * @abstract Delegate override for drawParameters

--- a/AsyncDisplayKit/ASDisplayNode+Subclasses.h
+++ b/AsyncDisplayKit/ASDisplayNode+Subclasses.h
@@ -195,7 +195,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @note Called on the display queue and/or main queue (MUST BE THREAD SAFE)
  */
 + (void)drawRect:(CGRect)bounds withParameters:(nullable id <NSObject>)parameters
-                                   isCancelled:(asdisplaynode_iscancelled_block_t)isCancelledBlock
+                                   isCancelled:(__attribute((noescape)) asdisplaynode_iscancelled_block_t)isCancelledBlock
                                  isRasterizing:(BOOL)isRasterizing;
 
 /**
@@ -212,7 +212,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @note Called on the display queue and/or main queue (MUST BE THREAD SAFE)
  */
 + (nullable UIImage *)displayWithParameters:(nullable id<NSObject>)parameters
-                       isCancelled:(asdisplaynode_iscancelled_block_t)isCancelledBlock;
+                       isCancelled:(__attribute((noescape)) asdisplaynode_iscancelled_block_t)isCancelledBlock;
 
 /**
  * @abstract Delegate override for drawParameters

--- a/AsyncDisplayKit/Details/_ASDisplayLayer.h
+++ b/AsyncDisplayKit/Details/_ASDisplayLayer.h
@@ -103,7 +103,7 @@ typedef BOOL(^asdisplaynode_iscancelled_block_t)(void);
  @param isCancelledBlock Execute this block to check whether the current drawing operation has been cancelled to avoid unnecessary work. A return value of YES means cancel drawing and return.
  @param isRasterizing YES if the layer is being rasterized into another layer, in which case drawRect: probably wants to avoid doing things like filling its bounds with a zero-alpha color to clear the backing store.
  */
-+ (void)drawRect:(CGRect)bounds withParameters:(id<NSObject>)parameters isCancelled:(asdisplaynode_iscancelled_block_t)isCancelledBlock isRasterizing:(BOOL)isRasterizing;
++ (void)drawRect:(CGRect)bounds withParameters:(id<NSObject>)parameters isCancelled:(__attribute((noescape)) asdisplaynode_iscancelled_block_t)isCancelledBlock isRasterizing:(BOOL)isRasterizing;
 
 /**
  @summary Delegate override to provide new layer contents as a UIImage.
@@ -111,19 +111,19 @@ typedef BOOL(^asdisplaynode_iscancelled_block_t)(void);
  @param isCancelledBlock Execute this block to check whether the current drawing operation has been cancelled to avoid unnecessary work. A return value of YES means cancel drawing and return.
  @return A UIImage with contents that are ready to display on the main thread. Make sure that the image is already decoded before returning it here.
  */
-+ (UIImage *)displayWithParameters:(id<NSObject>)parameters isCancelled:(asdisplaynode_iscancelled_block_t)isCancelledBlock;
++ (UIImage *)displayWithParameters:(id<NSObject>)parameters isCancelled:(__attribute((noescape)) asdisplaynode_iscancelled_block_t)isCancelledBlock;
 
 /**
  * @abstract instance version of drawRect class method
  * @see drawRect:withParameters:isCancelled:isRasterizing class method
  */
-- (void)drawRect:(CGRect)bounds withParameters:(id <NSObject>)parameters isCancelled:(asdisplaynode_iscancelled_block_t)isCancelledBlock isRasterizing:(BOOL)isRasterizing;
+- (void)drawRect:(CGRect)bounds withParameters:(id <NSObject>)parameters isCancelled:(__attribute((noescape)) asdisplaynode_iscancelled_block_t)isCancelledBlock isRasterizing:(BOOL)isRasterizing;
 
 /**
  * @abstract instance version of display class method
  * @see displayWithParameters:isCancelled class method
  */
-- (UIImage *)displayWithParameters:(id <NSObject>)parameters isCancelled:(asdisplaynode_iscancelled_block_t)isCancelled;
+- (UIImage *)displayWithParameters:(id <NSObject>)parameters isCancelled:(__attribute((noescape)) asdisplaynode_iscancelled_block_t)isCancelled;
 
 // Called on the main thread only
 


### PR DESCRIPTION
This resolves #2299 and improves the Swift import in general.