### PR TITLE
[UIImage+ASConvenience] as_resizableRoundedImage border doesn't respect roundedCorner argument

### DIFF
--- a/AsyncDisplayKit/UIImage+ASConvenience.m
+++ b/AsyncDisplayKit/UIImage+ASConvenience.m
@@ -76,9 +76,9 @@
   PathKey key = { roundedCorners, cornerRadius };
   NSValue *pathKeyObject = [[NSValue alloc] initWithBytes:&key objCType:@encode(PathKey)];
 
+  CGSize cornerRadii = CGSizeMake(cornerRadius, cornerRadius);
   UIBezierPath *path = [__pathCache objectForKey:pathKeyObject];
   if (path == nil) {
-    CGSize cornerRadii = CGSizeMake(cornerRadius, cornerRadius);
     path = [UIBezierPath bezierPathWithRoundedRect:bounds byRoundingCorners:roundedCorners cornerRadii:cornerRadii];
     [__pathCache setObject:path forKey:pathKeyObject];
   }
@@ -107,7 +107,9 @@
     
     // It is rarer to have a stroke path, and our cache key only handles rounded rects for the exact-stretchable
     // size calculated by cornerRadius, so we won't bother caching this path.  Profiling validates this decision.
-    UIBezierPath *strokePath = [UIBezierPath bezierPathWithRoundedRect:strokeRect cornerRadius:cornerRadius];
+    UIBezierPath *strokePath = [UIBezierPath bezierPathWithRoundedRect:strokeRect
+                                                     byRoundingCorners:roundedCorners
+                                                           cornerRadii:cornerRadii];
     [strokePath setLineWidth:borderWidth];
     BOOL canUseCopy = (CGColorGetAlpha(borderColor.CGColor) == 1);
     [strokePath strokeWithBlendMode:(canUseCopy ? kCGBlendModeCopy : kCGBlendModeNormal) alpha:1];

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ AsyncDisplayKit's basic unit is the `node`. An ASDisplayNode is an abstraction o
 
 To keep its user interface smooth and responsive, your app should render at 60 frames per second — the gold standard on iOS. This means the main thread has one-sixtieth of a second to push each frame. That's 16 milliseconds to execute all layout and drawing code! And because of system overhead, your code usually has less than ten milliseconds to run before it causes a frame drop.
 
-AsyncDisplayKit lets you move image decoding, text sizing and rendering, layout, and other expensive UI operations off the main thread, to keep the main thread available to respond to user interaction. 
+AsyncDisplayKit lets you move image decoding, text sizing and rendering, layout, and other expensive UI operations off the main thread, to keep the main thread available to respond to user interaction.
 
 ## Advanced Developer Features
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ AsyncDisplayKit's basic unit is the `node`. An ASDisplayNode is an abstraction o
 
 To keep its user interface smooth and responsive, your app should render at 60 frames per second — the gold standard on iOS. This means the main thread has one-sixtieth of a second to push each frame. That's 16 milliseconds to execute all layout and drawing code! And because of system overhead, your code usually has less than ten milliseconds to run before it causes a frame drop.
 
-AsyncDisplayKit lets you move image decoding, text sizing and rendering, layout, and other expensive UI operations off the main thread, to keep the main thread available to respond to user interaction.
+AsyncDisplayKit lets you move image decoding, text sizing and rendering, layout, and other expensive UI operations off the main thread, to keep the main thread available to respond to user interaction. 
 
 ## Advanced Developer Features
 


### PR DESCRIPTION
Resolves #2903.

#Incorrect:
<img width="578" alt="screen shot 2017-01-17 at 4 03 45 pm" src="https://cloud.githubusercontent.com/assets/3419380/22045436/124a8a70-dccf-11e6-8024-61007783c2ad.png">

Corrected:
<img width="578" alt="screen shot 2017-01-17 at 4 01 28 pm" src="https://cloud.githubusercontent.com/assets/3419380/22045446/1ee83f5c-dccf-11e6-8531-bf857e0e7bb0.png">
