### PR TITLE
Use Native convertRect:, convertPoint: Methods to Handle Nil Cases

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -1806,10 +1806,18 @@ static inline CATransform3D _calculateTransformFromReferenceToTarget(ASDisplayNo
 {
   ASDisplayNodeAssertThreadAffinity(self);
   
+  /**
+   * When passed node=nil, all methods in this family use the UIView-style
+   * behavior – that is, convert from/to window coordinates if there's a window,
+   * otherwise return the point untransformed.
+   */
   if (node == nil && self.nodeLoaded) {
     CALayer *layer = self.layer;
-    UIWindow *window = ASFindWindowOfLayer(layer);
-    return [layer convertPoint:point fromLayer:window.layer];
+    if (UIWindow *window = ASFindWindowOfLayer(layer)) {
+      return [layer convertPoint:point fromLayer:window.layer];
+    } else {
+      return point;
+    }
   }
   
   // Get root node of the accessible node hierarchy, if node not specified
@@ -1830,8 +1838,11 @@ static inline CATransform3D _calculateTransformFromReferenceToTarget(ASDisplayNo
   
   if (node == nil && self.nodeLoaded) {
     CALayer *layer = self.layer;
-    UIWindow *window = ASFindWindowOfLayer(layer);
-    return [layer convertPoint:point toLayer:window.layer];
+    if (UIWindow *window = ASFindWindowOfLayer(layer)) {
+      return [layer convertPoint:point toLayer:window.layer];
+    } else {
+      return point;
+    }
   }
   
   // Get root node of the accessible node hierarchy, if node not specified
@@ -1852,8 +1863,11 @@ static inline CATransform3D _calculateTransformFromReferenceToTarget(ASDisplayNo
   
   if (node == nil && self.nodeLoaded) {
     CALayer *layer = self.layer;
-    UIWindow *window = ASFindWindowOfLayer(layer);
-    return [layer convertRect:rect fromLayer:window.layer];
+    if (UIWindow *window = ASFindWindowOfLayer(layer)) {
+      return [layer convertRect:rect fromLayer:window.layer];
+    } else {
+      return rect;
+    }
   }
   
   // Get root node of the accessible node hierarchy, if node not specified
@@ -1874,8 +1888,11 @@ static inline CATransform3D _calculateTransformFromReferenceToTarget(ASDisplayNo
   
   if (node == nil && self.nodeLoaded) {
     CALayer *layer = self.layer;
-    UIWindow *window = ASFindWindowOfLayer(layer);
-    return [layer convertRect:rect toLayer:window.layer];
+    if (UIWindow *window = ASFindWindowOfLayer(layer)) {
+      return [layer convertRect:rect toLayer:window.layer];
+    } else {
+      return rect;
+    }
   }
   
   // Get root node of the accessible node hierarchy, if node not specified

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -1807,11 +1807,9 @@ static inline CATransform3D _calculateTransformFromReferenceToTarget(ASDisplayNo
   ASDisplayNodeAssertThreadAffinity(self);
   
   if (node == nil && self.nodeLoaded) {
-    if (self.layerBacked) {
-      return [self.layer convertPoint:point fromLayer:nil];
-    } else {
-      return [self.view convertPoint:point fromView:nil];
-    }
+    CALayer *layer = self.layer;
+    UIWindow *window = ASFindWindowOfLayer(layer);
+    return [layer convertPoint:point fromLayer:window.layer];
   }
   
   // Get root node of the accessible node hierarchy, if node not specified
@@ -1831,11 +1829,9 @@ static inline CATransform3D _calculateTransformFromReferenceToTarget(ASDisplayNo
   ASDisplayNodeAssertThreadAffinity(self);
   
   if (node == nil && self.nodeLoaded) {
-    if (self.layerBacked) {
-      return [self.layer convertPoint:point toLayer:nil];
-    } else {
-      return [self.view convertPoint:point toView:nil];
-    }
+    CALayer *layer = self.layer;
+    UIWindow *window = ASFindWindowOfLayer(layer);
+    return [layer convertPoint:point toLayer:window.layer];
   }
   
   // Get root node of the accessible node hierarchy, if node not specified
@@ -1855,11 +1851,9 @@ static inline CATransform3D _calculateTransformFromReferenceToTarget(ASDisplayNo
   ASDisplayNodeAssertThreadAffinity(self);
   
   if (node == nil && self.nodeLoaded) {
-    if (self.layerBacked) {
-      return [self.layer convertRect:rect fromLayer:nil];
-    } else {
-      return [self.view convertRect:rect fromView:nil];
-    }
+    CALayer *layer = self.layer;
+    UIWindow *window = ASFindWindowOfLayer(layer);
+    return [layer convertRect:rect fromLayer:window.layer];
   }
   
   // Get root node of the accessible node hierarchy, if node not specified
@@ -1879,11 +1873,9 @@ static inline CATransform3D _calculateTransformFromReferenceToTarget(ASDisplayNo
   ASDisplayNodeAssertThreadAffinity(self);
   
   if (node == nil && self.nodeLoaded) {
-    if (self.layerBacked) {
-      return [self.layer convertRect:rect toLayer:nil];
-    } else {
-      return [self.view convertRect:rect toView:nil];
-    }
+    CALayer *layer = self.layer;
+    UIWindow *window = ASFindWindowOfLayer(layer);
+    return [layer convertRect:rect toLayer:window.layer];
   }
   
   // Get root node of the accessible node hierarchy, if node not specified

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -1805,6 +1805,15 @@ static inline CATransform3D _calculateTransformFromReferenceToTarget(ASDisplayNo
 - (CGPoint)convertPoint:(CGPoint)point fromNode:(ASDisplayNode *)node
 {
   ASDisplayNodeAssertThreadAffinity(self);
+  
+  if (node == nil && self.nodeLoaded) {
+    if (self.layerBacked) {
+      return [self.layer convertPoint:point fromLayer:nil];
+    } else {
+      return [self.view convertPoint:point fromView:nil];
+    }
+  }
+  
   // Get root node of the accessible node hierarchy, if node not specified
   node = node ? : ASDisplayNodeUltimateParentOfNode(self);
 
@@ -1820,6 +1829,15 @@ static inline CATransform3D _calculateTransformFromReferenceToTarget(ASDisplayNo
 - (CGPoint)convertPoint:(CGPoint)point toNode:(ASDisplayNode *)node
 {
   ASDisplayNodeAssertThreadAffinity(self);
+  
+  if (node == nil && self.nodeLoaded) {
+    if (self.layerBacked) {
+      return [self.layer convertPoint:point toLayer:nil];
+    } else {
+      return [self.view convertPoint:point toView:nil];
+    }
+  }
+  
   // Get root node of the accessible node hierarchy, if node not specified
   node = node ? : ASDisplayNodeUltimateParentOfNode(self);
 
@@ -1835,6 +1853,15 @@ static inline CATransform3D _calculateTransformFromReferenceToTarget(ASDisplayNo
 - (CGRect)convertRect:(CGRect)rect fromNode:(ASDisplayNode *)node
 {
   ASDisplayNodeAssertThreadAffinity(self);
+  
+  if (node == nil && self.nodeLoaded) {
+    if (self.layerBacked) {
+      return [self.layer convertRect:rect fromLayer:nil];
+    } else {
+      return [self.view convertRect:rect fromView:nil];
+    }
+  }
+  
   // Get root node of the accessible node hierarchy, if node not specified
   node = node ? : ASDisplayNodeUltimateParentOfNode(self);
 
@@ -1850,6 +1877,15 @@ static inline CATransform3D _calculateTransformFromReferenceToTarget(ASDisplayNo
 - (CGRect)convertRect:(CGRect)rect toNode:(ASDisplayNode *)node
 {
   ASDisplayNodeAssertThreadAffinity(self);
+  
+  if (node == nil && self.nodeLoaded) {
+    if (self.layerBacked) {
+      return [self.layer convertRect:rect toLayer:nil];
+    } else {
+      return [self.view convertRect:rect toView:nil];
+    }
+  }
+  
   // Get root node of the accessible node hierarchy, if node not specified
   node = node ? : ASDisplayNodeUltimateParentOfNode(self);
 

--- a/AsyncDisplayKit/ASDisplayNodeExtras.h
+++ b/AsyncDisplayKit/ASDisplayNodeExtras.h
@@ -126,6 +126,11 @@ extern ASDisplayNode * _Nullable ASDisplayNodeFindFirstSupernode(ASDisplayNode *
 extern __kindof ASDisplayNode * _Nullable ASDisplayNodeFindFirstSupernodeOfClass(ASDisplayNode *start, Class c) AS_WARN_UNUSED_RESULT;
 
 /**
+ * Given a layer, find the window it lives in, if any.
+ */
+extern UIWindow * _Nullable ASFindWindowOfLayer(CALayer *layer) AS_WARN_UNUSED_RESULT;
+
+/**
  * Given two nodes, finds their most immediate common parent.  Used for geometry conversion methods.
  * NOTE: It is an error to try to convert between nodes which do not share a common ancestor. This behavior is
  * disallowed in UIKit documentation and the behavior is left undefined. The output does not have a rigorously defined

--- a/AsyncDisplayKit/ASDisplayNodeExtras.mm
+++ b/AsyncDisplayKit/ASDisplayNodeExtras.mm
@@ -249,6 +249,21 @@ static inline BOOL _ASDisplayNodeIsAncestorOfDisplayNode(ASDisplayNode *possible
   return NO;
 }
 
+extern UIWindow * _Nullable ASFindWindowOfLayer(CALayer *layer)
+{
+  while (layer != nil) {
+    if (UIView *view = ASDynamicCast(layer.delegate, UIView)) {
+      if ([view isKindOfClass:[UIWindow class]]) {
+        return (UIWindow *)view;
+      } else {
+        return view.window;
+      }
+    }
+    layer = layer.superlayer;
+  }
+  return nil;
+}
+
 extern ASDisplayNode *ASDisplayNodeFindClosestCommonAncestor(ASDisplayNode *node1, ASDisplayNode *node2)
 {
   ASDisplayNode *possibleAncestor = node1;

--- a/AsyncDisplayKitTests/ASDisplayNodeTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeTests.m
@@ -2288,4 +2288,15 @@ static bool stringContainsPointer(NSString *description, id p) {
   ASXCTAssertEqualPoints([node convertPoint:node.bounds.origin toNode:nil], expectedOrigin);
 }
 
+- (void)testThatConvertPointGoesToWindowWhenPassedNil_layerBacked
+{
+  UIWindow *window = [[UIWindow alloc] initWithFrame:CGRectMake(0, 0, 20, 20)];
+  ASDisplayNode *node = [[ASDisplayNode alloc] init];
+  node.layerBacked = YES;
+  node.frame = CGRectMake(10, 10, 10, 10);
+  [window addSubnode:node];
+  CGPoint expectedOrigin = CGPointMake(10, 10);
+  ASXCTAssertEqualPoints([node convertPoint:node.bounds.origin toNode:nil], expectedOrigin);
+}
+
 @end

--- a/AsyncDisplayKitTests/ASDisplayNodeTests.m
+++ b/AsyncDisplayKitTests/ASDisplayNodeTests.m
@@ -2278,4 +2278,14 @@ static bool stringContainsPointer(NSString *description, id p) {
   XCTAssertLessThan(underlayIndex, overlayIndex);
 }
 
+- (void)testThatConvertPointGoesToWindowWhenPassedNil
+{
+  UIWindow *window = [[UIWindow alloc] initWithFrame:CGRectMake(0, 0, 20, 20)];
+  ASDisplayNode *node = [[ASDisplayNode alloc] init];
+  node.frame = CGRectMake(10, 10, 10, 10);
+  [window addSubnode:node];
+  CGPoint expectedOrigin = CGPointMake(10, 10);
+  ASXCTAssertEqualPoints([node convertPoint:node.bounds.origin toNode:nil], expectedOrigin);
+}
+
 @end

--- a/Base/ASBaseDefines.h
+++ b/Base/ASBaseDefines.h
@@ -184,4 +184,7 @@
 #define ASOVERLOADABLE __attribute__((overloadable))
 
 /// Ensure that class is of certain kind
-#define ASDynamicCast(x, c) ((c *) ([x isKindOfClass:[c class]] ? x : nil))
+#define ASDynamicCast(x, c) ({ \
+  id __val = x;\
+  ((c *) ([__val isKindOfClass:[c class]] ? __val : nil));\
+})


### PR DESCRIPTION
Resolves #2888 @hannahmbanana 

I didn't know this, but `convertPoint:toLayer:nil` behaves a lot differently from `convertPoint:toView:nil` and so it's important that we call the appropriate method for the appropriate case.