### PR TITLE
Remove Vestigial Code Supporting Removed Methods

### DIFF
--- a/AsyncDisplayKit/ASMultiplexImageNode.mm
+++ b/AsyncDisplayKit/ASMultiplexImageNode.mm
@@ -86,10 +86,8 @@ typedef void(^ASMultiplexImageLoadCompletionBlock)(UIImage *image, id imageIdent
   BOOL _shouldRenderProgressImages;
   
   //set on init only
-  BOOL _downloaderSupportsNewProtocol;
   BOOL _downloaderImplementsSetProgress;
   BOOL _downloaderImplementsSetPriority;
-  BOOL _cacheSupportsCachedImage;
   BOOL _cacheSupportsClearing;
 }
 
@@ -174,16 +172,9 @@ typedef void(^ASMultiplexImageLoadCompletionBlock)(UIImage *image, id imageIdent
   _cache = (id<ASImageCacheProtocol>)cache;
   _downloader = (id<ASImageDownloaderProtocol>)downloader;
   
-  ASDisplayNodeAssert([downloader respondsToSelector:@selector(downloadImageWithURL:callbackQueue:downloadProgress:completion:)], @"downloader must respond to either downloadImageWithURL:callbackQueue:downloadProgress:completion:.");
-  
-  _downloaderSupportsNewProtocol = [downloader respondsToSelector:@selector(downloadImageWithURL:callbackQueue:downloadProgress:completion:)];
-  
-  ASDisplayNodeAssert(cache == nil || [cache respondsToSelector:@selector(cachedImageWithURL:callbackQueue:completion:)], @"cacher must respond to either cachedImageWithURL:callbackQueue:completion:");
-  
   _downloaderImplementsSetProgress = [downloader respondsToSelector:@selector(setProgressImageBlock:callbackQueue:withDownloadIdentifier:)];
   _downloaderImplementsSetPriority = [downloader respondsToSelector:@selector(setPriority:withDownloadIdentifier:)];
-  
-  _cacheSupportsCachedImage = [cache respondsToSelector:@selector(cachedImageWithURL:callbackQueue:completion:)];
+
   _cacheSupportsClearing = [cache respondsToSelector:@selector(clearFetchedImageFromCacheWithURL:)];
   
   _shouldRenderProgressImages = YES;
@@ -792,11 +783,9 @@ typedef void(^ASMultiplexImageLoadCompletionBlock)(UIImage *image, id imageIdent
   ASDisplayNodeAssertNotNil(completionBlock, @"completionBlock is required");
 
   if (_cache) {
-    if (_cacheSupportsCachedImage) {
-      [_cache cachedImageWithURL:imageURL callbackQueue:dispatch_get_main_queue() completion:^(id <ASImageContainerProtocol> imageContainer) {
-        completionBlock([imageContainer asdk_image]);
-      }];
-    }
+    [_cache cachedImageWithURL:imageURL callbackQueue:dispatch_get_main_queue() completion:^(id <ASImageContainerProtocol> imageContainer) {
+      completionBlock([imageContainer asdk_image]);
+    }];
   }
   // If we don't have a cache, just fail immediately.
   else {
@@ -827,29 +816,27 @@ typedef void(^ASMultiplexImageLoadCompletionBlock)(UIImage *image, id imageIdent
 
   // Download!
   ASPerformBlockOnBackgroundThread(^{
-    if (_downloaderSupportsNewProtocol) {
-      [self _setDownloadIdentifier:[_downloader downloadImageWithURL:imageURL
-                                                       callbackQueue:dispatch_get_main_queue()
-                                                    downloadProgress:downloadProgressBlock
-                                                          completion:^(id <ASImageContainerProtocol> imageContainer, NSError *error, id downloadIdentifier) {
-                                                            // We dereference iVars directly, so we can't have weakSelf going nil on us.
-                                                            __typeof__(self) strongSelf = weakSelf;
-                                                            if (!strongSelf)
-                                                              return;
-                                                            
-                                                            ASDN::MutexLocker l(_downloadIdentifierLock);
-                                                            //Getting a result back for a different download identifier, download must not have been successfully canceled
-                                                            if (ASObjectIsEqual(_downloadIdentifier, downloadIdentifier) == NO && downloadIdentifier != nil) {
-                                                              return;
-                                                            }
-                                                            
-                                                            completionBlock([imageContainer asdk_image], error);
-                                                            
-                                                            // Delegateify.
-                                                            if (strongSelf->_delegateFlags.downloadFinish)
-                                                              [strongSelf->_delegate multiplexImageNode:weakSelf didFinishDownloadingImageWithIdentifier:imageIdentifier error:error];
-                                                          }]];
-    }
+    [self _setDownloadIdentifier:[_downloader downloadImageWithURL:imageURL
+                                                     callbackQueue:dispatch_get_main_queue()
+                                                  downloadProgress:downloadProgressBlock
+                                                        completion:^(id <ASImageContainerProtocol> imageContainer, NSError *error, id downloadIdentifier) {
+                                                          // We dereference iVars directly, so we can't have weakSelf going nil on us.
+                                                          __typeof__(self) strongSelf = weakSelf;
+                                                          if (!strongSelf)
+                                                            return;
+                                                          
+                                                          ASDN::MutexLocker l(_downloadIdentifierLock);
+                                                          //Getting a result back for a different download identifier, download must not have been successfully canceled
+                                                          if (ASObjectIsEqual(_downloadIdentifier, downloadIdentifier) == NO && downloadIdentifier != nil) {
+                                                            return;
+                                                          }
+                                                          
+                                                          completionBlock([imageContainer asdk_image], error);
+                                                          
+                                                          // Delegateify.
+                                                          if (strongSelf->_delegateFlags.downloadFinish)
+                                                            [strongSelf->_delegate multiplexImageNode:weakSelf didFinishDownloadingImageWithIdentifier:imageIdentifier error:error];
+                                                        }]];
     [self _updateProgressImageBlockOnDownloaderIfNeeded];
   });
 }

--- a/AsyncDisplayKit/Details/ASImageProtocols.h
+++ b/AsyncDisplayKit/Details/ASImageProtocols.h
@@ -26,6 +26,19 @@ typedef void(^ASImageCacherCompletion)(id <ASImageContainerProtocol> _Nullable i
 
 @protocol ASImageCacheProtocol <NSObject>
 
+/**
+ @abstract Attempts to fetch an image with the given URL from the cache.
+ @param URL The URL of the image to retrieve from the cache.
+ @param callbackQueue The queue to call `completion` on.
+ @param completion The block to be called when the cache has either hit or missed.
+ @param imageFromCache The image that was retrieved from the cache, if the image could be retrieved; nil otherwise.
+ @discussion If `URL` is nil, `completion` will be invoked immediately with a nil image. This method should not block
+ the calling thread as it is likely to be called from the main thread.
+ */
+- (void)cachedImageWithURL:(NSURL *)URL
+             callbackQueue:(dispatch_queue_t)callbackQueue
+                completion:(ASImageCacherCompletion)completion;
+
 @optional
 
 /**
@@ -40,19 +53,6 @@ typedef void(^ASImageCacherCompletion)(id <ASImageContainerProtocol> _Nullable i
  support only cachedImageWithURL:callbackQueue:completion: however, synchronous rendering will not be possible.
  */
 - (nullable id <ASImageContainerProtocol>)synchronouslyFetchedCachedImageWithURL:(NSURL *)URL;
-
-/**
- @abstract Attempts to fetch an image with the given URL from the cache.
- @param URL The URL of the image to retrieve from the cache.
- @param callbackQueue The queue to call `completion` on.
- @param completion The block to be called when the cache has either hit or missed.
- @param imageFromCache The image that was retrieved from the cache, if the image could be retrieved; nil otherwise.
- @discussion If `URL` is nil, `completion` will be invoked immediately with a nil image. This method should not block
- the calling thread as it is likely to be called from the main thread.
- */
-- (void)cachedImageWithURL:(NSURL *)URL
-             callbackQueue:(dispatch_queue_t)callbackQueue
-                completion:(ASImageCacherCompletion)completion;
 
 /**
  @abstract Called during clearPreloadedData. Allows the cache to optionally trim items.
@@ -87,6 +87,21 @@ typedef NS_ENUM(NSUInteger, ASImageDownloaderPriority) {
 @required
 
 /**
+ @abstract Downloads an image with the given URL.
+ @param URL The URL of the image to download.
+ @param callbackQueue The queue to call `downloadProgressBlock` and `completion` on.
+ @param downloadProgress The block to be invoked when the download of `URL` progresses.
+ @param completion The block to be invoked when the download has completed, or has failed.
+ @discussion This method is likely to be called on the main thread, so any custom implementations should make sure to background any expensive download operations.
+ @result An opaque identifier to be used in canceling the download, via `cancelImageDownloadForIdentifier:`. You must
+ retain the identifier if you wish to use it later.
+ */
+- (nullable id)downloadImageWithURL:(NSURL *)URL
+                      callbackQueue:(dispatch_queue_t)callbackQueue
+                   downloadProgress:(nullable ASImageDownloaderProgress)downloadProgress
+                         completion:(ASImageDownloaderCompletion)completion;
+
+/**
   @abstract Cancels an image download.
   @param downloadIdentifier The opaque download identifier object returned from 
       `downloadImageWithURL:callbackQueue:downloadProgressBlock:completion:`.
@@ -101,23 +116,6 @@ typedef NS_ENUM(NSUInteger, ASImageDownloaderPriority) {
  @param animatedImageData Data that represents an animated image.
  */
 - (nullable id <ASAnimatedImageProtocol>)animatedImageWithData:(NSData *)animatedImageData;
-
-//You must implement the following method OR the deprecated method at the bottom
-
-/**
- @abstract Downloads an image with the given URL.
- @param URL The URL of the image to download.
- @param callbackQueue The queue to call `downloadProgressBlock` and `completion` on.
- @param downloadProgress The block to be invoked when the download of `URL` progresses.
- @param completion The block to be invoked when the download has completed, or has failed.
- @discussion This method is likely to be called on the main thread, so any custom implementations should make sure to background any expensive download operations.
- @result An opaque identifier to be used in canceling the download, via `cancelImageDownloadForIdentifier:`. You must
- retain the identifier if you wish to use it later.
- */
-- (nullable id)downloadImageWithURL:(NSURL *)URL
-                      callbackQueue:(dispatch_queue_t)callbackQueue
-                   downloadProgress:(nullable ASImageDownloaderProgress)downloadProgress
-                         completion:(ASImageDownloaderCompletion)completion;
 
 
 /**


### PR DESCRIPTION
When we removed some long-deprecated image downloader & cache methods, we didn't do a very thorough job of cleaning up. For example, now that there is only one primary image downloader method, we can mark it required and remove the silly assertion message `"You must implement either downloadImageWithURL:callbackQueue:downloadProgress:completion:."`

This ungunkifies our code, and lets the compiler enforce protocol requirements for us.