### PR TITLE
[ASPagerNode] Fix content insets are wrong in pager node if root node of ASViewController and transition back

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -1232,10 +1232,6 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
 
 - (void)layoutSubviews
 {
-  if (_zeroContentInsets) {
-    self.contentInset = UIEdgeInsetsZero;
-  }
-  
   // Flush any pending invalidation action if needed.
   ASCollectionViewInvalidationStyle invalidationStyle = _nextLayoutInvalidationStyle;
   _nextLayoutInvalidationStyle = ASCollectionViewInvalidationStyleNone;
@@ -1254,6 +1250,10 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   
   // To ensure _maxSizeForNodesConstrainedSize is up-to-date for every usage, this call to super must be done last
   [super layoutSubviews];
+    
+  if (_zeroContentInsets) {
+    self.contentInset = UIEdgeInsetsZero;
+  }
   
   // Update range controller immediately if possible & needed.
   // Calling -updateIfNeeded in here with self.window == nil (early in the collection view's life)
@@ -1750,6 +1750,12 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   if (visible) {
     [self _checkForBatchFetching];
   }
+}
+
+- (void)setContentInset:(UIEdgeInsets)contentInset
+{
+ // contentInset = _zeroContentInsets ? UIEdgeInsetsZero : contentInset;
+  [super setContentInset:contentInset];
 }
 
 #pragma mark ASCALayerExtendedDelegate

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -1752,12 +1752,6 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   }
 }
 
