### PR TITLE
[Layout] Don't crash if layout elements are created in `layoutSpecThatFits:`

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -433,6 +433,8 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
 
 - (void)dealloc
 {
+    NSLog(@"Dealloc: %@", self);
+    
   _flags.isDeallocating = YES;
 
   // Synchronous nodes may not be able to call the hierarchy notifications, so only enforce for regular nodes.

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -433,8 +433,6 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
 
 - (void)dealloc
 {
-    NSLog(@"Dealloc: %@", self);
-    
   _flags.isDeallocating = YES;
 
   // Synchronous nodes may not be able to call the hierarchy notifications, so only enforce for regular nodes.

--- a/AsyncDisplayKit/Layout/ASLayout.mm
+++ b/AsyncDisplayKit/Layout/ASLayout.mm
@@ -50,7 +50,7 @@ static inline NSString * descriptionIndents(NSUInteger indents)
 /*
  * Caches all sublayouts if set to YES or destroys the sublayout cache if set to NO. Defaults to YES
  */
-@property (nonatomic, assign) BOOL cacheSublayoutLayoutElements;
+@property (nonatomic, assign) BOOL retainSublayoutLayoutElements;
 
 /**
  * Array for explicitly retain sublayout layout elements in case they are created and references in layoutSpecThatFits: and no one else will hold a strong reference on it
@@ -99,7 +99,7 @@ static inline NSString * descriptionIndents(NSUInteger indents)
 
     _sublayouts = sublayouts != nil ? [sublayouts copy] : @[];
     _flattened = NO;
-    _cacheSublayoutLayoutElements = NO;
+    _retainSublayoutLayoutElements = NO;
   }
   
   return self;
@@ -152,18 +152,21 @@ static inline NSString * descriptionIndents(NSUInteger indents)
 
 #pragma mark - Sublayout Elements Caching
 
-- (void)setCacheSublayoutLayoutElements:(BOOL)cacheSublayoutLayoutElements
+- (void)setRetainSublayoutLayoutElements:(BOOL)retainSublayoutLayoutElements
 {
-  _cacheSublayoutLayoutElements = cacheSublayoutLayoutElements;
-  
-  if (cacheSublayoutLayoutElements == NO) {
-    _sublayoutLayoutElements = nil;
-  } else {
-    // Add sublayouts layout elements to an internal array to retain it while the layout lives
-    if (_sublayouts.count > 0) {
-      _sublayoutLayoutElements = [NSMutableArray array];
-      for (ASLayout *sublayout in _sublayouts) {
-        [_sublayoutLayoutElements addObject:sublayout.layoutElement];
+  if (_retainSublayoutLayoutElements != retainSublayoutLayoutElements) {
+    _retainSublayoutLayoutElements = retainSublayoutLayoutElements;
+    
+    if (retainSublayoutLayoutElements == NO) {
+      _sublayoutLayoutElements = nil;
+    } else {
+      // Add sublayouts layout elements to an internal array to retain it while the layout lives
+      NSUInteger sublayoutCount = _sublayouts.count;
+      if (sublayoutCount > 0) {
+        _sublayoutLayoutElements = [NSMutableArray arrayWithCapacity:sublayoutCount];
+        for (ASLayout *sublayout in _sublayouts) {
+          [_sublayoutLayoutElements addObject:sublayout.layoutElement];
+        }
       }
     }
   }
@@ -191,7 +194,6 @@ static inline NSString * descriptionIndents(NSUInteger indents)
     if (self != context.layout && context.layout.type == ASLayoutElementTypeDisplayNode) {
       ASLayout *layout = [ASLayout layoutWithLayout:context.layout position:context.absolutePosition];
       layout.flattened = YES;
-      layout.cacheSublayoutLayoutElements = YES;
       [flattenedSublayouts addObject:layout];
     }
     
@@ -205,7 +207,7 @@ static inline NSString * descriptionIndents(NSUInteger indents)
   }
   
   ASLayout *layout = [ASLayout layoutWithLayoutElement:_layoutElement size:_size position:CGPointZero sublayouts:flattenedSublayouts];
-  layout.cacheSublayoutLayoutElements = YES;
+  layout.retainSublayoutLayoutElements = YES;
   return layout;
 }
 

--- a/AsyncDisplayKit/Layout/ASLayout.mm
+++ b/AsyncDisplayKit/Layout/ASLayout.mm
@@ -47,6 +47,11 @@ static inline NSString * descriptionIndents(NSUInteger indents)
  */
 @property (nonatomic, getter=isFlattened) BOOL flattened;
 
+/**
+ * Array for explicitly retain sublayout layout elements in case they are created and references in layoutSpecThatFits: and no one else will hold a strong reference on it
+ */
+@property (nonatomic, strong) NSMutableArray *sublayoutLayoutElements;
+
 @end
 
 @implementation ASLayout
@@ -69,6 +74,7 @@ static inline NSString * descriptionIndents(NSUInteger indents)
 #endif
     
     _layoutElement = layoutElement;
+    
     // Read this now to avoid @c weak overhead later.
     _layoutElementType = layoutElement.layoutElementType;
     
@@ -88,6 +94,14 @@ static inline NSString * descriptionIndents(NSUInteger indents)
 
     _sublayouts = sublayouts != nil ? [sublayouts copy] : @[];
     _flattened = NO;
+    
+    // Add sublayouts layout elements to an internal array to retain it while the layout lives
+    if (sublayouts.count > 0) {
+      _sublayoutLayoutElements = [NSMutableArray array];
+      for (ASLayout *sublayout in sublayouts) {
+        [_sublayoutLayoutElements addObject:sublayout.layoutElement];
+      }
+    }
   }
   return self;
 }

