### PR TITLE
Use the Method Form for UIViewController.viewLoaded – Maintains Xcode Backwards Compatibility

### DIFF
--- a/AsyncDisplayKit/ASViewController.mm
+++ b/AsyncDisplayKit/ASViewController.mm
@@ -68,7 +68,7 @@
     // before the view controller
     __weak __typeof__(self) weakSelf = self;
     [_node onDidLoad:^(__kindof ASDisplayNode * _Nonnull node) {
-      if (weakSelf.viewLoaded == NO) {
+      if ([weakSelf isViewLoaded] == NO) {
         [weakSelf view];
       }
     }];


### PR DESCRIPTION
Syntax highlighting is still broken in Xcode 8 so I sometimes prefer using Xcode 7.3.1. Previously `isViewLoaded` was a method, not a property, and this uses that method explicitly.