### PR TITLE
Inject Data Source Class Name into Validation Exceptions

### DIFF
--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -154,7 +154,7 @@
 		34EFC7771B701D2D00AD841F /* ASStackUnpositionedLayout.h in Headers */ = {isa = PBXBuildFile; fileRef = ACF6ED491B17847A00DA7C62 /* ASStackUnpositionedLayout.h */; };
 		34EFC7781B701D3100AD841F /* ASStackUnpositionedLayout.mm in Sources */ = {isa = PBXBuildFile; fileRef = ACF6ED4A1B17847A00DA7C62 /* ASStackUnpositionedLayout.mm */; };
 		34EFC7791B701D3600AD841F /* ASLayoutSpecUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = ACF6ED451B17847A00DA7C62 /* ASLayoutSpecUtilities.h */; };
-		3C9C128519E616EF00E942A0 /* ASTableViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C9C128419E616EF00E942A0 /* ASTableViewTests.m */; };
+		3C9C128519E616EF00E942A0 /* ASTableViewTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3C9C128419E616EF00E942A0 /* ASTableViewTests.mm */; };
 		430E7C901B4C23F100697A4C /* ASIndexPath.h in Headers */ = {isa = PBXBuildFile; fileRef = 430E7C8D1B4C23F100697A4C /* ASIndexPath.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		430E7C911B4C23F100697A4C /* ASIndexPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 430E7C8E1B4C23F100697A4C /* ASIndexPath.m */; };
 		430E7C921B4C23F100697A4C /* ASIndexPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 430E7C8E1B4C23F100697A4C /* ASIndexPath.m */; };
@@ -972,7 +972,7 @@
 		299DA1A71A828D2900162D41 /* ASBatchContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASBatchContext.h; sourceTree = "<group>"; };
 		299DA1A81A828D2900162D41 /* ASBatchContext.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASBatchContext.mm; sourceTree = "<group>"; };
 		29CDC2E11AAE70D000833CA4 /* ASBasicImageDownloaderContextTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASBasicImageDownloaderContextTests.m; sourceTree = "<group>"; };
-		3C9C128419E616EF00E942A0 /* ASTableViewTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = ASTableViewTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
+		3C9C128419E616EF00E942A0 /* ASTableViewTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; lineEnding = 0; path = ASTableViewTests.mm; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		430E7C8D1B4C23F100697A4C /* ASIndexPath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASIndexPath.h; sourceTree = "<group>"; };
 		430E7C8E1B4C23F100697A4C /* ASIndexPath.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASIndexPath.m; sourceTree = "<group>"; };
 		464052191A3F83C40061C0BA /* ASDataController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = ASDataController.h; sourceTree = "<group>"; };
@@ -1451,7 +1451,7 @@
 				697B31591CFE4B410049936F /* ASEditableTextNodeTests.m */,
 				052EE0651A159FEF002C6279 /* ASMultiplexImageNodeTests.m */,
 				058D0A32195D057000B7D73C /* ASMutableAttributedStringBuilderTests.m */,
-				3C9C128419E616EF00E942A0 /* ASTableViewTests.m */,
+				3C9C128419E616EF00E942A0 /* ASTableViewTests.mm */,
 				CC4981B21D1A02BE004E13CC /* ASTableViewThrashTests.m */,
 				058D0A33195D057000B7D73C /* ASTextKitCoreTextAdditionsTests.m */,
 				254C6B511BF8FE6D003EC431 /* ASTextKitTruncationTests.mm */,
@@ -2357,7 +2357,7 @@
 				05EA6FE71AC0966E00E35788 /* ASSnapshotTestCase.m in Sources */,
 				ACF6ED631B178DC700DA7C62 /* ASStackLayoutSpecSnapshotTests.mm in Sources */,
 				81E95C141D62639600336598 /* ASTextNodeSnapshotTests.m in Sources */,
-				3C9C128519E616EF00E942A0 /* ASTableViewTests.m in Sources */,
+				3C9C128519E616EF00E942A0 /* ASTableViewTests.mm in Sources */,
 				AEEC47E41C21D3D200EC1693 /* ASVideoNodeTests.m in Sources */,
 				254C6B521BF8FE6D003EC431 /* ASTextKitTruncationTests.mm in Sources */,
 				058D0A3D195D057000B7D73C /* ASTextKitCoreTextAdditionsTests.m in Sources */,

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -444,6 +444,7 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
                         || _asyncDataSourceFlags.collectionViewNodeForItem, @"Data source must implement collectionNode:nodeBlockForItemAtIndexPath: or collectionNode:nodeForItemAtIndexPath:");
   }
   
+  _dataController.validationErrorSource = asyncDataSource;
   super.dataSource = (id<UICollectionViewDataSource>)_proxyDataSource;
   
   //Cache results of layoutInspector to ensure flags are up to date if getter lazily loads a new one.

