### PR TITLE
[ASDisplayNode] Add support for setting non-fatal error block

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -56,6 +56,12 @@ typedef void (^ASDisplayNodeContextModifier)(CGContextRef context);
 typedef ASLayoutSpec * _Nonnull(^ASLayoutSpecBlock)(__kindof ASDisplayNode * _Nonnull node, ASSizeRange constrainedSize);
 
 /**
+ * AsyncDisplayKit non-faltal error block. This block can be used for handling non-fatal errors. Useful for reporting
+ * errors that happens in production.
+ */
+typedef void (^ASDisplayNodeNonFatalErrorBlock)(__kindof NSError * _Nonnull error);
+
+/**
  * Interface state is available on ASDisplayNode and ASViewController, and
  * allows checking whether a node is in an interface situation where it is prudent to trigger certain
  * actions: measurement, data loading, display, and visibility (the latter for animations or other onscreen-only effects).
@@ -251,6 +257,15 @@ extern NSInteger const ASDefaultDrawingPriority;
  * @see ASInterfaceState
  */
 @property (readonly) ASInterfaceState interfaceState;
+
+/**
+ * @abstract Class property that allows to set a block that can be called on non-fatal errors. This
+ * property can be useful for cases when Async Display Kit can recover from an anormal behavior, but
+ * still gives the opportunity to use a reporting mechanism to catch occurrences in production.
+ *
+ * @warning This method is not thread-safe.
+ */
+@property (nonatomic, class, copy) ASDisplayNodeNonFatalErrorBlock nonFatalErrorBlock;
 
 
 /** @name Managing dimensions */

--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -56,7 +56,7 @@ typedef void (^ASDisplayNodeContextModifier)(CGContextRef context);
 typedef ASLayoutSpec * _Nonnull(^ASLayoutSpecBlock)(__kindof ASDisplayNode * _Nonnull node, ASSizeRange constrainedSize);
 
 /**
- * AsyncDisplayKit non-faltal error block. This block can be used for handling non-fatal errors. Useful for reporting
+ * AsyncDisplayKit non-fatal error block. This block can be used for handling non-fatal errors. Useful for reporting
  * errors that happens in production.
  */
 typedef void (^ASDisplayNodeNonFatalErrorBlock)(__kindof NSError * _Nonnull error);
@@ -260,8 +260,9 @@ extern NSInteger const ASDefaultDrawingPriority;
 
 /**
  * @abstract Class property that allows to set a block that can be called on non-fatal errors. This
- * property can be useful for cases when Async Display Kit can recover from an anormal behavior, but
- * still gives the opportunity to use a reporting mechanism to catch occurrences in production.
+ * property can be useful for cases when Async Display Kit can recover from an abnormal behavior, but
+ * still gives the opportunity to use a reporting mechanism to catch occurrences in production. In
+ * development, Async Display Kit will assert instead of calling this block.
  *
  * @warning This method is not thread-safe.
  */

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -63,6 +63,8 @@
   #define TIME_SCOPED(outVar)
 #endif
 
+static ASDisplayNodeNonFatalErrorBlock _nonFatalErrorBlock = nil;
+
 // Forward declare CALayerDelegate protocol as the iOS 10 SDK moves CALayerDelegate from a formal delegate to a protocol.
 // We have to forward declare the protocol as this place otherwise it will not compile compiling with an Base SDK < iOS 10
 @protocol CALayerDelegate;
@@ -2257,6 +2259,20 @@ static const char *ASDisplayNodeDrawingPriorityKey = "ASDrawingPriority";
 
   ASDisplayNodeAssert(_flags.layerBacked, @"We shouldn't get called back here if there is no layer");
   return (id)kCFNull;
+}
+
+#pragma mark - Error Handling
+
++ (void)setNonFatalErrorBlock:(ASDisplayNodeNonFatalErrorBlock)nonFatalErrorBlock
+{
+  if (_nonFatalErrorBlock != nonFatalErrorBlock) {
+    _nonFatalErrorBlock = [nonFatalErrorBlock copy];
+  }
+}
+
++ (ASDisplayNodeNonFatalErrorBlock)nonFatalErrorBlock
+{
+  return _nonFatalErrorBlock;
 }
 
 #pragma mark - Converting to and from the Node's Coordinate System

--- a/Base/ASAssert.h
+++ b/Base/ASAssert.h
@@ -59,3 +59,17 @@
 #define ASDisplayNodeCAssertPositiveReal(description, num) ASDisplayNodeCAssert(num >= 0 && num <= CGFLOAT_MAX, @"%@ must be a real positive integer.", description)
 #define ASDisplayNodeCAssertInfOrPositiveReal(description, num) ASDisplayNodeCAssert(isinf(num) || (num >= 0 && num <= CGFLOAT_MAX), @"%@ must be infinite or a real positive integer.", description)
 
