### PR TITLE
[ASNetworkImageNode] Assert if both URL and image are set

### DIFF
--- a/AsyncDisplayKit/ASNetworkImageNode.h
+++ b/AsyncDisplayKit/ASNetworkImageNode.h
@@ -60,20 +60,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nullable, nonatomic, strong) UIImage *image;
 
 /**
- * An image to be displayed until it is cleared out by loading a URL or exiting the preload state. This is different
- * than the @c defaultImage because it will only be retained and used until we load the URL or exit the preload state.
- * defaultImage will never be cleared out by ASNetworkImageNode.
- * This method exists as a convenience to clearing out defaultImage manually.
- *
- * @warning this method simply calls setImage on the super class. This means it will throw out any image that has
- * already been downloaded!
- */
-@property (nullable, nonatomic, strong) UIImage *ephemeralImage;
-
-//Because this is ephemeral, you shouldn't rely on its contents
-- (UIImage *)ephemeralImage NS_UNAVAILABLE;
-
-/**
  * A placeholder image to display while the URL is loading. This is slightly different than placeholderImage in the
  * ASDisplayNode superclass as defaultImage will *not* be displayed synchronously. If you wish to have the image
  * displayed synchronously, use @c placeholderImage.

--- a/AsyncDisplayKit/ASNetworkImageNode.h
+++ b/AsyncDisplayKit/ASNetworkImageNode.h
@@ -51,17 +51,32 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * The image to display.
  *
- * @discussion Setting an image to the image property of an ASNetworkImageNode will cause it to act like a plain
- * ASImageNode if a URL is not set as well. As soon as the URL is set the ASNetworkImageNode will act like an 
- * ASNetworkImageNode and the image property will be managed internally. This means the image property will be cleared
- * out and replaced by the placeholder (<defaultImage>) image while loading and the final image after the new image 
- * data was downloaded and processed. If you want to use a placholder image, use the defaultImage property 
- * instead.
+ * @discussion By setting an image to the image property the ASNetworkImageNode will act like a plain ASImageNode.
+ * As soon as the URL is set the ASNetworkImageNode will act like an ASNetworkImageNode and the image property
+ * will be managed internally. This means the image property will be cleared out and replaced by the placeholder 
+ * (<defaultImage>) image while loading and the final image after the new image data was downloaded and processed.
+ * If you want to use a placholder image functionality use the defaultImage property instead.
  */
 @property (nullable, nonatomic, strong) UIImage *image;
 
 /**
- * A placeholder image to display while the URL is loading.
+ * An image to be displayed until it is cleared out by loading a URL or exiting the preload state. This is different
+ * than the @c defaultImage because it will only be retained and used until we load the URL or exit the preload state.
+ * defaultImage will never be cleared out by ASNetworkImageNode.
+ * This method exists as a convenience to clearing out defaultImage manually.
+ *
+ * @warning this method simply calls setImage on the super class. This means it will throw out any image that has
+ * already been downloaded!
+ */
+@property (nullable, nonatomic, strong) UIImage *ephemeralImage;
+
+//Because this is ephemeral, you shouldn't rely on its contents
+- (UIImage *)ephemeralImage NS_UNAVAILABLE;
+
+/**
+ * A placeholder image to display while the URL is loading. This is slightly different than placeholderImage in the
+ * ASDisplayNode superclass as defaultImage will *not* be displayed synchronously. If you wish to have the image
+ * displayed synchronously, use @c placeholderImage.
  */
 @property (nullable, nonatomic, strong, readwrite) UIImage *defaultImage;
 

--- a/AsyncDisplayKit/ASNetworkImageNode.mm
+++ b/AsyncDisplayKit/ASNetworkImageNode.mm
@@ -109,7 +109,7 @@ static const CGSize kMinReleaseImageOnBackgroundSize = {20.0, 20.0};
 
 #pragma mark - Public methods -- must lock
 
