### PR TITLE
[ASDisplayNode] Fix flickering for nodes that support range managed interface state

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -2956,7 +2956,7 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
 - (void)recursivelyClearPreloadedData
 {
   ASDisplayNodePerformBlockOnEveryNode(nil, self, YES, ^(ASDisplayNode * _Nonnull node) {
-    [node didExitPreloadState];
+    [node _didExitPreloadState];
   });
 }
 
@@ -2990,15 +2990,22 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
   }
 }
 
+- (void)_didExitPreloadState
+{
+  // We don't want to call -didExitPreloadState on nodes that aren't being managed by a range controller.
+  // Otherwise we get flashing behavior from normal UIKit manipulations like navigation controller push / pop.
+  if ([self supportsRangeManagedInterfaceState]) {
+    [self didExitPreloadState];
+  }
+}
+
 - (void)didExitPreloadState
 {
   if (_methodOverrides & ASDisplayNodeMethodOverrideClearFetchedData) {
-    if ([self supportsRangeManagedInterfaceState]) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [self clearFetchedData];
 #pragma clang diagnostic pop
-    }
   }
 }
 
@@ -3068,7 +3075,7 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
     if (nowPreload) {
       [self didEnterPreloadState];
     } else {
-      [self didExitPreloadState];
+      [self _didExitPreloadState];
     }
   }
   
@@ -3951,7 +3958,7 @@ ASLayoutElementStyleForwarding
   if (inLoadState) {
     [self didEnterPreloadState];
   } else {
-    [self didExitPreloadState];
+    [self _didExitPreloadState];
   }
 }
 

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -2956,7 +2956,7 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
 - (void)recursivelyClearPreloadedData
 {
   ASDisplayNodePerformBlockOnEveryNode(nil, self, YES, ^(ASDisplayNode * _Nonnull node) {
-    [node _didExitPreloadState];
+    [node didExitPreloadState];
   });
 }
 
@@ -2987,15 +2987,6 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [self fetchData];
 #pragma clang diagnostic pop
-  }
-}
-
-- (void)_didExitPreloadState
-{
-  // We don't want to call -didExitPreloadState on nodes that aren't being managed by a range controller.
-  // Otherwise we get flashing behavior from normal UIKit manipulations like navigation controller push / pop.
-  if ([self supportsRangeManagedInterfaceState]) {
-    [self didExitPreloadState];
   }
 }
 
@@ -3075,7 +3066,11 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
     if (nowPreload) {
       [self didEnterPreloadState];
     } else {
-      [self _didExitPreloadState];
+      // We don't want to call -didExitPreloadState on nodes that aren't being managed by a range controller.
+      // Otherwise we get flashing behavior from normal UIKit manipulations like navigation controller push / pop.
+      if ([self supportsRangeManagedInterfaceState]) {
+        [self didExitPreloadState];
+      }
     }
   }
   
@@ -3958,7 +3953,7 @@ ASLayoutElementStyleForwarding
   if (inLoadState) {
     [self didEnterPreloadState];
   } else {
-    [self _didExitPreloadState];
+    [self didExitPreloadState];
   }
 }
 

--- a/AsyncDisplayKitTests/ASDisplayNodeTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeTests.m
@@ -1936,6 +1936,7 @@ static bool stringContainsPointer(NSString *description, id p) {
 - (void)testDidExitPreloadIsCalledWhenNodesExitPreloadRange
 {
   ASTestDisplayNode *node = [[ASTestDisplayNode alloc] init];
+  [node setHierarchyState:ASHierarchyStateRangeManaged];
   
   [node recursivelySetInterfaceState:ASInterfaceStatePreload];
   [node recursivelySetInterfaceState:ASInterfaceStateDisplay];


### PR DESCRIPTION
This bug was initially introduced in #2130 as moved the check for `supportsRangeManagedInterfaceState` for `clearFetchedData` from `setInterfaceState` to `didExitPreloadState` within #2130

Let's get the old behavior back and move the `supportsRangeManagedInterfaceState` check back to `setInterfaceStateState` as it was before all of this renaming PRs. This also does allows us to not have to introduce some internal `_didExitPreloadState` method.

Resolves: #2709