### PR TITLE
Safer checks in ASDisplayNode’s setFrame before assigning bounds and position

### DIFF
--- a/AsyncDisplayKit/Layout/ASDimension.h
+++ b/AsyncDisplayKit/Layout/ASDimension.h
@@ -39,6 +39,16 @@ ASDISPLAYNODE_INLINE BOOL AS_WARN_UNUSED_RESULT ASIsCGSizeValidForSize(CGSize si
   return (ASPointsValidForSize(size.width) && ASPointsValidForSize(size.height));
 }
 
+ASDISPLAYNODE_INLINE BOOL ASIsCGPointValidForLayout(CGPoint point)
+{
+  return (ASPointsValidForLayout(point.x) && ASPointsValidForLayout(point.y));
+}
+
+ASDISPLAYNODE_INLINE BOOL ASIsCGRectValidForLayout(CGRect rect)
+{
+  return (ASIsCGPointValidForLayout(rect.origin) && ASIsCGSizeValidForLayout(rect.size));
+}
+
 #pragma mark - ASDimension
 
 /**

--- a/AsyncDisplayKit/Layout/ASDimension.h
+++ b/AsyncDisplayKit/Layout/ASDimension.h
@@ -39,14 +39,19 @@ ASDISPLAYNODE_INLINE BOOL AS_WARN_UNUSED_RESULT ASIsCGSizeValidForSize(CGSize si
   return (ASPointsValidForSize(size.width) && ASPointsValidForSize(size.height));
 }
 
-ASDISPLAYNODE_INLINE BOOL ASIsCGPointValidForLayout(CGPoint point)
+ASDISPLAYNODE_INLINE BOOL ASIsCGPositionPointsValidForLayout(CGFloat points)
 {
-  return (ASPointsValidForLayout(point.x) && ASPointsValidForLayout(point.y));
+  return ((isnormal(points) || points == 0.0) && points < (CGFLOAT_MAX / 2.0));
+}
+
+ASDISPLAYNODE_INLINE BOOL ASIsCGPositionValidForLayout(CGPoint point)
+{
+  return (ASIsCGPositionPointsValidForLayout(point.x) && ASIsCGPositionPointsValidForLayout(point.y));
 }
 
 ASDISPLAYNODE_INLINE BOOL ASIsCGRectValidForLayout(CGRect rect)
 {
-  return (ASIsCGPointValidForLayout(rect.origin) && ASIsCGSizeValidForLayout(rect.size));
+  return (ASIsCGPositionValidForLayout(rect.origin) && ASIsCGSizeValidForLayout(rect.size));
 }
 
 #pragma mark - ASDimension

--- a/AsyncDisplayKit/Private/ASDisplayNode+UIViewBridge.mm
+++ b/AsyncDisplayKit/Private/ASDisplayNode+UIViewBridge.mm
@@ -255,12 +255,8 @@ if (shouldApply) { _layer.layerProperty = (layerValueExpr); } else { ASDisplayNo
       CGPoint newPosition = CGPointZero;
       ASBoundsAndPositionForFrame(rect, origin, anchorPoint, &newBounds, &newPosition);
 
-      if (ASIsCGRectValidForLayout(newBounds) == NO) {
-        ASDisplayNodeAssert(NO, @"-[ASDisplayNode setFrame:] - The new bounds are invalid and unsafe to be set.");
-        return;
-      }
-      if (ASIsCGPointValidForLayout(newPosition) == NO) {
-        ASDisplayNodeAssert(NO, @"-[ASDisplayNode setFrame:] - The new position is invalid and unsafe to set.");
+      if (ASIsCGRectValidForLayout(newBounds) == NO || ASIsCGPointValidForLayout(newPosition) == NO) {
+        ASDisplayNodeFailAssert(@"-[ASDisplayNode setFrame:] - The new frame (%@) is invalid and unsafe to be set.", NSStringFromCGRect(rect));
         return;
       }
       

--- a/AsyncDisplayKit/Private/ASDisplayNode+UIViewBridge.mm
+++ b/AsyncDisplayKit/Private/ASDisplayNode+UIViewBridge.mm
@@ -255,7 +255,7 @@ if (shouldApply) { _layer.layerProperty = (layerValueExpr); } else { ASDisplayNo
       CGPoint newPosition = CGPointZero;
       ASBoundsAndPositionForFrame(rect, origin, anchorPoint, &newBounds, &newPosition);
 
-      if (ASIsCGRectValidForLayout(newBounds) == NO || ASIsCGPointValidForLayout(newPosition) == NO) {
+      if (ASIsCGRectValidForLayout(newBounds) == NO || ASIsCGPositionValidForLayout(newPosition) == NO) {
         ASDisplayNodeAssertNonFatal(NO, @"-[ASDisplayNode setFrame:] - The new frame (%@) is invalid and unsafe to be set.", NSStringFromCGRect(rect));
         return;
       }

--- a/AsyncDisplayKit/Private/ASDisplayNode+UIViewBridge.mm
+++ b/AsyncDisplayKit/Private/ASDisplayNode+UIViewBridge.mm
@@ -255,6 +255,15 @@ if (shouldApply) { _layer.layerProperty = (layerValueExpr); } else { ASDisplayNo
       CGPoint newPosition = CGPointZero;
       ASBoundsAndPositionForFrame(rect, origin, anchorPoint, &newBounds, &newPosition);
 
+      if (ASIsCGRectValidForLayout(newBounds) == NO) {
+        ASDisplayNodeAssert(NO, @"-[ASDisplayNode setFrame:] - The new bounds are invalid and unsafe to be set.");
+        return;
+      }
+      if (ASIsCGPointValidForLayout(newPosition) == NO) {
+        ASDisplayNodeAssert(NO, @"-[ASDisplayNode setFrame:] - The new position is invalid and unsafe to set.");
+        return;
+      }
+      
       if (useLayer) {
         layer.bounds = newBounds;
         layer.position = newPosition;

--- a/AsyncDisplayKit/Private/ASDisplayNode+UIViewBridge.mm
+++ b/AsyncDisplayKit/Private/ASDisplayNode+UIViewBridge.mm
@@ -256,7 +256,7 @@ if (shouldApply) { _layer.layerProperty = (layerValueExpr); } else { ASDisplayNo
       ASBoundsAndPositionForFrame(rect, origin, anchorPoint, &newBounds, &newPosition);
 
       if (ASIsCGRectValidForLayout(newBounds) == NO || ASIsCGPointValidForLayout(newPosition) == NO) {
-        ASDisplayNodeFailAssert(@"-[ASDisplayNode setFrame:] - The new frame (%@) is invalid and unsafe to be set.", NSStringFromCGRect(rect));
+        ASDisplayNodeAssertNonFatal(NO, @"-[ASDisplayNode setFrame:] - The new frame (%@) is invalid and unsafe to be set.", NSStringFromCGRect(rect));
         return;
       }
       


### PR DESCRIPTION
Even with application checks (for Inf and NaN) before assigning a frame to a node, it is still possible to have the newPosition containing NaN values. Since there is still some logic being done in `setFrame:` where other values are considered to calculate the new position and new bounds, it is possible that the NaN is being generated here.

This PR is meant to prevent that from happening by checking the final values before assigning them.