### PR TITLE
Range Controller Explicitly Marks Disappeared Nodes as Invisible

### DIFF
--- a/AsyncDisplayKit/Details/ASRangeController.mm
+++ b/AsyncDisplayKit/Details/ASRangeController.mm
@@ -170,6 +170,24 @@ static UIApplicationState __ApplicationState = UIApplicationStateActive;
   }
 }
 
+// Clear the visible bit from any nodes that disappeared since last update.
+// Currently we guarantee that nodes will not be marked visible when deallocated,
+// but it's OK to be in e.g. the preload range. So for the visible bit specifically,
+// we add this extra mechanism to account for e.g. deleted items.
+//
+// NOTE: There is a minor risk here, if a node is transferred from one range controller
+// to another before the first rc updates and clears the node out of this set. It's a pretty
+// wild scenario that I doubt happens in practice.
+- (void)_setVisibleNodes:(ASWeakSet *)newVisibleNodes
+{
+  for (ASCellNode *node in _visibleNodes) {
+    if (![newVisibleNodes containsObject:node] && node.isVisible) {
+      [node exitInterfaceState:ASInterfaceStateVisible];
+    }
+  }
+  _visibleNodes = newVisibleNodes;
+}
+
 - (void)_updateVisibleNodeIndexPaths
 {
   ASDisplayNodeAssert(_layoutController, @"An ASLayoutController is required by ASRangeController");
@@ -188,8 +206,10 @@ static UIApplicationState __ApplicationState = UIApplicationStateActive;
   // TODO: Consider if we need to use this codepath, or can rely on something more similar to the data & display ranges
   // Example: ... = [_layoutController indexPathsForScrolling:scrollDirection rangeType:ASLayoutRangeTypeVisible];
   NSArray<NSIndexPath *> *visibleNodePaths = [_dataSource visibleNodeIndexPathsForRangeController:self];
-  
+  ASWeakSet *newVisibleNodes = [[ASWeakSet alloc] init];
+
   if (visibleNodePaths.count == 0) { // if we don't have any visibleNodes currently (scrolled before or after content)...
+    [self _setVisibleNodes:newVisibleNodes];
     return; // don't do anything for this update, but leave _rangeIsValid == NO to make sure we update it later
   }
   ASProfilingSignpostStart(1, self);
@@ -273,8 +293,7 @@ static UIApplicationState __ApplicationState = UIApplicationStateActive;
   ASDisplayNodeAssertTrue([visibleIndexPaths isSubsetOfSet:displayIndexPaths]);
   NSMutableArray<NSIndexPath *> *modifiedIndexPaths = (ASRangeControllerLoggingEnabled ? [NSMutableArray array] : nil);
 #endif
-  
-  ASWeakSet *newVisibleNodes = [[ASWeakSet alloc] init];
+
   for (NSIndexPath *indexPath in allIndexPaths) {
     // Before a node / indexPath is exposed to ASRangeController, ASDataController should have already measured it.
     // For consistency, make sure each node knows that it should measure itself if something changes.
@@ -351,20 +370,7 @@ static UIApplicationState __ApplicationState = UIApplicationStateActive;
     }
   }
 
