### PR TITLE
[ASViewController] Support optional node

### DIFF
--- a/AsyncDisplayKit/ASViewController.h
+++ b/AsyncDisplayKit/ASViewController.h
@@ -21,20 +21,25 @@ NS_ASSUME_NONNULL_BEGIN
 typedef ASTraitCollection * _Nonnull (^ASDisplayTraitsForTraitCollectionBlock)(UITraitCollection *traitCollection);
 typedef ASTraitCollection * _Nonnull (^ASDisplayTraitsForTraitWindowSizeBlock)(CGSize windowSize);
 
+/**
+ * ASViewController allows you to have a completely node backed hierarchy. It automatically
+ * handles @c ASVisibilityDepth, automatic range mode and propogating @c ASDisplayTraits to contained nodes.
+ *
+ * You can opt-out of node backed hierarchy and use it like a normal UIViewController.
+ * More importantly, you can use it as a base class for all of your view controllers among which some use a node hierarchy and some don't.
+ * See examples/ASDKgram project for actual implementation.
+ */
 @interface ASViewController<__covariant DisplayNodeType : ASDisplayNode *> : UIViewController <ASVisibilityDepth>
 
 /**
- * ASViewController Designated initializer.
- *
- * @discussion ASViewController allows you to have a completely node backed heirarchy. It automatically
- * handles @c ASVisibilityDepth, automatic range mode and propogating @c ASDisplayTraits to contained nodes.
+ * ASViewController initializer.
  *
  * @param node An ASDisplayNode which will provide the root view (self.view)
  * @return An ASViewController instance whose root view will be backed by the provided ASDisplayNode.
  *
  * @see ASVisibilityDepth
  */
-- (instancetype)initWithNode:(DisplayNodeType)node NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithNode:(DisplayNodeType)node;
 
 /**
  * @return node Returns the ASDisplayNode which provides the backing view to the view controller.
@@ -88,14 +93,6 @@ typedef ASTraitCollection * _Nonnull (^ASDisplayTraitsForTraitWindowSizeBlock)(C
  * backing node.
  */
 - (ASSizeRange)nodeConstrainedSize AS_WARN_UNUSED_RESULT ASDISPLAYNODE_DEPRECATED_MSG("Set the size directly to the view's frame");
-
-@end
-
-@interface ASViewController (Unavailable)
-
-- (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil AS_UNAVAILABLE("ASViewController requires using -initWithNode:");
-
-- (nullable instancetype)initWithCoder:(NSCoder *)aDecoder AS_UNAVAILABLE("ASViewController requires using -initWithNode:");
 
 @end
 

--- a/AsyncDisplayKit/ASViewController.mm
+++ b/AsyncDisplayKit/ASViewController.mm
@@ -24,6 +24,7 @@
 
 @implementation ASViewController
 {
+  BOOL _nodeProvided;
   BOOL _ensureDisplayed;
   BOOL _automaticallyAdjustRangeModeBasedOnViewEvents;
   BOOL _parentManagesVisibilityDepth;
@@ -38,9 +39,7 @@
     return nil;
   }
   
-  _node = [[ASDisplayNode alloc] initWithViewBlock:^UIView * _Nonnull{
-    return [[UIView alloc] init];
-  }];
+  _node = [[ASDisplayNode alloc] init];
   [self _initializeInstance];
   
   return self;
@@ -52,9 +51,7 @@
     return nil;
   }
   
-  _node = [[ASDisplayNode alloc] initWithViewBlock:^UIView * _Nonnull{
-    return [[UIView alloc] init];
-  }];
+  _node = [[ASDisplayNode alloc] init];
   [self _initializeInstance];
   
   return self;
@@ -66,6 +63,7 @@
     return nil;
   }
   
+  _nodeProvided = YES;
   _node = node;
   [self _initializeInstance];
 
