### PR TITLE
[ASCollectionNode] Add support for using UICollectionViewCells

### DIFF
--- a/AsyncDisplayKit/ASCellNode+Internal.h
+++ b/AsyncDisplayKit/ASCellNode+Internal.h
@@ -63,7 +63,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, copy, nullable) NSIndexPath *cachedIndexPath;
 
-@property (weak, nonatomic, nullable) ASDisplayNode *owningNode;
+@property (nonatomic, weak, nullable) ASDisplayNode *owningNode;
+
+@property (nonatomic, assign) BOOL shouldUseUIKitCell;
 
 @end
 

--- a/AsyncDisplayKit/ASCollectionNode.h
+++ b/AsyncDisplayKit/ASCollectionNode.h
@@ -502,6 +502,27 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable id<ASSectionContext>)collectionNode:(ASCollectionNode *)collectionNode contextForSection:(NSInteger)section;
 
 /**
+ * This method offers compatibility with synchronous, standard UICollectionViewCell objects.
+ * These cells will **not** have the performance benefits of ASCellNodes (like preloading, async layout, and
+ * async drawing) - even when mixed within the same ASCollectionNode.
+ *
+ * In order to use this method, you must:
+ * 1. Implement it on your ASCollectionDataSource object.
+ * 2. Call registerCellClass: on the collectionNode.view (in viewDidLoad, or register an onDidLoad: block).
+ * 3. Return nil from the nodeBlockForItem...: or nodeForItem...: method. NOTE: it is an error to return
+ *    nil from within a nodeBlock, if you have returned a nodeBlock object.
+ * 4. Lastly, you must implement a method to provide the size for the cell. There are two ways this is done:
+ * 4a. UICollectionViewFlowLayout (incl. ASPagerNode). Implement
+       collectionNode:constrainedSizeForItemAtIndexPath:.
+ * 4b. Custom collection layouts. Set .view.layoutInspector and have it implement
+       collectionView:constrainedSizeForNodeAtIndexPath:.
+ *
+ * For an example of using this method with all steps above (including a custom layout, 4b.),
+ * see the app in examples/CustomCollectionView and enable kShowUICollectionViewCells = YES.
+ */
+- (__kindof UICollectionViewCell *)collectionView:(UICollectionView *)collectionView cellForItemAtIndexPath:(NSIndexPath *)indexPath;
+
+/**
  * Similar to -collectionView:cellForItemAtIndexPath:.
  *
  * @param collectionView The sender.
@@ -579,7 +600,19 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)collectionNode:(ASCollectionNode *)collectionNode willDisplayItemWithNode:(ASCellNode *)node;
 
+/**
+ * This method will only be called if you are using cellForItemAtIndexPath: (not ASCellNode's). 
+ * See documentation at collectionView:cellForItemAtIndexPath: method in this class.
+ */
+- (void)collectionView:(UICollectionView *)collectionView willDisplayCell:(UICollectionViewCell *)cell forItemAtIndexPath:(NSIndexPath *)indexPath NS_AVAILABLE_IOS(8_0);
+
 - (void)collectionNode:(ASCollectionNode *)collectionNode didEndDisplayingItemWithNode:(ASCellNode *)node;
+
+/**
+ * This method will only be called if you are using cellForItemAtIndexPath: (not ASCellNode's). 
+ * See documentation at collectionView:cellForItemAtIndexPath: method in this class.
+ */
+- (void)collectionView:(UICollectionView *)collectionView didEndDisplayingCell:(UICollectionViewCell *)cell forItemAtIndexPath:(NSIndexPath *)indexPath;
 
 - (void)collectionNode:(ASCollectionNode *)collectionNode willDisplaySupplementaryElementWithNode:(ASCellNode *)node NS_AVAILABLE_IOS(8_0);
 - (void)collectionNode:(ASCollectionNode *)collectionNode didEndDisplayingSupplementaryElementWithNode:(ASCellNode *)node;
@@ -634,6 +667,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @return A constrained size range for layout the node at this index path.
  */
 - (ASSizeRange)collectionView:(ASCollectionView *)collectionView constrainedSizeForNodeAtIndexPath:(NSIndexPath *)indexPath ASDISPLAYNODE_DEPRECATED_MSG("Use ASCollectionNode's constrainedSizeForItemAtIndexPath: instead. PLEASE NOTE the very subtle method name change.");
