### PR TITLE
Force ASPagerNode Pages to Fill Pager Bounds

### DIFF
--- a/AsyncDisplayKit/ASPagerNode.h
+++ b/AsyncDisplayKit/ASPagerNode.h
@@ -66,7 +66,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param index The index of the node.
  * @return A constrained size range for layout the node at this index.
  */
-- (ASSizeRange)pagerNode:(ASPagerNode *)pagerNode constrainedSizeForNodeAtIndex:(NSInteger)index;
+- (ASSizeRange)pagerNode:(ASPagerNode *)pagerNode constrainedSizeForNodeAtIndex:(NSInteger)index ASDISPLAYNODE_DEPRECATED_MSG("Pages in a pager node should be the exact size of the collection node (default behavior).");
 
 @end
 

--- a/AsyncDisplayKit/ASPagerNode.m
+++ b/AsyncDisplayKit/ASPagerNode.m
@@ -153,11 +153,14 @@
 
 - (ASSizeRange)collectionNode:(ASCollectionNode *)collectionNode constrainedSizeForItemAtIndexPath:(NSIndexPath *)indexPath
 {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   if (_pagerDelegateFlags.constrainedSizeForNode) {
     return [_pagerDelegate pagerNode:self constrainedSizeForNodeAtIndex:indexPath.item];
   }
+#pragma clang diagnostic pop
 
-  return ASSizeRangeMake(CGSizeZero, self.bounds.size);
+  return ASSizeRangeMake(self.bounds.size);
 }
 
 #pragma mark - Data Source Proxy


### PR DESCRIPTION
- Instead of using `[CGSizeZero, pagerNode.bounds.size]` as the size range for pages, use exactly `pagerNode.bounds.size`. Much of the logic in `ASPagerNode` depends on the pages filling the bounds, and we've had issues in Pinterest where pages did not fill the bounds and that was very unexpected and annoying.
- Deprecate `pagerNode:constrainedSizeForNodeAtIndex:` with no replacement. As said above, the only appropriate size range for a page in a pager node is exactly `pagerNode.bounds.size` which is now the default behavior.