### PR TITLE
Restore IGListKit Support

### DIFF
--- a/AsyncDisplayKit/ASCollectionNode.h
+++ b/AsyncDisplayKit/ASCollectionNode.h
@@ -729,11 +729,29 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (__kindof UICollectionViewCell *)collectionView:(UICollectionView *)collectionView cellForItemAtIndexPath:(NSIndexPath *)indexPath;
 
+@optional
+
 - (UICollectionReusableView *)collectionView:(UICollectionView *)collectionView viewForSupplementaryElementOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath;
+
+/**
+ * Implement this property and return YES if you want your interop data source to be
+ * used when dequeuing cells for node-backed items.
+ *
+ * If NO (the default), the interop data source will only be consulted in cases
+ * where no ASCellNode was provided to AsyncDisplayKit.
+ *
+ * If YES, the interop data source will always be consulted to dequeue cells, and
+ * will be expected to return _ASCollectionViewCells in cases where a node was provided.
+ *
+ * The default value is NO.
+ */
+@property (class, nonatomic, readonly) BOOL dequeuesCellsForNodeBackedItems;
 
 @end
 
 @protocol ASCollectionDelegateInterop <ASCollectionDelegate>
+
+@optional
 
 - (void)collectionView:(UICollectionView *)collectionView willDisplayCell:(UICollectionViewCell *)cell forItemAtIndexPath:(NSIndexPath *)indexPath;
 

--- a/AsyncDisplayKit/Private/ASIGListAdapterBasedDataSource.h
+++ b/AsyncDisplayKit/Private/ASIGListAdapterBasedDataSource.h
@@ -12,6 +12,8 @@
 #import <AsyncDisplayKit/ASCollectionView.h>
 #import <AsyncDisplayKit/ASCollectionNode.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 AS_SUBCLASSING_RESTRICTED
 @interface ASIGListAdapterBasedDataSource : NSObject <ASCollectionDataSourceInterop, ASCollectionDelegateInterop, ASCollectionDelegateFlowLayout>
 
@@ -20,3 +22,5 @@ AS_SUBCLASSING_RESTRICTED
 @end
 
 #endif
+
+NS_ASSUME_NONNULL_END

--- a/AsyncDisplayKit/Private/ASIGListAdapterBasedDataSource.m
+++ b/AsyncDisplayKit/Private/ASIGListAdapterBasedDataSource.m
@@ -221,6 +221,11 @@ typedef struct {
   return [self.dataSource collectionView:collectionView viewForSupplementaryElementOfKind:kind atIndexPath:indexPath];
 }
 
++ (BOOL)dequeuesCellsForNodeBackedItems
+{
+  return YES;
+}
+
 #pragma mark - Helpers
 
 - (id<ASIGSupplementaryNodeSource>)supplementaryElementSourceForSection:(NSInteger)section


### PR DESCRIPTION
We recently accidentally broke IGListKit support when we added support for full nodeless interop.

This diff ensures that both modes (IGListKit and full passthrough) work correctly.