-  // Clear the visible bit from any nodes that disappeared since last update.
-  // Currently we guarantee that nodes will not be marked visible when deallocated,
-  // but it's OK to be in e.g. the preload range. So for the visible bit specifically,
-  // we add this extra mechanism to account for e.g. deleted items.
-  //
-  // NOTE: There is a minor risk here, if a node is transferred from one range controller
-  // to another before the first rc updates and clears the node out of this set. It's a pretty
-  // wild scenario that I doubt happens in practice.
-  for (ASCellNode *node in _visibleNodes) {
-    if (![newVisibleNodes containsObject:node] && node.isVisible) {
-      [node exitInterfaceState:ASInterfaceStateVisible];
-    }
-  }
-  _visibleNodes = newVisibleNodes;
+  [self _setVisibleNodes:newVisibleNodes];
   
   // TODO: This code is for debugging only, but would be great to clean up with a delegate method implementation.
   if ([ASRangeController shouldShowRangeDebugOverlay]) {

--- a/AsyncDisplayKit/Details/ASWeakSet.h
+++ b/AsyncDisplayKit/Details/ASWeakSet.h
@@ -15,6 +15,11 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+ * A class similar to NSSet that stores objects weakly.
+ * Note that this class uses NSPointerFunctionsObjectPointerPersonality –
+ * that is, it uses shifted pointer for hashing, and identity comparison for equality.
+ */
 @interface ASWeakSet<__covariant ObjectType> : NSObject<NSFastEnumeration>
 
 /// Returns YES if the receiver is empty, NO otherwise.

--- a/AsyncDisplayKit/Details/ASWeakSet.m
+++ b/AsyncDisplayKit/Details/ASWeakSet.m
@@ -22,7 +22,7 @@
 {
   self = [super init];
   if (self) {
-    _hashTable = [NSHashTable weakObjectsHashTable];
+    _hashTable = [NSHashTable hashTableWithOptions:NSPointerFunctionsWeakMemory | NSPointerFunctionsObjectPointerPersonality];
   }
   return self;
 }
@@ -59,7 +59,7 @@
 
 /**
  Note: The `count` property of NSHashTable is unreliable
- in the case of weak-object hash tables because entries
+ in the case of weak-memory hash tables because entries
  that have been deallocated are not removed immediately.
  
  In order to get the true count we have to fall back to using

--- a/AsyncDisplayKitTests/ASCollectionViewTests.mm
+++ b/AsyncDisplayKitTests/ASCollectionViewTests.mm
@@ -815,6 +815,27 @@
   [cn performBatchAnimated:NO updates:nil completion:nil];
 }
 
+- (void)testThatDeletedItemsAreMarkedInvisible
+{
+  UIWindow *window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  ASCollectionViewTestController *testController = [[ASCollectionViewTestController alloc] initWithNibName:nil bundle:nil];
+  window.rootViewController = testController;
+
+  __block NSInteger itemCount = 1;
+  testController.asyncDelegate->_itemCounts = {itemCount};
+  [window makeKeyAndVisible];
+  [window layoutIfNeeded];
+
+  ASCollectionNode *cn = testController.collectionNode;
+  [cn waitUntilAllUpdatesAreCommitted];
+  ASCellNode *node = [cn nodeForItemAtIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]];
+  XCTAssertTrue(node.visible);
+  testController.asyncDelegate->_itemCounts = {0};
+  [cn deleteItemsAtIndexPaths: @[[NSIndexPath indexPathForItem:0 inSection:0]]];
+  [self expectationForPredicate:[NSPredicate predicateWithFormat:@"visible = NO"] evaluatedWithObject:node handler:nil];
+  [self waitForExpectationsWithTimeout:3 handler:nil];
+}
+
 - (void)testThatMultipleBatchFetchesDontHappenUnnecessarily
 {
   UIWindow *window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];

--- a/AsyncDisplayKitTests/ASTableViewThrashTests.m
+++ b/AsyncDisplayKitTests/ASTableViewThrashTests.m
@@ -27,7 +27,7 @@
 #define kMinimumItemCount 5
 #define kMinimumSectionCount 3
 #define kFickleness 0.1
-#define kThrashingIterationCount 100
+#define kThrashingIterationCount 10
 
 static NSString *ASThrashArrayDescription(NSArray *array) {
   NSMutableString *str = [NSMutableString stringWithString:@"(\n"];

--- a/AsyncDisplayKitTests/ASTableViewThrashTests.m
+++ b/AsyncDisplayKitTests/ASTableViewThrashTests.m
@@ -27,7 +27,7 @@
 #define kMinimumItemCount 5
 #define kMinimumSectionCount 3
 #define kFickleness 0.1
-#define kThrashingIterationCount 10
+#define kThrashingIterationCount 100
 
 static NSString *ASThrashArrayDescription(NSArray *array) {
   NSMutableString *str = [NSMutableString stringWithString:@"(\n"];
@@ -492,7 +492,7 @@ static NSInteger ASThrashUpdateCurrentSerializationVersion = 1;
 }
 
 // Disabled temporarily due to issue where cell nodes are not marked invisible before deallocation.
-- (void)testThrashingWildly {
+- (void)DISABLED_testThrashingWildly {
   for (NSInteger i = 0; i < kThrashingIterationCount; i++) {
     [self setUp];
     ASThrashDataSource *ds = [[ASThrashDataSource alloc] initWithData:[ASThrashTestSection sectionsWithCount:kInitialSectionCount]];

--- a/AsyncDisplayKitTests/ASTableViewThrashTests.m
+++ b/AsyncDisplayKitTests/ASTableViewThrashTests.m
@@ -492,7 +492,7 @@ static NSInteger ASThrashUpdateCurrentSerializationVersion = 1;
 }
 
 // Disabled temporarily due to issue where cell nodes are not marked invisible before deallocation.
-- (void)DISABLED_testThrashingWildly {
+- (void)testThrashingWildly {
   for (NSInteger i = 0; i < kThrashingIterationCount; i++) {
     [self setUp];
     ASThrashDataSource *ds = [[ASThrashDataSource alloc] initWithData:[ASThrashTestSection sectionsWithCount:kInitialSectionCount]];


### PR DESCRIPTION
This should resolve a huge swath of our cell node visibility issues, such as #2436 #2203 #2658.