### PR TITLE
Pin Collection cellNode.frame = contentView.bounds

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -119,6 +119,15 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   self.layoutAttributes = layoutAttributes;
 }
 
+/**
+ * Keep our node filling our content view.
+ */
+- (void)layoutSubviews
+{
+  [super layoutSubviews];
+  self.node.frame = self.contentView.bounds;
+}
+
 @end
 
 #pragma mark -


### PR DESCRIPTION
Resolves #2659 

Doing the same thing for `_ASTableViewCell` is actually pretty complex because we have a separate architecture for handling content view size changes. This is at least a step forward.