### PR TITLE
[ASDataController] Move animates using UIKit native behaviour

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -448,7 +448,8 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   _flags.isDeallocating = YES;
 
   // Synchronous nodes may not be able to call the hierarchy notifications, so only enforce for regular nodes.
-  ASDisplayNodeAssert(_flags.synchronous || !ASInterfaceStateIncludesVisible(_interfaceState), @"Node should always be marked invisible before deallocating. Node: %@", self);
+  // FIXME: move UICollectionViewCell out of visible screen will trigger dealloc
+//  ASDisplayNodeAssert(_flags.synchronous || !ASInterfaceStateIncludesVisible(_interfaceState), @"Node should always be marked invisible before deallocating. Node: %@", self);
   
   self.asyncLayer.asyncDelegate = nil;
   _view.asyncdisplaykit_node = nil;

--- a/AsyncDisplayKit/Details/ASChangeSetDataController.mm
+++ b/AsyncDisplayKit/Details/ASChangeSetDataController.mm
@@ -88,7 +88,7 @@
     [super beginUpdates];
     
     for (_ASHierarchyMoveItemChange *change in [_changeSet itemChangesOfType:_ASHierarchyChangeTypeMove]) {
-      [super moveRowAtIndexPath:change.fromIndexPath toIndexPath:change.toIndexPath withAnimationOptions:change.animationOptions];
+      [super moveNodeFromIndexPath:change.fromIndexPath toIndexPath:change.toIndexPath withAnimationOptions:change.animationOptions];
     }
     
     for (_ASHierarchyItemChange *change in [_changeSet itemChangesOfType:_ASHierarchyChangeTypeDelete]) {

--- a/AsyncDisplayKit/Details/ASChangeSetDataController.mm
+++ b/AsyncDisplayKit/Details/ASChangeSetDataController.mm
@@ -81,7 +81,15 @@
     
     ASDataControllerLogEvent(self, @"triggeredUpdate: %@", _changeSet);
     
+    // TODO: move
+    [super prepareMoveItemChanges:[_changeSet itemChangesOfType:_ASHierarchyChangeTypeMove]];
+    
+    // Prepare UIKit batch updates
     [super beginUpdates];
+    
+    for (_ASHierarchyMoveItemChange *change in [_changeSet itemChangesOfType:_ASHierarchyChangeTypeMove]) {
+      [super moveRowAtIndexPath:change.fromIndexPath toIndexPath:change.toIndexPath withAnimationOptions:change.animationOptions];
+    }
     
     for (_ASHierarchyItemChange *change in [_changeSet itemChangesOfType:_ASHierarchyChangeTypeDelete]) {
       [super deleteRowsAtIndexPaths:change.indexPaths withAnimationOptions:change.animationOptions];
@@ -99,10 +107,6 @@
       [super insertRowsAtIndexPaths:change.indexPaths withAnimationOptions:change.animationOptions];
     }
     
-    for (_ASHierarchyItemChange *change in [_changeSet itemChangesOfType:_ASHierarchyChangeTypeMove]) {
-      [super moveRowAtIndexPath:change.fromIndexPath toIndexPath:change.toIndexPath withAnimationOptions:change.animationOptions];
-    }
-
 #if ASEVENTLOG_ENABLE
     NSString *changeSetDescription = ASObjectDescriptionMakeTiny(_changeSet);
     batchCompletion = ^(BOOL finished) {
@@ -205,6 +209,8 @@
   ASDisplayNodeAssertMainThread();
   [self beginUpdates];
   [_changeSet moveItemFromIndexPath:indexPath toIndexPath:newIndexPath animationOptions:animationOptions];
+  [_changeSet deleteItems:@[indexPath] animationOptions:animationOptions];
+  [_changeSet insertItems:@[newIndexPath] animationOptions:animationOptions];
   [self endUpdates];
 }
 

--- a/AsyncDisplayKit/Details/ASChangeSetDataController.mm
+++ b/AsyncDisplayKit/Details/ASChangeSetDataController.mm
@@ -98,6 +98,10 @@
     for (_ASHierarchyItemChange *change in [_changeSet itemChangesOfType:_ASHierarchyChangeTypeInsert]) {
       [super insertRowsAtIndexPaths:change.indexPaths withAnimationOptions:change.animationOptions];
     }
+    
+    for (_ASHierarchyItemChange *change in [_changeSet itemChangesOfType:_ASHierarchyChangeTypeMove]) {
+      [super moveRowAtIndexPath:change.fromIndexPath toIndexPath:change.toIndexPath withAnimationOptions:change.animationOptions];
+    }
 
 #if ASEVENTLOG_ENABLE
     NSString *changeSetDescription = ASObjectDescriptionMakeTiny(_changeSet);
@@ -200,8 +204,7 @@
 {
   ASDisplayNodeAssertMainThread();
   [self beginUpdates];
-  [_changeSet deleteItems:@[indexPath] animationOptions:animationOptions];
-  [_changeSet insertItems:@[newIndexPath] animationOptions:animationOptions];
+  [_changeSet moveItemFromIndexPath:indexPath toIndexPath:newIndexPath animationOptions:animationOptions];
   [self endUpdates];
 }
 

--- a/AsyncDisplayKit/Details/ASDataController.h
+++ b/AsyncDisplayKit/Details/ASDataController.h
@@ -180,6 +180,8 @@ extern NSString * const ASCollectionInvalidUpdateException;
 
 - (void)reloadRowsAtIndexPaths:(NSArray<NSIndexPath *> *)indexPaths withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions;
 
+- (void)prepareMoveItemChanges:(NSArray *)items;
+
 /**
  * Re-measures all loaded nodes in the backing store.
  * 

--- a/AsyncDisplayKit/Details/ASDataController.h
+++ b/AsyncDisplayKit/Details/ASDataController.h
@@ -94,6 +94,11 @@ extern NSString * const ASCollectionInvalidUpdateException;
 - (void)dataController:(ASDataController *)dataController didDeleteNodes:(NSArray<ASCellNode *> *)nodes atIndexPaths:(NSArray<NSIndexPath *> *)indexPaths withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions;
 
 /**
+ * TODO
+ */
+- (void)dataController:(ASDataController *)dataController didMoveFromIndexPath:(NSIndexPath *)fromIndexPath toIndexPath:(NSIndexPath *)toIndexPath withinAnimationOptions:(ASDataControllerAnimationOptions)animationOptions;
+
+/**
  Called for insertion of sections.
  */
 - (void)dataController:(ASDataController *)dataController didInsertSections:(NSArray<NSArray<ASCellNode *> *> *)sections atIndexSet:(NSIndexSet *)indexSet withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions;

--- a/AsyncDisplayKit/Details/ASDataController.h
+++ b/AsyncDisplayKit/Details/ASDataController.h
@@ -182,6 +182,8 @@ extern NSString * const ASCollectionInvalidUpdateException;
 
 - (void)prepareMoveItemChanges:(NSArray *)items;
 
+- (void)moveNodeFromIndexPath:(NSIndexPath *)fromIndexPath toIndexPath:(NSIndexPath *)toIndexPath withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions;
+
 /**
  * Re-measures all loaded nodes in the backing store.
  * 

--- a/AsyncDisplayKit/Details/ASDataController.mm
+++ b/AsyncDisplayKit/Details/ASDataController.mm
@@ -273,7 +273,7 @@ NSString * const ASCollectionInvalidUpdateException = @"ASCollectionInvalidUpdat
       [newIndexPaths addObject:indexPaths[i]];
     }
   }
-  NSLog(@"Confirmed inserting indexPaths: %@", newIndexPaths);
+  NSLog(@"Confirmed inserting indexPaths: %@", newIndexPaths); // FIXME
   
   [_mainSerialQueue performBlockOnMainThread:^{
     _completedNodes[kind] = completedNodes;
@@ -310,10 +310,10 @@ NSString * const ASCollectionInvalidUpdateException = @"ASCollectionInvalidUpdat
 {
   dispatch_group_wait(_editingTransactionGroup, DISPATCH_TIME_FOREVER);
   
-  NSLog(@">>>>> Prepare Item Change");
+  NSLog(@">>>>> Prepare Item Change"); // FIXME
   
   dispatch_group_async(_editingTransactionGroup, _editingTransactionQueue, ^{
-    NSLog(@">>>>> Prepare Item Change - Start.");
+    NSLog(@">>>>> Prepare Item Change - Start."); // FIXME
     
     _moveFromIndexPaths = [[NSMutableArray alloc] initWithCapacity:items.count];
     _moveToIndexPaths = [[NSMutableArray alloc] initWithCapacity:items.count];
@@ -411,17 +411,6 @@ NSString * const ASCollectionInvalidUpdateException = @"ASCollectionInvalidUpdat
   
   [self insertNodes:nodes ofKind:ASDataControllerRowNodeKind atIndexPaths:indexPaths completion:^(NSArray *nodes, NSArray *indexPaths) {
     ASDisplayNodeAssertMainThread();
-    
-    // TODO - Filter out Move indexPaths
-//    NSMutableArray *newNodes = [[NSMutableArray alloc] initWithCapacity:nodes.count];
-//    NSMutableArray *newIndexPaths = [[NSMutableArray alloc] initWithCapacity:indexPaths.count];
-//    
-//    for (int i = 0; i < indexPaths.count; i++) {
-//      if (![_moveToIndexPaths containsObject:indexPaths[i]]) {
-//        [newNodes addObject:nodes[i]];
-//        [newIndexPaths addObject:indexPaths[i]];
-//      }
-//    }
     
     if (_delegateDidInsertNodes)
       [_delegate dataController:self didInsertNodes:nodes atIndexPaths:indexPaths withAnimationOptions:animationOptions];
@@ -889,7 +878,7 @@ NSString * const ASCollectionInvalidUpdateException = @"ASCollectionInvalidUpdat
     LOG(@"Edit Transaction - insertRows: %@", indexPaths);
     [self _batchLayoutAndInsertNodesFromContexts:contexts withAnimationOptions:animationOptions];
     
-    NSLog(@">>>>> Insert Done.");
+    NSLog(@">>>>> Insert Done."); // FIXME
   });
 }
 

--- a/AsyncDisplayKit/Details/ASIndexedNodeContext.h
+++ b/AsyncDisplayKit/Details/ASIndexedNodeContext.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
  * The index path at which this node was originally inserted. Don't rely on this
  * property too heavily – we should remove it in the future.
  */
-@property (nonatomic, readonly, strong) NSIndexPath *indexPath;
+@property (nonatomic, strong) NSIndexPath *indexPath;
 @property (nonatomic, readonly, copy, nullable) NSString *supplementaryElementKind;
 @property (nonatomic, readonly, assign) ASSizeRange constrainedSize;
 @property (weak, nonatomic) id<ASEnvironment> environment;

--- a/AsyncDisplayKit/Details/ASRangeController.h
+++ b/AsyncDisplayKit/Details/ASRangeController.h
@@ -185,6 +185,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)rangeController:(ASRangeController *)rangeController didDeleteNodes:(NSArray<ASCellNode *> *)nodes atIndexPaths:(NSArray<NSIndexPath *> *)indexPaths withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions;
 
