### PR TITLE
Fix CatDealsCollectionView Supplementary Node Handling

### DIFF
--- a/examples/CatDealsCollectionView/Sample/ViewController.m
+++ b/examples/CatDealsCollectionView/Sample/ViewController.m
@@ -205,7 +205,7 @@ static const CGFloat kVerticalSectionPadding = 20.0f;
 
 #pragma mark - ASCollectionDelegateFlowLayout
 
-- (ASSizeRange)collectionNode:(ASCollectionNode *)collectionNode referenceConstrainedSizeForHeaderInSection:(NSInteger)section
+- (ASSizeRange)collectionNode:(ASCollectionNode *)collectionNode sizeRangeForHeaderInSection:(NSInteger)section
 {
   if (section == 0) {
     return ASSizeRangeUnconstrained;
@@ -214,7 +214,7 @@ static const CGFloat kVerticalSectionPadding = 20.0f;
   }
 }
 
-- (ASSizeRange)collectionNode:(ASCollectionNode *)collectionNode referenceConstrainedSizeForFooterInSection:(NSInteger)section
+- (ASSizeRange)collectionNode:(ASCollectionNode *)collectionNode sizeRangeForFooterInSection:(NSInteger)section
 {
   if (section == 0) {
     return ASSizeRangeUnconstrained;


### PR DESCRIPTION
I accidentally landed some unused method names into this example – `referenceConstrainedSizeForHeaderInSection:` which actually ended up being named `sizeRangeForHeaderInSection:`. This restores the supplementary views.

Will land after CI passes.