+- (ASSizeRange)collectionNode:(ASCollectionNode *)collectionNode constrainedSizeForNodeAtIndexPath:(NSIndexPath *)indexPath ASDISPLAYNODE_DEPRECATED_MSG("Use ASCollectionNode's constrainedSizeForItemAtIndexPath: instead. PLEASE NOTE the very subtle method name change.");
 
 /**
  * Informs the delegate that the collection view will add the given node

--- a/AsyncDisplayKit/ASCollectionNode.h
+++ b/AsyncDisplayKit/ASCollectionNode.h
@@ -599,19 +599,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (ASSizeRange)collectionNode:(ASCollectionNode *)collectionNode constrainedSizeForItemAtIndexPath:(NSIndexPath *)indexPath;
 
 - (void)collectionNode:(ASCollectionNode *)collectionNode willDisplayItemWithNode:(ASCellNode *)node;
-
-/**
- * This method will only be called if you are using cellForItemAtIndexPath: (not ASCellNode's). 
- * See documentation at collectionView:cellForItemAtIndexPath: method in this class.
- */
-- (void)collectionView:(UICollectionView *)collectionView willDisplayCell:(UICollectionViewCell *)cell forItemAtIndexPath:(NSIndexPath *)indexPath NS_AVAILABLE_IOS(8_0);
-
 - (void)collectionNode:(ASCollectionNode *)collectionNode didEndDisplayingItemWithNode:(ASCellNode *)node;
 
 /**
- * This method will only be called if you are using cellForItemAtIndexPath: (not ASCellNode's). 
+ * These two methods will only be called if you are using cellForItemAtIndexPath: (not ASCellNode's).
  * See documentation at collectionView:cellForItemAtIndexPath: method in this class.
  */
+- (void)collectionView:(UICollectionView *)collectionView willDisplayCell:(UICollectionViewCell *)cell forItemAtIndexPath:(NSIndexPath *)indexPath NS_AVAILABLE_IOS(8_0);
 - (void)collectionView:(UICollectionView *)collectionView didEndDisplayingCell:(UICollectionViewCell *)cell forItemAtIndexPath:(NSIndexPath *)indexPath;
 
 - (void)collectionNode:(ASCollectionNode *)collectionNode willDisplaySupplementaryElementWithNode:(ASCellNode *)node NS_AVAILABLE_IOS(8_0);

--- a/AsyncDisplayKit/Details/ASDataController.mm
+++ b/AsyncDisplayKit/Details/ASDataController.mm
@@ -526,6 +526,7 @@ NSString * const ASCollectionInvalidUpdateException = @"ASCollectionInvalidUpdat
         ASCellNodeBlock nodeBlock = [_dataSource dataController:self nodeBlockAtIndexPath:indexPath];
         
         ASSizeRange constrainedSize = [self constrainedSizeForNodeOfKind:ASDataControllerRowNodeKind atIndexPath:indexPath];
