### PR TITLE
[ASEditableTextNode] Maximum number of lines to display (#2777)

### DIFF
--- a/AsyncDisplayKit/ASEditableTextNode.h
+++ b/AsyncDisplayKit/ASEditableTextNode.h
@@ -93,6 +93,12 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readwrite) UIEdgeInsets textContainerInset;
 
 /**
+ @abstract The maximum number of lines to display. Additional lines will require scrolling.
+ @default 0 (No limit)
+ */
+@property (nonatomic, assign) NSUInteger maximumLinesToDisplay;
+
+/**
  @abstract <UITextInputTraits> properties.
  */
 @property(nonatomic, readwrite, assign) UITextAutocapitalizationType autocapitalizationType; // default is UITextAutocapitalizationTypeSentences

--- a/AsyncDisplayKit/ASEditableTextNode.mm
+++ b/AsyncDisplayKit/ASEditableTextNode.mm
@@ -243,7 +243,6 @@
   CGSize textSize;
   
   if (_maximumLinesToDisplay > 0) {
-    // *** TODO: My version of calculation
     textSize = [displayedComponents sizeForConstrainedWidth:constrainedSize.width
                                         forMaxNumberOfLines: _maximumLinesToDisplay];
   } else {

--- a/AsyncDisplayKit/ASEditableTextNode.mm
+++ b/AsyncDisplayKit/ASEditableTextNode.mm
@@ -476,7 +476,10 @@
   [_textKitComponents.layoutManager invalidateLayoutForCharacterRange:NSMakeRange(0, [_textKitComponents.textStorage length]) actualCharacterRange:NULL];
 
   // When you type beyond UITextView's bounds it scrolls you down a line. We need to remain at the top.
-  [_textKitComponents.textView setContentOffset:CGPointZero animated:NO];
+  // [Question] Is there a good reason why we are forcing content offset to top? Why not
+  // keep at the current offset of the text view?
+  CGPoint offset = _textKitComponents.textView.contentOffset;
+  [_textKitComponents.textView setContentOffset:offset animated:NO];
 }
 
 #pragma mark - Keyboard

--- a/AsyncDisplayKit/ASEditableTextNode.mm
+++ b/AsyncDisplayKit/ASEditableTextNode.mm
@@ -476,7 +476,7 @@
   [_textKitComponents.layoutManager invalidateLayoutForCharacterRange:NSMakeRange(0, [_textKitComponents.textStorage length]) actualCharacterRange:NULL];
 
   // When you type beyond UITextView's bounds it scrolls you down a line. We need to remain at the top.
-  // [Question] Is there a good reason why we are forcing content offset to top? Why not
+  // [Question - leotumwattana] Is there a good reason why we are forcing content offset to top? Why not
   // keep at the current offset of the text view?
   CGPoint offset = _textKitComponents.textView.contentOffset;
   [_textKitComponents.textView setContentOffset:offset animated:NO];

--- a/AsyncDisplayKit/ASEditableTextNode.mm
+++ b/AsyncDisplayKit/ASEditableTextNode.mm
@@ -237,11 +237,23 @@
 
 - (CGSize)calculateSizeThatFits:(CGSize)constrainedSize
 {
+  
   ASTextKitComponents *displayedComponents = [self isDisplayingPlaceholder] ? _placeholderTextKitComponents : _textKitComponents;
-  CGSize textSize = [displayedComponents sizeForConstrainedWidth:constrainedSize.width];
+  
+  CGSize textSize
+  
+  if maximumLinesToDisplay >= 0 {
+    // *** TODO: My version of calculation
+    CGSize textSize = [displayedComponents sizeForConstrainedWidth:constrainedSize.width
+                                               forMaxNumberOfLines: maximumLinesToDisplay]
+  } else {
+    CGSize textSize = [displayedComponents sizeForConstrainedWidth:constrainedSize.width];
+  }
+  
   CGFloat width = std::ceil(textSize.width + _textContainerInset.left + _textContainerInset.right);
   CGFloat height = std::ceil(textSize.height + _textContainerInset.top + _textContainerInset.bottom);
   return CGSizeMake(std::fmin(width, constrainedSize.width), std::fmin(height, constrainedSize.height));
+  
 }
 
 - (void)layout

