### PR TITLE
[AS{Overlay,Background}LayoutSpec] Don't allow nil layout elements

### DIFF
--- a/AsyncDisplayKit/Layout/ASBackgroundLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASBackgroundLayoutSpec.h
@@ -20,15 +20,15 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Background layoutElement for this layout spec
  */
-@property (nullable, nonatomic, strong) id<ASLayoutElement> background;
+@property (nonatomic, strong) id<ASLayoutElement> background;
 
 /**
  * Creates and returns an ASBackgroundLayoutSpec object
  *
  * @param child A child that is laid out to determine the size of this spec.
- * @param background A layoutElement object that is laid out behind the child. If this is nil, the background is omitted.
+ * @param background A layoutElement object that is laid out behind the child.
  */
-+ (instancetype)backgroundLayoutSpecWithChild:(id<ASLayoutElement>)child background:(nullable id<ASLayoutElement>)background AS_WARN_UNUSED_RESULT;
++ (instancetype)backgroundLayoutSpecWithChild:(id<ASLayoutElement>)child background:(id<ASLayoutElement>)background AS_WARN_UNUSED_RESULT;
 
 @end
 

--- a/AsyncDisplayKit/Layout/ASOverlayLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASOverlayLayoutSpec.h
@@ -20,15 +20,15 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Overlay layoutElement of this layout spec
  */
-@property (nullable, nonatomic, strong) id<ASLayoutElement> overlay;
+@property (nonatomic, strong) id<ASLayoutElement> overlay;
 
 /**
  * Creates and returns an ASOverlayLayoutSpec object with a given child and an layoutElement that act as overlay.
  *
  * @param child A child that is laid out to determine the size of this spec.
- * @param overlay A layoutElement object that is laid out over the child. If this is nil, the overlay is omitted.
+ * @param overlay A layoutElement object that is laid out over the child.
  */
-+ (instancetype)overlayLayoutSpecWithChild:(id<ASLayoutElement>)child overlay:(nullable id<ASLayoutElement>)overlay AS_WARN_UNUSED_RESULT;
++ (instancetype)overlayLayoutSpecWithChild:(id<ASLayoutElement>)child overlay:(id<ASLayoutElement>)overlay AS_WARN_UNUSED_RESULT;
 
 @end
 


### PR DESCRIPTION
Resolves #2747.

Michael and I couldn't think of a use case for allowing an `ASBackgroundLayoutSpec` with a nil background layout element. cc @nguyenhuy