+#define ASDisplayNodeErrorDomain @"ASDisplayNodeErrorDomain"
+#define ASDisplayNodeNonFatalErrorCode 0
+
+#define ASDisplayNodeAssertNonFatal(desc, ...)                                                                                  \
+  ASDisplayNodeAssert(NO, desc, ##__VA_ARGS__);                                                                                 \
+  ASDisplayNodeNonFatalErrorBlock block = [ASDisplayNode nonFatalErrorBlock];                                                   \
+  if (block != nil) {                                                                                                           \
+    NSDictionary *userInfo = nil;                                                                                               \
+    if (desc.length > 0) {                                                                                                      \
+      userInfo = @{ NSLocalizedDescriptionKey : desc };                                                                         \
+    }                                                                                                                           \
+    NSError *error = [NSError errorWithDomain:ASDisplayNodeErrorDomain code:ASDisplayNodeNonFatalErrorCode userInfo:userInfo];  \
+    block(error);                                                                                                               \
+  }

--- a/Base/ASAssert.h
+++ b/Base/ASAssert.h
@@ -60,7 +60,7 @@
 #define ASDisplayNodeCAssertInfOrPositiveReal(description, num) ASDisplayNodeCAssert(isinf(num) || (num >= 0 && num <= CGFLOAT_MAX), @"%@ must be infinite or a real positive integer.", description)
 
 #define ASDisplayNodeErrorDomain @"ASDisplayNodeErrorDomain"
-#define ASDisplayNodeNonFatalErrorCode 0
+#define ASDisplayNodeNonFatalErrorCode 1
 
 #define ASDisplayNodeAssertNonFatal(desc, ...)                                                                                  \
   ASDisplayNodeAssert(NO, desc, ##__VA_ARGS__);                                                                                 \

--- a/Base/ASAssert.h
+++ b/Base/ASAssert.h
@@ -62,14 +62,16 @@
 #define ASDisplayNodeErrorDomain @"ASDisplayNodeErrorDomain"
 #define ASDisplayNodeNonFatalErrorCode 1
 
-#define ASDisplayNodeAssertNonFatal(condition, desc, ...)                                                                       \
-  ASDisplayNodeAssert(condition, desc, ##__VA_ARGS__);                                                                          \
-  ASDisplayNodeNonFatalErrorBlock block = [ASDisplayNode nonFatalErrorBlock];                                                   \
-  if (block != nil) {                                                                                                           \
-    NSDictionary *userInfo = nil;                                                                                               \
-    if (desc.length > 0) {                                                                                                      \
-      userInfo = @{ NSLocalizedDescriptionKey : desc };                                                                         \
-    }                                                                                                                           \
-    NSError *error = [NSError errorWithDomain:ASDisplayNodeErrorDomain code:ASDisplayNodeNonFatalErrorCode userInfo:userInfo];  \
-    block(error);                                                                                                               \
+#define ASDisplayNodeAssertNonFatal(condition, desc, ...)                                                                         \
+  ASDisplayNodeAssert(condition, desc, ##__VA_ARGS__);                                                                            \
+  if (condition ==  NO) {                                                                                                         \
+    ASDisplayNodeNonFatalErrorBlock block = [ASDisplayNode nonFatalErrorBlock];                                                   \
+    if (block != nil) {                                                                                                           \
+      NSDictionary *userInfo = nil;                                                                                               \
+      if (desc.length > 0) {                                                                                                      \
+        userInfo = @{ NSLocalizedDescriptionKey : desc };                                                                         \
+      }                                                                                                                           \
+      NSError *error = [NSError errorWithDomain:ASDisplayNodeErrorDomain code:ASDisplayNodeNonFatalErrorCode userInfo:userInfo];  \
+      block(error);                                                                                                               \
+    }                                                                                                                             \
   }

--- a/Base/ASAssert.h
+++ b/Base/ASAssert.h
@@ -62,8 +62,8 @@
 #define ASDisplayNodeErrorDomain @"ASDisplayNodeErrorDomain"
 #define ASDisplayNodeNonFatalErrorCode 1
 
-#define ASDisplayNodeAssertNonFatal(desc, ...)                                                                                  \
-  ASDisplayNodeAssert(NO, desc, ##__VA_ARGS__);                                                                                 \
+#define ASDisplayNodeAssertNonFatal(condition, desc, ...)                                                                       \
+  ASDisplayNodeAssert(condition, desc, ##__VA_ARGS__);                                                                          \
   ASDisplayNodeNonFatalErrorBlock block = [ASDisplayNode nonFatalErrorBlock];                                                   \
   if (block != nil) {                                                                                                           \
     NSDictionary *userInfo = nil;                                                                                               \


### PR DESCRIPTION
Currently Async Display Kit doesn't provide a mechanism for "asserting" in production. In many the framework can recover from failures, but that would happen silently when in production.

This code changes gives the ability to set a "non-fatal error block" on `ASDisplayNode` class, so it can be plugged in many areas where we have asserts, for example, so developers have the change to capture and report such failures in production.

This addresses #2807 .