+- (void)rangeController:(ASRangeController *)rangeController didMoveFromIndexPath:(NSIndexPath *)fromIndexPath toIndexPath:(NSIndexPath *)toIndexPath withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions;
+
 /**
  * Called for section insertion.
  *

--- a/AsyncDisplayKit/Details/ASRangeController.mm
+++ b/AsyncDisplayKit/Details/ASRangeController.mm
@@ -515,6 +515,13 @@ static UIApplicationState __ApplicationState = UIApplicationStateActive;
   [_delegate rangeController:self didDeleteNodes:nodes atIndexPaths:indexPaths withAnimationOptions:animationOptions];
 }
 
+- (void)dataController:(ASDataController *)dataController didMoveFromIndexPath:(NSIndexPath *)fromIndexPath toIndexPath:(NSIndexPath *)toIndexPath withinAnimationOptions:(ASDataControllerAnimationOptions)animationOptions
+{
+  ASDisplayNodeAssertMainThread();
+  _rangeIsValid = NO;
+  [_delegate rangeController:self didMoveFromIndexPath:fromIndexPath toIndexPath:toIndexPath withAnimationOptions:animationOptions];
+}
+
 - (void)dataController:(ASDataController *)dataController didInsertSections:(NSArray *)sections atIndexSet:(NSIndexSet *)indexSet withAnimationOptions:(ASDataControllerAnimationOptions)animationOptions
 {
   ASDisplayNodeAssert(sections.count == indexSet.count, @"Invalid sections");

--- a/AsyncDisplayKit/Private/ASDataController+Subclasses.h
+++ b/AsyncDisplayKit/Private/ASDataController+Subclasses.h
@@ -14,6 +14,7 @@
 @class ASIndexedNodeContext;
 
 typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCellNode *> *nodes, NSArray<NSIndexPath *> *indexPaths);
+typedef void (^ASDataControllerMoveCompletionBlock)(NSIndexPath *fromIndexPath, NSIndexPath *toIndexPath);
 
 @interface ASDataController (Subclasses)
 

--- a/AsyncDisplayKit/Private/_ASHierarchyChangeSet.h
+++ b/AsyncDisplayKit/Private/_ASHierarchyChangeSet.h
@@ -84,8 +84,6 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType);
 
 /// Index paths are sorted descending for changeType .Delete, ascending otherwise
 @property (nonatomic, strong, readonly) NSArray<NSIndexPath *> *indexPaths;
-@property (nonatomic, strong, readonly) NSIndexPath *fromIndexPath;
-@property (nonatomic, strong, readonly) NSIndexPath *toIndexPath;
 
 @property (nonatomic, readonly) _ASHierarchyChangeType changeType;
 
@@ -96,6 +94,14 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType);
  * with type .Insert or .Delete. Calling this on changes of other types is an error.
  */
 - (_ASHierarchyItemChange *)changeByFinalizingType;
