### PR TITLE
Improve Handling of Rasterized Node Interface & Hierarchy States

### DIFF
--- a/AsyncDisplayKit.xcodeproj/xcshareddata/xcschemes/AsyncDisplayKit.xcscheme
+++ b/AsyncDisplayKit.xcodeproj/xcshareddata/xcschemes/AsyncDisplayKit.xcscheme
@@ -54,6 +54,9 @@
             </BuildableReference>
             <SkippedTests>
                <Test
+                  Identifier = "ASDisplayNodeTests/testThatLoadedNodeGetsUnloadedIfAddedToRasterizedSubtree">
+               </Test>
+               <Test
                   Identifier = "ASTextNodePerformanceTests">
                </Test>
                <Test

--- a/AsyncDisplayKit.xcodeproj/xcshareddata/xcschemes/AsyncDisplayKit.xcscheme
+++ b/AsyncDisplayKit.xcodeproj/xcshareddata/xcschemes/AsyncDisplayKit.xcscheme
@@ -54,9 +54,6 @@
             </BuildableReference>
             <SkippedTests>
                <Test
-                  Identifier = "ASDisplayNodeTests/testThatLoadedNodeGetsUnloadedIfAddedToRasterizedSubtree">
-               </Test>
-               <Test
                   Identifier = "ASTextNodePerformanceTests">
                </Test>
                <Test