+        NSLog(@"constrainedSize = %@, index = %@", NSStringFromCGSize(constrainedSize.max), indexPath);
         [contexts addObject:[[ASIndexedNodeContext alloc] initWithNodeBlock:nodeBlock
                                                                   indexPath:indexPath
                                                    supplementaryElementKind:nil

--- a/examples/CustomCollectionView/Sample.xcodeproj/project.pbxproj
+++ b/examples/CustomCollectionView/Sample.xcodeproj/project.pbxproj
@@ -1,790 +1,381 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>archiveVersion</key>
-	<string>1</string>
-	<key>classes</key>
-	<dict/>
-	<key>objectVersion</key>
-	<string>46</string>
-	<key>objects</key>
-	<dict>
-		<key>25A1FA831C02F7AC00193875</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>MosaicCollectionViewLayout.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25A1FA841C02F7AC00193875</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>MosaicCollectionViewLayout.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25A1FA851C02F7AC00193875</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25A1FA841C02F7AC00193875</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25A1FA861C02FCB000193875</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ImageCellNode.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25A1FA871C02FCB000193875</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ImageCellNode.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25A1FA881C02FCB000193875</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25A1FA871C02FCB000193875</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>3760AAE3843D6EA89A9A166B</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>Embed Pods Frameworks</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>"${SRCROOT}/Pods/Target Support Files/Pods-Sample/Pods-Sample-frameworks.sh"
-</string>
-			<key>showEnvVarsInLog</key>
-			<string>0</string>
-		</dict>
-		<key>4CC0FB9EE0030992E8FBC0A0</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>libPods-Sample.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>576F970133B34DFD583D5CE4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>4CC0FB9EE0030992E8FBC0A0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>90A2B9C5397C46134C8A793B</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>F36BCD8EBAF79797AB5C6708</string>
-				<string>E2F287D91FFDEA2A747630CE</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Pods</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9BA2CEA01BB2579C00D18414</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>file.storyboard</string>
-			<key>path</key>
-			<string>Launchboard.storyboard</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9BA2CEA11BB2579C00D18414</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9BA2CEA01BB2579C00D18414</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>A6902C454C7661D0D277AC62</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>Copy Pods Resources</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>"${SRCROOT}/Pods/Target Support Files/Pods-Sample/Pods-Sample-resources.sh"
-</string>
-			<key>showEnvVarsInLog</key>
-			<string>0</string>
-		</dict>
-		<key>AC3C4A551A11F47200143C57</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>AC3C4A601A11F47200143C57</string>
-				<string>AC3C4A5F1A11F47200143C57</string>
-				<string>90A2B9C5397C46134C8A793B</string>
-				<string>D6E38FF0CB18E3F55CF06437</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AC3C4A561A11F47200143C57</key>
-		<dict>
-			<key>attributes</key>
-			<dict>
-				<key>LastUpgradeCheck</key>
-				<string>0610</string>
-				<key>ORGANIZATIONNAME</key>
-				<string>Facebook</string>
-				<key>TargetAttributes</key>
-				<dict>
-					<key>AC3C4A5D1A11F47200143C57</key>
-					<dict>
-						<key>CreatedOnToolsVersion</key>
-						<string>6.1</string>
-					</dict>
-				</dict>
-			</dict>
-			<key>buildConfigurationList</key>
-			<string>AC3C4A591A11F47200143C57</string>
-			<key>compatibilityVersion</key>
-			<string>Xcode 3.2</string>
-			<key>developmentRegion</key>
-			<string>English</string>
-			<key>hasScannedForEncodings</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXProject</string>
-			<key>knownRegions</key>
-			<array>
-				<string>en</string>
-				<string>Base</string>
-			</array>
-			<key>mainGroup</key>
-			<string>AC3C4A551A11F47200143C57</string>
-			<key>productRefGroup</key>
-			<string>AC3C4A5F1A11F47200143C57</string>
-			<key>projectDirPath</key>
-			<string></string>
-			<key>projectReferences</key>
-			<array/>
-			<key>projectRoot</key>
-			<string></string>
-			<key>targets</key>
-			<array>
-				<string>AC3C4A5D1A11F47200143C57</string>
-			</array>
-		</dict>
-		<key>AC3C4A591A11F47200143C57</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>AC3C4A7F1A11F47200143C57</string>
-				<string>AC3C4A801A11F47200143C57</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>AC3C4A5A1A11F47200143C57</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>25A1FA851C02F7AC00193875</string>
-				<string>AC3C4A6A1A11F47200143C57</string>
-				<string>AC3C4A671A11F47200143C57</string>
-				<string>AC3C4A641A11F47200143C57</string>
-				<string>25A1FA881C02FCB000193875</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>AC3C4A5B1A11F47200143C57</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>576F970133B34DFD583D5CE4</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>AC3C4A5C1A11F47200143C57</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>9BA2CEA11BB2579C00D18414</string>
-				<string>AC3C4A8E1A11F80C00143C57</string>
-			</array>
-			<key>isa</key>
-			<string>PBXResourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>AC3C4A5D1A11F47200143C57</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>AC3C4A811A11F47200143C57</string>
-			<key>buildPhases</key>
-			<array>
-				<string>F868CFBB21824CC9521B6588</string>
-				<string>AC3C4A5A1A11F47200143C57</string>
-				<string>AC3C4A5B1A11F47200143C57</string>
-				<string>AC3C4A5C1A11F47200143C57</string>
-				<string>A6902C454C7661D0D277AC62</string>
-				<string>3760AAE3843D6EA89A9A166B</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>Sample</string>
-			<key>productName</key>
-			<string>Sample</string>
-			<key>productReference</key>
-			<string>AC3C4A5E1A11F47200143C57</string>
-			<key>productType</key>
-			<string>com.apple.product-type.application</string>
-		</dict>
-		<key>AC3C4A5E1A11F47200143C57</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.application</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>Sample.app</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>AC3C4A5F1A11F47200143C57</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>AC3C4A5E1A11F47200143C57</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Products</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AC3C4A601A11F47200143C57</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>25A1FA831C02F7AC00193875</string>
-				<string>25A1FA841C02F7AC00193875</string>
-				<string>AC3C4A651A11F47200143C57</string>
-				<string>AC3C4A661A11F47200143C57</string>
-				<string>AC3C4A681A11F47200143C57</string>
-				<string>AC3C4A691A11F47200143C57</string>
-				<string>25A1FA861C02FCB000193875</string>
-				<string>25A1FA871C02FCB000193875</string>
-				<string>AC3C4A8D1A11F80C00143C57</string>
-				<string>AC3C4A611A11F47200143C57</string>
-			</array>
-			<key>indentWidth</key>
-			<string>2</string>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>Sample</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-			<key>tabWidth</key>
-			<string>2</string>
-			<key>usesTabs</key>
-			<string>0</string>
-		</dict>
-		<key>AC3C4A611A11F47200143C57</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>AC3C4A621A11F47200143C57</string>
-				<string>AC3C4A631A11F47200143C57</string>
-				<string>9BA2CEA01BB2579C00D18414</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Supporting Files</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AC3C4A621A11F47200143C57</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AC3C4A631A11F47200143C57</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>main.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AC3C4A641A11F47200143C57</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AC3C4A631A11F47200143C57</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>AC3C4A651A11F47200143C57</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>AppDelegate.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AC3C4A661A11F47200143C57</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>AppDelegate.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AC3C4A671A11F47200143C57</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AC3C4A661A11F47200143C57</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>AC3C4A681A11F47200143C57</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ViewController.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AC3C4A691A11F47200143C57</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ViewController.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AC3C4A6A1A11F47200143C57</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AC3C4A691A11F47200143C57</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>AC3C4A7F1A11F47200143C57</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>gnu++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_MODULES</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN_UNREACHABLE_CODE</key>
-				<string>YES</string>
-				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
-				<string>YES</string>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_DYNAMIC_NO_PIC</key>
-				<string>NO</string>
-				<key>GCC_OPTIMIZATION_LEVEL</key>
-				<string>0</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
-				<string>NO</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES_ERROR</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES_AGGRESSIVE</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.1</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>YES</string>
-				<key>ONLY_ACTIVE_ARCH</key>
-				<string>YES</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>AC3C4A801A11F47200143C57</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>gnu++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_MODULES</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN_UNREACHABLE_CODE</key>
-				<string>YES</string>
-				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
-				<string>YES</string>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>ENABLE_NS_ASSERTIONS</key>
-				<string>NO</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES_ERROR</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES_AGGRESSIVE</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.1</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>NO</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-				<key>VALIDATE_PRODUCT</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>AC3C4A811A11F47200143C57</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>AC3C4A821A11F47200143C57</string>
-				<string>AC3C4A831A11F47200143C57</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>AC3C4A821A11F47200143C57</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>F36BCD8EBAF79797AB5C6708</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME</key>
-				<string>LaunchImage</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Sample/Info.plist</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.1</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<string>$(inherited) @executable_path/Frameworks</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>AC3C4A831A11F47200143C57</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>E2F287D91FFDEA2A747630CE</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME</key>
-				<string>LaunchImage</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Sample/Info.plist</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.1</string>
-				<key>LD_RUNPATH_SEARCH_PATHS</key>
-				<string>$(inherited) @executable_path/Frameworks</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>AC3C4A8D1A11F80C00143C57</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>folder.assetcatalog</string>
-			<key>path</key>
-			<string>Images.xcassets</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AC3C4A8E1A11F80C00143C57</key>
-		<dict>
-			<key>fileRef</key>
-			<string>AC3C4A8D1A11F80C00143C57</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>D6E38FF0CB18E3F55CF06437</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>4CC0FB9EE0030992E8FBC0A0</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Frameworks</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E2F287D91FFDEA2A747630CE</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-Sample.release.xcconfig</string>
-			<key>path</key>
-			<string>Pods/Target Support Files/Pods-Sample/Pods-Sample.release.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F36BCD8EBAF79797AB5C6708</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-Sample.debug.xcconfig</string>
-			<key>path</key>
-			<string>Pods/Target Support Files/Pods-Sample/Pods-Sample.debug.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F868CFBB21824CC9521B6588</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>Check Pods Manifest.lock</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>diff "${PODS_ROOT}/../Podfile.lock" "${PODS_ROOT}/Manifest.lock" &gt; /dev/null
-if [[ $? != 0 ]] ; then
-    cat &lt;&lt; EOM
-error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.
-EOM
-    exit 1
-fi
-</string>
-			<key>showEnvVarsInLog</key>
-			<string>0</string>
-		</dict>
-	</dict>
-	<key>rootObject</key>
-	<string>AC3C4A561A11F47200143C57</string>
-</dict>
-</plist>
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		25A1FA851C02F7AC00193875 /* MosaicCollectionViewLayout.m in Sources */ = {isa = PBXBuildFile; fileRef = 25A1FA841C02F7AC00193875 /* MosaicCollectionViewLayout.m */; };
+		25A1FA881C02FCB000193875 /* ImageCellNode.m in Sources */ = {isa = PBXBuildFile; fileRef = 25A1FA871C02FCB000193875 /* ImageCellNode.m */; };
+		576F970133B34DFD583D5CE4 /* libPods-Sample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4CC0FB9EE0030992E8FBC0A0 /* libPods-Sample.a */; };
+		80364CCA1E3D95A90094400C /* ImageCollectionViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 80364CC91E3D95A90094400C /* ImageCollectionViewCell.m */; };
+		9BA2CEA11BB2579C00D18414 /* Launchboard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9BA2CEA01BB2579C00D18414 /* Launchboard.storyboard */; };
+		AC3C4A641A11F47200143C57 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = AC3C4A631A11F47200143C57 /* main.m */; };
+		AC3C4A671A11F47200143C57 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = AC3C4A661A11F47200143C57 /* AppDelegate.m */; };
+		AC3C4A6A1A11F47200143C57 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = AC3C4A691A11F47200143C57 /* ViewController.m */; };
+		AC3C4A8E1A11F80C00143C57 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AC3C4A8D1A11F80C00143C57 /* Images.xcassets */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		25A1FA831C02F7AC00193875 /* MosaicCollectionViewLayout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MosaicCollectionViewLayout.h; sourceTree = "<group>"; };
+		25A1FA841C02F7AC00193875 /* MosaicCollectionViewLayout.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MosaicCollectionViewLayout.m; sourceTree = "<group>"; };
+		25A1FA861C02FCB000193875 /* ImageCellNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ImageCellNode.h; sourceTree = "<group>"; };
+		25A1FA871C02FCB000193875 /* ImageCellNode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ImageCellNode.m; sourceTree = "<group>"; };
+		4CC0FB9EE0030992E8FBC0A0 /* libPods-Sample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Sample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		80364CC81E3D95A90094400C /* ImageCollectionViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ImageCollectionViewCell.h; sourceTree = "<group>"; };
+		80364CC91E3D95A90094400C /* ImageCollectionViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ImageCollectionViewCell.m; sourceTree = "<group>"; };
+		9BA2CEA01BB2579C00D18414 /* Launchboard.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Launchboard.storyboard; sourceTree = "<group>"; };
+		AC3C4A5E1A11F47200143C57 /* Sample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Sample.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		AC3C4A621A11F47200143C57 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		AC3C4A631A11F47200143C57 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		AC3C4A651A11F47200143C57 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		AC3C4A661A11F47200143C57 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		AC3C4A681A11F47200143C57 /* ViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
+		AC3C4A691A11F47200143C57 /* ViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
+		AC3C4A8D1A11F80C00143C57 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
+		E2F287D91FFDEA2A747630CE /* Pods-Sample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Sample.release.xcconfig"; path = "Pods/Target Support Files/Pods-Sample/Pods-Sample.release.xcconfig"; sourceTree = "<group>"; };
+		F36BCD8EBAF79797AB5C6708 /* Pods-Sample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Sample.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Sample/Pods-Sample.debug.xcconfig"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		AC3C4A5B1A11F47200143C57 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				576F970133B34DFD583D5CE4 /* libPods-Sample.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		90A2B9C5397C46134C8A793B /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				F36BCD8EBAF79797AB5C6708 /* Pods-Sample.debug.xcconfig */,
+				E2F287D91FFDEA2A747630CE /* Pods-Sample.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+		AC3C4A551A11F47200143C57 = {
+			isa = PBXGroup;
+			children = (
+				AC3C4A601A11F47200143C57 /* Sample */,
+				AC3C4A5F1A11F47200143C57 /* Products */,
+				90A2B9C5397C46134C8A793B /* Pods */,
+				D6E38FF0CB18E3F55CF06437 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		AC3C4A5F1A11F47200143C57 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				AC3C4A5E1A11F47200143C57 /* Sample.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		AC3C4A601A11F47200143C57 /* Sample */ = {
+			isa = PBXGroup;
+			children = (
+				25A1FA831C02F7AC00193875 /* MosaicCollectionViewLayout.h */,
+				25A1FA841C02F7AC00193875 /* MosaicCollectionViewLayout.m */,
+				AC3C4A651A11F47200143C57 /* AppDelegate.h */,
+				AC3C4A661A11F47200143C57 /* AppDelegate.m */,
+				AC3C4A681A11F47200143C57 /* ViewController.h */,
+				AC3C4A691A11F47200143C57 /* ViewController.m */,
+				80364CC81E3D95A90094400C /* ImageCollectionViewCell.h */,
+				80364CC91E3D95A90094400C /* ImageCollectionViewCell.m */,
+				25A1FA861C02FCB000193875 /* ImageCellNode.h */,
+				25A1FA871C02FCB000193875 /* ImageCellNode.m */,
+				AC3C4A8D1A11F80C00143C57 /* Images.xcassets */,
+				AC3C4A611A11F47200143C57 /* Supporting Files */,
+			);
+			indentWidth = 2;
+			path = Sample;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		AC3C4A611A11F47200143C57 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				AC3C4A621A11F47200143C57 /* Info.plist */,
+				AC3C4A631A11F47200143C57 /* main.m */,
+				9BA2CEA01BB2579C00D18414 /* Launchboard.storyboard */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		D6E38FF0CB18E3F55CF06437 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				4CC0FB9EE0030992E8FBC0A0 /* libPods-Sample.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		AC3C4A5D1A11F47200143C57 /* Sample */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = AC3C4A811A11F47200143C57 /* Build configuration list for PBXNativeTarget "Sample" */;
+			buildPhases = (
+				F868CFBB21824CC9521B6588 /* [CP] Check Pods Manifest.lock */,
+				AC3C4A5A1A11F47200143C57 /* Sources */,
+				AC3C4A5B1A11F47200143C57 /* Frameworks */,
+				AC3C4A5C1A11F47200143C57 /* Resources */,
+				A6902C454C7661D0D277AC62 /* [CP] Copy Pods Resources */,
+				3760AAE3843D6EA89A9A166B /* [CP] Embed Pods Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Sample;
+			productName = Sample;
+			productReference = AC3C4A5E1A11F47200143C57 /* Sample.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		AC3C4A561A11F47200143C57 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0610;
+				ORGANIZATIONNAME = Facebook;
+				TargetAttributes = {
+					AC3C4A5D1A11F47200143C57 = {
+						CreatedOnToolsVersion = 6.1;
+					};
+				};
+			};
+			buildConfigurationList = AC3C4A591A11F47200143C57 /* Build configuration list for PBXProject "Sample" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = AC3C4A551A11F47200143C57;
+			productRefGroup = AC3C4A5F1A11F47200143C57 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				AC3C4A5D1A11F47200143C57 /* Sample */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		AC3C4A5C1A11F47200143C57 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9BA2CEA11BB2579C00D18414 /* Launchboard.storyboard in Resources */,
+				AC3C4A8E1A11F80C00143C57 /* Images.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		3760AAE3843D6EA89A9A166B /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Sample/Pods-Sample-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		A6902C454C7661D0D277AC62 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Sample/Pods-Sample-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		F868CFBB21824CC9521B6588 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		AC3C4A5A1A11F47200143C57 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				25A1FA851C02F7AC00193875 /* MosaicCollectionViewLayout.m in Sources */,
+				AC3C4A6A1A11F47200143C57 /* ViewController.m in Sources */,
+				AC3C4A671A11F47200143C57 /* AppDelegate.m in Sources */,
+				AC3C4A641A11F47200143C57 /* main.m in Sources */,
+				80364CCA1E3D95A90094400C /* ImageCollectionViewCell.m in Sources */,
+				25A1FA881C02FCB000193875 /* ImageCellNode.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		AC3C4A7F1A11F47200143C57 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		AC3C4A801A11F47200143C57 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		AC3C4A821A11F47200143C57 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = F36BCD8EBAF79797AB5C6708 /* Pods-Sample.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				INFOPLIST_FILE = Sample/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Debug;
+		};
+		AC3C4A831A11F47200143C57 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = E2F287D91FFDEA2A747630CE /* Pods-Sample.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				INFOPLIST_FILE = Sample/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		AC3C4A591A11F47200143C57 /* Build configuration list for PBXProject "Sample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AC3C4A7F1A11F47200143C57 /* Debug */,
+				AC3C4A801A11F47200143C57 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		AC3C4A811A11F47200143C57 /* Build configuration list for PBXNativeTarget "Sample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AC3C4A821A11F47200143C57 /* Debug */,
+				AC3C4A831A11F47200143C57 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = AC3C4A561A11F47200143C57 /* Project object */;
+}

--- a/examples/CustomCollectionView/Sample/ImageCellNode.h
+++ b/examples/CustomCollectionView/Sample/ImageCellNode.h
@@ -22,5 +22,6 @@
 @interface ImageCellNode : ASCellNode
 
 - (instancetype)initWithImage:(UIImage *)image;
+@property (nonatomic, strong) UIImage *image;
 
 @end

--- a/examples/CustomCollectionView/Sample/ImageCellNode.m
+++ b/examples/CustomCollectionView/Sample/ImageCellNode.m
@@ -39,4 +39,14 @@
   return [ASInsetLayoutSpec insetLayoutSpecWithInsets:UIEdgeInsetsZero child:_imageNode];
 }
 
