### PR TITLE
[Layout Transition] Reset the alpha value for inserted and removed subnode to initial value

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -1058,9 +1058,6 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
       
       // Kick off animating the layout transition
       [self animateLayoutTransition:_pendingLayoutTransitionContext];
-        
-      // Mark transaction as finished
-      [self _finishOrCancelTransition];
     });
   };
   
@@ -1249,7 +1246,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   }];
 }
 
-/*
+/**
  * Hook for subclasses to clean up nodes after the transition happened. Furthermore this can be used from subclasses
  * to manually perform deletions.
  */
@@ -1260,9 +1257,9 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
 
 #pragma mark _ASTransitionContextCompletionDelegate
 
-/*
+/**
  * After completeTransition: is called on the ASContextTransitioning object in animateLayoutTransition: this
- * delegate method will be called that start the completion process of the 
+ * delegate method will be called that start the completion process of the transition
  */
 - (void)transitionContext:(_ASTransitionContext *)context didComplete:(BOOL)didComplete
 {
@@ -1270,6 +1267,9 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   _pendingLayoutTransitionContext = nil;
 
   [self _pendingLayoutTransitionDidComplete];
+    
+  // Mark transaction as finished
+  [self _finishOrCancelTransition];
 }
 
 #pragma mark - Layout

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -1238,6 +1238,9 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
       movedSubnode.frame = [context finalFrameForNode:movedSubnode];
     }
   } completion:^(BOOL finished) {
+    for (ASDisplayNode *removedSubnode in removedSubnodes) {
+      removedSubnode.alpha = 1;
+    }
     for (UIView *removedView in removedViews) {
       [removedView removeFromSuperview];
     }

--- a/AsyncDisplayKit/_ASTransitionContext.h
+++ b/AsyncDisplayKit/_ASTransitionContext.h
@@ -44,3 +44,9 @@
                completionDelegate:(id<_ASTransitionContextCompletionDelegate>)completionDelegate;
 
 @end
+
+@interface _ASAnimatedTransitionContext : NSObject
+@property (nonatomic, strong, readonly) ASDisplayNode *node;
+@property (nonatomic, assign, readonly) CGFloat alpha;
++ (instancetype)contextForNode:(ASDisplayNode *)node alpha:(CGFloat)alphaValue;
+@end

--- a/AsyncDisplayKit/_ASTransitionContext.m
+++ b/AsyncDisplayKit/_ASTransitionContext.m
@@ -97,3 +97,21 @@ NSString * const ASTransitionContextToLayoutKey = @"org.asyncdisplaykit.ASTransi
 }
 
 @end
+
+
+@interface _ASAnimatedTransitionContext ()
+@property (nonatomic, strong, readwrite) ASDisplayNode *node;
+@property (nonatomic, assign, readwrite) CGFloat alpha;
+@end
+
+@implementation _ASAnimatedTransitionContext
+
++ (instancetype)contextForNode:(ASDisplayNode *)node alpha:(CGFloat)alpha
+{
+  _ASAnimatedTransitionContext *context = [[_ASAnimatedTransitionContext alloc] init];
+  context.node = node;
+  context.alpha = alpha;
+  return context;
+}
+
+@end


### PR DESCRIPTION
After removing a subnode via the animated layout transition we should set the alpha value back to the old value.

The reasoning behind is that if the subnode would be added back via a next non animated layout transition (e.g. instead of calling `transitionLayout...`, call `setNeedsLayout` it would still have an alpha value of 0 and although measured the right size it not show up. Furthermore we should also do the same for inserted nodes.