### PR TITLE
[ASDisplayNode] Remove node from supernode before adding it as a subview

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -3857,6 +3857,9 @@ static const char *ASDisplayNodeAssociatedNodeKey = "ASAssociatedNode";
     if (selfNode) {
       [selfNode addSubnode:subnode];
     } else {
+      if (subnode.supernode) {
+        [subnode removeFromSupernode];
+      }
       [self addSubview:subnode.view];
     }
   }

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -3875,6 +3875,9 @@ static const char *ASDisplayNodeAssociatedNodeKey = "ASAssociatedNode";
   if (selfNode) {
     [selfNode addSubnode:subnode];
   } else {
+    if (subnode.supernode) {
+      [subnode removeFromSupernode];
+    }
     [self addSublayer:subnode.layer];
   }
 }


### PR DESCRIPTION
If a node is being added as a subview to a UIVIew, we must make sure to remove it as a subnode of its supernode.