### PR TITLE
[ASViewController] Remove Extra recursivelyFetchData Call 

### DIFF
--- a/AsyncDisplayKit/ASViewController.mm
+++ b/AsyncDisplayKit/ASViewController.mm
@@ -161,8 +161,6 @@ ASVisibilityDidMoveToParentViewController;
   // is enabled. Otherwise the insets would not be applied.
   [_node layoutThatFits:[self nodeConstrainedSize]];
   [_node.view layoutIfNeeded];
-
-  [_node recursivelyFetchData];
   
   if (_parentManagesVisibilityDepth == NO) {
     [self setVisibilityDepth:0];


### PR DESCRIPTION
This call has been there since the initial implementation of ASViewController, but it's not needed.