+- (void)setImage:(UIImage *)image
+{
+  _imageNode.image = image;
+}
+
+- (UIImage *)image
+{
+  return _imageNode.image;
+}
+
 @end

--- a/examples/CustomCollectionView/Sample/ImageCollectionViewCell.h
+++ b/examples/CustomCollectionView/Sample/ImageCollectionViewCell.h
@@ -1,0 +1,13 @@
+//
+//  ImageCollectionViewCell.h
+//  Sample
+//
+//  Created by Hannah Troisi on 1/28/17.
+//  Copyright © 2017 Facebook. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface ImageCollectionViewCell : UICollectionViewCell
+
+@end

--- a/examples/CustomCollectionView/Sample/ImageCollectionViewCell.m
+++ b/examples/CustomCollectionView/Sample/ImageCollectionViewCell.m
@@ -1,0 +1,46 @@
+//
+//  ImageCollectionViewCell.m
+//  Sample
+//
+//  Created by Hannah Troisi on 1/28/17.
+//  Copyright © 2017 Facebook. All rights reserved.
+//
+
+#import "ImageCollectionViewCell.h"
+
+@implementation ImageCollectionViewCell
+{
+  UILabel *_title;
+  UILabel *_description;
+}
+
+- (id)initWithFrame:(CGRect)aRect
+{
+  self = [super initWithFrame:aRect];
+  if (self) {
+    _title = [[UILabel alloc] init];
+    _title.text = @"UICollectionViewCell";
+    [self.contentView addSubview:_title];
+    
+    _description = [[UILabel alloc] init];
+    _description.text = @"description for cell";
+    [self.contentView addSubview:_description];
+    
+    self.contentView.backgroundColor = [UIColor orangeColor];
+  }
+  return self;
+}
+
+- (void)layoutSubviews
+{
+  [super layoutSubviews];
+  
+  [_title sizeToFit];
+  [_description sizeToFit];
+  
+  CGRect frame = _title.frame;
+  frame.origin.y = _title.frame.size.height;
+  _description.frame = frame;
+}
+
+@end

