### PR TITLE
Improve Batch Fetching Call Pattern to Reduce Fetch Calls

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -1080,6 +1080,7 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   ASInterfaceState interfaceState = [self interfaceStateForRangeController:_rangeController];
   if (ASInterfaceStateIncludesVisible(interfaceState)) {
     [_rangeController updateCurrentRangeWithMode:ASLayoutRangeModeFull];
+    [self _checkForBatchFetching];
   }
   
   for (_ASCollectionViewCell *collectionCell in _cellsForVisibilityUpdates) {

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -1103,7 +1103,7 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
 
   if (targetContentOffset != NULL) {
     ASDisplayNodeAssert(_batchContext != nil, @"Batch context should exist");
-    [self _beginBatchFetchingIfNeededWithScrollView:self forScrollDirection:[self scrollDirection] contentOffset:*targetContentOffset];
+    [self _beginBatchFetchingIfNeededWithContentOffset:*targetContentOffset];
   }
   
   if (_asyncDelegateFlags.scrollViewWillEndDragging) {
@@ -1261,12 +1261,12 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
     return;
   }
   
-  [self _beginBatchFetchingIfNeededWithScrollView:self forScrollDirection:[self scrollableDirections] contentOffset:self.contentOffset];
+  [self _beginBatchFetchingIfNeededWithContentOffset:self.contentOffset];
 }
 
-- (void)_beginBatchFetchingIfNeededWithScrollView:(UIScrollView<ASBatchFetchingScrollView> *)scrollView forScrollDirection:(ASScrollDirection)scrollDirection contentOffset:(CGPoint)contentOffset
+- (void)_beginBatchFetchingIfNeededWithContentOffset:(CGPoint)contentOffset
 {
-  if (ASDisplayShouldFetchBatchForScrollView(self, scrollDirection, contentOffset)) {
+  if (ASDisplayShouldFetchBatchForScrollView(self, self.scrollDirection, self.scrollableDirections, contentOffset)) {
     [self _beginBatchFetching];
   }
 }

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -1521,11 +1521,6 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   _performingBatchUpdates = NO;
 }
 
