### PR TITLE
Lock ASTextNode.attributedText

### DIFF
--- a/AsyncDisplayKit/ASTextNode.mm
+++ b/AsyncDisplayKit/ASTextNode.mm
@@ -134,6 +134,7 @@ static ASTextKitRenderer *rendererForAttributes(ASTextKitAttributes attributes, 
 
   NSArray *_exclusionPaths;
 
+  NSAttributedString *_attributedText;
   NSAttributedString *_composedTruncationText;
 
   NSString *_highlightedLinkAttributeName;
@@ -366,6 +367,12 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
     lineHeight = MIN(lineHeight, paragraphStyle.maximumLineHeight);
   }
   return lineHeight + font.descender;
+}
+
+- (NSAttributedString *)attributedText
+{
+  ASDN::MutexLocker l(__instanceLock__);
+  return _attributedText;
 }
 
 - (void)setAttributedText:(NSAttributedString *)attributedText


### PR DESCRIPTION
This was actually causing practical problems. Resolves #2976 .