@@ -104,13 +102,15 @@
 
 - (void)loadView
 {
-  ASDisplayNodeAssertTrue(!_node.layerBacked);
-  
   // Apple applies a frame and autoresizing masks we need.  Allocating a view is not
   // nearly as expensive as adding and removing it from a hierarchy, and fortunately
   // we can avoid that here.  Enabling layerBacking on a single node in the hierarchy
   // will have a greater performance benefit than the impact of this transient view.
   [super loadView];
+  
+  if (!_nodeProvided) { return; }
+  
+  ASDisplayNodeAssertTrue(!_node.layerBacked);
   
   UIView *view = self.view;
   CGRect frame = view.frame;

--- a/AsyncDisplayKit/ASViewController.mm
+++ b/AsyncDisplayKit/ASViewController.mm
@@ -34,14 +34,30 @@
 
 - (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
 {
-  ASDisplayNodeAssert(NO, @"ASViewController requires using -initWithNode:");
-  return [self initWithNode:[[ASDisplayNode alloc] init]];
+  if (!(self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil])) {
+    return nil;
+  }
+  
+  _node = [[ASDisplayNode alloc] initWithViewBlock:^UIView * _Nonnull{
+    return [[UIView alloc] init];
+  }];
+  [self _initializeInstance];
+  
+  return self;
 }
 
 - (instancetype)initWithCoder:(NSCoder *)aDecoder
 {
-  ASDisplayNodeAssert(NO, @"ASViewController requires using -initWithNode:");
-  return [self initWithNode:[[ASDisplayNode alloc] init]];
+  if (!(self = [super initWithCoder:aDecoder])) {
+    return nil;
+  }
+  
+  _node = [[ASDisplayNode alloc] initWithViewBlock:^UIView * _Nonnull{
+    return [[UIView alloc] init];
+  }];
+  [self _initializeInstance];
+  
+  return self;
 }
 
 - (instancetype)initWithNode:(ASDisplayNode *)node
@@ -50,10 +66,17 @@
     return nil;
   }
   
-  ASDisplayNodeAssertNotNil(node, @"Node must not be nil");
-  ASDisplayNodeAssertTrue(!node.layerBacked);
   _node = node;
+  [self _initializeInstance];
 
+  return self;
+}
+
+- (void)_initializeInstance
+{
+  ASDisplayNodeAssertNotNil(_node, @"Node must not be nil");
+  ASDisplayNodeAssertTrue(!_node.layerBacked);
+  
   _selfConformsToRangeModeProtocol = [self conformsToProtocol:@protocol(ASRangeControllerUpdateRangeProtocol)];
   _nodeConformsToRangeModeProtocol = [_node conformsToProtocol:@protocol(ASRangeControllerUpdateRangeProtocol)];
   _automaticallyAdjustRangeModeBasedOnViewEvents = _selfConformsToRangeModeProtocol || _nodeConformsToRangeModeProtocol;
@@ -63,7 +86,7 @@
     // Node already loaded the view
     [self view];
   } else {
-    // If the node didn't load yet add ourselves as on did load observer to laod the view in case the node gets loaded
+    // If the node didn't load yet add ourselves as on did load observer to load the view in case the node gets loaded
     // before the view controller
     __weak __typeof__(self) weakSelf = self;
     [_node onDidLoad:^(__kindof ASDisplayNode * _Nonnull node) {
@@ -72,8 +95,6 @@
       }
     }];
   }
-
-  return self;
 }
 
 - (void)dealloc
@@ -90,6 +111,7 @@
   // we can avoid that here.  Enabling layerBacking on a single node in the hierarchy
   // will have a greater performance benefit than the impact of this transient view.
   [super loadView];
+  
   UIView *view = self.view;
   CGRect frame = view.frame;
   UIViewAutoresizing autoresizingMask = view.autoresizingMask;

--- a/examples/ASDKgram/Sample.xcodeproj/project.pbxproj
+++ b/examples/ASDKgram/Sample.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		768843931CAA37EF00D8629E /* UserModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 7688437B1CAA37EF00D8629E /* UserModel.m */; };
 		768843961CAA37EF00D8629E /* Utilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 7688437E1CAA37EF00D8629E /* Utilities.m */; };
 		B13424EE6D36C2EC5D1030B6 /* libPods-Sample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = AD5DDA0A29B0F32AA5CC47BA /* libPods-Sample.a */; };
