### PR TITLE
[ASIndexedNodeContext] Do not cache the envTraitCollection, use the delegate to request it when needed

### DIFF
--- a/AsyncDisplayKit/Details/ASIndexedNodeContext.h
+++ b/AsyncDisplayKit/Details/ASIndexedNodeContext.h
@@ -25,7 +25,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, copy, nullable) NSString *supplementaryElementKind;
 @property (nonatomic, readonly, assign) ASSizeRange constrainedSize;
 @property (weak, nonatomic) id<ASEnvironment> environment;
-@property (nonatomic, readonly, assign) ASEnvironmentTraitCollection environmentTraitCollection;
 
 - (instancetype)initWithNodeBlock:(ASCellNodeBlock)nodeBlock
                         indexPath:(NSIndexPath *)indexPath

--- a/AsyncDisplayKit/Details/ASIndexedNodeContext.mm
+++ b/AsyncDisplayKit/Details/ASIndexedNodeContext.mm
@@ -41,7 +41,6 @@
     _supplementaryElementKind = [supplementaryElementKind copy];
     _constrainedSize = constrainedSize;
     _environment = environment;
-    _environmentTraitCollection = environment.environmentTraitCollection;
   }
   return self;
 }
@@ -59,7 +58,7 @@
     node.cachedIndexPath = _indexPath;
     node.supplementaryElementKind = _supplementaryElementKind;
     node.owningNode = (ASDisplayNode *)_environment;
-    ASEnvironmentStatePropagateDown(node, _environmentTraitCollection);
+    ASEnvironmentStatePropagateDown(node, [_environment environmentTraitCollection]);
     _node = node;
   }
   return _node;


### PR DESCRIPTION
Caching the `ASEnvironmentTraitCollection` upon creation of `ASIndexedNodeContext` can lead to it becoming out of date. Ask the `id<ASEnvironment>` object for the trait collection when we need it.