### PR TITLE
[ASControlNode] Add ASControlNodeEventValueChanged to support creating switches, sliders, etc.

### DIFF
--- a/AsyncDisplayKit/ASControlNode.h
+++ b/AsyncDisplayKit/ASControlNode.h
@@ -34,6 +34,8 @@ typedef NS_OPTIONS(NSUInteger, ASControlNodeEvent)
   ASControlNodeEventTouchUpOutside    = 1 << 5,
   /** A system event canceling the current touches for the control node. */
   ASControlNodeEventTouchCancel       = 1 << 6,
+  /** A system event triggered when controls like switches, slides, etc change state. */
+  ASControlNodeEventValueChanged      = 1 << 12,
   /** A system event when the Play/Pause button on the Apple TV remote is pressed. */
   ASControlNodeEventPrimaryActionTriggered = 1 << 13,
     

--- a/AsyncDisplayKit/ASControlNode.mm
+++ b/AsyncDisplayKit/ASControlNode.mm
@@ -420,8 +420,8 @@ void _ASEnumerateControlEventsIncludedInMaskWithBlock(ASControlNodeEvent mask, v
   if (block == nil) {
     return;
   }
-  // Start with our first event (touch down) and work our way up to the last event (touch cancel)
-  for (ASControlNodeEvent thisEvent = ASControlNodeEventTouchDown; thisEvent <= ASControlNodeEventTouchCancel; thisEvent <<= 1){
+  // Start with our first event (touch down) and work our way up to the last event (PrimaryActionTriggered)
+  for (ASControlNodeEvent thisEvent = ASControlNodeEventTouchDown; thisEvent <= ASControlNodeEventPrimaryActionTriggered; thisEvent <<= 1) {
     // If it's included in the mask, invoke the block.
     if ((mask & thisEvent) == thisEvent)
       block(thisEvent);


### PR DESCRIPTION
There is a use for this in Pinterest -- however, I've also seen external requests for it, and it's quite generally useful.

This does increase the number of iterations we check for the mask, but this should be instantaneous at runtime.  It scans across some currently unused values, but this could also allow third parties to add their own if they want to be especially crafty and life on the edge :).