-/// Setter for public image property. It has the side effect to set an internal _imageWasSetExternally that prevents setting an image internally. Setting an image internally should happen with the _setImage: method
+/// Setter for public image property. It has the side effect of setting an internal _imageWasSetExternally that prevents setting an image internally. Setting an image internally should happen with the _setImage: method
 - (void)setImage:(UIImage *)image
 {
   ASDN::MutexLocker l(__instanceLock__);

--- a/AsyncDisplayKit/ASNetworkImageNode.mm
+++ b/AsyncDisplayKit/ASNetworkImageNode.mm
@@ -70,6 +70,7 @@ static const CGSize kMinReleaseImageOnBackgroundSize = {20.0, 20.0};
 @implementation ASNetworkImageNode
 
 @dynamic image;
+@dynamic ephemeralImage;
 
 - (instancetype)initWithCache:(id<ASImageCacheProtocol>)cache downloader:(id<ASImageDownloaderProtocol>)downloader
 {

--- a/AsyncDisplayKit/ASNetworkImageNode.mm
+++ b/AsyncDisplayKit/ASNetworkImageNode.mm
@@ -70,7 +70,6 @@ static const CGSize kMinReleaseImageOnBackgroundSize = {20.0, 20.0};
 @implementation ASNetworkImageNode
 
 @dynamic image;
-@dynamic ephemeralImage;
 
 - (instancetype)initWithCache:(id<ASImageCacheProtocol>)cache downloader:(id<ASImageDownloaderProtocol>)downloader
 {
@@ -117,17 +116,12 @@ static const CGSize kMinReleaseImageOnBackgroundSize = {20.0, 20.0};
   
   _imageWasSetExternally = (image != nil);
   if (_imageWasSetExternally) {
-    ASDisplayNodeAssertNil(_URL, @"Directly setting an image on an ASNetworkImageNode causes it to behave like an ASImageNode instead of an ASNetworkImageNode. If you need to set the image temporarily use setEphemeralImage");
+    ASDisplayNodeAssertNil(_URL, @"Directly setting an image on an ASNetworkImageNode causes it to behave like an ASImageNode instead of an ASNetworkImageNode. If this is what you want, set the URL to nil first.");
     [self _cancelDownloadAndClearImage];
     _URL = nil;
   }
   
   [self _setImage:image];
-}
-
-- (void)setEphemeralImage:(UIImage *)ephemeralImage
-{
-  [self _setImage:ephemeralImage];
 }
 
 - (void)_setImage:(UIImage *)image
@@ -145,7 +139,7 @@ static const CGSize kMinReleaseImageOnBackgroundSize = {20.0, 20.0};
   {
     ASDN::MutexLocker l(__instanceLock__);
     
-    ASDisplayNodeAssert(_imageWasSetExternally == NO, @"Setting a URL to an ASNetworkImageNode after setting an image changes its behavior from an ASImageNode to an ASNetworkImageNode. If this is what you want, set the image to nil first");
+    ASDisplayNodeAssert(_imageWasSetExternally == NO, @"Setting a URL to an ASNetworkImageNode after setting an image changes its behavior from an ASImageNode to an ASNetworkImageNode. If this is what you want, set the image to nil first.");
     
     _imageWasSetExternally = NO;
     

--- a/AsyncDisplayKit/ASNetworkImageNode.mm
+++ b/AsyncDisplayKit/ASNetworkImageNode.mm
@@ -109,14 +109,24 @@ static const CGSize kMinReleaseImageOnBackgroundSize = {20.0, 20.0};
 
 #pragma mark - Public methods -- must lock
 
-/// Setter for public image property. It has the side effect of setting an internal _imageWasSetExternally that prevents setting an image internally. Setting an image internally should happen with the _setImage: method
+/// Setter for public image property. It has the side effect to set an internal _imageWasSetExternally that prevents setting an image internally. Setting an image internally should happen with the _setImage: method
 - (void)setImage:(UIImage *)image
 {
   ASDN::MutexLocker l(__instanceLock__);
   
-  _imageWasSetExternally = (image != nil && _URL == nil);
+  _imageWasSetExternally = (image != nil);
+  if (_imageWasSetExternally) {
+    ASDisplayNodeAssertNil(_URL, @"Directly setting an image on an ASNetworkImageNode causes it to behave like an ASImageNode instead of an ASNetworkImageNode. If you need to set the image temporarily use setEphemeralImage");
+    [self _cancelDownloadAndClearImage];
+    _URL = nil;
+  }
   
   [self _setImage:image];
+}
+
+- (void)setEphemeralImage:(UIImage *)ephemeralImage
+{
+  [self _setImage:ephemeralImage];
 }
 
 - (void)_setImage:(UIImage *)image
@@ -133,6 +143,8 @@ static const CGSize kMinReleaseImageOnBackgroundSize = {20.0, 20.0};
 {
   {
     ASDN::MutexLocker l(__instanceLock__);
+    
+    ASDisplayNodeAssert(_imageWasSetExternally == NO, @"Setting a URL to an ASNetworkImageNode after setting an image changes its behavior from an ASImageNode to an ASNetworkImageNode. If this is what you want, set the image to nil first");
     
     _imageWasSetExternally = NO;
     


### PR DESCRIPTION
Here's one other idea for addressing this problem. Essentially,
we assert if you've set both the URL and the image. I've played around
with Pinterest and there's only one case where we hit this (the transition).

So I've also added another method (which is a bummer, it's weird I know)
but there's one good reason to add this method, ephemeralImage, which is
the user doesn't have to manually clear it out like they would if they
used defaultImage to save memory.

Putting this up for discussion.