-- (void)setContentInset:(UIEdgeInsets)contentInset
-{
- // contentInset = _zeroContentInsets ? UIEdgeInsetsZero : contentInset;
-  [super setContentInset:contentInset];
-}
-
 #pragma mark ASCALayerExtendedDelegate
 
 /**

--- a/AsyncDisplayKitTests/ASPagerNodeTests.m
+++ b/AsyncDisplayKitTests/ASPagerNodeTests.m
@@ -7,8 +7,7 @@
 //
 
 #import <XCTest/XCTest.h>
-#import "ASPagerNode.h"
-#import "ASCellNode.h"
+#import <AsyncDisplayKit/AsyncDisplayKit.h>
 
 @interface ASPagerNodeTestDataSource : NSObject <ASPagerDataSource>
 @end
@@ -92,6 +91,74 @@
   [testController.pagerNode setNeedsLayout];
   
   return testController;
+}
+
+- (void)testThatRootPagerNodeDoesGetTheRightInsetWhilePoppingBack
+{
+  UICollectionViewCell *cell = nil;
+  
+  UIWindow *window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  ASDisplayNode *node = [[ASDisplayNode alloc] init];
+  node.automaticallyManagesSubnodes = YES;
+  
+  ASPagerNodeTestDataSource *dataSource = [[ASPagerNodeTestDataSource alloc] init];
+  ASPagerNode *pagerNode = [[ASPagerNode alloc] init];
+  pagerNode.dataSource = dataSource;
+  node.layoutSpecBlock = ^(ASDisplayNode *node, ASSizeRange constrainedSize){
+    return [ASInsetLayoutSpec insetLayoutSpecWithInsets:UIEdgeInsetsZero child:pagerNode];
+  };
+  ASViewController *vc = [[ASViewController alloc] initWithNode:node];
+  UINavigationController *nav = [[UINavigationController alloc] initWithRootViewController:vc];
+  window.rootViewController = nav;
+  [window makeKeyAndVisible];
+  [window layoutIfNeeded];
+  
+  // Wait until view controller is visible
+  XCTestExpectation *e = [self expectationWithDescription:@"Transition completed"];
+  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+    [e fulfill];
+  });
+  [self waitForExpectationsWithTimeout:2 handler:nil];
+  
+  // Test initial values
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  cell = [pagerNode.view cellForItemAtIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]];
+#pragma clang diagnostic pop
+  XCTAssertEqualObjects(NSStringFromCGRect(window.bounds), NSStringFromCGRect(node.frame));
+  XCTAssertEqualObjects(NSStringFromCGRect(window.bounds), NSStringFromCGRect(cell.frame));
+  XCTAssertEqual(pagerNode.view.contentOffset.y, 0);
+  XCTAssertEqual(pagerNode.view.contentInset.top, 0);
+  
+  e = [self expectationWithDescription:@"Transition completed"];
+  // Push another view controller
+  UIViewController *vc2 = [[UIViewController alloc] init];
+  vc2.view.frame = nav.view.bounds;
+  vc2.view.backgroundColor = [UIColor blueColor];
+  [nav pushViewController:vc2 animated:YES];
+  
+  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.505 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+    [e fulfill];
+  });
+  [self waitForExpectationsWithTimeout:2 handler:nil];
+  
+  // Pop view controller
+  e = [self expectationWithDescription:@"Transition completed"];
+  [vc2.navigationController popViewControllerAnimated:YES];
+  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.505 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+    [e fulfill];
+  });
+  [self waitForExpectationsWithTimeout:2 handler:nil];
+  
+  // Test values again after popping the view controller
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  cell = [pagerNode.view cellForItemAtIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]];
+#pragma clang diagnostic pop
+  XCTAssertEqualObjects(NSStringFromCGRect(window.bounds), NSStringFromCGRect(node.frame));
+  XCTAssertEqualObjects(NSStringFromCGRect(window.bounds), NSStringFromCGRect(cell.frame));
+  XCTAssertEqual(pagerNode.view.contentOffset.y, 0);
+  XCTAssertEqual(pagerNode.view.contentInset.top, 0);
 }
 
 @end

--- a/AsyncDisplayKitTests/ASViewControllerTests.m
+++ b/AsyncDisplayKitTests/ASViewControllerTests.m
@@ -11,29 +11,9 @@
 #import <OCMock/OCMock.h>
 #import <OCMock/NSInvocation+OCMAdditions.h>
 
-@interface ASPagerNodeTestDataSourceTwo : NSObject <ASPagerDataSource>
+@interface ASViewControllerTests : XCTestCase
 
 @end
-
-@implementation ASPagerNodeTestDataSourceTwo
-
-- (NSInteger)numberOfPagesInPagerNode:(ASPagerNode *)pagerNode
-{
-  return 5;
-}
-
-- (ASCellNodeBlock)pagerNode:(ASPagerNode *)pagerNode nodeBlockAtIndex:(NSInteger)index
-{
-  return ^{
-    ASCellNode *cellNode = [ASCellNode new];
-    cellNode.backgroundColor = [UIColor redColor];
-    return cellNode;
-  };
-}
-
-@end
-
-@interface ASViewControllerTests : XCTestCase @end
 
 @implementation ASViewControllerTests
 
@@ -99,74 +79,6 @@
   XCTAssertEqualObjects(NSStringFromCGRect(expectedRect), NSStringFromCGRect(node.frame));
   [navDelegate verify];
   [animator verify];
-}
-
-- (void)testThatRootPagerNodeDoesGetTheRightInsetWhilePoppingBack
-{
-  UICollectionViewCell *cell = nil;
-  
-  UIWindow *window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
-  ASDisplayNode *node = [[ASDisplayNode alloc] init];
-  node.automaticallyManagesSubnodes = YES;
-  
-  ASPagerNodeTestDataSourceTwo *dataSource = [[ASPagerNodeTestDataSourceTwo alloc] init];
-  ASPagerNode *pagerNode = [[ASPagerNode alloc] init];
-  pagerNode.dataSource = dataSource;
-  node.layoutSpecBlock = ^(ASDisplayNode *node, ASSizeRange constrainedSize){
-    return [ASInsetLayoutSpec insetLayoutSpecWithInsets:UIEdgeInsetsZero child:pagerNode];
-  };
-  ASViewController *vc = [[ASViewController alloc] initWithNode:node];
-  UINavigationController *nav = [[UINavigationController alloc] initWithRootViewController:vc];
-  window.rootViewController = nav;
-  [window makeKeyAndVisible];
-  [window layoutIfNeeded];
-  
-  // Wait until view controller is visible
-  XCTestExpectation *e = [self expectationWithDescription:@"Transition completed"];
-  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
-    [e fulfill];
-  });
-  [self waitForExpectationsWithTimeout:2 handler:nil];
-  
-  // Test initial values
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  cell = [pagerNode.view cellForItemAtIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]];
-#pragma clang diagnostic pop
-  XCTAssertEqualObjects(NSStringFromCGRect(window.bounds), NSStringFromCGRect(node.frame));
-  XCTAssertEqualObjects(NSStringFromCGRect(window.bounds), NSStringFromCGRect(cell.frame));
-  XCTAssertEqual(pagerNode.view.contentOffset.y, 0);
-  XCTAssertEqual(pagerNode.view.contentInset.top, 0);
-  
-  e = [self expectationWithDescription:@"Transition completed"];
-  // Push another view controller
-  UIViewController *vc2 = [[UIViewController alloc] init];
-  vc2.view.frame = nav.view.bounds;
-  vc2.view.backgroundColor = [UIColor blueColor];
-  [nav pushViewController:vc2 animated:YES];
-  
-  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.505 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
-    [e fulfill];
-  });
-  [self waitForExpectationsWithTimeout:2 handler:nil];
-  
-  // Pop view controller
-  e = [self expectationWithDescription:@"Transition completed"];
-  [vc2.navigationController popViewControllerAnimated:YES];
-  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.505 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
-    [e fulfill];
-  });
-  [self waitForExpectationsWithTimeout:2 handler:nil];
-  
-  // Test values again after popping the view controller
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  cell = [pagerNode.view cellForItemAtIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]];
-#pragma clang diagnostic pop
-  XCTAssertEqualObjects(NSStringFromCGRect(window.bounds), NSStringFromCGRect(node.frame));
-  XCTAssertEqualObjects(NSStringFromCGRect(window.bounds), NSStringFromCGRect(cell.frame));
-  XCTAssertEqual(pagerNode.view.contentOffset.y, 0);
-  XCTAssertEqual(pagerNode.view.contentInset.top, 0);
 }
 
 @end

--- a/AsyncDisplayKitTests/ASViewControllerTests.m
+++ b/AsyncDisplayKitTests/ASViewControllerTests.m
@@ -11,9 +11,29 @@
 #import <OCMock/OCMock.h>
 #import <OCMock/NSInvocation+OCMAdditions.h>
 
-@interface ASViewControllerTests : XCTestCase
+@interface ASPagerNodeTestDataSourceTwo : NSObject <ASPagerDataSource>
 
 @end
+
+@implementation ASPagerNodeTestDataSourceTwo
+
+- (NSInteger)numberOfPagesInPagerNode:(ASPagerNode *)pagerNode
+{
+  return 5;
+}
+
+- (ASCellNodeBlock)pagerNode:(ASPagerNode *)pagerNode nodeBlockAtIndex:(NSInteger)index
+{
+  return ^{
+    ASCellNode *cellNode = [ASCellNode new];
+    cellNode.backgroundColor = [UIColor redColor];
+    return cellNode;
+  };
+}
+
+@end
+
+@interface ASViewControllerTests : XCTestCase @end
 
 @implementation ASViewControllerTests
 
@@ -79,6 +99,67 @@
   XCTAssertEqualObjects(NSStringFromCGRect(expectedRect), NSStringFromCGRect(node.frame));
   [navDelegate verify];
   [animator verify];
+}
+
+- (void)testThatRootPagerNodeDoesGetTheRightInsetWhilePoppingBack
+{
+  UIWindow *window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  ASDisplayNode *node = [[ASDisplayNode alloc] init];
+  node.automaticallyManagesSubnodes = YES;
+  
+  ASPagerNodeTestDataSourceTwo *dataSource = [[ASPagerNodeTestDataSourceTwo alloc] init];
+  ASPagerNode *pagerNode = [[ASPagerNode alloc] init];
+  pagerNode.dataSource = dataSource;
+  node.layoutSpecBlock = ^(ASDisplayNode *node, ASSizeRange constrainedSize){
+    return [ASInsetLayoutSpec insetLayoutSpecWithInsets:UIEdgeInsetsZero child:pagerNode];
+  };
+  ASViewController *vc = [[ASViewController alloc] initWithNode:node];
+  UINavigationController *nav = [[UINavigationController alloc] initWithRootViewController:vc];
+  window.rootViewController = nav;
+  [window makeKeyAndVisible];
+  [window layoutIfNeeded];
+  
+  // Wait until view controller is visible
+  [[NSRunLoop mainRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate date]];
+  
+  // Test initial content inset
+  XCTAssertEqualObjects(NSStringFromCGRect(window.bounds), NSStringFromCGRect(node.frame));
+  XCTAssertEqual(pagerNode.view.contentOffset.y, 0);
+  XCTAssertEqual(pagerNode.view.contentInset.top, 0);
+  
+  XCTestExpectation *e = [self expectationWithDescription:@"Transition completed"];
+  // Push another view controller
+  UIViewController *viewControllerTwo = [[UIViewController alloc] init];
+  viewControllerTwo.view.frame = nav.view.bounds;
+  viewControllerTwo.view.backgroundColor = [UIColor blueColor];
+  [nav pushViewController:viewControllerTwo animated:YES];
+  
+  //double delayInSeconds = 3.0;
+  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 1 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+    //XCTAssertTrue([Te.topViewController isKindOfClass:[requiredClass class]],@"View Controller not pushed properly");
+    [e fulfill];
+  });
+  [self waitForExpectationsWithTimeout:2 handler:nil];
+  
+  // Pop view controller
+  e = [self expectationWithDescription:@"Transition completed"];
+  [viewControllerTwo.navigationController popViewControllerAnimated:YES];
+  //double delayInSeconds = 3.0;
+  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 1 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+    //XCTAssertTrue([Te.topViewController isKindOfClass:[requiredClass class]],@"View Controller not pushed properly");
+    [e fulfill];
+  });
+  [self waitForExpectationsWithTimeout:2 handler:nil];
+  
+  // Test again
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  UICollectionViewCell *cell = [pagerNode.view cellForItemAtIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]];
+#pragma clang diagnostic pop
+  XCTAssertEqualObjects(NSStringFromCGRect(window.bounds), NSStringFromCGRect(node.frame));
+  XCTAssertEqualObjects(NSStringFromCGRect(window.bounds), NSStringFromCGRect(cell.frame));
+  XCTAssertEqual(pagerNode.view.contentOffset.y, 0);
+  XCTAssertEqual(pagerNode.view.contentInset.top, 0);
 }
 
 @end

--- a/AsyncDisplayKitTests/ASViewControllerTests.m
+++ b/AsyncDisplayKitTests/ASViewControllerTests.m
@@ -116,19 +116,19 @@
     return [ASInsetLayoutSpec insetLayoutSpecWithInsets:UIEdgeInsetsZero child:pagerNode];
   };
   ASViewController *vc = [[ASViewController alloc] initWithNode:node];
-  
-  // This needs to be enabled for a full screen pager to remove the error message while popping back
-  vc.automaticallyAdjustsScrollViewInsets = NO;
-  
   UINavigationController *nav = [[UINavigationController alloc] initWithRootViewController:vc];
   window.rootViewController = nav;
   [window makeKeyAndVisible];
   [window layoutIfNeeded];
   
   // Wait until view controller is visible
-  [[NSRunLoop mainRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate date]];
+  XCTestExpectation *e = [self expectationWithDescription:@"Transition completed"];
+  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+    [e fulfill];
+  });
+  [self waitForExpectationsWithTimeout:2 handler:nil];
   
-  // Test initial content inset
+  // Test initial values
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
   cell = [pagerNode.view cellForItemAtIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]];
@@ -138,7 +138,7 @@
   XCTAssertEqual(pagerNode.view.contentOffset.y, 0);
   XCTAssertEqual(pagerNode.view.contentInset.top, 0);
   
-  XCTestExpectation *e = [self expectationWithDescription:@"Transition completed"];
+  e = [self expectationWithDescription:@"Transition completed"];
   // Push another view controller
   UIViewController *vc2 = [[UIViewController alloc] init];
   vc2.view.frame = nav.view.bounds;
@@ -158,7 +158,7 @@
   });
   [self waitForExpectationsWithTimeout:2 handler:nil];
   
-  // Test again
+  // Test values again after popping the view controller
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
   cell = [pagerNode.view cellForItemAtIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]];


### PR DESCRIPTION
This PR will fix the problem that if pushed back to a full screen pager node the UICollectionViewCell that contains the ASCellNode will have an y value of -64.

It does not fix the ASPagerFlowLayout message that comes up. To fix that we will add some more documentation that view controller should use `self.automaticallyAdjustScrollViewInsets = NO` if the pager node is used full screen.

Addresses: #1949