### PR TITLE
Invalidate Cell Node Layout Before Measuring

### DIFF
--- a/AsyncDisplayKit/Details/ASDataController.mm
+++ b/AsyncDisplayKit/Details/ASDataController.mm
@@ -174,6 +174,8 @@ NSString * const ASCollectionInvalidUpdateException = @"ASCollectionInvalidUpdat
  */
 - (void)_layoutNode:(ASCellNode *)node withConstrainedSize:(ASSizeRange)constrainedSize
 {
+  [node setNeedsLayout];
+  
   CGRect frame = CGRectZero;
   frame.size = [node layoutThatFits:constrainedSize].size;
   node.frame = frame;


### PR DESCRIPTION
Worked with @binl and @maicki on this – if a node has a `_pendingDisplayNodeLayout`, that layout will take precedence over the one calculated by this method, while the node waits for UIKit to run a layout pass on it.

However, in the case of a collection/table, UIKit may not run a layout pass for a long time and so it's important that we invalidate that pending layout when we remeasure the node. For example, when rotating, if a node has a pending layout designed for portrait and we rotate to landscape, we need to immediately discard the pending portrait layout.