--- a/AsyncDisplayKit/ASDisplayNode+Beta.h
+++ b/AsyncDisplayKit/ASDisplayNode+Beta.h
@@ -123,6 +123,28 @@ typedef struct {
  */
 + (void)setRangeModeForMemoryWarnings:(ASLayoutRangeMode)rangeMode;
 
+/**
+ * @abstract Whether to draw all descendant nodes' layers/views into this node's layer/view's backing store.
+ *
+ * @discussion
+ * When set to YES, causes all descendant nodes' layers/views to be drawn directly into this node's layer/view's backing
+ * store.  Defaults to NO.
+ *
+ * If a node's descendants are static (never animated or never change attributes after creation) then that node is a
+ * good candidate for rasterization.  Rasterizing descendants has two main benefits:
+ * 1) Backing stores for descendant layers are not created.  Instead the layers are drawn directly into the rasterized
+ * container.  This can save a great deal of memory.
+ * 2) Since the entire subtree is drawn into one backing store, compositing and blending are eliminated in that subtree
+ * which can help improve animation/scrolling/etc performance.
+ *
+ * Rasterization does not currently support descendants with transform, sublayerTransform, or alpha. Those properties
+ * will be ignored when rasterizing descendants.
+ *
+ * Note: this has nothing to do with -[CALayer shouldRasterize], which doesn't work with ASDisplayNode's asynchronous
+ * rendering model.
+ */
+@property (nonatomic, assign) BOOL shouldRasterizeDescendants;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -417,28 +417,6 @@ extern NSInteger const ASDefaultDrawingPriority;
 @property (nonatomic, assign) BOOL displaysAsynchronously;
 
 /** 
- * @abstract Whether to draw all descendant nodes' layers/views into this node's layer/view's backing store.
- *
- * @discussion
- * When set to YES, causes all descendant nodes' layers/views to be drawn directly into this node's layer/view's backing 
- * store.  Defaults to NO.
- *
- * If a node's descendants are static (never animated or never change attributes after creation) then that node is a 
- * good candidate for rasterization.  Rasterizing descendants has two main benefits:
- * 1) Backing stores for descendant layers are not created.  Instead the layers are drawn directly into the rasterized
- * container.  This can save a great deal of memory.
- * 2) Since the entire subtree is drawn into one backing store, compositing and blending are eliminated in that subtree
- * which can help improve animation/scrolling/etc performance.
- *
- * Rasterization does not currently support descendants with transform, sublayerTransform, or alpha. Those properties 
- * will be ignored when rasterizing descendants.
- *
- * Note: this has nothing to do with -[CALayer shouldRasterize], which doesn't work with ASDisplayNode's asynchronous 
- * rendering model.
- */
-@property (nonatomic, assign) BOOL shouldRasterizeDescendants;
-
-/** 
  * @abstract Prevent the node's layer from displaying.
  *
  * @discussion A subclass may check this flag during -display or -drawInContext: to cancel a display that is already in 

--- a/AsyncDisplayKit/ASDisplayNodeExtras.h
+++ b/AsyncDisplayKit/ASDisplayNodeExtras.h
@@ -19,7 +19,11 @@
  * For instance, in `MYButtonNode` if you call `ASSetDebugNames(self.titleNode, _countNode)` the debug names
  * for the nodes will be set to `MYButtonNode.titleNode` and `MYButtonNode.countNode`.
  */
-#define ASSetDebugNames(...) _ASSetDebugNames(self.class, @"" # __VA_ARGS__, __VA_ARGS__, nil)
+#if DEBUG
+  #define ASSetDebugNames(...) _ASSetDebugNames(self.class, @"" # __VA_ARGS__, __VA_ARGS__, nil)
+#else
+  #define ASSetDebugNames(...)
+#endif
 
 /// For deallocation of objects on the main thread across multiple run loops.
 extern void ASPerformMainThreadDeallocation(_Nullable id object);

--- a/AsyncDisplayKit/ASDisplayNodeExtras.h
+++ b/AsyncDisplayKit/ASDisplayNodeExtras.h
@@ -14,6 +14,13 @@
 #import <AsyncDisplayKit/ASBaseDefines.h>
 #import <AsyncDisplayKit/ASDisplayNode.h>
 
+/**
+ * Sets the debugName field for these nodes to the given symbol names, within the domain of "self.class"
+ * For instance, in `MYButtonNode` if you call `ASSetDebugNames(self.titleNode, _countNode)` the debug names
+ * for the nodes will be set to `MYButtonNode.titleNode` and `MYButtonNode.countNode`.
+ */
+#define ASSetDebugNames(...) _ASSetDebugNames(self.class, @"" # __VA_ARGS__, __VA_ARGS__, nil)
+
 /// For deallocation of objects on the main thread across multiple run loops.
 extern void ASPerformMainThreadDeallocation(_Nullable id object);
 
@@ -38,18 +45,6 @@ ASDISPLAYNODE_INLINE BOOL ASInterfaceStateIncludesMeasureLayout(ASInterfaceState
 {
   return ((interfaceState & ASInterfaceStateMeasureLayout) == ASInterfaceStateMeasureLayout);
 }
-
-#define ASSetDebugNames(...) _ASSetDebugNames(@"" # __VA_ARGS__, __VA_ARGS__, nil)
-__unused static void _ASSetDebugNames(NSString * _Nonnull names, ASDisplayNode * _Nullable object, ...) {
-  NSArray *nameArray = [names componentsSeparatedByString:@", "];
-  va_list args;
-  va_start(args, object);
-  NSInteger i = 0;
-  for (ASDisplayNode *node = object; node != nil; node = va_arg(args, id), i++) {
-    node.debugName = nameArray[i];
-  }
-  va_end(args);
-};
 
 __unused static NSString * _Nonnull NSStringFromASInterfaceState(ASInterfaceState interfaceState)
 {
@@ -174,6 +169,9 @@ extern UIColor *ASDisplayNodeDefaultTintColor() AS_WARN_UNUSED_RESULT;
  */
 extern void ASDisplayNodeDisableHierarchyNotifications(ASDisplayNode *node);
 extern void ASDisplayNodeEnableHierarchyNotifications(ASDisplayNode *node);
+
+// Not to be called directly.
+extern void _ASSetDebugNames(Class _Nonnull owningClass, NSString * _Nonnull names, ASDisplayNode * _Nullable object, ...);
 
 ASDISPLAYNODE_EXTERN_C_END
 

--- a/AsyncDisplayKit/ASDisplayNodeExtras.h
+++ b/AsyncDisplayKit/ASDisplayNodeExtras.h
@@ -39,6 +39,30 @@ ASDISPLAYNODE_INLINE BOOL ASInterfaceStateIncludesMeasureLayout(ASInterfaceState
   return ((interfaceState & ASInterfaceStateMeasureLayout) == ASInterfaceStateMeasureLayout);
 }
 
+#define ASSetDebugNames(node, ...) _ASSetDebugNames(@"" # __VA_ARGS__, __VA_ARGS__, nil)
+__unused static void _ASSetDebugNames(NSString * _Nonnull names, ASDisplayNode * _Nullable object, ...) {
+  if (object == nil) {
+    return;
+  }
+  static NSCharacterSet *separators;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    NSMutableCharacterSet *s = [NSMutableCharacterSet characterSetWithCharactersInString:@","];
+    [s formUnionWithCharacterSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    separators = s;
+  });
+  NSArray *nameArray = [names componentsSeparatedByCharactersInSet:separators];
+  va_list args;
+  va_start(args, object);
+  NSInteger i = 0;
+  for (NSString *name in nameArray) {
+    ASDisplayNode *node = va_arg(args, id);
+    node.debugName = name;
+    i += 1;
+  }
+  va_end(args);
+};
+
 __unused static NSString * _Nonnull NSStringFromASInterfaceState(ASInterfaceState interfaceState)
 {
   NSMutableArray *states = [NSMutableArray array];

--- a/AsyncDisplayKit/ASDisplayNodeExtras.h
+++ b/AsyncDisplayKit/ASDisplayNodeExtras.h
@@ -39,26 +39,14 @@ ASDISPLAYNODE_INLINE BOOL ASInterfaceStateIncludesMeasureLayout(ASInterfaceState
   return ((interfaceState & ASInterfaceStateMeasureLayout) == ASInterfaceStateMeasureLayout);
 }
 
-#define ASSetDebugNames(node, ...) _ASSetDebugNames(@"" # __VA_ARGS__, __VA_ARGS__, nil)
+#define ASSetDebugNames(...) _ASSetDebugNames(@"" # __VA_ARGS__, __VA_ARGS__, nil)
 __unused static void _ASSetDebugNames(NSString * _Nonnull names, ASDisplayNode * _Nullable object, ...) {
-  if (object == nil) {
-    return;
-  }
-  static NSCharacterSet *separators;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    NSMutableCharacterSet *s = [NSMutableCharacterSet characterSetWithCharactersInString:@","];
-    [s formUnionWithCharacterSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
-    separators = s;
-  });
-  NSArray *nameArray = [names componentsSeparatedByCharactersInSet:separators];
+  NSArray *nameArray = [names componentsSeparatedByString:@", "];
   va_list args;
   va_start(args, object);
   NSInteger i = 0;
-  for (NSString *name in nameArray) {
-    ASDisplayNode *node = va_arg(args, id);
-    node.debugName = name;
-    i += 1;
+  for (ASDisplayNode *node = object; node != nil; node = va_arg(args, id), i++) {
+    node.debugName = nameArray[i];
   }
   va_end(args);
 };

--- a/AsyncDisplayKit/ASDisplayNodeExtras.mm
+++ b/AsyncDisplayKit/ASDisplayNodeExtras.mm
@@ -32,6 +32,24 @@ extern void ASPerformMainThreadDeallocation(_Nullable id object)
   }
 }
 
+extern void _ASSetDebugNames(Class _Nonnull owningClass, NSString * _Nonnull names, ASDisplayNode * _Nullable object, ...)
+{
+  NSString *owningClassName = NSStringFromClass(owningClass);
+  NSArray *nameArray = [names componentsSeparatedByString:@", "];
+  va_list args;
+  va_start(args, object);
+  NSInteger i = 0;
+  for (ASDisplayNode *node = object; node != nil; node = va_arg(args, id), i++) {
+    NSMutableString *symbolName = [nameArray[i] mutableCopy];
+    // Remove any `self.` or `_` prefix
+    [symbolName replaceOccurrencesOfString:@"self." withString:@"" options:NSAnchoredSearch range:NSMakeRange(0, symbolName.length)];
+    [symbolName replaceOccurrencesOfString:@"_" withString:@"" options:NSAnchoredSearch range:NSMakeRange(0, symbolName.length)];
+    node.debugName = [NSString stringWithFormat:@"%@.%@", owningClassName, symbolName];
+  }
+  ASDisplayNodeCAssert(nameArray.count == i, @"Malformed call to ASSetDebugNames: %@", names);
+  va_end(args);
+}
+
 extern ASInterfaceState ASInterfaceStateForDisplayNode(ASDisplayNode *displayNode, UIWindow *window)
 {
     ASDisplayNodeCAssert(![displayNode isLayerBacked], @"displayNode must not be layer backed as it may have a nil window");

--- a/AsyncDisplayKit/Details/_ASDisplayViewAccessiblity.mm
+++ b/AsyncDisplayKit/Details/_ASDisplayViewAccessiblity.mm
@@ -13,6 +13,7 @@
 #import "_ASDisplayView.h"
 #import "ASDisplayNodeExtras.h"
 #import "ASDisplayNode+FrameworkPrivate.h"
+#import "ASDisplayNode+Beta.h"
 
 #pragma mark - UIAccessibilityElement
 

--- a/AsyncDisplayKit/Private/ASDisplayNode+FrameworkPrivate.h
+++ b/AsyncDisplayKit/Private/ASDisplayNode+FrameworkPrivate.h
@@ -115,7 +115,7 @@ __unused static NSString * _Nonnull NSStringFromASHierarchyState(ASHierarchyStat
 - (void)exitHierarchyState:(ASHierarchyState)hierarchyState;
 
 // Changed before calling willEnterHierarchy / didExitHierarchy.
-@property (nonatomic, readwrite, assign, getter = isInHierarchy) BOOL inHierarchy;
+@property (readonly, assign, getter = isInHierarchy) BOOL inHierarchy;
 // Call willEnterHierarchy if necessary and set inHierarchy = YES if visibility notifications are enabled on all of its parents
 - (void)__enterHierarchy;
 // Call didExitHierarchy if necessary and set inHierarchy = NO if visibility notifications are enabled on all of its parents

--- a/AsyncDisplayKitTests/ASDisplayNodeTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeTests.m
@@ -1971,33 +1971,43 @@ static bool stringContainsPointer(NSString *description, id p) {
 }
 
 // Underlying issue for: https://github.com/facebook/AsyncDisplayKit/issues/2205
-- (void)DISABLED_testThatNodesAreMarkedInvisibleWhenRemovedFromAVisibleRasterizedHierarchy
+- (void)testThatRasterizedNodesGetInterfaceStateUpdatesWhenContainerEntersHierarchy
 {
-  ASCellNode *supernode = [[ASCellNode alloc] init];
+  ASDisplayNode *supernode = [[ASDisplayNode alloc] init];
   supernode.shouldRasterizeDescendants = YES;
-  ASDisplayNode *node = [[ASDisplayNode alloc] init];
+  ASDisplayNode *subnode = [[ASDisplayNode alloc] init];
+  [NSDictionaryOfVariableBindings(supernode, subnode) enumerateKeysAndObjectsUsingBlock:^(NSString *_Nonnull name, ASDisplayNode *node, BOOL * _Nonnull stop) {
+    node.debugName = name;
+  }];
   UIWindow *window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
-  [supernode addSubnode:node];
+  [supernode addSubnode:subnode];
   [window addSubnode:supernode];
   [window makeKeyAndVisible];
-  XCTAssertTrue(node.isVisible);
-  [node removeFromSupernode];
-  XCTAssertFalse(node.isVisible);
+  XCTAssertTrue(ASHierarchyStateIncludesRasterized(subnode.hierarchyState));
+  XCTAssertTrue(subnode.isVisible);
+  [supernode.view removeFromSuperview];
+  XCTAssertTrue(ASHierarchyStateIncludesRasterized(subnode.hierarchyState));
+  XCTAssertFalse(subnode.isVisible);
 }
 
 // Underlying issue for: https://github.com/facebook/AsyncDisplayKit/issues/2205
-- (void)DISABLED_testThatNodesAreMarkedVisibleWhenAddedToARasterizedHierarchyAlreadyOnscreen
+- (void)testThatRasterizedNodesGetInterfaceStateUpdatesWhenAddedToContainerThatIsInHierarchy
 {
-  ASCellNode *supernode = [[ASCellNode alloc] init];
+  ASDisplayNode *supernode = [[ASDisplayNode alloc] init];
   supernode.shouldRasterizeDescendants = YES;
-  ASDisplayNode *node = [[ASDisplayNode alloc] init];
+  ASDisplayNode *subnode = [[ASDisplayNode alloc] init];
+  [NSDictionaryOfVariableBindings(supernode, subnode) enumerateKeysAndObjectsUsingBlock:^(NSString *_Nonnull name, ASDisplayNode *node, BOOL * _Nonnull stop) {
+    node.debugName = name;
+  }];
   UIWindow *window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
   [window addSubnode:supernode];
   [window makeKeyAndVisible];
-  [supernode addSubnode:node];
-  XCTAssertTrue(node.isVisible);
-  [node removeFromSupernode];
-  XCTAssertFalse(node.isVisible);
+  [supernode addSubnode:subnode];
+  XCTAssertTrue(ASHierarchyStateIncludesRasterized(subnode.hierarchyState));
+  XCTAssertTrue(subnode.isVisible);
+  [subnode removeFromSupernode];
+  XCTAssertFalse(ASHierarchyStateIncludesRasterized(subnode.hierarchyState));
+  XCTAssertFalse(subnode.isVisible);
 }
 
 // Underlying issue for: https://github.com/facebook/AsyncDisplayKit/issues/2011

--- a/AsyncDisplayKitTests/ASDisplayNodeTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeTests.m
@@ -2021,7 +2021,6 @@ static bool stringContainsPointer(NSString *description, id p) {
   XCTAssertFalse(subnode.nodeLoaded);
 }
 
-// TODO: Create an issue to enable this test
 - (void)testThatLoadedNodeGetsUnloadedIfAddedToRasterizedSubtree
 {
   ASDisplayNode *supernode = [[ASDisplayNode alloc] init];

--- a/AsyncDisplayKitTests/ASLayoutSpecSnapshotTestsHelper.m
+++ b/AsyncDisplayKitTests/ASLayoutSpecSnapshotTestsHelper.m
@@ -13,6 +13,7 @@
 #import "ASDisplayNode.h"
 #import "ASLayoutSpec.h"
 #import "ASLayout.h"
+#import "ASDisplayNode+Beta.h"
 
 @interface ASTestNode : ASDisplayNode
 @property (strong, nonatomic, nullable) ASLayoutSpec *layoutSpecUnderTest;

--- a/examples/ASDKgram/Sample/PhotoCellNode.m
+++ b/examples/ASDKgram/Sample/PhotoCellNode.m
@@ -91,8 +91,8 @@
     _photoDescriptionLabel.maximumNumberOfLines = 3;
     
     _photoCommentsView = [[CommentsNode alloc] init];
-    // For now disable shouldRasterizeDescendants as it will throw an assertion: 'Node should always be marked invisible before deallocating. ...'
-    //_photoCommentsView.shouldRasterizeDescendants = YES;
+    
+    _photoCommentsView.shouldRasterizeDescendants = YES;
     
     // instead of adding everything addSubnode:
     self.automaticallyManagesSubnodes = YES;


### PR DESCRIPTION
This resolves #2205 and restores the rasterization used in ASDKgram.

All of the test cases added in this diff were failing before the diff.

`shouldRasterizeDescendants` has been moved to a Beta header while we continue to develop it. If in the future we decide that its performance benefits don't justify its maintenance cost, we may deprecate it and later remove it.

In addition to fixing those behaviors, this diff
- Removes `-deallocSafeSupernode` since it's literally the exact same code as `-supernode` and updates the documentation for the latter to specify that it needs to be dealloc-safe.
- Removes cases where we were calling `ASPerformBlockOnMainThread` in cases where, in the same method, we had already asserted that we were on the main thread.
- Adds a handy little macro `ASSetDebugNames(...)` that captures the current class name so that if you're in `MYButtonNode` and you call `ASSetDebugNames(self.titleNode, _subtitleNode)` you'll get the names set to `MYButtonNode.titleNode` and `MYButtonNode.subtitleNode`. The macro has no effect in production.
