### PR TITLE
[ASDataController] Ensure ASRangeController has an opportunity to update visible nodes before they're deleted by -reloadData path.

### DIFF
--- a/AsyncDisplayKit/Details/ASDataController.h
+++ b/AsyncDisplayKit/Details/ASDataController.h
@@ -76,12 +76,11 @@ extern NSString * const ASCollectionInvalidUpdateException;
  */
 @protocol ASDataControllerDelegate <NSObject>
 
-@optional
-
 /**
  Called for batch update.
  */
 - (void)dataControllerBeginUpdates:(ASDataController *)dataController;
+- (void)dataControllerWillDeleteAllData:(ASDataController *)dataController;
 - (void)dataController:(ASDataController *)dataController endUpdatesAnimated:(BOOL)animated completion:(void (^ _Nullable)(BOOL))completion;
 
 /**

--- a/AsyncDisplayKit/Details/ASDataController.mm
+++ b/AsyncDisplayKit/Details/ASDataController.mm
@@ -452,6 +452,7 @@ NSString * const ASCollectionInvalidUpdateException = @"ASCollectionInvalidUpdat
         // -beginUpdates
         [_mainSerialQueue performBlockOnMainThread:^{
           [_delegate dataControllerBeginUpdates:self];
+          [_delegate dataControllerWillDeleteAllData:self];
         }];
         
         // deleteSections:

--- a/AsyncDisplayKit/Details/ASRangeController.mm
+++ b/AsyncDisplayKit/Details/ASRangeController.mm
@@ -476,6 +476,11 @@ static UIApplicationState __ApplicationState = UIApplicationStateActive;
   [_delegate didBeginUpdatesInRangeController:self];
 }
 
+- (void)dataControllerWillDeleteAllData:(ASDataController *)dataController
+{
+  [self _setVisibleNodes:nil];
+}
+
 - (void)dataController:(ASDataController *)dataController endUpdatesAnimated:(BOOL)animated completion:(void (^)(BOOL))completion
 {
   ASDisplayNodeAssertMainThread();


### PR DESCRIPTION
This change is specific to the reloadData path, which had the last-known occurrence of "deallocated while marked visible".

https://github.com/facebook/AsyncDisplayKit/issues/2711