--- a/AsyncDisplayKit/ASDisplayNode+Beta.h
+++ b/AsyncDisplayKit/ASDisplayNode+Beta.h
@@ -58,8 +58,8 @@ typedef struct {
  *
  * This property defaults to NO. It will be removed in a future release.
  */
-+ (BOOL)suppressesInvalidCollectionUpdateExceptions AS_WARN_UNUSED_RESULT;
-+ (void)setSuppressesInvalidCollectionUpdateExceptions:(BOOL)suppresses;
++ (BOOL)suppressesInvalidCollectionUpdateExceptions AS_WARN_UNUSED_RESULT ASDISPLAYNODE_DEPRECATED_MSG("Collection update exceptions are thrown if assertions are enabled.");
++ (void)setSuppressesInvalidCollectionUpdateExceptions:(BOOL)suppresses ASDISPLAYNODE_DEPRECATED_MSG("Collection update exceptions are thrown if assertions are enabled.");;
 
 /**
  * @abstract Recursively ensures node and all subnodes are displayed.

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -365,6 +365,7 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     ASDisplayNodeAssert(_asyncDataSourceFlags.tableNodeNumberOfRowsInSection || _asyncDataSourceFlags.tableViewNumberOfRowsInSection, @"Data source must implement tableNode:numberOfRowsInSection:");
   }
   
+  _dataController.validationErrorSource = asyncDataSource;
   super.dataSource = (id<UITableViewDataSource>)_proxyDataSource;
 }
 

--- a/AsyncDisplayKit/Details/ASDataController.h
+++ b/AsyncDisplayKit/Details/ASDataController.h
@@ -34,7 +34,8 @@ typedef NSUInteger ASDataControllerAnimationOptions;
  */
 typedef ASCellNode * _Nonnull(^ASCellNodeBlock)();
 
-FOUNDATION_EXPORT NSString * const ASDataControllerRowNodeKind;
+extern NSString * const ASDataControllerRowNodeKind;
+extern NSString * const ASCollectionInvalidUpdateException;
 
 /**
  Data source for data controller
@@ -121,6 +122,11 @@ FOUNDATION_EXPORT NSString * const ASDataControllerRowNodeKind;
  Data source for fetching data info.
  */
 @property (nonatomic, weak, readonly) id<ASDataControllerSource> dataSource;
+
+/**
+ An object that will be included in the backtrace of any update validation exceptions that occur.
+ */
+@property (nonatomic, weak) id validationErrorSource;
 
 /**
  Delegate to notify when data is updated.

--- a/AsyncDisplayKit/Details/ASDataController.mm
+++ b/AsyncDisplayKit/Details/ASDataController.mm
@@ -36,6 +36,7 @@ const static char * kASDataControllerEditingQueueKey = "kASDataControllerEditing
 const static char * kASDataControllerEditingQueueContext = "kASDataControllerEditingQueueContext";
 
 NSString * const ASDataControllerRowNodeKind = @"_ASDataControllerRowNodeKind";
+NSString * const ASCollectionInvalidUpdateException = @"ASCollectionInvalidUpdateException";
 
 #if AS_MEASURE_AVOIDED_DATACONTROLLER_WORK
 @interface ASDataController (AvoidedWorkMeasuring)

--- a/AsyncDisplayKit/Private/_ASHierarchyChangeSet.mm
+++ b/AsyncDisplayKit/Private/_ASHierarchyChangeSet.mm
@@ -17,15 +17,25 @@
 #import "ASDisplayNode+Beta.h"
 #import "ASObjectDescriptionHelpers.h"
 #import <unordered_map>
+#import "ASDataController.h"
+#import "ASBaseDefines.h"
 
-// NOTE: We log before throwing so they don't have to let it bubble up to see the error.
-#define ASFailUpdateValidation(...)\
-  if ([ASDisplayNode suppressesInvalidCollectionUpdateExceptions]) {\
-    NSLog(__VA_ARGS__);\
-  } else {\
-    NSLog(__VA_ARGS__);\
-    ASDisplayNodeFailAssert(__VA_ARGS__);\
-  }
+// If assertions are enabled and they haven't forced us to suppress the exception,
+// then throw, otherwise log.
+#if ASDISPLAYNODE_ASSERTIONS_ENABLED
+  #define ASFailUpdateValidation(...)\
+    _Pragma("clang diagnostic push")\
+    _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")\
+    if ([ASDisplayNode suppressesInvalidCollectionUpdateExceptions]) {\
+      NSLog(__VA_ARGS__);\
+    } else {\
+      NSLog(__VA_ARGS__);\
+      [NSException raise:ASCollectionInvalidUpdateException format:__VA_ARGS__];\
+    }\
+  _Pragma("clang diagnostic pop")
+#else
+  #define ASFailUpdateValidation(...) NSLog(__VA_ARGS__);
+#endif
 
 BOOL ASHierarchyChangeTypeIsFinal(_ASHierarchyChangeType changeType) {
     switch (changeType) {

--- a/AsyncDisplayKitTests/ASCollectionViewTests.mm
+++ b/AsyncDisplayKitTests/ASCollectionViewTests.mm
@@ -222,8 +222,6 @@
 
 - (void)testReloadIfNeeded
 {
-  [ASDisplayNode setSuppressesInvalidCollectionUpdateExceptions:NO];
-
   __block ASCollectionViewTestController *testController = [[ASCollectionViewTestController alloc] initWithNibName:nil bundle:nil];
   __block ASCollectionViewTestDelegate *del = testController.asyncDelegate;
   __block ASCollectionNode *cn = testController.collectionNode;
@@ -383,7 +381,6 @@
 #pragma mark - Update Validations
 
 #define updateValidationTestPrologue \
-  [ASDisplayNode setSuppressesInvalidCollectionUpdateExceptions:NO];\
   ASCollectionViewTestController *testController = [[ASCollectionViewTestController alloc] initWithNibName:nil bundle:nil];\
   __unused ASCollectionViewTestDelegate *del = testController.asyncDelegate;\
   __unused ASCollectionView *cv = testController.collectionView;\


### PR DESCRIPTION
Resolves #2529 to the best of our ability.

The original hope was to get the data source class into the exception backtrace, but since the symbols are set at compile-time and loaded from the _actual_ implementation, we have no way to do that without adding an optional `collectionNode:handleInvalidUpdateWithError:` data source method that users would have to implement.

Instead this diff injects the data source's class name into the exception reason, which is still extremely helpful.

This diff also deprecates the `suppressesInvalidCollectionUpdateExceptions` now that the exceptions have matured and this flag has defaulted to `NO` for a couple months. We will remove it soon.