### PR TITLE
ASLayoutSpec and ASDisplayNode should respect ASLayoutElementSize passed to them

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -2793,7 +2793,7 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
                      restrictedToSize:(ASLayoutElementSize)size
                  relativeToParentSize:(CGSize)parentSize
 {
-  const ASSizeRange resolvedRange = ASSizeRangeIntersect(constrainedSize, ASLayoutElementSizeResolve(self.style.size, parentSize));
+  const ASSizeRange resolvedRange = ASSizeRangeIntersect(constrainedSize, ASLayoutElementSizeResolve(size, parentSize));
   return [self calculateLayoutThatFits:resolvedRange];
 }
 

--- a/AsyncDisplayKit/Layout/ASLayoutSpec.mm
+++ b/AsyncDisplayKit/Layout/ASLayoutSpec.mm
@@ -128,7 +128,7 @@
                      restrictedToSize:(ASLayoutElementSize)size
                  relativeToParentSize:(CGSize)parentSize
 {
-  const ASSizeRange resolvedRange = ASSizeRangeIntersect(constrainedSize, ASLayoutElementSizeResolve(self.style.size, parentSize));
+  const ASSizeRange resolvedRange = ASSizeRangeIntersect(constrainedSize, ASLayoutElementSizeResolve(size, parentSize));
   return [self calculateLayoutThatFits:resolvedRange];
 }
 


### PR DESCRIPTION
- The size is passed as a param of `-calculateLayoutThatFits:restrictedToSize:relativeToParentSize:`.
- It's almost always the same as `self.style.size`, but it should be used nevertheless as part of the API contract.

Would love to have a review from @maicki. Thanks!