### PR TITLE
[WIP] [ASCellNode] Remove view from superview if the UICollectionViewCell is not displayed any more

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -885,6 +885,10 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   
   cellNode.scrollView = nil;
   cell.layoutAttributes = nil;
+
+  // It's important to remove our view now, so that the node will be released immediately.
+  // Rather than waiting for the cell to be assigned to a new node
+  [cellNode.view removeFromSuperview];
 }
 
 - (void)collectionView:(UICollectionView *)collectionView willDisplaySupplementaryView:(UICollectionReusableView *)view forElementKind:(NSString *)elementKind atIndexPath:(NSIndexPath *)indexPath

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -856,6 +856,10 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
   [_cellsForVisibilityUpdates removeObject:cell];
   
   cellNode.scrollView = nil;
+  
+  // It's important to remove our view now, so that the node will be released immediately.
+  // Rather than waiting for the cell to be assigned to a new node
+  [cellNode.view removeFromSuperview];
 }
 
 - (NSIndexPath *)tableView:(UITableView *)tableView willSelectRowAtIndexPath:(nonnull NSIndexPath *)indexPath


### PR DESCRIPTION
`UICollectionViewCell`s are usually reused and not deallocated. Currently the `ASCellNode` view only get's removed from it's superview if the `UICollectionViewCell` get's reused or the `UICollectionView` get's deallocated. The problem with this if `UICollectionViewCell`s get removed, but not immediately reused. All of the `ASCellNode`'s still stay alive as the view is still a subview of the `UICollectionView` content view and the `ASCellNode` view holds a back pointer to the `ASCellNode`. One of the problems with this is that visibility calls are not called or later called e.g. if `UICollectionView` gets deallocated.

To be able to solve this we should remove the `ASCellNode` view from the superview within `...didEndDisplayingCell:..` in `ASCollectionView` and `ASTableView`.

Resolves: #2658