### PR TITLE
[Debug] Move debugName into it’s own protocol out of the ASLayoutElement protocol

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.h
+++ b/AsyncDisplayKit/ASDisplayNode.h
@@ -16,6 +16,7 @@
 #import <AsyncDisplayKit/ASBaseDefines.h>
 #import <AsyncDisplayKit/ASDimension.h>
 #import <AsyncDisplayKit/ASAsciiArtBoxCreator.h>
+#import <AsyncDisplayKit/ASObjectDescriptionHelpers.h>
 #import <AsyncDisplayKit/ASLayoutElement.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -558,7 +559,7 @@ extern NSInteger const ASDefaultDrawingPriority;
 /**
  * Convenience methods for debugging.
  */
-@interface ASDisplayNode (Debugging) <ASLayoutElementAsciiArtProtocol>
+@interface ASDisplayNode (Debugging) <ASLayoutElementAsciiArtProtocol, ASDebugNameProvider>
 
 /**
  * @abstract Return a description of the node hierarchy.

--- a/AsyncDisplayKit/Details/ASObjectDescriptionHelpers.h
+++ b/AsyncDisplayKit/Details/ASObjectDescriptionHelpers.h
@@ -11,6 +11,16 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@protocol ASDebugNameProvider <NSObject>
+
+@required
+/**
+ * @abstract Name that is printed by ascii art string and displayed in description.
+ */
+@property (nullable, nonatomic, copy) NSString *debugName;
+
+@end
+
 /**
  * Your base class should conform to this and override `-debugDescription`
  * to call `[self propertiesForDebugDescription]` and use `ASObjectDescriptionMake`

--- a/AsyncDisplayKit/Layout/ASLayoutElement.h
+++ b/AsyncDisplayKit/Layout/ASLayoutElement.h
@@ -89,11 +89,6 @@ ASDISPLAYNODE_EXTERN_C_END
  */
 - (nullable NSArray<id<ASLayoutElement>> *)sublayoutElements;
 
-/**
- * @abstract Optional name that is printed by ascii art string and displayed in description.
- */
-@property (nullable, nonatomic, copy) NSString *debugName;
-
 #pragma mark - Calculate layout
 
 /**

--- a/AsyncDisplayKit/Layout/ASLayoutSpec.h
+++ b/AsyncDisplayKit/Layout/ASLayoutSpec.h
@@ -10,6 +10,7 @@
 
 #import <AsyncDisplayKit/ASLayoutElement.h>
 #import <AsyncDisplayKit/ASAsciiArtBoxCreator.h>
+#import <AsyncDisplayKit/ASObjectDescriptionHelpers.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -96,7 +97,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface ASLayoutSpec (Debugging) <ASLayoutElementAsciiArtProtocol>
+@interface ASLayoutSpec (Debugging) <ASLayoutElementAsciiArtProtocol, ASDebugNameProvider>
 /**
  *  Used by other layout specs to create ascii art debug strings
  */


### PR DESCRIPTION
We currently have the `debugName` property in `ASLayoutElement` although it can live in the debug layer and does not need to be in the layout layer.

Let's move this into a separate protocol in the debug layer.