### PR TITLE
Disable UICollectionView Prefetching to Improve Scroll Performance

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -280,7 +280,15 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
 {
   if (!(self = [super initWithFrame:frame collectionViewLayout:layout]))
     return nil;
-  
+
+  // Disable UICollectionView prefetching.
+  // Experiments done by Instagram show that this option being YES (default)
+  // when unused causes a significant hit to scroll performance.
+  // https://github.com/Instagram/IGListKit/issues/318
+  if (AS_AT_LEAST_IOS10) {
+    self.prefetchingEnabled = NO;
+  }
+
   _layoutController = [[ASCollectionViewLayoutController alloc] initWithCollectionView:self];
   
   _rangeController = [[ASRangeController alloc] init];


### PR DESCRIPTION
According to Instagram, having this option set to `YES` when unused degrades scroll performance ~5% https://github.com/Instagram/IGListKit/issues/318