### PR TITLE
Route setDelegate: to setAsyncDelegate:

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.h
+++ b/AsyncDisplayKit/ASCollectionView.h
@@ -125,6 +125,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ASCollectionView (Deprecated)
 
+@property (nonatomic, weak) id<UICollectionViewDelegate> delegate AS_UNAVAILABLE("Use ASCollectionNode.delegate instead.");
+@property (nonatomic, weak) id<UICollectionViewDataSource> dataSource AS_UNAVAILABLE("Use ASCollectionNode.dataSource instead.");
+
 /**
  * The object that acts as the asynchronous delegate of the collection view
  *

--- a/AsyncDisplayKit/ASCollectionView.h
+++ b/AsyncDisplayKit/ASCollectionView.h
@@ -125,8 +125,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ASCollectionView (Deprecated)
 
-@property (nonatomic, weak) id<UICollectionViewDelegate> delegate AS_UNAVAILABLE("Use ASCollectionNode.delegate instead.");
-@property (nonatomic, weak) id<UICollectionViewDataSource> dataSource AS_UNAVAILABLE("Use ASCollectionNode.dataSource instead.");
+@property (nonatomic, weak) id<UICollectionViewDelegate> delegate ASDISPLAYNODE_DEPRECATED_MSG("Use ASCollectionNode.delegate instead. If you REALLY want to use this, cast to a UICollectionView but don't rely on the return value.");
+@property (nonatomic, weak) id<UICollectionViewDataSource> dataSource ASDISPLAYNODE_DEPRECATED_MSG("Use ASCollectionNode.dataSource instead. If you REALLY want to use this, cast to a UICollectionView but don't rely on the return value.");
 
 /**
  * The object that acts as the asynchronous delegate of the collection view

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -367,8 +367,10 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
 
 - (void)setDelegate:(id<UICollectionViewDelegate>)delegate
 {
-  // Our UIScrollView superclass sets its delegate to nil on dealloc. Only assert if we get a non-nil value here. We also allow this when we're doing interop.
-  ASDisplayNodeAssert(_asyncDelegateFlags.interop || delegate == nil, @"ASCollectionView uses asyncDelegate, not UICollectionView's delegate property.");
+  // The compiler will prevent users from calling this,
+  // but we will automatically route to @c asyncDelegate
+  // to support interop with frameworks like TLYShyNavBar.
+  self.asyncDelegate = (id<ASCollectionDelegate>)delegate;
 }
 
 - (void)proxyTargetHasDeallocated:(ASDelegateProxy *)proxy

--- a/AsyncDisplayKit/ASTableView.h
+++ b/AsyncDisplayKit/ASTableView.h
@@ -69,6 +69,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ASTableView (Deprecated)
 
+@property (nonatomic, weak) id<UITableViewDelegate> delegate AS_UNAVAILABLE("Use ASTableNode.delegate instead.");
+@property (nonatomic, weak) id<UITableViewDataSource> dataSource AS_UNAVAILABLE("Use ASTableNode.dataSource instead.");
+
 @property (nonatomic, weak) id<ASTableDelegate>   asyncDelegate ASDISPLAYNODE_DEPRECATED_MSG("Use ASTableNode's .delegate property instead.");
 @property (nonatomic, weak) id<ASTableDataSource> asyncDataSource ASDISPLAYNODE_DEPRECATED_MSG("Use ASTableNode .dataSource property instead.");
 

--- a/AsyncDisplayKit/ASTableView.h
+++ b/AsyncDisplayKit/ASTableView.h
@@ -69,8 +69,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ASTableView (Deprecated)
 
-@property (nonatomic, weak) id<UITableViewDelegate> delegate AS_UNAVAILABLE("Use ASTableNode.delegate instead.");
-@property (nonatomic, weak) id<UITableViewDataSource> dataSource AS_UNAVAILABLE("Use ASTableNode.dataSource instead.");
+@property (nonatomic, weak) id<UITableViewDelegate> delegate ASDISPLAYNODE_DEPRECATED_MSG("Use ASTableNode.delegate instead. If you REALLY want to use this, cast to UITableView but don't rely on the return value.");
+@property (nonatomic, weak) id<UITableViewDataSource> dataSource ASDISPLAYNODE_DEPRECATED_MSG("Use ASTableNode.dataSource instead. If you REALLY want to use this, cast to UITableView but don't rely on the return value.");
 
 @property (nonatomic, weak) id<ASTableDelegate>   asyncDelegate ASDISPLAYNODE_DEPRECATED_MSG("Use ASTableNode's .delegate property instead.");
 @property (nonatomic, weak) id<ASTableDataSource> asyncDataSource ASDISPLAYNODE_DEPRECATED_MSG("Use ASTableNode .dataSource property instead.");

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -337,8 +337,10 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
 
 - (void)setDelegate:(id<UITableViewDelegate>)delegate
 {
-  // Our UIScrollView superclass sets its delegate to nil on dealloc. Only assert if we get a non-nil value here.
-  ASDisplayNodeAssert(delegate == nil, @"ASTableView uses asyncDelegate, not UITableView's delegate property.");
+  // The compiler will prevent users from calling this,
+  // but we will automatically route to @c asyncDelegate
+  // to support interop with frameworks like TLYShyNavBar.
+  self.asyncDelegate = (id<ASTableDelegate>)delegate;
 }
 
 - (id<ASTableDataSource>)asyncDataSource
@@ -355,7 +357,7 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
   // the (common) case of nilling the asyncDataSource in the ViewController's dealloc. In this case our _asyncDataSource
   // will return as nil (ARC magic) even though the _proxyDataSource still exists. It's really important to hold a strong
   // reference to the old dataSource in this case because calls to ASTableViewProxy will start failing and cause crashes.
-  NS_VALID_UNTIL_END_OF_SCOPE id oldDataSource = self.dataSource;
+  NS_VALID_UNTIL_END_OF_SCOPE id oldDataSource = super.dataSource;
   
   if (asyncDataSource == nil) {
     _asyncDataSource = nil;

--- a/examples/CustomCollectionView-Swift/Sample/MosaicCollectionViewLayout.swift
+++ b/examples/CustomCollectionView-Swift/Sample/MosaicCollectionViewLayout.swift
@@ -229,17 +229,6 @@ class MosaicCollectionViewLayoutInspector: NSObject, ASCollectionViewLayoutInspe
   }
   
   /**
-   * Asks the inspector for the number of supplementary sections in the collection view for the given kind.
-   */
-  func collectionView(_ collectionView: ASCollectionView, numberOfSectionsForSupplementaryNodeOfKind kind: String) -> UInt {
-    if (kind == UICollectionElementKindSectionHeader) {
-      return UInt((collectionView.dataSource?.numberOfSections!(in: collectionView))!)
-    } else {
-      return 0
-    }
-  }
-  
-  /**
    * Asks the inspector for the number of supplementary views for the given kind in the specified section.
    */
   func collectionView(_ collectionView: ASCollectionView, supplementaryNodesOfKind kind: String, inSection section: UInt) -> UInt {
@@ -251,6 +240,6 @@ class MosaicCollectionViewLayoutInspector: NSObject, ASCollectionViewLayoutInspe
   }
   
   func scrollableDirections() -> ASScrollDirection {
-    return ASScrollDirectionVerticalDirections;
+    return ASScrollDirectionVerticalDirections
   }
 }


### PR DESCRIPTION
Resolves #2245 and improves interop with frameworks like TLYShyNavBar which set the delegate of the table/collection view.

We do not guarantee that we support these other frameworks, but in cases like this where the cost is low, we can help.