### PR TITLE
[ASNetworkImageNode] Don't behave like an image node if URL is set.

### DIFF
--- a/AsyncDisplayKit/ASNetworkImageNode.h
+++ b/AsyncDisplayKit/ASNetworkImageNode.h
@@ -52,11 +52,12 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * The image to display.
  *
- * @discussion By setting an image to the image property the ASNetworkImageNode will act like a plain ASImageNode.
- * As soon as the URL is set the ASNetworkImageNode will act like an ASNetworkImageNode and the image property
- * will be managed internally. This means the image property will be cleared out and replaced by the placeholder 
- * (<defaultImage>) image while loading and the final image after the new image data was downloaded and processed.
- * If you want to use a placholder image functionality use the defaultImage property instead.
+ * @discussion Setting an image to the image property of an ASNetworkImageNode will cause it to act like a plain
+ * ASImageNode if a URL is not set as well. As soon as the URL is set the ASNetworkImageNode will act like an 
+ * ASNetworkImageNode and the image property will be managed internally. This means the image property will be cleared
+ * out and replaced by the placeholder (<defaultImage>) image while loading and the final image after the new image 
+ * data was downloaded and processed. If you want to use a placholder image, use the defaultImage property 
+ * instead.
  */
 @property (nullable, nonatomic, strong) UIImage *image;
 

--- a/AsyncDisplayKit/ASNetworkImageNode.mm
+++ b/AsyncDisplayKit/ASNetworkImageNode.mm
@@ -109,16 +109,12 @@ static const CGSize kMinReleaseImageOnBackgroundSize = {20.0, 20.0};
 
 #pragma mark - Public methods -- must lock
 
-/// Setter for public image property. It has the side effect to set an internal _imageWasSetExternally that prevents setting an image internally. Setting an image internally should happen with the _setImage: method
+/// Setter for public image property. It has the side effect of setting an internal _imageWasSetExternally that prevents setting an image internally. Setting an image internally should happen with the _setImage: method
 - (void)setImage:(UIImage *)image
 {
   ASDN::MutexLocker l(__instanceLock__);
   
-  _imageWasSetExternally = (image != nil);
-  if (_imageWasSetExternally) {
-    [self _cancelDownloadAndClearImage];
-    _URL = nil;
-  }
+  _imageWasSetExternally = (image != nil && _URL != nil);
   
   [self _setImage:image];
 }


### PR DESCRIPTION
After much discussion I think this is the correct behavior. It seems
like it's much more likely to be the expected behavior but still enables
you to use the network image node like an regular image node.

Resolves https://github.com/facebook/AsyncDisplayKit/issues/2756