### PR TITLE
Remove Buck abstract target in Podfile

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -2,16 +2,15 @@ source 'https://github.com/CocoaPods/Specs.git'
 
 platform :ios, '7.0'
 
-#TODO CocoaPods plugin instead?
-abstract_target 'Buck' do
+target :'AsyncDisplayKitTests' do
+  pod 'OCMock', '~> 2.2'
+  pod 'FBSnapshotTestCase/Core', '~> 2.1'
+  pod 'JGMethodSwizzler', :git => 'https://github.com/JonasGessner/JGMethodSwizzler', :branch => 'master'
+
+  # Only for buck build
   pod 'PINRemoteImage', '3.0.0-beta.7'
 
-  target :'AsyncDisplayKitTests' do
-    pod 'OCMock', '~> 2.2'
-    pod 'FBSnapshotTestCase/Core', '~> 2.1'
-    pod 'JGMethodSwizzler', :git => 'https://github.com/JonasGessner/JGMethodSwizzler', :branch => 'master'
-  end
-
+  #TODO CocoaPods plugin instead?
   post_install do |installer|
     require 'fileutils'
 


### PR DESCRIPTION
I've just realized that the new Buck abstract target can mess up with tests target. Since the post_install hook is the only necessary thing, let's remove buck target.