### PR TITLE
Minor Collection Simplifications

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -57,7 +57,9 @@ typedef NS_ENUM(NSUInteger, ASCollectionViewInvalidationStyle) {
 };
 
 static const NSUInteger kASCollectionViewAnimationNone = UITableViewRowAnimationNone;
-static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
+
+/// Used for all cells and supplementaries. UICV keys by supp-kind+reuseID so this is plenty.
+static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
 
 #pragma mark -
 #pragma mark ASCellNode<->UICollectionViewCell bridging.
@@ -338,7 +340,7 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   _cellsForVisibilityUpdates = [NSMutableSet set];
   self.backgroundColor = [UIColor whiteColor];
   
-  [self registerClass:[_ASCollectionViewCell class] forCellWithReuseIdentifier:kCellReuseIdentifier];
+  [self registerClass:[_ASCollectionViewCell class] forCellWithReuseIdentifier:kReuseIdentifier];
   
   if (!AS_AT_LEAST_IOS9) {
     _retainedLayer = self.layer;
@@ -780,8 +782,7 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
 {
   ASDisplayNodeAssert(elementKind != nil, @"A kind is needed for supplementary node registration");
   [_registeredSupplementaryKinds addObject:elementKind];
-  [self registerClass:[UICollectionReusableView class] forSupplementaryViewOfKind:elementKind
-                                            withReuseIdentifier:[self __reuseIdentifierForKind:elementKind]];
+  [self registerClass:[UICollectionReusableView class] forSupplementaryViewOfKind:elementKind withReuseIdentifier:kReuseIdentifier];
 }
 
 - (void)insertSections:(NSIndexSet *)sections
@@ -844,11 +845,6 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
   [_dataController moveRowAtIndexPath:indexPath toIndexPath:newIndexPath withAnimationOptions:kASCollectionViewAnimationNone];
 }
 
-- (NSString *)__reuseIdentifierForKind:(NSString *)kind
-{
-  return [@"_ASCollectionSupplementaryView_" stringByAppendingString:kind];
-}
-
 #pragma mark -
 #pragma mark Intercepted selectors.
 
@@ -870,8 +866,7 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
 
 - (UICollectionReusableView *)collectionView:(UICollectionView *)collectionView viewForSupplementaryElementOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath
 {
-  NSString *identifier = [self __reuseIdentifierForKind:kind];
-  UICollectionReusableView *view = [self dequeueReusableSupplementaryViewOfKind:kind withReuseIdentifier:identifier forIndexPath:indexPath];
+  UICollectionReusableView *view = [self dequeueReusableSupplementaryViewOfKind:kind withReuseIdentifier:kReuseIdentifier forIndexPath:indexPath];
   ASCellNode *node = [_dataController supplementaryNodeOfKind:kind atIndexPath:indexPath];
   ASDisplayNodeAssert(node != nil, @"Supplementary node should exist.  Kind = %@, indexPath = %@, collectionDataSource = %@", kind, indexPath, self);
   [_rangeController configureContentView:view forCellNode:node];
@@ -882,7 +877,7 @@ static NSString * const kCellReuseIdentifier = @"_ASCollectionViewCell";
 
 - (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView cellForItemAtIndexPath:(NSIndexPath *)indexPath
 {
-  _ASCollectionViewCell *cell = [self dequeueReusableCellWithReuseIdentifier:kCellReuseIdentifier forIndexPath:indexPath];
+  _ASCollectionViewCell *cell = [self dequeueReusableCellWithReuseIdentifier:kReuseIdentifier forIndexPath:indexPath];
   
   ASCellNode *node = [self nodeForItemAtIndexPath:indexPath];
   cell.node = node;

--- a/AsyncDisplayKit/Details/ASCollectionViewFlowLayoutInspector.h
+++ b/AsyncDisplayKit/Details/ASCollectionViewFlowLayoutInspector.h
@@ -17,6 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * A layout inspector implementation specific for the sizing behavior of UICollectionViewFlowLayouts
  */
+AS_SUBCLASSING_RESTRICTED
 @interface ASCollectionViewFlowLayoutInspector : NSObject <ASCollectionViewLayoutInspecting>
 
 @property (nonatomic, weak, readonly) UICollectionViewFlowLayout *layout;

--- a/AsyncDisplayKit/Details/ASCollectionViewFlowLayoutInspector.m
+++ b/AsyncDisplayKit/Details/ASCollectionViewFlowLayoutInspector.m
@@ -29,10 +29,6 @@
     unsigned int implementsConstrainedSizeForNodeAtIndexPathDeprecated:1;
     unsigned int implementsConstrainedSizeForItemAtIndexPath:1;
   } _delegateFlags;
-  
-  struct {
-    unsigned int implementsNumberOfSectionsInCollectionView:1;
-  } _dataSourceFlags;
 }
 
 #pragma mark Lifecycle
@@ -67,11 +63,7 @@
 
 - (void)didChangeCollectionViewDataSource:(id<ASCollectionDataSource>)dataSource
 {
-  if (dataSource == nil) {
-    memset(&_dataSourceFlags, 0, sizeof(_dataSourceFlags));
-  } else {
-    _dataSourceFlags.implementsNumberOfSectionsInCollectionView = [dataSource respondsToSelector:@selector(numberOfSectionsInCollectionView:)];
-  }
+  // nop
 }
 
 - (ASSizeRange)collectionView:(ASCollectionView *)collectionView constrainedSizeForNodeAtIndexPath:(NSIndexPath *)indexPath

--- a/AsyncDisplayKit/Details/ASCollectionViewFlowLayoutInspector.m
+++ b/AsyncDisplayKit/Details/ASCollectionViewFlowLayoutInspector.m
@@ -40,7 +40,6 @@
   
   self = [super init];
   if (self != nil) {
-    [self didChangeCollectionViewDataSource:collectionView.asyncDataSource];
     [self didChangeCollectionViewDelegate:collectionView.asyncDelegate];
     _layout = flowLayout;
   }
@@ -59,11 +58,6 @@
     _delegateFlags.implementsConstrainedSizeForNodeAtIndexPathDeprecated = [delegate respondsToSelector:@selector(collectionView:constrainedSizeForNodeAtIndexPath:)];
     _delegateFlags.implementsConstrainedSizeForItemAtIndexPath = [delegate respondsToSelector:@selector(collectionNode:constrainedSizeForItemAtIndexPath:)];
   }
-}
-
-- (void)didChangeCollectionViewDataSource:(id<ASCollectionDataSource>)dataSource
-{
-  // nop
 }
 
 - (ASSizeRange)collectionView:(ASCollectionView *)collectionView constrainedSizeForNodeAtIndexPath:(NSIndexPath *)indexPath

--- a/Base/ASBaseDefines.h
+++ b/Base/ASBaseDefines.h
@@ -190,6 +190,12 @@
 #define AS_NOESCAPE
 #endif
 
+#if __has_attribute(objc_subclassing_restricted)
+#define AS_SUBCLASSING_RESTRICTED __attribute__((objc_subclassing_restricted))
+#else
+#define AS_SUBCLASSING_RESTRICTED
+#endif
+
 /// Ensure that class is of certain kind
 #define ASDynamicCast(x, c) ({ \
   id __val = x;\


### PR DESCRIPTION
I found these while working on IGListKit support, and wanted to break them out into their own PR:

- Always use the same reuse identifier. As documented, UICV separates supplementaries by kind so we don't have to.
- Remove unused code from `ASCollectionViewFlowLayoutInspector`