### PR TITLE
[WIP][ASLayoutTransition] Relayout a node if one of its subnodes has a new size after layout transition

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -1072,9 +1072,6 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
       
       // Kick off animating the layout transition
       [self animateLayoutTransition:_pendingLayoutTransitionContext];
-      
-      // Mark transaction as finished
-      [self _finishOrCancelTransition];
     });
   };
   
@@ -1298,6 +1295,9 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   _pendingLayoutTransitionContext = nil;
 
   [self _pendingLayoutTransitionDidComplete];
+    
+  // Mark transaction as finished
+  [self _finishOrCancelTransition];
 }
 
 #pragma mark - Layout

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -1742,8 +1742,6 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
     // particular ASLayout object, and shouldn't loop asking again unless we have a different ASLayout.
     nextLayout->requestedLayoutFromAbove = YES;
     [self setNeedsLayoutFromAbove];
-    // Assuming the parent's update finished within `[self setNeedsLayoutFromAbove]`, this flag has served its purpose. Turn it off.
-    nextLayout->requestedLayoutFromAbove = NO;
   }
 
   // Prepare to transition to nextLayout

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -1046,6 +1046,7 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
       __instanceLock__.lock();
       
       if ([self _shouldAbortTransitionWithID:transitionID]) {
+        __instanceLock__.unlock();
         return;
       }
 

--- a/AsyncDisplayKit/UIImage+ASConvenience.m
+++ b/AsyncDisplayKit/UIImage+ASConvenience.m
@@ -12,8 +12,6 @@
 
 #import "UIImage+ASConvenience.h"
 #import <UIKit/UIKit.h>
-#import "ASInternalHelpers.h"
-#import "ASAssert.h"
 
 @implementation UIImage (ASDKAdditions)
 


### PR DESCRIPTION
- Revert 7872cfb because a transition isn't complete until its CAAnimation finishes. If `_transitionInProgress` flag is turned off before that, any layout pass occurs afterward, but before `-transitionContext:didComplete:` is called, can erase all pending states of the transition, causing old subviews to remain in the hierarchy forever.
- If a layout transition causes the node to have a different size, notify its supernode to resize. Currently we're already doing this with ASCellNode via measurement completion block, but not with normal ASDisplayNode. ASScrollNode in particular isn't notified and thus doesn't update its content size.

@maicki, @garrettmoon, @appleguy, @Adlai-Holler: Would love to have your feedbacks here.

@hannahmbanana Please help me to test this diff with Pinterest master. I already did that, as well as with ASDKLayoutTransition example and the sample projects in #2841 and #2816. However, with all the branch and context switchings, I may overlooked something. Gonna test it more tomorrow!