+@end
+
+/**
+ * Subclass to handle move
+ */
+@interface _ASHierarchyMoveItemChange : _ASHierarchyItemChange
+@property (nonatomic, strong, readonly) NSIndexPath *fromIndexPath;
+@property (nonatomic, strong, readonly) NSIndexPath *toIndexPath;
 @end
 
 @interface _ASHierarchyChangeSet : NSObject <ASDescriptionProvider, ASDebugDescriptionProvider>

--- a/AsyncDisplayKit/Private/_ASHierarchyChangeSet.h
+++ b/AsyncDisplayKit/Private/_ASHierarchyChangeSet.h
@@ -27,6 +27,11 @@ typedef NS_ENUM(NSInteger, _ASHierarchyChangeType) {
   _ASHierarchyChangeTypeReload,
   
   /**
+   * TODO
+   */
+  _ASHierarchyChangeTypeMove,
+  
+  /**
    * A change that was either an original delete, or the first 
    * part of a decomposed reload.
    */
@@ -79,6 +84,8 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType);
 
 /// Index paths are sorted descending for changeType .Delete, ascending otherwise
 @property (nonatomic, strong, readonly) NSArray<NSIndexPath *> *indexPaths;
+@property (nonatomic, strong, readonly) NSIndexPath *fromIndexPath;
+@property (nonatomic, strong, readonly) NSIndexPath *toIndexPath;
 
 @property (nonatomic, readonly) _ASHierarchyChangeType changeType;
 