--- a/examples/CustomCollectionView/Sample/MosaicCollectionViewLayout.h
+++ b/examples/CustomCollectionView/Sample/MosaicCollectionViewLayout.h
@@ -28,14 +28,13 @@
 @property (assign, nonatomic) UIEdgeInsets interItemSpacing;
 @property (assign, nonatomic) CGFloat headerHeight;
 
+- (CGSize)itemSizeAtIndexPath:(NSIndexPath *)indexPath;
+- (CGSize)headerSizeForSection:(NSInteger)section;
+
 @end
 
 @protocol MosaicCollectionViewLayoutDelegate <ASCollectionDelegate>
 
 - (CGSize)collectionView:(UICollectionView *)collectionView layout:(MosaicCollectionViewLayout *)layout originalItemSizeAtIndexPath:(NSIndexPath *)indexPath;
-
-@end
-
-@interface MosaicCollectionViewLayoutInspector : NSObject <ASCollectionViewLayoutInspecting>
 
 @end

--- a/examples/CustomCollectionView/Sample/MosaicCollectionViewLayout.m
+++ b/examples/CustomCollectionView/Sample/MosaicCollectionViewLayout.m
@@ -54,7 +54,7 @@
     top += _sectionInset.top;
     
     if (_headerHeight > 0) {
-      CGSize headerSize = [self _headerSizeForSection:section];
+      CGSize headerSize = [self headerSizeForSection:section];
       UICollectionViewLayoutAttributes *attributes = [UICollectionViewLayoutAttributes
                                                       layoutAttributesForSupplementaryViewOfKind:UICollectionElementKindSectionHeader
                                                       withIndexPath:[NSIndexPath indexPathForItem:0 inSection:section]];
@@ -75,7 +75,7 @@
       NSUInteger columnIndex = [self _shortestColumnIndexInSection:section];
       NSIndexPath *indexPath = [NSIndexPath indexPathForItem:idx inSection:section];
       
-      CGSize itemSize = [self _itemSizeAtIndexPath:indexPath];
+      CGSize itemSize = [self itemSizeAtIndexPath:indexPath];
       CGFloat xOffset = _sectionInset.left + (columnWidth + _columnSpacing) * columnIndex;
       CGFloat yOffset = [_columnHeights[section][columnIndex] floatValue];
       
@@ -146,7 +146,7 @@
   return ([self _widthForSection:section] - ((_numberOfColumns - 1) * _columnSpacing)) / _numberOfColumns;
 }
 
