### PR TITLE
Fix Test Failures Caused by Pollution Between Test Cases

### DIFF
--- a/AsyncDisplayKitTests/ASCollectionViewTests.mm
+++ b/AsyncDisplayKitTests/ASCollectionViewTests.mm
@@ -174,6 +174,18 @@
 
 @implementation ASCollectionViewTests
 
+- (void)tearDown
+{
+  // We can't prevent the system from retaining windows, but we can at least clear them out to avoid
+  // pollution between test cases.
+  for (UIWindow *window in [UIApplication sharedApplication].windows) {
+    for (UIView *subview in window.subviews) {
+      [subview removeFromSuperview];
+    }
+  }
+  [super tearDown];
+}
+
 - (void)testDataSourceImplementsNecessaryMethods
 {
   UICollectionViewFlowLayout *layout = [[UICollectionViewFlowLayout alloc] init];
@@ -901,7 +913,7 @@
   [self waitForExpectationsWithTimeout:3 handler:nil];
 }
 
-- (void)DISABLED_testThatWeBatchFetchUntilContentRequirementIsMet_Animated
+- (void)testThatWeBatchFetchUntilContentRequirementIsMet_Animated
 {
   [self _primitiveBatchFetchingFillTestAnimated:YES visible:YES controller:nil];
 }


### PR DESCRIPTION
Our collection view is not exception-safe, and this was increased by #2923 . In our collection view tests, windows pile up because the system retains them (animation delegates etc.), and when the device is rotated during some tests, the collection views that were killed by intentional exceptions in prior tests crash.

I tried waiting for the windows to die on their own – by a couple different methods – but no dice. This suffices to fix it.