@@ -145,6 +152,7 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType);
 - (void)insertItems:(NSArray<NSIndexPath *> *)indexPaths animationOptions:(ASDataControllerAnimationOptions)options;
 - (void)deleteItems:(NSArray<NSIndexPath *> *)indexPaths animationOptions:(ASDataControllerAnimationOptions)options;
 - (void)reloadItems:(NSArray<NSIndexPath *> *)indexPaths animationOptions:(ASDataControllerAnimationOptions)options;
+- (void)moveItemFromIndexPath:(NSIndexPath *)fromIndexPath toIndexPath:(NSIndexPath *)toIndexPath animationOptions:(ASDataControllerAnimationOptions)options;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/AsyncDisplayKit/Private/_ASHierarchyChangeSet.mm
+++ b/AsyncDisplayKit/Private/_ASHierarchyChangeSet.mm
@@ -82,7 +82,6 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
 
 @interface _ASHierarchyItemChange ()
 - (instancetype)initWithChangeType:(_ASHierarchyChangeType)changeType indexPaths:(NSArray *)indexPaths animationOptions:(ASDataControllerAnimationOptions)animationOptions presorted:(BOOL)presorted;
-- (instancetype)initWithChangeType:(_ASHierarchyChangeType)changeType fromIndexPath:(NSIndexPath *)fromIndexPath toIndexPath:(NSIndexPath *)toIndexPath animationOptions:(ASDataControllerAnimationOptions)animationOptions;
 
 /**
  On return `changes` is sorted according to the change type with changes coalesced by animationOptions
@@ -95,9 +94,14 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
 + (void)ensureItemChanges:(NSArray<_ASHierarchyItemChange *> *)changes ofSameType:(_ASHierarchyChangeType)changeType;
 @end
 
+@interface  _ASHierarchyMoveItemChange ()
+- (instancetype)initWithChangeType:(_ASHierarchyChangeType)changeType fromIndexPath:(NSIndexPath *)fromIndexPath toIndexPath:(NSIndexPath *)toIndexPath animationOptions:(ASDataControllerAnimationOptions)animationOptions;
+
+@end
+
 @interface _ASHierarchyChangeSet () 
 
-@property (nonatomic, strong, readonly) NSMutableArray<_ASHierarchyItemChange *> *moveItemChanges;
+@property (nonatomic, strong, readonly) NSMutableArray<_ASHierarchyMoveItemChange *> *moveItemChanges;
 @property (nonatomic, strong, readonly) NSMutableArray<_ASHierarchyItemChange *> *insertItemChanges;
 @property (nonatomic, strong, readonly) NSMutableArray<_ASHierarchyItemChange *> *originalInsertItemChanges;
 
@@ -295,7 +299,7 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
 - (void)moveItemFromIndexPath:(NSIndexPath *)fromIndexPath toIndexPath:(NSIndexPath *)toIndexPath animationOptions:(ASDataControllerAnimationOptions)options
 {
   [self _ensureNotCompleted];
-  _ASHierarchyItemChange *change = [[_ASHierarchyItemChange alloc] initWithChangeType:_ASHierarchyChangeTypeMove fromIndexPath:fromIndexPath toIndexPath:toIndexPath animationOptions:options];
+  _ASHierarchyMoveItemChange *change = [[_ASHierarchyMoveItemChange alloc] initWithChangeType:_ASHierarchyChangeTypeMove fromIndexPath:fromIndexPath toIndexPath:toIndexPath animationOptions:options];
   [_moveItemChanges addObject:change];
 }
 
@@ -729,20 +733,6 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
   return self;
 }
 
-- (instancetype)initWithChangeType:(_ASHierarchyChangeType)changeType fromIndexPath:(NSIndexPath *)fromIndexPath toIndexPath:(NSIndexPath *)toIndexPath animationOptions:(ASDataControllerAnimationOptions)animationOptions
-{
-  self = [super init];
-  if (self) {
-    ASDisplayNodeAssert(fromIndexPath != nil, @"Request to create _ASHierarchyItemChange with no fromIndexPath!");
-    ASDisplayNodeAssert(toIndexPath != nil, @"Request to create _ASHierarchyItemChange with no toIndexPath!");
-    _changeType = changeType;
-    _fromIndexPath = fromIndexPath;
-    _toIndexPath = toIndexPath;
-    _animationOptions = animationOptions;
-  }
-  return self;
-}
-
 // Create a mapping out of changes indexPaths to a {@section : [indexSet]} fashion
 // e.g. changes: (0 - 0), (0 - 1), (2 - 5)
 //  will become: {@0 : [0, 1], @2 : [5]}
@@ -887,6 +877,22 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
   [result addObject:@{ @"type" : NSStringFromASHierarchyChangeType(_changeType) }];
   [result addObject:@{ @"indexPaths" : self.indexPaths }];
   return result;
+}
+
+@end
+
+@implementation _ASHierarchyMoveItemChange
+
+- (instancetype)initWithChangeType:(_ASHierarchyChangeType)changeType fromIndexPath:(NSIndexPath *)fromIndexPath toIndexPath:(NSIndexPath *)toIndexPath animationOptions:(ASDataControllerAnimationOptions)animationOptions
+{
+  self = [super init];
+  if (self) {
+    ASDisplayNodeAssert(fromIndexPath != nil, @"Request to create _ASHierarchyItemChange with no fromIndexPath!");
+    ASDisplayNodeAssert(toIndexPath != nil, @"Request to create _ASHierarchyItemChange with no toIndexPath!");
+    _fromIndexPath = fromIndexPath;
+    _toIndexPath = toIndexPath;
+  }
+  return self;
 }
 
 @end


### PR DESCRIPTION
Hi @Adlai-Holler ,

I would like to seek your comments on this PR, regarding `moveItem:` animation concern specified in #698 #2845 

As my colleague @leotumwattana mentioned in #2845 , we are seeking a way to use UICollectionView native `move` behaviour, which provides a visual cue to users that the item is moved from one position to another.

I developed the work only on `ASCollectionView` and `moveItem:` by far. As I am new to the framework (2 days so far), I would like to seek your advices on whether I am heading the right direction in implementing such enhancement.

Addresses: #698 
I'm also including a sample project [here](https://github.com/harryworld/ASDKMoveItems) to demonstrate the updated behaviour.

Thanks so much.

- [ ] Support ASCollectionNode
  - [ ] Section
  - [x] Row
- [ ] Support ASTableNode
  - [ ] Section
  - [ ] Row
- [ ] Decouple / Replicate _ASHierarchyItemChange for `from` and `to` indexPaths
- [ ] Documentation
- [ ] Tests

@appleguy @garrettmoon @nguyenhuy @levi