### PR TITLE
[AS{Overlay,Background}LayoutSpec] Assert when attempting to set a nil background / overlay layout element.

### DIFF
--- a/AsyncDisplayKit/Layout/ASBackgroundLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASBackgroundLayoutSpec.mm
@@ -67,6 +67,7 @@ static NSUInteger const kBackgroundChildIndex = 1;
 
 - (void)setBackground:(id<ASLayoutElement>)background
 {
+  ASDisplayNodeAssertNotNil(background, @"Background cannot be nil");
   [super setChild:background atIndex:kBackgroundChildIndex];
 }
 

--- a/AsyncDisplayKit/Layout/ASOverlayLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASOverlayLayoutSpec.mm
@@ -43,6 +43,7 @@ static NSUInteger const kOverlayChildIndex = 1;
 
 - (void)setOverlay:(id<ASLayoutElement>)overlay
 {
+  ASDisplayNodeAssertNotNil(overlay, @"Overlay cannot be nil");
   [super setChild:overlay atIndex:kOverlayChildIndex];
 }
 


### PR DESCRIPTION
Addresses https://github.com/facebook/AsyncDisplayKit/pull/2795#issuecomment-267878024

Add assertions here to reenforce the non-nullability of the background and overlay layout elements.

cc  @maicki