### PR TITLE
[ASThread][ASDisplayNode] Detect and avoid deadlocks caused by upward lock gathering in didEnter/Exit states

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode+Subclasses.h
+++ b/AsyncDisplayKit/ASDisplayNode+Subclasses.h
@@ -327,7 +327,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Provides an opportunity to clear backing store and other memory-intensive intermediates, such as text layout managers
  * on the current node.
  *
- * @discussion Called by -recursivelyClearContents. Base class implements self.contents = nil, clearing any backing
+ * @discussion Called by -recursivelyClearContents. Always called on main thread. Base class implements self.contents = nil, clearing any backing
  * store, for asynchronous regeneration when needed.
  */
 - (void)clearContents ASDISPLAYNODE_REQUIRES_SUPER;

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -2979,6 +2979,7 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
 
 - (void)clearContents
 {
+  ASDisplayNodeAssertMainThread();
   if (_flags.canClearContentsOfLayer) {
     // No-op if these haven't been created yet, as that guarantees they don't have contents that needs to be released.
     _layer.contents = nil;

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -40,6 +40,13 @@
   #define AS_DEDUPE_LAYOUT_SPEC_TREE 1
 #endif
 
+/**
+ * Assert if the current thread owns a mutex.
+ * This assertion is useful when you want to indicate and enforce the locking policy/expectation of methods.
+ * To determine when and which methods acquired a (recursive) mutex (to debug deadlocks, for example), 
+ * put breakpoints at some of these assertions. When the breakpoints hit, walk through stack trace frames 
+ * and check ownership count of the mutex.
+ */
 #if CHECK_LOCKING_SAFETY
   #define ASDisplayNodeAssertLockUnownedByCurrentThread(lock) ASDisplayNodeAssertFalse(lock.ownedByCurrentThread());
 #else

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -766,11 +766,13 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
 
 - (BOOL)isSynchronous
 {
+  ASDN::MutexLocker l(__instanceLock__);
   return _flags.synchronous;
 }
 
 - (void)setSynchronous:(BOOL)flag
 {
+  ASDN::MutexLocker l(__instanceLock__);
   _flags.synchronous = flag;
 }
 

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -3019,25 +3019,31 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
 - (void)didEnterVisibleState
 {
   // subclass override
+  ASDisplayNodeAssertLockUnownedByCurrentThread(__instanceLock__);
 }
 
 - (void)didExitVisibleState
 {
   // subclass override
+  ASDisplayNodeAssertLockUnownedByCurrentThread(__instanceLock__);
 }
 
 - (void)didEnterDisplayState
 {
   // subclass override
+  ASDisplayNodeAssertLockUnownedByCurrentThread(__instanceLock__);
 }
 
 - (void)didExitDisplayState
 {
   // subclass override
+  ASDisplayNodeAssertLockUnownedByCurrentThread(__instanceLock__);
 }
 
 - (void)didEnterPreloadState
 {
+  ASDisplayNodeAssertLockUnownedByCurrentThread(__instanceLock__);
+  
   if (_methodOverrides & ASDisplayNodeMethodOverrideFetchData) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
@@ -3048,6 +3054,8 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
 
 - (void)didExitPreloadState
 {
+  ASDisplayNodeAssertLockUnownedByCurrentThread(__instanceLock__);
+  
   if (_methodOverrides & ASDisplayNodeMethodOverrideClearFetchedData) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
@@ -3202,6 +3210,7 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
 - (void)interfaceStateDidChange:(ASInterfaceState)newState fromState:(ASInterfaceState)oldState
 {
   // subclass hook
+  ASDisplayNodeAssertLockUnownedByCurrentThread(__instanceLock__);
 }
 
 - (void)enterInterfaceState:(ASInterfaceState)interfaceState

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -2431,6 +2431,12 @@ ASDISPLAYNODE_INLINE BOOL nodeIsInRasterizedTree(ASDisplayNode *node) {
 // NOTE: This method must be dealloc-safe (should not retain self).
 - (ASDisplayNode *)supernode
 {
+#if CHECK_LOCKING_SAFETY
+  if (__instanceLock__.ownedByCurrentThread()) {
+    NSLog(@"WARNING: Accessing supernode while holding recursive instance lock of this node is worrisome. It's likely that you will soon try to acquire the supernode's lock, and this can easily cause deadlocks.");
+  }
+#endif
+  
   ASDN::MutexLocker l(__instanceLock__);
   return _supernode;
 }

--- a/AsyncDisplayKit/ASNetworkImageNode.mm
+++ b/AsyncDisplayKit/ASNetworkImageNode.mm
@@ -135,28 +135,30 @@ static const CGSize kMinReleaseImageOnBackgroundSize = {20.0, 20.0};
 
 - (void)setURL:(NSURL *)URL resetToDefault:(BOOL)reset
 {
-  ASDN::MutexLocker l(__instanceLock__);
-
-  _imageWasSetExternally = NO;
-
-  if (ASObjectIsEqual(URL, _URL)) {
-    return;
-  }
-
-  [self _cancelImageDownload];
-  _imageLoaded = NO;
-
-  _URL = URL;
-
-  BOOL hasURL = _URL == nil;
-  if (reset || hasURL) {
-    [self _setImage:_defaultImage];
-    /* We want to maintain the order that currentImageQuality is set regardless of the calling thread,
-     so always use a dispatch_async to ensure that we queue the operations in the correct order.
-     (see comment in displayDidFinish) */
-    dispatch_async(dispatch_get_main_queue(), ^{
-      self.currentImageQuality = hasURL ? 0.0 : 1.0;
-    });
+  {
+    ASDN::MutexLocker l(__instanceLock__);
+    
+    _imageWasSetExternally = NO;
+    
+    if (ASObjectIsEqual(URL, _URL)) {
+      return;
+    }
+    
+    [self _cancelImageDownload];
+    _imageLoaded = NO;
+    
+    _URL = URL;
+    
+    BOOL hasURL = _URL == nil;
+    if (reset || hasURL) {
+      [self _setImage:_defaultImage];
+      /* We want to maintain the order that currentImageQuality is set regardless of the calling thread,
+       so always use a dispatch_async to ensure that we queue the operations in the correct order.
+       (see comment in displayDidFinish) */
+      dispatch_async(dispatch_get_main_queue(), ^{
+        self.currentImageQuality = hasURL ? 0.0 : 1.0;
+      });
+    }
   }
 
   [self setNeedsPreload];

--- a/AsyncDisplayKit/ASVideoNode.mm
+++ b/AsyncDisplayKit/ASVideoNode.mm
@@ -487,7 +487,7 @@ static NSString * const kRate = @"rate";
 
 - (void)setAsset:(AVAsset *)asset
 {
-  if (ASAssetIsEqual(asset, _asset) == NO) {
+  if (ASAssetIsEqual(asset, self.asset) == NO) {
     [self setAndFetchAsset:asset url:nil];
   }
 }

--- a/AsyncDisplayKit/ASVideoNode.mm
+++ b/AsyncDisplayKit/ASVideoNode.mm
@@ -627,8 +627,9 @@ static NSString * const kRate = @"rate";
   if (_playerNode == nil) {
     _playerNode = [self constructPlayerNode];
 
-    [self addSubnode:_playerNode];
-
+    __instanceLock__.unlock();
+      [self addSubnode:_playerNode];
+    __instanceLock__.lock();
       
     [self setNeedsLayout];
   }

--- a/AsyncDisplayKit/ASVideoNode.mm
+++ b/AsyncDisplayKit/ASVideoNode.mm
@@ -117,6 +117,7 @@ static NSString * const kRate = @"rate";
 
 - (AVPlayerItem *)constructPlayerItem
 {
+  ASDisplayNodeAssertMainThread();
   ASDN::MutexLocker l(__instanceLock__);
 
   AVPlayerItem *playerItem = nil;
@@ -134,6 +135,8 @@ static NSString * const kRate = @"rate";
 
 - (void)prepareToPlayAsset:(AVAsset *)asset withKeys:(NSArray<NSString *> *)requestedKeys
 {
+  ASDisplayNodeAssertMainThread();
+  
   for (NSString *key in requestedKeys) {
     NSError *error = nil;
     AVKeyValueStatus keyStatus = [asset statusOfValueForKey:key error:&error];
@@ -467,6 +470,8 @@ static NSString * const kRate = @"rate";
 
 - (void)setAssetURL:(NSURL *)assetURL
 {
+  ASDisplayNodeAssertMainThread();
+  
   if (ASObjectIsEqual(assetURL, self.assetURL) == NO) {
     [self setAndFetchAsset:[AVURLAsset assetWithURL:assetURL] url:assetURL];
   }
@@ -487,6 +492,8 @@ static NSString * const kRate = @"rate";
 
 - (void)setAsset:(AVAsset *)asset
 {
+  ASDisplayNodeAssertMainThread();
+  
   if (ASAssetIsEqual(asset, self.asset) == NO) {
     [self setAndFetchAsset:asset url:nil];
   }
@@ -500,6 +507,8 @@ static NSString * const kRate = @"rate";
 
 - (void)setAndFetchAsset:(AVAsset *)asset url:(NSURL *)assetURL
 {
+  ASDisplayNodeAssertMainThread();
+  
   [self didExitPreloadState];
   
   {

--- a/AsyncDisplayKit/Details/ASThread.h
+++ b/AsyncDisplayKit/Details/ASThread.h
@@ -29,6 +29,14 @@ static inline BOOL ASDisplayNodeThreadIsMain()
 #ifdef __cplusplus
 
 #define TIME_LOCKER 0
+/**
+ * Enable this flag to collect information on the owning thread and ownership level of a mutex.
+ * These properties are useful to determine if a mutext has been acquired and in case of a recursive mutex, how many times that happened.
+ * ASDisplayNodeAssertLockUnownedByCurrentThread(node) is also useful when you want to enforce locking policy/expectation of a method.
+ * By putting a breakpoint at a lock assertion, walking through stack trace frames and
+ * checking ownership count of a mutex, you can determine when and which methods acquired it.
+ * Very helpful when you debug deadlocks.
+ */
 #define CHECK_LOCKING_SAFETY 0
 
 #if TIME_LOCKER

--- a/AsyncDisplayKit/Details/ASThread.h
+++ b/AsyncDisplayKit/Details/ASThread.h
@@ -32,10 +32,12 @@ static inline BOOL ASDisplayNodeThreadIsMain()
 /**
  * Enable this flag to collect information on the owning thread and ownership level of a mutex.
  * These properties are useful to determine if a mutext has been acquired and in case of a recursive mutex, how many times that happened.
- * ASDisplayNodeAssertLockUnownedByCurrentThread(node) is also useful when you want to enforce locking policy/expectation of a method.
- * By putting a breakpoint at a lock assertion, walking through stack trace frames and
- * checking ownership count of a mutex, you can determine when and which methods acquired it.
- * Very helpful when you debug deadlocks.
+ * 
+ * This flag also enable locking assertions (e.g ASDisplayNodeAssertLockUnownedByCurrentThread(node)).
+ * The assertions are useful when you want to indicate and enforce the locking policy/expectation of methods.
+ * To determine when and which methods acquired a (recursive) mutex (to debug deadlocks, for example),
+ * put breakpoints at some assertions. When the breakpoints hit, walk through stack trace frames 
+ * and check ownership count of the mutex.
  */
 #define CHECK_LOCKING_SAFETY 0
 


### PR DESCRIPTION
This PR adds a mechanism that detects if a thread tries to access supernode of a node while holding its recursive lock (e.g early sign of upward lock gathering). To detect that, I eventually had to record mutex's owner and level of the ownership. The new code is turned off by default to avoid rather significant overheads.

This PR also changes the locking strategy in ASDisplayNode to avoid situations in which we hold a node's instance lock and call methods outside the scope of `self` (for example, [subnode __setSuperNode:self]`) or didEnter/Exit state. These methods can trigger methods that are meant to be overridden by developers in which they walk up the node tree and grab other locks and potentially cause deadlocks (like #2605). Moreover, they perform expensive tasks that cause the lock to be held for too long.

The code paths changed by the PR are well covered by our test suite. I also tested this patch using a small sample project. Moreover, I'm gonna test it with Pinterest master.

I believe this PR should fix #2605 and other deadlocks with similar traces.