### PR TITLE
Allow ASTextNode to use a custom NSLayoutManager subclass

### DIFF
--- a/AsyncDisplayKit.podspec
+++ b/AsyncDisplayKit.podspec
@@ -27,7 +27,8 @@ Pod::Spec.new do |spec|
         'Base/*.h',
         'AsyncDisplayKit/Debug/ASLayoutElementInspectorNode.h',
         'AsyncDisplayKit/TextKit/ASTextNodeTypes.h',
-        'AsyncDisplayKit/TextKit/ASTextKitComponents.h'
+        'AsyncDisplayKit/TextKit/ASTextKitComponents.h',
+        'AsyncDisplayKit/TextKit/ASLayoutManager.h'
     ]
     
     core.source_files = [

--- a/AsyncDisplayKit/ASTextNode.h
+++ b/AsyncDisplayKit/ASTextNode.h
@@ -35,6 +35,9 @@ typedef NS_ENUM(NSUInteger, ASTextNodeHighlightStyle) {
  */
 @interface ASTextNode : ASControlNode
 
+- (instancetype)init; // ASLayoutManager
+- (instancetype)initWithLayoutManagerClass:(Class)layoutManagerClass;
+
 /**
  @abstract The styled text displayed by the node.
  @discussion Defaults to nil, no text is shown.

--- a/AsyncDisplayKit/ASTextNode.mm
+++ b/AsyncDisplayKit/ASTextNode.mm
@@ -22,6 +22,7 @@
 #import <AsyncDisplayKit/ASTextKitCoreTextAdditions.h>
 #import <AsyncDisplayKit/ASTextKitRenderer+Positioning.h>
 #import <AsyncDisplayKit/ASTextKitShadower.h>
+#import <AsyncDisplayKit/ASLayoutManager.h>
 
 #import <AsyncDisplayKit/ASInternalHelpers.h>
 #import <AsyncDisplayKit/ASLayout.h>
@@ -102,7 +103,7 @@ static NSCache *sharedRendererCache()
  we maintain a LRU renderer cache that is queried via a unique key based on text kit attributes and constrained size. 
  */
 
-static ASTextKitRenderer *rendererForAttributes(ASTextKitAttributes attributes, CGSize constrainedSize)
+static ASTextKitRenderer *rendererForAttributes(ASTextKitAttributes attributes, CGSize constrainedSize, Class layoutManagerClass)
 {
   NSCache *cache = sharedRendererCache();
   
@@ -112,7 +113,7 @@ static ASTextKitRenderer *rendererForAttributes(ASTextKitAttributes attributes, 
 
   ASTextKitRenderer *renderer = [cache objectForKey:key];
   if (renderer == nil) {
-    renderer = [[ASTextKitRenderer alloc] initWithTextKitAttributes:attributes constrainedSize:constrainedSize];
+    renderer = [[ASTextKitRenderer alloc] initWithTextKitAttributes:attributes constrainedSize:constrainedSize layoutManagerClass:layoutManagerClass];
     [cache setObject:renderer forKey:key];
   }
   
@@ -130,6 +131,8 @@ static ASTextKitRenderer *rendererForAttributes(ASTextKitAttributes attributes, 
   CGFloat _shadowOpacity;
   CGFloat _shadowRadius;
   
+  Class _layoutManagerClass;
+
   UIEdgeInsets _textContainerInset;
 
   NSArray *_exclusionPaths;
@@ -162,7 +165,11 @@ static ASTextKitRenderer *rendererForAttributes(ASTextKitAttributes attributes, 
 
 static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
 
-- (instancetype)init
+- (instancetype)init {
+    return [self initWithLayoutManagerClass:[ASLayoutManager class]];
+}
+
+- (instancetype)initWithLayoutManagerClass:(Class)layoutManagerClass
 {
   if (self = [super init]) {
     // Load default values from superclass.
@@ -171,6 +178,8 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
     _shadowOpacity = [super shadowOpacity];
     _shadowRadius = [super shadowRadius];
 
+    _layoutManagerClass = layoutManagerClass;
+    
     // Disable user interaction for text node by default.
     self.userInteractionEnabled = NO;
     self.needsDisplayOnBoundsChange = YES;
@@ -277,7 +286,7 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
   ASDN::MutexLocker l(__instanceLock__);
   bounds.size.width -= (_textContainerInset.left + _textContainerInset.right);
   bounds.size.height -= (_textContainerInset.top + _textContainerInset.bottom);
-  return rendererForAttributes([self _rendererAttributes], bounds.size);
+  return rendererForAttributes([self _rendererAttributes], bounds.size, _layoutManagerClass);
 }
 
 
@@ -384,7 +393,7 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
 
     _attributedText = ASCleanseAttributedStringOfCoreTextAttributes(attributedText);
 #if AS_TEXTNODE_RECORD_ATTRIBUTED_STRINGS
-	  [ASTextNode _registerAttributedText:_attributedText];
+    [ASTextNode _registerAttributedText:_attributedText];
 #endif
     // Sync the truncation string with attributes from the updated _attributedString
     // Without this, the size calculation of the text with truncation applied will

--- a/AsyncDisplayKit/AsyncDisplayKit.h
+++ b/AsyncDisplayKit/AsyncDisplayKit.h
@@ -94,6 +94,7 @@
 #import <AsyncDisplayKit/ASThread.h>
 #import <AsyncDisplayKit/ASRunLoopQueue.h>
 #import <AsyncDisplayKit/ASTextKitComponents.h>
+#import <AsyncDisplayKit/ASLayoutManager.h>
 #import <AsyncDisplayKit/ASTraitCollection.h>
 #import <AsyncDisplayKit/ASVisibilityProtocols.h>
 #import <AsyncDisplayKit/ASWeakSet.h>

--- a/AsyncDisplayKit/TextKit/ASLayoutManager.h
+++ b/AsyncDisplayKit/TextKit/ASLayoutManager.h
@@ -11,7 +11,6 @@
 #import <UIKit/UIKit.h>
 #import <AsyncDisplayKit/ASBaseDefines.h>
 
-AS_SUBCLASSING_RESTRICTED
 @interface ASLayoutManager : NSLayoutManager
 
 @end

--- a/AsyncDisplayKit/TextKit/ASTextKitContext.h
+++ b/AsyncDisplayKit/TextKit/ASTextKitContext.h
@@ -29,7 +29,8 @@ AS_SUBCLASSING_RESTRICTED
                            lineBreakMode:(NSLineBreakMode)lineBreakMode
                     maximumNumberOfLines:(NSUInteger)maximumNumberOfLines
                           exclusionPaths:(NSArray *)exclusionPaths
-                         constrainedSize:(CGSize)constrainedSize;
+                         constrainedSize:(CGSize)constrainedSize
+                      layoutManagerClass:(Class)layoutManagerClass;
 
 /**
  All operations on TextKit values MUST occur within this locked context.  Simultaneous access (even non-mutative) to

--- a/AsyncDisplayKit/TextKit/ASTextKitContext.mm
+++ b/AsyncDisplayKit/TextKit/ASTextKitContext.mm
@@ -29,7 +29,7 @@
                     maximumNumberOfLines:(NSUInteger)maximumNumberOfLines
                           exclusionPaths:(NSArray *)exclusionPaths
                          constrainedSize:(CGSize)constrainedSize
-
+                      layoutManagerClass:(Class)layoutManagerClass
 {
   if (self = [super init]) {
     // Concurrently initialising TextKit components crashes (rdar://18448377) so we use a global lock.
@@ -40,7 +40,7 @@
     
     // Create the TextKit component stack with our default configuration.
     _textStorage = (attributedString ? [[NSTextStorage alloc] initWithAttributedString:attributedString] : [[NSTextStorage alloc] init]);
-    _layoutManager = [[ASLayoutManager alloc] init];
+    _layoutManager = [[layoutManagerClass alloc] init];
     _layoutManager.usesFontLeading = NO;
     [_textStorage addLayoutManager:_layoutManager];
     _textContainer = [[NSTextContainer alloc] initWithSize:constrainedSize];

--- a/AsyncDisplayKit/TextKit/ASTextKitRenderer.h
+++ b/AsyncDisplayKit/TextKit/ASTextKitRenderer.h
@@ -41,7 +41,8 @@
  @discussion Sizing will occur as a result of initialization, so be careful when/where you use this.
  */
 - (instancetype)initWithTextKitAttributes:(const ASTextKitAttributes &)textComponentAttributes
-                          constrainedSize:(const CGSize)constrainedSize;
+                          constrainedSize:(const CGSize)constrainedSize
+                       layoutManagerClass:(Class)layoutManagerClass;
 
 @property (nonatomic, strong, readonly) ASTextKitContext *context;
 

--- a/AsyncDisplayKit/TextKit/ASTextKitRenderer.mm
+++ b/AsyncDisplayKit/TextKit/ASTextKitRenderer.mm
@@ -44,6 +44,7 @@ static NSCharacterSet *_defaultAvoidTruncationCharacterSet()
 
 - (instancetype)initWithTextKitAttributes:(const ASTextKitAttributes &)attributes
                           constrainedSize:(const CGSize)constrainedSize
+                       layoutManagerClass:(Class)layoutManagerClass
 {
   if (self = [super init]) {
     _constrainedSize = constrainedSize;
@@ -63,7 +64,8 @@ static NSCharacterSet *_defaultAvoidTruncationCharacterSet()
                                                     lineBreakMode:attributes.lineBreakMode
                                              maximumNumberOfLines:attributes.maximumNumberOfLines
                                                    exclusionPaths:attributes.exclusionPaths
-                                                  constrainedSize:shadowConstrainedSize];
+                                                  constrainedSize:shadowConstrainedSize
+                                               layoutManagerClass:layoutManagerClass];
     
     NSCharacterSet *avoidTailTruncationSet = attributes.avoidTailTruncationSet ?: _defaultAvoidTruncationCharacterSet();
     _truncater = [[ASTextKitTailTruncater alloc] initWithContext:[self context]

--- a/AsyncDisplayKit/TextKit/ASTextKitTailTruncater.mm
+++ b/AsyncDisplayKit/TextKit/ASTextKitTailTruncater.mm
@@ -10,6 +10,7 @@
 
 #import <AsyncDisplayKit/ASTextKitContext.h>
 #import <AsyncDisplayKit/ASTextKitTailTruncater.h>
+#import <AsyncDisplayKit/ASLayoutManager.h>
 
 @implementation ASTextKitTailTruncater
 {
@@ -66,7 +67,8 @@
                                                                              lineBreakMode:NSLineBreakByWordWrapping
                                                                       maximumNumberOfLines:1
                                                                             exclusionPaths:nil
-                                                                           constrainedSize:constrainedRect.size];
+                                                                           constrainedSize:constrainedRect.size
+                                                                        layoutManagerClass:[ASLayoutManager class]];
   __block CGRect truncationUsedRect;
 
   [truncationContext performBlockWithLockedTextKitComponents:^(NSLayoutManager *truncationLayoutManager, NSTextStorage *truncationTextStorage, NSTextContainer *truncationTextContainer) {


### PR DESCRIPTION
## Overview

`ASTextNode` is currently hardcoded to use `ASLayoutManager` as its layout manager for drawing. Allowing users to provide a custom layout manager to `ASTextNode` would provide a lot of power in terms of custom drawing and what `ASTextNode` can achieve for people.

## Why Use a Custom Layout Manager

As `NSLayoutManager` is really the meat and potatoes of the TextKit stack and controls drawing, subclassing it allows for easy tweaking of how things are drawn, and allows you to perform additional drawing steps.

In my case, I render Markdown into cells. Markdown has a lot of styling that purely using `NSAttributedString` doesn't allow you to accomplish, things you can see easily with GitHub's Markdown, such as quotes:

> ← `NSAttributedString` doesn't have an attribute to draw lines on the side

Or even just `inline code`, where `NSBackgroundStyleAttributeName` falls short in allowing you to do things such as round the squared off rectangle, add a border, padding, etc.

Subclassing `NSLayoutManager` allows you to do all this quite easily, and to my understanding without creating any issues with AsyncDisplayKit if this capability is introduced properly. For instance, subclassing and overriding `fillBackgroundRectArray(_:count:forCharacterRange:color:)` allows you to easily round the rectangles drawn with `NSBackgroundStyleAttributeName`, and further drawing can be done in `drawGlyphs(forGlyphRange:at:)`. 

## Example

**Example Project:** [TestCustomLayoutManager.zip](https://github.com/facebook/AsyncDisplayKit/files/765018/TestCustomLayoutManager.zip)

As I said, I render Markdown in my app. Subclassing `NSLayoutManager` allows me to add lines on the side of quotes, introduce inline code formatting, and show horizontal rules (`<hr>`s), among other things by simply adding an extra attribute onto the `NSAttributedString`, as shown in a simple example in the example project.

![simulator screenshot](https://cloud.githubusercontent.com/assets/4311814/22803769/b58b137e-eeec-11e6-8eee-55d23d5669ef.png)
*Image showing line-intended-blockquote, inline code and horizontal rule in `ASTextNode` from subclassing `NSLayoutManager`*

Which simply required the following subclass (truncated):

````swift
class MarkdownLayoutManager: ASLayoutManager {
    override func drawGlyphs(forGlyphRange glyphsToShow: NSRange, at origin: CGPoint) {
        performCustomDrawing()
        
        super.drawGlyphs(forGlyphRange: glyphsToShow, at: origin)
    }
    
    /// Custom Markdown drawing that can't be expressed in `NSAttributedString`.
    private func performCustomDrawing() {
        guard let textStorage = textStorage, textContainers.count > 0 else { return }
        let textContainer = textContainers[0]
        
        // Draw quote lines
        textStorage.enumerateAttribute("QuoteDepth", in: NSRange(location: 0, length: textStorage.length), options: [], using: { (value, range, stop) in
            guard let quoteDepth = value as? Int else { return }
            
            let quoteRect = boundingRect(forGlyphRange: range, in: textContainer)
            
            // Draw quote line
            let rectanglePath = UIBezierPath(rect: CGRect(x: (CGFloat(quoteDepth) * 15.0), y: quoteRect.minY, width: 2.0, height: quoteRect.height))
            UIColor.lightGray.setFill()
            rectanglePath.fill()
        })
        
	...

	}
    }
}
````

## How to Do It

My proposed solution is to allow `ASTextNode` to be provided with an `NSLayoutManager` *class* at init time, eg: `[[ASTextNode alloc] initWithLayoutManagerClass:[MyLayoutManager class]]`.

The advantage of this way is that it makes it really hard to shoot yourself in the foot. Talking with some people like @appleguy and @maicki among others in Slack who know infinitely more about ASDK than I do, they've mentioned this functionality has been there in the past but caused some issues with the layout manager being mutable after the fact. By only passing the subclass (akin to `NSPersistentStoreCoordinator`'s `registerStoreClass(_:forStoreType:)` model) and creating it at the end only when needed, issues with people changing it after the fact, or holding a reference to it are obviated.

Other methods such as passing in an actual `NSLayoutManager` object at init, or passing in a block are viable too, but would only provide the capability to tweak it slightly initially, which I'm not sure would have much use (especially to be worth the cost of complicating it further).

@appleguy mentioned some other awesome options in how to tackle this, such as using composition to have separate `ASDisplayNodes` behind the `ASTextNode` that operate as the rounded rects and whatnot, but I think `NSLayoutManager` overall adds a simpler, easy-to-point-to place to perform custom text drawing such as that. And furthermore, if people come to AsyncDisplayKit with existing TextKit stacks and custom `NSLayoutManager`s (*-waves-* that's me) it would make it really easy to integrate your existing work and get up and running with ASDK quickly.

## End

Hope I did this right! @maicki mentioned it would be a good idea to put this up as a point of discussion and see what people think, so that's exactly what I'm doing. Would love to hear what all you brilliant folk think.