### PR TITLE
[ASDisplayNode Deallocation] Fix for crash when certain types are used as instance variables.

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -542,7 +542,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
     Ivar ivar = allMyIvars[i];
     const char *type = ivar_getTypeEncoding(ivar);
 
-    if (type != nil && strcmp(type, @encode(id)) == 0) {
+    if (type != NULL && strcmp(type, @encode(id)) == 0) {
       // If it's `id` we have to include it just in case.
       resultIvars[resultCount] = ivar;
       resultCount += 1;

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -542,7 +542,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
     Ivar ivar = allMyIvars[i];
     const char *type = ivar_getTypeEncoding(ivar);
 
-    if (strcmp(type, @encode(id)) == 0) {
+    if (type != nil && strcmp(type, @encode(id)) == 0) {
       // If it's `id` we have to include it just in case.
       resultIvars[resultCount] = ivar;
       resultCount += 1;

--- a/AsyncDisplayKit/Private/ASInternalHelpers.m
+++ b/AsyncDisplayKit/Private/ASInternalHelpers.m
@@ -107,7 +107,7 @@ BOOL ASClassRequiresMainThreadDeallocation(Class class)
 Class _Nullable ASGetClassFromType(const char *type)
 {
   // Class types all start with @"
-  if (strncmp(type, "@\"", 2) != 0) {
+  if (type == nil || strncmp(type, "@\"", 2) != 0) {
     return nil;
   }
 

--- a/AsyncDisplayKit/Private/ASInternalHelpers.m
+++ b/AsyncDisplayKit/Private/ASInternalHelpers.m
@@ -107,7 +107,7 @@ BOOL ASClassRequiresMainThreadDeallocation(Class class)
 Class _Nullable ASGetClassFromType(const char *type)
 {
   // Class types all start with @"
-  if (type == nil || strncmp(type, "@\"", 2) != 0) {
+  if (type == NULL || strncmp(type, "@\"", 2) != 0) {
     return nil;
   }
 


### PR DESCRIPTION
Fix [this](https://github.com/facebook/AsyncDisplayKit/issues/2802) issue