### PR TITLE
Add a Unit Test For Automatic Subnode Management Interface State Issue

### DIFF
--- a/AsyncDisplayKit/ASCellNode.h
+++ b/AsyncDisplayKit/ASCellNode.h
@@ -12,7 +12,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class ASCellNode;
+@class ASCellNode, ASTextNode;
 
 typedef NSUInteger ASCellNodeAnimation;
 
@@ -204,6 +204,11 @@ typedef NS_ENUM(NSUInteger, ASCellNodeVisibilityEvent) {
  * The text inset or outset for each edge. The default value is 15.0 horizontal and 11.0 vertical padding.
  */
 @property (nonatomic, assign) UIEdgeInsets textInsets;
+
+/**
+ * The text node used by this cell node.
+ */
+@property (nonatomic, strong, readonly) ASTextNode *textNode;
 
 @end
 

--- a/AsyncDisplayKit/ASCellNode.mm
+++ b/AsyncDisplayKit/ASCellNode.mm
@@ -395,13 +395,6 @@ static NSMutableSet *__cellClassesForVisibilityNotifications = nil; // See +init
 #pragma mark -
 #pragma mark ASTextCellNode
 
-@interface ASTextCellNode ()
-
-@property (nonatomic, strong) ASTextNode *textNode;
-
-@end
-
-
 @implementation ASTextCellNode
 
 static const CGFloat kASTextCellNodeDefaultFontSize = 18.0f;
@@ -420,7 +413,7 @@ static const CGFloat kASTextCellNodeDefaultVerticalPadding = 11.0f;
     _textInsets = textInsets;
     _textAttributes = [textAttributes copy];
     _textNode = [[ASTextNode alloc] init];
-    [self addSubnode:_textNode];
+    self.automaticallyManagesSubnodes = YES;
   }
   return self;
 }


### PR DESCRIPTION
Adds a (disabled) unit test for #2825.

This has the side effect of making ASTextCellNode use automatic subnode management. @garrettmoon @appleguy 