### PR TITLE
[ASTableNode] Fix returning nil from willSelectRowAtIndexPath

### DIFF
--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -911,6 +911,9 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
       return indexPath;
     } else {
       result = [_asyncDelegate tableNode:tableNode willSelectRowAtIndexPath:result];
+      if (result == nil) {
+        return nil; // If consumer explicitly returned nil, just pass it as-is to the table view.
+      }
       result = [self convertIndexPathFromTableNode:result waitingIfNeeded:YES];
       return result;
     }


### PR DESCRIPTION
Fixes #2840

Allow implementations of `-tableNode:willSelectRowAtIndexPath:` to return `nil`,
in order to match UIKit behavior. Previously, returning `nil` caused the first
cell node to become selected.