### PR TITLE
Disable background deallocation on iOS 8 and below

### DIFF
--- a/AsyncDisplayKit/ASRunLoopQueue.mm
+++ b/AsyncDisplayKit/ASRunLoopQueue.mm
@@ -48,6 +48,11 @@ static void runLoopSourceCallback(void *info) {
 
 - (void)releaseObjectInBackground:(id)object
 {
+  // Disable background deallocation on iOS 8 and below to avoid crashes related to UIAXDelegateClearer (#2767).
+  if (!AS_AT_LEAST_IOS9) {
+    return;
+  }
+
   _queueLock.lock();
   _queue.push_back(object);
   _queueLock.unlock();


### PR DESCRIPTION
- The crash mainly occurs on these old iOS versions (~93%) and p6.16.1. There might be a client code issue that causes this crash, but it's hard to tell if it also crashes on newer iOS versions AND p6.17.
- Let's disable this feature for now and re-investigate if it resurfaces on p6.19 and iOS 9/10.

Closes #2767.