### PR TITLE
[ASVideoNode] Should play when its player is ready and if it is expected to play

### DIFF
--- a/AsyncDisplayKit/ASVideoNode.mm
+++ b/AsyncDisplayKit/ASVideoNode.mm
@@ -314,6 +314,9 @@ static NSString * const kRate = @"rate";
       if ([change[NSKeyValueChangeNewKey] integerValue] == AVPlayerItemStatusReadyToPlay) {
         if (self.playerState != ASVideoNodePlayerStatePlaying) {
           self.playerState = ASVideoNodePlayerStateReadyToPlay;
+          if (_shouldBePlaying && ASInterfaceStateIncludesVisible(self.interfaceState)) {
+            [self play];
+          }
         }
         // If we don't yet have a placeholder image update it now that we should have data available for it
         if (self.image == nil && self.URL == nil) {


### PR DESCRIPTION
- When a video node is first visible, it's player is called to play if `_shouldAutoplay` flag is on. However, the player might not be ready by that time, especially when the video is loaded on a slow network. The player just continues loading its asset.
- When the player is ready, we should check if it is expected to be playing and if true, try to play again.

Tested on sample project provided in #2835, under DSL network (Network Link Conditioner).