+		E5F128F01E09625400B4335F /* PhotoFeedBaseController.m in Sources */ = {isa = PBXBuildFile; fileRef = E5F128EF1E09625400B4335F /* PhotoFeedBaseController.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -81,6 +82,8 @@
 		97A9B1BAF4265967672F9EA3 /* Pods-Sample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Sample.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Sample/Pods-Sample.debug.xcconfig"; sourceTree = "<group>"; };
 		AD5DDA0A29B0F32AA5CC47BA /* libPods-Sample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Sample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D09B5DF0BFB37583DE8F3142 /* Pods-Sample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Sample.release.xcconfig"; path = "Pods/Target Support Files/Pods-Sample/Pods-Sample.release.xcconfig"; sourceTree = "<group>"; };
+		E5F128EE1E09612700B4335F /* PhotoFeedBaseController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PhotoFeedBaseController.h; sourceTree = "<group>"; };
+		E5F128EF1E09625400B4335F /* PhotoFeedBaseController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PhotoFeedBaseController.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -167,6 +170,8 @@
 		767A5F141CAA3D8A004CDA8D /* Controller */ = {
 			isa = PBXGroup;
 			children = (
+				E5F128EE1E09612700B4335F /* PhotoFeedBaseController.h */,
+				E5F128EF1E09625400B4335F /* PhotoFeedBaseController.m */,
 				767A5F161CAA3D96004CDA8D /* UIKit */,
 				767A5F151CAA3D90004CDA8D /* ASDK */,
 			);
@@ -377,6 +382,7 @@
 				768843821CAA37EF00D8629E /* CommentModel.m in Sources */,
 				768843831CAA37EF00D8629E /* CommentsNode.m in Sources */,
 				768843961CAA37EF00D8629E /* Utilities.m in Sources */,
+				E5F128F01E09625400B4335F /* PhotoFeedBaseController.m in Sources */,
 				768843931CAA37EF00D8629E /* UserModel.m in Sources */,
 				768843801CAA37EF00D8629E /* AppDelegate.m in Sources */,
 				768843811CAA37EF00D8629E /* CommentFeedModel.m in Sources */,

--- a/examples/ASDKgram/Sample/PhotoFeedBaseController.h
+++ b/examples/ASDKgram/Sample/PhotoFeedBaseController.h
@@ -1,8 +1,8 @@
 //
-//  PhotoFeedViewController.h
+//  PhotoFeedBaseController.h
 //  Sample
 //
-//  Created by Hannah Troisi on 2/17/16.
+//  Created by Huy Nguyen on 20/12/16.
 //
 //  Copyright (c) 2014-present, Facebook, Inc.  All rights reserved.
 //  This source code is licensed under the BSD-style license found in the
@@ -17,8 +17,22 @@
 //  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#import "PhotoFeedBaseController.h"
+#import <AsyncDisplayKit/AsyncDisplayKit.h>
+#import "AppDelegate.h"
 
-@interface PhotoFeedViewController : PhotoFeedBaseController
+@class PhotoFeedModel;
+
+@interface PhotoFeedBaseController : ASViewController <PhotoFeedControllerProtocol>
+
+@property (nonatomic, strong, readonly) PhotoFeedModel *photoFeed;
+@property (nonatomic, strong, readonly) UITableView *tableView;
+
+- (void)refreshFeed;
+- (void)insertNewRows:(NSArray *)newPhotos;
+
+#pragma mark - Subclasses must override these methods
+
+- (void)loadPage;
+- (void)requestCommentsForPhotos:(NSArray *)newPhotos;
 
 @end

--- a/examples/ASDKgram/Sample/PhotoFeedBaseController.m
+++ b/examples/ASDKgram/Sample/PhotoFeedBaseController.m
@@ -1,0 +1,123 @@
+//
+//  PhotoFeedBaseController.m
+//  Sample
+//
+//  Created by Huy Nguyen on 20/12/16.
+//  Copyright © 2016 Facebook. All rights reserved.
+//
+//  Copyright (c) 2014-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under the BSD-style license found in the
+//  LICENSE file in the root directory of this source tree. An additional grant
+//  of patent rights can be found in the PATENTS file in the same directory.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+//  FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+//  ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+#import "PhotoFeedBaseController.h"
+#import "PhotoFeedModel.h"
+
+@implementation PhotoFeedBaseController
+{
+  UIActivityIndicatorView *_activityIndicatorView;
+}
+
+// -loadView is guaranteed to be called on the main thread and is the appropriate place to
+// set up an UIKit objects you may be using.
+- (void)loadView
+{
+  [super loadView];
+  
+  _activityIndicatorView = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleGray];
+  
+  _photoFeed = [[PhotoFeedModel alloc] initWithPhotoFeedModelType:PhotoFeedModelTypePopular imageSize:[self imageSizeForScreenWidth]];
+  [self refreshFeed];
+  
+  CGSize boundSize = self.view.bounds.size;
+  [_activityIndicatorView sizeToFit];
+  CGRect refreshRect = _activityIndicatorView.frame;
+  refreshRect.origin = CGPointMake((boundSize.width - _activityIndicatorView.frame.size.width) / 2.0,
+                                   (boundSize.height - _activityIndicatorView.frame.size.height) / 2.0);
+  _activityIndicatorView.frame = refreshRect;
+  [self.view addSubview:_activityIndicatorView];
+  
+  self.tableView.allowsSelection = NO;
+  self.tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
+  
+  self.view.backgroundColor = [UIColor whiteColor];
+}
+
+- (void)refreshFeed
+{
+  [_activityIndicatorView startAnimating];
+  // small first batch
+  [_photoFeed refreshFeedWithCompletionBlock:^(NSArray *newPhotos){
+    
+    [_activityIndicatorView stopAnimating];
+    
+    [self insertNewRows:newPhotos];
+    [self requestCommentsForPhotos:newPhotos];
+    
+    // immediately start second larger fetch
+    [self loadPage];
+    
+  } numResultsToReturn:4];
+}
+
+- (void)insertNewRows:(NSArray *)newPhotos
+{
+  NSInteger section = 0;
+  NSMutableArray *indexPaths = [NSMutableArray array];
+  
+  NSInteger newTotalNumberOfPhotos = [_photoFeed numberOfItemsInFeed];
+  for (NSInteger row = newTotalNumberOfPhotos - newPhotos.count; row < newTotalNumberOfPhotos; row++) {
+    NSIndexPath *path = [NSIndexPath indexPathForRow:row inSection:section];
+    [indexPaths addObject:path];
+  }
+  [self.tableView insertRowsAtIndexPaths:indexPaths withRowAnimation:UITableViewRowAnimationNone];
+}
+
+- (UIStatusBarStyle)preferredStatusBarStyle
+{
+  return UIStatusBarStyleLightContent;
+}
+
+- (CGSize)imageSizeForScreenWidth
+{
+  CGRect screenRect   = [[UIScreen mainScreen] bounds];
+  CGFloat screenScale = [[UIScreen mainScreen] scale];
+  return CGSizeMake(screenRect.size.width * screenScale, screenRect.size.width * screenScale);
+}
+
+#pragma mark - PhotoFeedViewControllerProtocol
+
+- (void)resetAllData
+{
+  [_photoFeed clearFeed];
+  [self.tableView reloadData];
+  [self refreshFeed];
+}
+
+#pragma mark - Subclassing
+
+- (UITableView *)tableView
+{
+  NSAssert(NO, @"Subclasses must override this method");
+  return nil;
+}
+
+- (void)loadPage
+{
+  NSAssert(NO, @"Subclasses must override this method");
+}
+
+- (void)requestCommentsForPhotos:(NSArray *)newPhotos
+{
+  NSAssert(NO, @"Subclasses must override this method");
+}
+
+@end

--- a/examples/ASDKgram/Sample/PhotoFeedNodeController.h
+++ b/examples/ASDKgram/Sample/PhotoFeedNodeController.h
@@ -17,9 +17,8 @@
 //  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#import <AsyncDisplayKit/AsyncDisplayKit.h>
-#import "AppDelegate.h"
+#import "PhotoFeedBaseController.h"
 
-@interface PhotoFeedNodeController : ASViewController <PhotoFeedControllerProtocol>
+@interface PhotoFeedNodeController : PhotoFeedBaseController
 
 @end


### PR DESCRIPTION
This PR makes ASViewController's node optional. This allows developers to use ASViewController like a normal UIViewController. More importantly, it can be used as a base class for view controllers among which some use a node hierarchy and some don't. 

Resolve #2760.