### PR TITLE
Fix Edge Cases of Table Cell Nodes Deallocated While Visible

### DIFF
--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -1231,12 +1231,7 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     return @[];
   }
 
-  // This is a very hot path of code. Since the return value is (in current versions of iOS) already mutable,
-  // skip making the extra copy when possible.
-  NSMutableArray *visibleIndexPaths = (NSMutableArray *)self.indexPathsForVisibleRows;
-  if ([visibleIndexPaths classForCoder] != [NSMutableArray class]) {
-    visibleIndexPaths = [visibleIndexPaths mutableCopy];
-  }
+  NSMutableArray *visibleIndexPaths = [self.indexPathsForVisibleRows mutableCopy];
 
   [visibleIndexPaths sortUsingSelector:@selector(compare:)];
 

--- a/AsyncDisplayKitTests/ASTableViewTests.m
+++ b/AsyncDisplayKitTests/ASTableViewTests.m
@@ -551,7 +551,7 @@
   XCTestExpectation *reloadDataExpectation = [self expectationWithDescription:@"reloadData"];
   [tableView reloadDataWithCompletion:^{
     for (int section = 0; section < NumberOfSections; section++) {
-      for (int row = 0; row < 20; row++) {
+      for (int row = 0; row < [tableView numberOfRowsInSection:section]; row++) {
         NSIndexPath *indexPath = [NSIndexPath indexPathForRow:row inSection:section];
         ASTestTextCellNode *node = (ASTestTextCellNode *)[tableView nodeForRowAtIndexPath:indexPath];
         XCTAssertEqual(node.numberOfLayoutsOnMainThread, 0);


### PR DESCRIPTION
Resolves #2252 

This is one _very strange_ edge case and huge props to @tomizimobile for providing a reliable repro. I distilled the repro down into a unit test and found the problem.

In `grouped` style with section headers and footers, table views will sometimes return more index paths than necessary from `indexPathsForVisibleRows`. We knew this, but considered the risk acceptable. The risk isn't really acceptable – if we mark a node as `visible` we are relying on the fact that it is hosted in an actual cell, so that if the range controller doesn't mark the node invisible before it is removed (say, the item is deleted from the collection or the collection is deallocated) the code in `ASDisplayNode.didExitHierarchy` will retain the node and clear the visible bit before deallocating.

Added a failing unit test and modified the table view visible index paths method to account for this case. Ready for review!