### PR TITLE
[ASVideoNode] Remove duplicated _delegate ivar

### DIFF
--- a/AsyncDisplayKit/ASVideoNode.mm
+++ b/AsyncDisplayKit/ASVideoNode.mm
@@ -40,7 +40,6 @@ static NSString * const kRate = @"rate";
 
 @interface ASVideoNode ()
 {
-  __weak id<ASVideoNodeDelegate> _delegate;
   struct {
     unsigned int delegateVideNodeShouldChangePlayerStateTo:1;
     unsigned int delegateVideoDidPlayToEnd:1;
@@ -84,6 +83,8 @@ static NSString * const kRate = @"rate";
 @end
 
 @implementation ASVideoNode
+
+@dynamic delegate;
 
 // TODO: Support preview images with HTTP Live Streaming videos.
 
@@ -160,7 +161,7 @@ static NSString * const kRate = @"rate";
   }
 
   if (_delegateFlags.delegateVideoNodeDidSetCurrentItem) {
-    [_delegate videoNode:self didSetCurrentItem:playerItem];
+    [self.delegate videoNode:self didSetCurrentItem:playerItem];
   }
 
   if (self.image == nil && self.URL == nil) {
@@ -331,7 +332,7 @@ static NSString * const kRate = @"rate";
       }
       if (_shouldBePlaying && (_shouldAggressivelyRecoverFromStall || likelyToKeepUp) && ASInterfaceStateIncludesVisible(self.interfaceState)) {
         if (self.playerState == ASVideoNodePlayerStateLoading && _delegateFlags.delegateVideoNodeDidRecoverFromStall) {
-          [_delegate videoNodeDidRecoverFromStall:self];
+          [self.delegate videoNodeDidRecoverFromStall:self];
         }
         [self play]; // autoresume after buffer catches up
       }
@@ -356,7 +357,7 @@ static NSString * const kRate = @"rate";
 - (void)tapped
 {
   if (_delegateFlags.delegateDidTapVideoNode) {
-    [_delegate didTapVideoNode:self];
+    [self.delegate didTapVideoNode:self];
     
   } else {
     if (_shouldBePlaying) {
@@ -380,14 +381,14 @@ static NSString * const kRate = @"rate";
 
   self.playerState = ASVideoNodePlayerStateLoading;
   if (_delegateFlags.delegateVideoNodeDidStartInitialLoading) {
-      [_delegate videoNodeDidStartInitialLoading:self];
+      [self.delegate videoNodeDidStartInitialLoading:self];
   }
   
   NSArray<NSString *> *requestedKeys = @[@"playable"];
   [asset loadValuesAsynchronouslyForKeys:requestedKeys completionHandler:^{
     ASPerformBlockOnMainThread(^{
       if (_delegateFlags.delegateVideoNodeDidFinishInitialLoading) {
-        [_delegate videoNodeDidFinishInitialLoading:self];
+        [self.delegate videoNodeDidFinishInitialLoading:self];
       }
       [self prepareToPlayAsset:asset withKeys:requestedKeys];
     });
@@ -402,7 +403,7 @@ static NSString * const kRate = @"rate";
   }
   
   if (_delegateFlags.delegateVideoNodeDidPlayToTimeInterval) {
-    [_delegate videoNode:self didPlayToTimeInterval:timeInSeconds];
+    [self.delegate videoNode:self didPlayToTimeInterval:timeInSeconds];
     
   }
 }
@@ -462,7 +463,7 @@ static NSString * const kRate = @"rate";
   }
   
   if (_delegateFlags.delegateVideoNodeWillChangePlayerStateToState) {
-    [_delegate videoNode:self willChangePlayerState:oldState toState:playerState];
+    [self.delegate videoNode:self willChangePlayerState:oldState toState:playerState];
   }
   
   _playerState = playerState;
@@ -561,28 +562,23 @@ static NSString * const kRate = @"rate";
   return (AVPlayerLayer *)_playerNode.layer;
 }
 
-- (id<ASVideoNodeDelegate>)delegate{
-  return _delegate;
-}
-
 - (void)setDelegate:(id<ASVideoNodeDelegate>)delegate
 {
   [super setDelegate:delegate];
-  _delegate = delegate;
   
-  if (_delegate == nil) {
+  if (delegate == nil) {
     memset(&_delegateFlags, 0, sizeof(_delegateFlags));
   } else {
-    _delegateFlags.delegateVideNodeShouldChangePlayerStateTo = [_delegate respondsToSelector:@selector(videoNode:shouldChangePlayerStateTo:)];
-    _delegateFlags.delegateVideoDidPlayToEnd = [_delegate respondsToSelector:@selector(videoDidPlayToEnd:)];
-    _delegateFlags.delegateDidTapVideoNode = [_delegate respondsToSelector:@selector(didTapVideoNode:)];
-    _delegateFlags.delegateVideoNodeWillChangePlayerStateToState = [_delegate respondsToSelector:@selector(videoNode:willChangePlayerState:toState:)];
-    _delegateFlags.delegateVideoNodeDidPlayToTimeInterval = [_delegate respondsToSelector:@selector(videoNode:didPlayToTimeInterval:)];
-    _delegateFlags.delegateVideoNodeDidStartInitialLoading = [_delegate respondsToSelector:@selector(videoNodeDidStartInitialLoading:)];
-    _delegateFlags.delegateVideoNodeDidFinishInitialLoading = [_delegate respondsToSelector:@selector(videoNodeDidFinishInitialLoading:)];
-    _delegateFlags.delegateVideoNodeDidSetCurrentItem = [_delegate respondsToSelector:@selector(videoNode:didSetCurrentItem:)];
-    _delegateFlags.delegateVideoNodeDidStallAtTimeInterval = [_delegate respondsToSelector:@selector(videoNode:didStallAtTimeInterval:)];
-    _delegateFlags.delegateVideoNodeDidRecoverFromStall = [_delegate respondsToSelector:@selector(videoNodeDidRecoverFromStall:)];
+    _delegateFlags.delegateVideNodeShouldChangePlayerStateTo = [delegate respondsToSelector:@selector(videoNode:shouldChangePlayerStateTo:)];
+    _delegateFlags.delegateVideoDidPlayToEnd = [delegate respondsToSelector:@selector(videoDidPlayToEnd:)];
+    _delegateFlags.delegateDidTapVideoNode = [delegate respondsToSelector:@selector(didTapVideoNode:)];
+    _delegateFlags.delegateVideoNodeWillChangePlayerStateToState = [delegate respondsToSelector:@selector(videoNode:willChangePlayerState:toState:)];
+    _delegateFlags.delegateVideoNodeDidPlayToTimeInterval = [delegate respondsToSelector:@selector(videoNode:didPlayToTimeInterval:)];
+    _delegateFlags.delegateVideoNodeDidStartInitialLoading = [delegate respondsToSelector:@selector(videoNodeDidStartInitialLoading:)];
+    _delegateFlags.delegateVideoNodeDidFinishInitialLoading = [delegate respondsToSelector:@selector(videoNodeDidFinishInitialLoading:)];
+    _delegateFlags.delegateVideoNodeDidSetCurrentItem = [delegate respondsToSelector:@selector(videoNode:didSetCurrentItem:)];
+    _delegateFlags.delegateVideoNodeDidStallAtTimeInterval = [delegate respondsToSelector:@selector(videoNode:didStallAtTimeInterval:)];
+    _delegateFlags.delegateVideoNodeDidRecoverFromStall = [delegate respondsToSelector:@selector(videoNodeDidRecoverFromStall:)];
   }
 }
 
@@ -674,7 +670,7 @@ static NSString * const kRate = @"rate";
 - (BOOL)isStateChangeValid:(ASVideoNodePlayerState)state
 {
   if (_delegateFlags.delegateVideNodeShouldChangePlayerStateTo) {
-    if (![_delegate videoNode:self shouldChangePlayerStateTo:state]) {
+    if (![self.delegate videoNode:self shouldChangePlayerStateTo:state]) {
       return NO;
     }
   }
@@ -701,7 +697,7 @@ static NSString * const kRate = @"rate";
 {
   self.playerState = ASVideoNodePlayerStateFinished;
   if (_delegateFlags.delegateVideoDidPlayToEnd) {
-    [_delegate videoDidPlayToEnd:self];
+    [self.delegate videoDidPlayToEnd:self];
   }
 
   if (_shouldAutorepeat) {
@@ -716,7 +712,7 @@ static NSString * const kRate = @"rate";
 {
   self.playerState = ASVideoNodePlayerStateLoading;
   if (_delegateFlags.delegateVideoNodeDidStallAtTimeInterval) {
-    [_delegate videoNode:self didStallAtTimeInterval:CMTimeGetSeconds(_player.currentItem.currentTime)];
+    [self.delegate videoNode:self didStallAtTimeInterval:CMTimeGetSeconds(_player.currentItem.currentTime)];
   }
 }
 

--- a/AsyncDisplayKitTests/ASVideoNodeTests.m
+++ b/AsyncDisplayKitTests/ASVideoNodeTests.m
@@ -25,12 +25,6 @@
 }
 @end
 
-@interface ASNetworkImageNode () {
-  @public __weak id<ASNetworkImageNodeDelegate> _delegate;
-}
-@end
-
-
 @interface ASVideoNode () {
   ASDisplayNode *_playerNode;
   AVPlayer *_player;
@@ -419,11 +413,9 @@
   XCTAssertTrue([_videoNode.delegate conformsToProtocol:@protocol(ASVideoNodeDelegate)]);
   XCTAssertTrue([_videoNode.delegate conformsToProtocol:@protocol(ASNetworkImageNodeDelegate)]);
   XCTAssertTrue([((ASNetworkImageNode*)_videoNode).delegate conformsToProtocol:@protocol(ASNetworkImageNodeDelegate)]);
-  XCTAssertTrue([((ASNetworkImageNode*)_videoNode)->_delegate conformsToProtocol:@protocol(ASNetworkImageNodeDelegate)]);
   
   XCTAssertEqual(_videoNode.delegate, self);
   XCTAssertEqual(((ASNetworkImageNode*)_videoNode).delegate, self);
-  XCTAssertEqual(((ASNetworkImageNode*)_videoNode)->_delegate, self);
 }
 
 @end


### PR DESCRIPTION
It's confusing to have 2 `_delegate` ivars at the same time: one `ASVideoNode` and another in its super class (e.g `ASNetworkImageNode`), and both of them are accessed/set by the same pair of getter/setter. It also introduces a bit of boilerplate code in `ASVideoNodeTests`.