### PR TITLE
[ASImageNode] Copy ASTextNode’s implementation of placeholderImage into ASImageNode in order to fix usage of ASImageNode.placeholderColor (#2865)

### DIFF
--- a/AsyncDisplayKit/ASImageNode.mm
+++ b/AsyncDisplayKit/ASImageNode.mm
@@ -27,6 +27,7 @@
 #import "ASEqualityHelpers.h"
 #import "ASEqualityHashHelpers.h"
 #import "ASWeakMap.h"
+#import "CoreGraphics+ASConvenience.h"
 
 // TODO: It would be nice to remove this dependency; it's the only subclass using more than +FrameworkSubclasses.h
 #import "ASDisplayNodeInternal.h"
@@ -181,6 +182,26 @@ struct ASImageNodeDrawParameters {
 {
   // Invalidate all components around animated images
   [self invalidateAnimatedImage];
+}
+
+- (UIImage *)placeholderImage
+{
+  // FIXME: Replace this implementation with reusable CALayers that have .backgroundColor set.
+  // This would completely eliminate the memory and performance cost of the backing store.
+  CGSize size = self.calculatedSize;
+  if ((size.width * size.height) < CGFLOAT_EPSILON) {
+    return nil;
+  }
+  
+  ASDN::MutexLocker l(__instanceLock__);
+  
+  UIGraphicsBeginImageContext(size);
+  [self.placeholderColor setFill];
+  UIRectFill(CGRectMake(0, 0, size.width, size.height));
+  UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
+  UIGraphicsEndImageContext();
+  
+  return image;
 }
 
 #pragma mark - Layout and Sizing

--- a/examples/Kittens/Sample/KittenNode.mm
+++ b/examples/Kittens/Sample/KittenNode.mm
@@ -88,10 +88,11 @@ static const CGFloat kInnerPadding = 10.0f;
   
   // kitten image, with a solid background colour serving as placeholder
   _imageNode = [[ASNetworkImageNode alloc] init];
-  _imageNode.backgroundColor = ASDisplayNodeDefaultPlaceholderColor();
   _imageNode.URL = [NSURL URLWithString:[NSString stringWithFormat:@"https://placekitten.com/%zd/%zd",
                                          (NSInteger)roundl(_kittenSize.width),
                                          (NSInteger)roundl(_kittenSize.height)]];
+  _imageNode.placeholderFadeDuration = .5;
+  _imageNode.placeholderColor = ASDisplayNodeDefaultPlaceholderColor();
   //  _imageNode.contentMode = UIViewContentModeCenter;
   [_imageNode addTarget:self action:@selector(toggleNodesSwap) forControlEvents:ASControlNodeEventTouchUpInside];
   [self addSubnode:_imageNode];


### PR DESCRIPTION
Implementation copied from ASTextNode: https://github.com/facebook/AsyncDisplayKit/blob/f637392a770ae193c41b7aadd9a01b49b335d9d3/AsyncDisplayKit/ASTextNode.mm#L849

Addresses: https://github.com/facebook/AsyncDisplayKit/issues/2865

Also updates the `Kitten` sample project to demonstrate the `placeholderColor`/`placeholderFadeDuration` APIs.