-- (CGSize)_itemSizeAtIndexPath:(NSIndexPath *)indexPath
+- (CGSize)itemSizeAtIndexPath:(NSIndexPath *)indexPath
 {
   CGSize size = CGSizeMake([self _columnWidthForSection:indexPath.section], 0);
   CGSize originalSize = [[self _delegate] collectionView:self.collectionView layout:self originalItemSizeAtIndexPath:indexPath];
@@ -156,7 +156,7 @@
   return size;
 }
 
-- (CGSize)_headerSizeForSection:(NSUInteger)section
+- (CGSize)headerSizeForSection:(NSInteger)section
 {
   return CGSizeMake([self _widthForSection:section], _headerHeight);
 }
@@ -196,39 +196,6 @@
 - (id<MosaicCollectionViewLayoutDelegate>)_delegate
 {
   return (id<MosaicCollectionViewLayoutDelegate>)self.collectionView.delegate;
-}
-
-@end
-
-@implementation MosaicCollectionViewLayoutInspector
-
-- (ASSizeRange)collectionView:(ASCollectionView *)collectionView constrainedSizeForNodeAtIndexPath:(NSIndexPath *)indexPath
-{
-  MosaicCollectionViewLayout *layout = (MosaicCollectionViewLayout *)[collectionView collectionViewLayout];
-  return ASSizeRangeMake(CGSizeZero, [layout _itemSizeAtIndexPath:indexPath]);
-}
-
-- (ASSizeRange)collectionView:(ASCollectionView *)collectionView constrainedSizeForSupplementaryNodeOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath
-{
-  MosaicCollectionViewLayout *layout = (MosaicCollectionViewLayout *)[collectionView collectionViewLayout];
-  return ASSizeRangeMake(CGSizeZero, [layout _headerSizeForSection:indexPath.section]);
-}
-
-- (ASScrollDirection)scrollableDirections
-{
-  return ASScrollDirectionVerticalDirections;
-}
-
-/**
- * Asks the inspector for the number of supplementary views for the given kind in the specified section.
- */
-- (NSUInteger)collectionView:(ASCollectionView *)collectionView supplementaryNodesOfKind:(NSString *)kind inSection:(NSUInteger)section
-{
-  if ([kind isEqualToString:UICollectionElementKindSectionHeader]) {
-    return 1;
-  } else {
-    return 0;
-  }
 }
 
 @end