--- a/AsyncDisplayKitTests/ASDisplayNodeLayoutTests.mm
+++ b/AsyncDisplayKitTests/ASDisplayNodeLayoutTests.mm
@@ -13,19 +13,6 @@
 #import "ASLayoutSpecSnapshotTestsHelper.h"
 #import "ASDisplayNode+FrameworkPrivate.h"
 
-@interface DisplayNode : ASDisplayNode
-
-@end
-
-@implementation DisplayNode
-
-- (ASLayoutSpec *)layoutSpecThatFits:(ASSizeRange)constrainedSize
-{
-  ASTextNode *someOtherNode = [ASTextNode new];
-  return [ASInsetLayoutSpec insetLayoutSpecWithInsets:UIEdgeInsetsZero child:someOtherNode];
-}
-@end
-
 @interface ASDisplayNodeLayoutTests : XCTestCase
 @end
 
@@ -136,76 +123,35 @@
 
 - (void)testThatLayoutElementCreatedInLayoutSpecThatFitsDoesNotGetDeallocated
 {
-  ASDisplayNode *displayNode = [DisplayNode new];
-  displayNode.automaticallyManagesSubnodes = YES;
+  const CGSize kSize = CGSizeMake(300, 300);
   
-  //[displayNode addSubnode:someOtherNode];
-  /*displayNode.layoutSpecBlock = ^(ASDisplayNode * _Nonnull node, ASSizeRange constrainedSize) {
+  ASDisplayNode *displayNode = [[ASDisplayNode alloc] init];
+  displayNode.automaticallyManagesSubnodes = YES;
+  displayNode.layoutSpecBlock = ^(ASDisplayNode * _Nonnull node, ASSizeRange constrainedSize) {
     ASTextNode *someOtherNode = [ASTextNode new];
     return [ASInsetLayoutSpec insetLayoutSpecWithInsets:UIEdgeInsetsZero child:someOtherNode];
-  };*/
-  
-  XCTestExpectation *expectation = [self expectationWithDescription:@"Query timed out."];
-  //CGSize s = CGSizeZero;
-  displayNode.frame = CGRectMake(0, 0, 300, 300);
+  };
+
+  displayNode.frame = CGRectMake(0, 0, kSize.width, kSize.height);
   [displayNode view];
   
-  __unused CGSize s = CGSizeZero;
+  XCTestExpectation *expectation = [self expectationWithDescription:@"Execute measure and layout pass"];
   
-  dispatch_async(dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-    //ASLayout *layout
+  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
     
-    @autoreleasepool {
-      __unused CGSize s = [displayNode layoutThatFits:ASSizeRangeMake(CGSizeZero, CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX))].size;
-      //s = [displayNode layoutThatFits:ASSizeRangeMake(CGSizeZero, CGSizeMake(100, CGFLOAT_MAX))].size;
-      //[displayNode setNeedsLayout];
-      //s = [displayNode layoutThatFits:ASSizeRangeMake(CGSizeZero, CGSizeMake(200, CGFLOAT_MAX))].size;
-      //[displayNode setNeedsLayout];
-      s = [displayNode layoutThatFits:ASSizeRangeMake(CGSizeMake(300, 300), CGSizeMake(300, 300))].size;
-      //[displayNode setNeedsLayout];
-    }
-
+    [displayNode layoutThatFits:ASSizeRangeMake(kSize)];
     
     dispatch_async(dispatch_get_main_queue(), ^{
-      
-      //__unused CGSize s = [displayNode layoutThatFits:ASSizeRangeMake(CGSizeZero, CGSizeMake(CGFLOAT_MAX, 200))].size;
-      
-      //[displayNode setNeedsLayout];
-      [displayNode.view layoutIfNeeded];
-      
-      dispatch_async(dispatch_get_main_queue(), ^{
-        [expectation fulfill];
-      });
+      XCTAssertNoThrow([displayNode.view layoutIfNeeded]);
+      [expectation fulfill];
     });
   });
   
