### PR TITLE
[Nitpick] Update CocoaPod badges to be dynamic.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![AsyncDisplayKit](https://github.com/AsyncDisplayKit/Documentation/raw/master/docs/static/images/logo.png)
 
-[![Apps Using](https://img.shields.io/badge/Apps%20Using%20ASDK-%3E4,974-28B9FE.svg)](http://cocoapods.org/pods/AsyncDisplayKit)
-[![Downloads](https://img.shields.io/badge/Total%20Downloads-%3E512,000-28B9FE.svg)](http://cocoapods.org/pods/AsyncDisplayKit)
+[![Apps Using](https://img.shields.io/cocoapods/at/AsyncDisplayKit.svg?label=Apps%20Using%20ASDK&colorB=28B9FE)](http://cocoapods.org/pods/AsyncDisplayKit)
+[![Downloads](https://img.shields.io/cocoapods/dt/AsyncDisplayKit.svg?label=Total%20Downloads&colorB=28B9FE)](http://cocoapods.org/pods/AsyncDisplayKit)
 
 [![Platform](https://img.shields.io/badge/platforms-iOS%20%7C%20tvOS-orange.svg)](http://AsyncDisplayKit.org)
 [![Languages](https://img.shields.io/badge/languages-ObjC%20%7C%20Swift-orange.svg)](http://AsyncDisplayKit.org)


### PR DESCRIPTION
This updates the values automatically, which is perfect to reflect the growth of ASDK. I've wanted to do this for ages but the shield.io API didn't have the support up till now. We lose some granularity but I think this is worth it.

Maybe @hannahmbanana or @nguyenhuy could take a quick look. Sorry it's been a while since I've kept up to date with the project, not sure if @appleguy is still directly involved.