--- a/examples/CustomCollectionView/Sample/ViewController.m
+++ b/examples/CustomCollectionView/Sample/ViewController.m
@@ -20,14 +20,16 @@
 #import <AsyncDisplayKit/AsyncDisplayKit.h>
 #import "MosaicCollectionViewLayout.h"
 #import "ImageCellNode.h"
+#import "ImageCollectionViewCell.h"
 
+// This option demonstrates that raw UIKit cells can still be used alongside native ASCellNodes.
+static BOOL kShowUICollectionViewCells = NO;
 static NSUInteger kNumberOfImages = 14;
 
-@interface ViewController () <ASCollectionDataSource, ASCollectionDelegate>
+@interface ViewController () <ASCollectionDataSource, ASCollectionDelegate, ASCollectionViewLayoutInspecting>
 {
   NSMutableArray *_sections;
   ASCollectionNode *_collectionNode;
-  MosaicCollectionViewLayoutInspector *_layoutInspector;
 }
 
 @end
@@ -35,7 +37,7 @@ static NSUInteger kNumberOfImages = 14;
 @implementation ViewController
 
 #pragma mark -
-#pragma mark UIViewController.
+#pragma mark UIViewController
 
 - (instancetype)init
 {
@@ -48,8 +50,6 @@ static NSUInteger kNumberOfImages = 14;
   _collectionNode.delegate = self;
   _collectionNode.backgroundColor = [UIColor whiteColor];
   
-  _layoutInspector = [[MosaicCollectionViewLayoutInspector alloc] init];
-
   if (!(self = [super initWithNode:_collectionNode]))
     return nil;
   
@@ -73,7 +73,8 @@ static NSUInteger kNumberOfImages = 14;
 {
   [super viewDidLoad];
   
-  _collectionNode.view.layoutInspector = _layoutInspector;
+  _collectionNode.view.layoutInspector = self;
+  [_collectionNode.view registerClass:[ImageCollectionViewCell class] forCellWithReuseIdentifier:@"ImageCollectionViewCell"];
 }
 
 - (void)reloadTapped
@@ -85,12 +86,50 @@ static NSUInteger kNumberOfImages = 14;
 
 - (ASCellNodeBlock)collectionNode:(ASCollectionNode *)collectionNode nodeBlockForItemAtIndexPath:(NSIndexPath *)indexPath
 {
+  if (kShowUICollectionViewCells && indexPath.item % 3 == 1) {
+    // When enabled, return nil for every third cell and then cellForItemAtIndexPath: will be called.
+    return nil;
+  }
+  
   UIImage *image = _sections[indexPath.section][indexPath.item];
   return ^{
     return [[ImageCellNode alloc] initWithImage:image];
   };
 }
 
+- (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView cellForItemAtIndexPath:(NSIndexPath *)indexPath
+{
+  return [_collectionNode.view dequeueReusableCellWithReuseIdentifier:@"ImageCollectionViewCell" forIndexPath:indexPath];
+}
+
+- (ASSizeRange)collectionView:(ASCollectionView *)collectionView constrainedSizeForNodeAtIndexPath:(NSIndexPath *)indexPath
+{
+  MosaicCollectionViewLayout *layout = (MosaicCollectionViewLayout *)[collectionView collectionViewLayout];
+  return ASSizeRangeMake(CGSizeZero, [layout itemSizeAtIndexPath:indexPath]);
+}
+
+- (ASSizeRange)collectionView:(ASCollectionView *)collectionView constrainedSizeForSupplementaryNodeOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath
+{
+  MosaicCollectionViewLayout *layout = (MosaicCollectionViewLayout *)[collectionView collectionViewLayout];
+  return ASSizeRangeMake(CGSizeZero, [layout headerSizeForSection:indexPath.section]);
+}
+
+- (ASScrollDirection)scrollableDirections
+{
+  return ASScrollDirectionVerticalDirections;
+}
+
+/**
+ * Asks the inspector for the number of supplementary views for the given kind in the specified section.
+ */
+- (NSUInteger)collectionView:(ASCollectionView *)collectionView supplementaryNodesOfKind:(NSString *)kind inSection:(NSUInteger)section
+{
+  if ([kind isEqualToString:UICollectionElementKindSectionHeader]) {
+    return 1;
+  } else {
+    return 0;
+  }
+}
 
 - (ASCellNode *)collectionNode:(ASCollectionNode *)collectionNode nodeForSupplementaryElementOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath
 {
@@ -116,7 +155,12 @@ static NSUInteger kNumberOfImages = 14;
 
 - (CGSize)collectionView:(ASCollectionNode *)collectionNode layout:(UICollectionViewLayout *)collectionViewLayout originalItemSizeAtIndexPath:(NSIndexPath *)indexPath
 {
-  return [(UIImage *)_sections[indexPath.section][indexPath.item] size];
+  ASCellNode *cellNode = [collectionNode nodeForItemAtIndexPath:indexPath];
+  if ([cellNode isKindOfClass:[ImageCellNode class]]) {
+    return [[(ImageCellNode *)cellNode image] size];
+  } else {
+    return CGSizeMake(100, 100);
+  }
 }
 
 @end


### PR DESCRIPTION
Paired programming with @appleguy.

This method offers compatibility with synchronous, standard UICollectionViewCell objects. These cells will **not** have the performance benefits of ASCellNodes (like preloading, async layout, and async drawing) - even when mixed within the same ASCollectionNode.

In order to use this method, you must:
1. Implement it on your ASCollectionDataSource object.
2. Call registerCellClass: on the collectionNode.view (in viewDidLoad, or register an onDidLoad: block).
3. Return nil from the nodeBlockForItem...: or nodeForItem...: method. NOTE: it is an error to return nil from within a nodeBlock, if you have returned a nodeBlock object.
4. Lastly, you must implement a method to provide the size for the cell. There are two ways this is done:
4a. UICollectionViewFlowLayout (incl. ASPagerNode). Implement collectionNode:constrainedSizeForItemAtIndexPath:.
4b. Custom collection layouts. Set .view.layoutInspector and have it implement collectionView:constrainedSizeForNodeAtIndexPath:.

For an example of using this method with all steps above (including a custom layout, 4b.), see the app in examples/CustomCollectionView and enable kShowUICollectionViewCells = YES (example project included in this PR).