### PR TITLE
[ASLayout] Consider the dedupe compiler flag to check for duplicate elements in a subtree

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -2823,13 +2823,15 @@ void recursivelyTriggerDisplayForLayer(CALayer *layer, BOOL shouldBlock)
   // Certain properties are necessary to set on an element of type ASLayoutSpec
   if (layoutElement.layoutElementType == ASLayoutElementTypeLayoutSpec) {
     ASLayoutSpec *layoutSpec = (ASLayoutSpec *)layoutElement;
-    
+  
+#if AS_DEDUPE_LAYOUT_SPEC_TREE
     NSSet *duplicateElements = [layoutSpec findDuplicatedElementsInSubtree];
     if (duplicateElements.count > 0) {
       ASDisplayNodeFailAssert(@"Node %@ returned a layout spec that contains the same elements in multiple positions. Elements: %@", self, duplicateElements);
       // Use an empty layout spec to avoid crashes
       layoutSpec = [[ASLayoutSpec alloc] init];
     }
+#endif
 
     if (_shouldCacheLayoutSpec) {
       _layoutSpec = layoutSpec;


### PR DESCRIPTION
We are currently check for duplicate layout elements in a subtree although the compiler flag to check it is not defined / enabled. We should consider the compiler flag so in production no extra work is done.