--- a/AsyncDisplayKit/TextKit/ASTextKitComponents.m
+++ b/AsyncDisplayKit/TextKit/ASTextKitComponents.m
@@ -66,4 +66,19 @@
   return textSize;
 }
 
+// *** TODO
+- (CGSize)sizeForConstrainedWidth:(CGFloat)constrainedWidth
+                  forMaxNumberOfLines:(NSInteger)numberOfLines {
+  
+  
+  // Force glyph generation and layout, which may not have happened yet (and isn't triggered by - usedRectForTextContainer:).
+  [components.layoutManager ensurelayoutForTextContainer:components.textContainer];
+  
+  while (index < numberOfGlyphs, numLines += 1) {
+    fragmentRect = layoutManager.lineFragmentRect(forGlyphAt: index, effectiveRange: &lineRange)
+    index = NSMaxRange(lineRange)
+  }
+  
+}
+
 @end

--- a/AsyncDisplayKit/TextKit/ASTextKitComponents.mm
+++ b/AsyncDisplayKit/TextKit/ASTextKitComponents.mm
@@ -68,7 +68,6 @@
   return textSize;
 }
 
-// *** TODO
 - (CGSize)sizeForConstrainedWidth:(CGFloat)constrainedWidth
                   forMaxNumberOfLines:(NSInteger)numberOfLines {
   

--- a/AsyncDisplayKit/TextKit/ASTextKitComponents.mm
+++ b/AsyncDisplayKit/TextKit/ASTextKitComponents.mm
@@ -84,6 +84,8 @@
   // Force glyph generation and layout, which may not have happened yet (and isn't triggered by - usedRectForTextContainer:).
   [components.layoutManager ensureLayoutForTextContainer:components.textContainer];
   
+  CGFloat width = [components.layoutManager usedRectForTextContainer:components.textContainer].size.width;
+  
   // Calculate height based on line fragments
   // Based on calculating number of lines from: http://asciiwwdc.com/2013/sessions/220
   NSRange glyphRange, lineRange = NSMakeRange(0, 0);
@@ -115,7 +117,7 @@
   CGFloat fragmentHeight = rect.origin.y + rect.size.height;
   CGFloat finalHeight = std::ceil(std::fmax(height, fragmentHeight));
   
-  CGSize size = CGSizeMake(constrainedWidth, finalHeight);
+  CGSize size = CGSizeMake(width, finalHeight);
   
   return size;
 }

--- a/AsyncDisplayKit/TextKit/ASTextKitComponents.mm
+++ b/AsyncDisplayKit/TextKit/ASTextKitComponents.mm
@@ -77,9 +77,8 @@
   
   ASTextKitComponents *components = self;
   
-  if (CGRectGetWidth(components.textView.bounds) != constrainedWidth) {
-    components = [ASTextKitComponents componentsWithAttributedSeedString:components.textStorage textContainerSize:CGSizeMake(constrainedWidth, CGFLOAT_MAX)];
-  }
+  // Always use temporary stack in case of threading issues
+  components = [ASTextKitComponents componentsWithAttributedSeedString:components.textStorage textContainerSize:CGSizeMake(constrainedWidth, CGFLOAT_MAX)];
   
   // Force glyph generation and layout, which may not have happened yet (and isn't triggered by - usedRectForTextContainer:).
   [components.layoutManager ensureLayoutForTextContainer:components.textContainer];


### PR DESCRIPTION
This adds the property `. maximumLinesToDisplay` to `ASEditableTextNode` which will limit the size calculation of the `editableTextNode` to the specified number of lines.

Calculation is done using TextKit's `lineFragment` to ensure height calculation is accurate even under mixed font conditions.

Addresses Issue: #2777