### PR TITLE
Have ASVideoNode Override Superclass's Designated Initializer

### DIFF
--- a/AsyncDisplayKit/ASVideoNode.mm
+++ b/AsyncDisplayKit/ASVideoNode.mm
@@ -90,9 +90,9 @@ static NSString * const kRate = @"rate";
 
 #pragma mark - Construction and Layout
 
-- (instancetype)init
+- (instancetype)initWithCache:(id<ASImageCacheProtocol>)cache downloader:(id<ASImageDownloaderProtocol>)downloader
 {
-  if (!(self = [super init])) {
+  if (!(self = [super initWithCache:cache downloader:downloader])) {
     return nil;
   }
 


### PR DESCRIPTION
Resolves #2230 

It's scary that this wasn't triggering a warning, even when I explicitly added the warning flag.