-  
-  //[displayNode view];
-  
-  /*dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-    
-    //displayNode.frame = CGRectMake(0, 0, 100, 100);
-    [displayNode setNeedsLayout];
-    [displayNode.view layoutIfNeeded];
-    
-    
-    // First layout pass
-    //displayNode.frame = CGRectMake(0, 0, layout.size.width, layout.size.height);
-    //[displayNode setNeedsLayout];
-    //[displayNode.view layoutIfNeeded];
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-      [displayNode transitionLayoutWithSizeRange:ASSizeRangeMake(CGSizeZero, CGSizeMake(80, 80)) animated:NO shouldMeasureAsync:NO measurementCompletion:nil];
-      [expectation fulfill];
-    });  
-  });*/
-  
-  
   [self waitForExpectationsWithTimeout:5.0 handler:^(NSError *error) {
     if (error) {
-      NSLog(@"Error: %@", error);
+      XCTFail(@"Expectation failed: %@", error);
     }
   }];
-  //XCTAssertNoThrow([displayNode layoutThatFits:ASSizeRangeMake(CGSizeMake(0, FLT_MAX))]);
 }
 
 @end

--- a/AsyncDisplayKitTests/ASDisplayNodeLayoutTests.mm
+++ b/AsyncDisplayKitTests/ASDisplayNodeLayoutTests.mm
@@ -125,24 +125,41 @@
 {
   const CGSize kSize = CGSizeMake(300, 300);
   
-  ASDisplayNode *displayNode = [[ASDisplayNode alloc] init];
-  displayNode.automaticallyManagesSubnodes = YES;
-  displayNode.layoutSpecBlock = ^(ASDisplayNode * _Nonnull node, ASSizeRange constrainedSize) {
-    ASTextNode *someOtherNode = [ASTextNode new];
-    return [ASInsetLayoutSpec insetLayoutSpecWithInsets:UIEdgeInsetsZero child:someOtherNode];
+  ASDisplayNode *subNode = [[ASDisplayNode alloc] init];
+  subNode.automaticallyManagesSubnodes = YES;
+  subNode.layoutSpecBlock = ^(ASDisplayNode * _Nonnull node, ASSizeRange constrainedSize) {
+    ASTextNode *textNode = [ASTextNode new];
+    textNode.attributedText = [[NSAttributedString alloc] initWithString:@"Test Test Test Test Test Test Test Test"];
+    ASInsetLayoutSpec *insetSpec = [ASInsetLayoutSpec insetLayoutSpecWithInsets:UIEdgeInsetsZero child:textNode];
+    return [ASInsetLayoutSpec insetLayoutSpecWithInsets:UIEdgeInsetsZero child:insetSpec];
+  };
+  
+  ASDisplayNode *rootNode = [[ASDisplayNode alloc] init];
+  rootNode.automaticallyManagesSubnodes = YES;
+  rootNode.layoutSpecBlock = ^(ASDisplayNode * _Nonnull node, ASSizeRange constrainedSize) {
+    ASTextNode *textNode = [ASTextNode new];
+    textNode.attributedText = [[NSAttributedString alloc] initWithString:@"Test Test Test Test Test"];
+    ASInsetLayoutSpec *insetSpec = [ASInsetLayoutSpec insetLayoutSpecWithInsets:UIEdgeInsetsZero child:textNode];
+    
+    return [ASStackLayoutSpec
+            stackLayoutSpecWithDirection:ASStackLayoutDirectionVertical
+            spacing:0.0
+            justifyContent:ASStackLayoutJustifyContentStart
+            alignItems:ASStackLayoutAlignItemsStretch
+            children:@[insetSpec, subNode]];
   };
 
-  displayNode.frame = CGRectMake(0, 0, kSize.width, kSize.height);
-  [displayNode view];
+  rootNode.frame = CGRectMake(0, 0, kSize.width, kSize.height);
+  [rootNode view];
   
   XCTestExpectation *expectation = [self expectationWithDescription:@"Execute measure and layout pass"];
   
   dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
     
-    [displayNode layoutThatFits:ASSizeRangeMake(kSize)];
+    [rootNode layoutThatFits:ASSizeRangeMake(kSize)];
     
     dispatch_async(dispatch_get_main_queue(), ^{
-      XCTAssertNoThrow([displayNode.view layoutIfNeeded]);
+      XCTAssertNoThrow([rootNode.view layoutIfNeeded]);
       [expectation fulfill];
     });
   });

--- a/AsyncDisplayKitTests/ASDisplayNodeLayoutTests.mm
+++ b/AsyncDisplayKitTests/ASDisplayNodeLayoutTests.mm
@@ -121,7 +121,7 @@
   XCTAssertThrows([ASLayout layoutWithLayoutElement:displayNode size:CGSizeMake(INFINITY, INFINITY)]);
 }
 
-- (void)testThatLayoutElementCreatedInLayoutSpecThatFitsDoesNotGetDeallocated
+- (void)testThatLayoutElementCreatedInLayoutSpecThatFitsDoNotGetDeallocated
 {
   const CGSize kSize = CGSizeMake(300, 300);
   


### PR DESCRIPTION
Referencing `ASLayoutElement`'s in `layoutSpecThatFits:` without holding a strong reference can to lead crashes if the measurement pass happens in a background thread and applied later in a layout pass. 

To assure that layout elements that are referenced in sublayouts life while the root layout is alive we should hold a strong reference to the sub layout layout elements while the root layout is alive.

Resolves: #2673 