-- (void)didCompleteUpdatesInRangeController:(ASRangeController *)rangeController
-{
-  [self _checkForBatchFetching];
-}
-
 - (void)rangeController:(ASRangeController *)rangeController didInsertNodes:(NSArray *)nodes atIndexPaths:(NSArray *)indexPaths withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions
 {
   ASDisplayNodeAssertMainThread();

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -1040,6 +1040,7 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
   ASInterfaceState interfaceState = [self interfaceStateForRangeController:_rangeController];
   if (ASInterfaceStateIncludesVisible(interfaceState)) {
     [_rangeController updateCurrentRangeWithMode:ASLayoutRangeModeFull];
+    [self _checkForBatchFetching];
   }
   
   for (_ASTableViewCell *tableCell in _cellsForVisibilityUpdates) {

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -140,6 +140,9 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
   BOOL _performingBatchUpdates;
   NSMutableSet *_cellsForVisibilityUpdates;
 
+  // See documentation on same property in ASCollectionView
+  BOOL _hasEverCheckedForBatchFetchingDueToUpdate;
+
   // The section index overlay view, if there is one present.
   // This is useful because we need to measure our row nodes against (width - indexView.width).
   __weak UIView *_sectionIndexView;
@@ -1169,9 +1172,10 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
 - (void)_scheduleCheckForBatchFetchingForNumberOfChanges:(NSUInteger)changes
 {
   // Prevent fetching will continually trigger in a loop after reaching end of content and no new content was provided
-  if (changes == 0) {
+  if (changes == 0 && _hasEverCheckedForBatchFetchingDueToUpdate) {
     return;
   }
+  _hasEverCheckedForBatchFetchingDueToUpdate = YES;
 
   // Push this to the next runloop to be sure the scroll view has the right content size
   dispatch_async(dispatch_get_main_queue(), ^{

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -1062,7 +1062,7 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
 
   if (targetContentOffset != NULL) {
     ASDisplayNodeAssert(_batchContext != nil, @"Batch context should exist");
-    [self _beginBatchFetchingIfNeededWithScrollView:self forScrollDirection:[self scrollDirection] contentOffset:*targetContentOffset];
+    [self _beginBatchFetchingIfNeededWithContentOffset:*targetContentOffset];
   }
   
   if (_asyncDelegateFlags.scrollViewWillEndDragging) {
@@ -1185,12 +1185,12 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     return;
   }
   
-  [self _beginBatchFetchingIfNeededWithScrollView:self forScrollDirection:[self scrollableDirections] contentOffset:self.contentOffset];
+  [self _beginBatchFetchingIfNeededWithContentOffset:self.contentOffset];
 }
 
-- (void)_beginBatchFetchingIfNeededWithScrollView:(UIScrollView<ASBatchFetchingScrollView> *)scrollView forScrollDirection:(ASScrollDirection)scrollDirection contentOffset:(CGPoint)contentOffset
+- (void)_beginBatchFetchingIfNeededWithContentOffset:(CGPoint)contentOffset
 {
-  if (ASDisplayShouldFetchBatchForScrollView(self, scrollDirection, contentOffset)) {
+  if (ASDisplayShouldFetchBatchForScrollView(self, self.scrollDirection, ASScrollDirectionVerticalDirections, contentOffset)) {
     [self _beginBatchFetching];
   }
 }

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -1329,11 +1329,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
   }
 }
 
-- (void)didCompleteUpdatesInRangeController:(ASRangeController *)rangeController
-{
-  [self _checkForBatchFetching];
-}
-
 - (void)rangeController:(ASRangeController *)rangeController didInsertNodes:(NSArray *)nodes atIndexPaths:(NSArray *)indexPaths withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions
 {
   ASDisplayNodeAssertMainThread();

--- a/AsyncDisplayKit/Details/ASRangeController.h
+++ b/AsyncDisplayKit/Details/ASRangeController.h
@@ -160,13 +160,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)rangeController:(ASRangeController * )rangeController didEndUpdatesAnimated:(BOOL)animated completion:(void (^)(BOOL))completion;
 
 /**
- * Completed updates to cell node addition and removal.
- *
- * @param rangeController Sender.
- */
-- (void)didCompleteUpdatesInRangeController:(ASRangeController *)rangeController;
-
-/**
  * Called for nodes insertion.
  *
  * @param rangeController Sender.

--- a/AsyncDisplayKit/Details/ASRangeController.mm
+++ b/AsyncDisplayKit/Details/ASRangeController.mm
@@ -379,7 +379,6 @@ static UIApplicationState __ApplicationState = UIApplicationStateActive;
   [modifiedIndexPaths sortUsingSelector:@selector(compare:)];
   NSLog(@"Range update complete; modifiedIndexPaths: %@", [self descriptionWithIndexPaths:modifiedIndexPaths]);
 #endif
-  [_delegate didCompleteUpdatesInRangeController:self];
   
   ASProfilingSignpostEnd(1, self);
 }

--- a/AsyncDisplayKit/Private/ASBatchFetching.h
+++ b/AsyncDisplayKit/Private/ASBatchFetching.h
@@ -29,16 +29,18 @@ ASDISPLAYNODE_EXTERN_C_BEGIN
  * ASCollectionView batch fetching API.
  @param context The scroll view that in-flight fetches are happening.
  @param scrollDirection The current scrolling direction of the scroll view.
+ @param scrollableDirections The possible scrolling directions of the scroll view.
  @param targetOffset The offset that the scrollview will scroll to.
  @return Whether or not the current state should proceed with batch fetching.
  */
-BOOL ASDisplayShouldFetchBatchForScrollView(UIScrollView<ASBatchFetchingScrollView> *scrollView, ASScrollDirection scrollDirection, CGPoint contentOffset);
+BOOL ASDisplayShouldFetchBatchForScrollView(UIScrollView<ASBatchFetchingScrollView> *scrollView, ASScrollDirection scrollDirection, ASScrollDirection scrollableDirections, CGPoint contentOffset);
 
 
 /**
  @abstract Determine if batch fetching should begin based on the state of the parameters.
  @param context The batch fetching context that contains knowledge about in-flight fetches.
  @param scrollDirection The current scrolling direction of the scroll view.
+ @param scrollableDirections The possible scrolling directions of the scroll view.
  @param bounds The bounds of the scrollview.
  @param contentSize The content size of the scrollview.
  @param targetOffset The offset that the scrollview will scroll to.
@@ -49,6 +51,7 @@ BOOL ASDisplayShouldFetchBatchForScrollView(UIScrollView<ASBatchFetchingScrollVi
  */
 extern BOOL ASDisplayShouldFetchBatchForContext(ASBatchContext *context,
                                                 ASScrollDirection scrollDirection,
+                                                ASScrollDirection scrollableDirections,
                                                 CGRect bounds,
                                                 CGSize contentSize,
                                                 CGPoint targetOffset,

--- a/AsyncDisplayKit/Private/ASBatchFetching.m
+++ b/AsyncDisplayKit/Private/ASBatchFetching.m
@@ -10,7 +10,7 @@
 
 #import "ASBatchFetching.h"
 
-BOOL ASDisplayShouldFetchBatchForScrollView(UIScrollView<ASBatchFetchingScrollView> *scrollView, ASScrollDirection scrollDirection, CGPoint contentOffset)
+BOOL ASDisplayShouldFetchBatchForScrollView(UIScrollView<ASBatchFetchingScrollView> *scrollView, ASScrollDirection scrollDirection, ASScrollDirection scrollableDirections, CGPoint contentOffset)
 {
   // Don't fetch if the scroll view does not allow
   if (![scrollView canBatchFetch]) {
@@ -22,11 +22,12 @@ BOOL ASDisplayShouldFetchBatchForScrollView(UIScrollView<ASBatchFetchingScrollVi
   CGRect bounds = scrollView.bounds;
   CGSize contentSize = scrollView.contentSize;
   CGFloat leadingScreens = scrollView.leadingScreensForBatching;
-  return ASDisplayShouldFetchBatchForContext(context, scrollDirection, bounds, contentSize, contentOffset, leadingScreens);
+  return ASDisplayShouldFetchBatchForContext(context, scrollDirection, scrollableDirections, bounds, contentSize, contentOffset, leadingScreens);
 }
 
 BOOL ASDisplayShouldFetchBatchForContext(ASBatchContext *context,
                                          ASScrollDirection scrollDirection,
+                                         ASScrollDirection scrollableDirections,
                                          CGRect bounds,
                                          CGSize contentSize,
                                          CGPoint targetOffset,
@@ -37,19 +38,14 @@ BOOL ASDisplayShouldFetchBatchForContext(ASBatchContext *context,
     return NO;
   }
 
-  // Only Down and Right scrolls are currently supported (tail loading)
-  if (!ASScrollDirectionContainsDown(scrollDirection) && !ASScrollDirectionContainsRight(scrollDirection)) {
-    return NO;
-  }
-
   // No fetching for null states
-  if (leadingScreens <= 0.0 || CGRectEqualToRect(bounds, CGRectZero)) {
+  if (leadingScreens <= 0.0 || CGRectIsEmpty(bounds)) {
     return NO;
   }
 
   CGFloat viewLength, offset, contentLength;
 
-  if (ASScrollDirectionContainsDown(scrollDirection)) {
+  if (ASScrollDirectionContainsVerticalDirection(scrollableDirections)) {
     viewLength = bounds.size.height;
     offset = targetOffset.y;
     contentLength = contentSize.height;
@@ -61,9 +57,14 @@ BOOL ASDisplayShouldFetchBatchForContext(ASBatchContext *context,
 
   // target offset will always be 0 if the content size is smaller than the viewport
   BOOL hasSmallContent = offset == 0.0 && contentLength < viewLength;
+  if (hasSmallContent) {
+    return YES;
+  }
+
+  BOOL isScrollingTowardEnd = (ASScrollDirectionContainsDown(scrollDirection) || ASScrollDirectionContainsRight(scrollDirection));
 
   CGFloat triggerDistance = viewLength * leadingScreens;
   CGFloat remainingDistance = contentLength - viewLength - offset;
 
-  return hasSmallContent || remainingDistance <= triggerDistance;
+  return isScrollingTowardEnd && remainingDistance <= triggerDistance;
 }

--- a/AsyncDisplayKitTests/ASBatchFetchingTests.m
+++ b/AsyncDisplayKitTests/ASBatchFetchingTests.m
@@ -21,35 +21,35 @@
 #define PASSING_RECT CGRectMake(0,0,1,1)
 #define PASSING_SIZE CGSizeMake(1,1)
 #define PASSING_POINT CGPointMake(1,1)
-#define VERTICAL_RECT(h) CGRectMake(0,0,0,h)
+#define VERTICAL_RECT(h) CGRectMake(0,0,1,h)
 #define VERTICAL_SIZE(h) CGSizeMake(0,h)
 #define VERTICAL_OFFSET(y) CGPointMake(0,y)
-#define HORIZONTAL_RECT(w) CGRectMake(0,0,w,0)
+#define HORIZONTAL_RECT(w) CGRectMake(0,0,w,1)
 #define HORIZONTAL_SIZE(w) CGSizeMake(w,0)
 #define HORIZONTAL_OFFSET(x) CGPointMake(x,0)
 
 - (void)testBatchNullState {
   ASBatchContext *context = [[ASBatchContext alloc] init];
-  BOOL shouldFetch = ASDisplayShouldFetchBatchForContext(context, ASScrollDirectionDown, CGRectZero, CGSizeZero, CGPointZero, 0.0);
+  BOOL shouldFetch = ASDisplayShouldFetchBatchForContext(context, ASScrollDirectionDown, ASScrollDirectionVerticalDirections, CGRectZero, CGSizeZero, CGPointZero, 0.0);
   XCTAssert(shouldFetch == NO, @"Should not fetch in the null state");
 }
 
 - (void)testBatchAlreadyFetching {
   ASBatchContext *context = [[ASBatchContext alloc] init];
   [context beginBatchFetching];
-  BOOL shouldFetch = ASDisplayShouldFetchBatchForContext(context, ASScrollDirectionDown, PASSING_RECT, PASSING_SIZE, PASSING_POINT, 1.0);
+  BOOL shouldFetch = ASDisplayShouldFetchBatchForContext(context, ASScrollDirectionDown, ASScrollDirectionVerticalDirections, PASSING_RECT, PASSING_SIZE, PASSING_POINT, 1.0);
   XCTAssert(shouldFetch == NO, @"Should not fetch when context is already fetching");
 }
 
 - (void)testUnsupportedScrollDirections {
   ASBatchContext *context = [[ASBatchContext alloc] init];
-  BOOL fetchRight = ASDisplayShouldFetchBatchForContext(context, ASScrollDirectionRight, PASSING_RECT, PASSING_SIZE, PASSING_POINT, 1.0);
+  BOOL fetchRight = ASDisplayShouldFetchBatchForContext(context, ASScrollDirectionRight, ASScrollDirectionHorizontalDirections, PASSING_RECT, PASSING_SIZE, PASSING_POINT, 1.0);
   XCTAssert(fetchRight == YES, @"Should fetch for scrolling right");
-  BOOL fetchDown = ASDisplayShouldFetchBatchForContext(context, ASScrollDirectionDown, PASSING_RECT, PASSING_SIZE, PASSING_POINT, 1.0);
+  BOOL fetchDown = ASDisplayShouldFetchBatchForContext(context, ASScrollDirectionDown, ASScrollDirectionVerticalDirections, PASSING_RECT, PASSING_SIZE, PASSING_POINT, 1.0);
   XCTAssert(fetchDown == YES, @"Should fetch for scrolling down");
-  BOOL fetchUp = ASDisplayShouldFetchBatchForContext(context, ASScrollDirectionUp, PASSING_RECT, PASSING_SIZE, PASSING_POINT, 1.0);
+  BOOL fetchUp = ASDisplayShouldFetchBatchForContext(context, ASScrollDirectionUp, ASScrollDirectionVerticalDirections, PASSING_RECT, PASSING_SIZE, PASSING_POINT, 1.0);
   XCTAssert(fetchUp == NO, @"Should not fetch for scrolling up");
-  BOOL fetchLeft = ASDisplayShouldFetchBatchForContext(context, ASScrollDirectionLeft, PASSING_RECT, PASSING_SIZE, PASSING_POINT, 1.0);
+  BOOL fetchLeft = ASDisplayShouldFetchBatchForContext(context, ASScrollDirectionLeft, ASScrollDirectionHorizontalDirections, PASSING_RECT, PASSING_SIZE, PASSING_POINT, 1.0);
   XCTAssert(fetchLeft == NO, @"Should not fetch for scrolling left");
 }
 
@@ -57,7 +57,7 @@
   CGFloat screen = 1.0;
   ASBatchContext *context = [[ASBatchContext alloc] init];
   // scroll to 1-screen top offset, height is 1 screen, so bottom is 1 screen away from end of content
-  BOOL shouldFetch = ASDisplayShouldFetchBatchForContext(context, ASScrollDirectionDown, VERTICAL_RECT(screen), VERTICAL_SIZE(screen * 3.0), VERTICAL_OFFSET(screen * 1.0), 1.0);
+  BOOL shouldFetch = ASDisplayShouldFetchBatchForContext(context, ASScrollDirectionDown, ASScrollDirectionVerticalDirections, VERTICAL_RECT(screen), VERTICAL_SIZE(screen * 3.0), VERTICAL_OFFSET(screen * 1.0), 1.0);
   XCTAssert(shouldFetch == YES, @"Fetch should begin when vertically scrolling to exactly 1 leading screen away");
 }
 
@@ -65,7 +65,7 @@
   CGFloat screen = 1.0;
   ASBatchContext *context = [[ASBatchContext alloc] init];
   // 3 screens of content, scroll only 1/2 of one screen
-  BOOL shouldFetch = ASDisplayShouldFetchBatchForContext(context, ASScrollDirectionDown, VERTICAL_RECT(screen), VERTICAL_SIZE(screen * 3.0), VERTICAL_OFFSET(screen * 0.5), 1.0);
+  BOOL shouldFetch = ASDisplayShouldFetchBatchForContext(context, ASScrollDirectionDown, ASScrollDirectionVerticalDirections, VERTICAL_RECT(screen), VERTICAL_SIZE(screen * 3.0), VERTICAL_OFFSET(screen * 0.5), 1.0);
   XCTAssert(shouldFetch == NO, @"Fetch should not begin when vertically scrolling less than the leading distance away");
 }
 
@@ -73,7 +73,7 @@
   CGFloat screen = 1.0;
   ASBatchContext *context = [[ASBatchContext alloc] init];
   // 3 screens of content, top offset to 3-screens, height 1 screen, so its 1 screen past the leading
-  BOOL shouldFetch = ASDisplayShouldFetchBatchForContext(context, ASScrollDirectionDown, VERTICAL_RECT(screen), VERTICAL_SIZE(screen * 3.0), VERTICAL_OFFSET(screen * 3.0), 1.0);
+  BOOL shouldFetch = ASDisplayShouldFetchBatchForContext(context, ASScrollDirectionDown, ASScrollDirectionVerticalDirections, VERTICAL_RECT(screen), VERTICAL_SIZE(screen * 3.0), VERTICAL_OFFSET(screen * 3.0), 1.0);
   XCTAssert(shouldFetch == YES, @"Fetch should begin when vertically scrolling past the content size");
 }
 
@@ -81,7 +81,7 @@
   CGFloat screen = 1.0;
   ASBatchContext *context = [[ASBatchContext alloc] init];
   // scroll to 1-screen left offset, width is 1 screen, so right is 1 screen away from end of content
-  BOOL shouldFetch = ASDisplayShouldFetchBatchForContext(context, ASScrollDirectionRight, HORIZONTAL_RECT(screen), HORIZONTAL_SIZE(screen * 3.0), HORIZONTAL_OFFSET(screen * 1.0), 1.0);
+  BOOL shouldFetch = ASDisplayShouldFetchBatchForContext(context, ASScrollDirectionRight, ASScrollDirectionVerticalDirections, HORIZONTAL_RECT(screen), HORIZONTAL_SIZE(screen * 3.0), HORIZONTAL_OFFSET(screen * 1.0), 1.0);
   XCTAssert(shouldFetch == YES, @"Fetch should begin when horizontally scrolling to exactly 1 leading screen away");
 }
 
@@ -89,7 +89,7 @@
   CGFloat screen = 1.0;
   ASBatchContext *context = [[ASBatchContext alloc] init];
   // 3 screens of content, scroll only 1/2 of one screen
-  BOOL shouldFetch = ASDisplayShouldFetchBatchForContext(context, ASScrollDirectionLeft, HORIZONTAL_RECT(screen), HORIZONTAL_SIZE(screen * 3.0), HORIZONTAL_OFFSET(screen * 0.5), 1.0);
+  BOOL shouldFetch = ASDisplayShouldFetchBatchForContext(context, ASScrollDirectionLeft, ASScrollDirectionHorizontalDirections, HORIZONTAL_RECT(screen), HORIZONTAL_SIZE(screen * 3.0), HORIZONTAL_OFFSET(screen * 0.5), 1.0);
   XCTAssert(shouldFetch == NO, @"Fetch should not begin when horizontally scrolling less than the leading distance away");
 }
 
@@ -97,7 +97,7 @@
   CGFloat screen = 1.0;
   ASBatchContext *context = [[ASBatchContext alloc] init];
   // 3 screens of content, left offset to 3-screens, width 1 screen, so its 1 screen past the leading
-  BOOL shouldFetch = ASDisplayShouldFetchBatchForContext(context, ASScrollDirectionDown, HORIZONTAL_RECT(screen), HORIZONTAL_SIZE(screen * 3.0), HORIZONTAL_OFFSET(screen * 3.0), 1.0);
+  BOOL shouldFetch = ASDisplayShouldFetchBatchForContext(context, ASScrollDirectionDown, ASScrollDirectionHorizontalDirections, HORIZONTAL_RECT(screen), HORIZONTAL_SIZE(screen * 3.0), HORIZONTAL_OFFSET(screen * 3.0), 1.0);
   XCTAssert(shouldFetch == YES, @"Fetch should begin when vertically scrolling past the content size");
 }
 
@@ -105,7 +105,7 @@
   CGFloat screen = 1.0;
   ASBatchContext *context = [[ASBatchContext alloc] init];
   // when the content size is < screen size, the target offset will always be 0
-  BOOL shouldFetch = ASDisplayShouldFetchBatchForContext(context, ASScrollDirectionDown, VERTICAL_RECT(screen), VERTICAL_SIZE(screen * 0.5), VERTICAL_OFFSET(0.0), 1.0);
+  BOOL shouldFetch = ASDisplayShouldFetchBatchForContext(context, ASScrollDirectionDown, ASScrollDirectionVerticalDirections, VERTICAL_RECT(screen), VERTICAL_SIZE(screen * 0.5), VERTICAL_OFFSET(0.0), 1.0);
   XCTAssert(shouldFetch == YES, @"Fetch should begin when the target is 0 and the content size is smaller than the scree");
 }
 
@@ -113,7 +113,7 @@
   CGFloat screen = 1.0;
   ASBatchContext *context = [[ASBatchContext alloc] init];
   // when the content size is < screen size, the target offset will always be 0
-  BOOL shouldFetch = ASDisplayShouldFetchBatchForContext(context, ASScrollDirectionRight, HORIZONTAL_RECT(screen), HORIZONTAL_SIZE(screen * 0.5), HORIZONTAL_OFFSET(0.0), 1.0);
+  BOOL shouldFetch = ASDisplayShouldFetchBatchForContext(context, ASScrollDirectionRight, ASScrollDirectionHorizontalDirections, HORIZONTAL_RECT(screen), HORIZONTAL_SIZE(screen * 0.5), HORIZONTAL_OFFSET(0.0), 1.0);
   XCTAssert(shouldFetch == YES, @"Fetch should begin when the target is 0 and the content size is smaller than the scree");
 }
 

--- a/AsyncDisplayKitTests/ASCollectionViewTests.mm
+++ b/AsyncDisplayKitTests/ASCollectionViewTests.mm
@@ -841,7 +841,7 @@
       XCTFail(@"Too many batch fetches!");
       return;
     }
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+    dispatch_async(dispatch_get_main_queue(), ^{
       NSMutableArray *indexPaths = [NSMutableArray array];
       for (; itemCount < 1000; itemCount++) {
         [indexPaths addObject:[NSIndexPath indexPathForItem:itemCount inSection:0]];

--- a/AsyncDisplayKitTests/ASCollectionViewTests.mm
+++ b/AsyncDisplayKitTests/ASCollectionViewTests.mm
@@ -866,4 +866,32 @@
   [self waitForExpectationsWithTimeout:3 handler:nil];
 }
 
+- (void)testThatBatchFetchHappensForEmptyCollection
+{
+  UIWindow *window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  ASCollectionViewTestController *testController = [[ASCollectionViewTestController alloc] initWithNibName:nil bundle:nil];
+  window.rootViewController = testController;
+
+  // Start with 1 item so that our content does not fill bounds.
+  testController.asyncDelegate->_itemCounts = {};
+  [window makeKeyAndVisible];
+  [window layoutIfNeeded];
+
+  ASCollectionNode *cn = testController.collectionNode;
+  [cn waitUntilAllUpdatesAreCommitted];
+
+  __block NSUInteger batchFetchCount = 0;
+  XCTestExpectation *e = [self expectationWithDescription:@"Batch fetching completed"];
+  testController.asyncDelegate.willBeginBatchFetch = ^(ASBatchContext *context) {
+    // Ensure only 1 batch fetch happens
+    batchFetchCount += 1;
+    if (batchFetchCount > 1) {
+      XCTFail(@"Too many batch fetches!");
+      return;
+    }
+    [e fulfill];
+  };
+  [self waitForExpectationsWithTimeout:3 handler:nil];
+}
+
 @end


### PR DESCRIPTION
- Add a (previously-failing) unit test that when the content starts off not filling the screen, and then a batch fetch is issued that results in the new content filling the screen, we do not start another batch fetch.
- Remove `didCompleteUpdatesInRangeController:`
  - This required callback is to inform ASCollectionView/ASTableView that the range controller has updated the ranges of visible nodes.
  - Its name is easily confused with `rangeController:didEndUpdatesAnimated:completion:`
  - It was previously used to schedule a batch fetch check when the ranges were updated.
  - Batch fetching here has two issues:
    - It doesn't really make sense. The range controller updating the interface state of nodes has no impact on whether it is appropriate to batch fetch or not.
    - It may cause batch fetches to be issued at bad times. When we issue an update to UICollectionView, if the update caused the visible cells to change, then we synchronously update the range controller (in order to make our API guarantees about visibility). However, UICollectionView does not immediately update its `contentSize` and so we may _think_ we're still near the end, when in reality a new batch of content has just arrived and we do not need to fetch again.
- Pass `self.scrollDirection` for the `scrollDirection` param, rather than passing `self.scrollableDirections` (!!) 
- Add a new `scrollableDirections` arg to the batch checking algorithm, so that even if the user is not scrolling (content-not-filling-bounds case) we can still use the correct axes when computing e.g. "total length."
- Update the batch fetching algorithm to use `CGRectIsEmpty` rather than comparing the rect to zero. It is common for UICollectionView to have e.g. `(0, -64, 0, 0)` early in its lifecycle due to contentInset.
- Update batch checking algorithm to correctly issue a batch update in the small-content case even if not scrolling.
  - This was previously working due to us passing `self.scrollableDirections` rather than `self.scrollDirection`. Two wrongs made a right in this isolated case 😛 .
- Update the prior unit tests to be compatible with the new code.

I am about to start testing this with Pinterest, but I'm very confident in the code and I think it's important to land this ASAP. @garrettmoon