### PR TITLE
[TextKit] Fix text layout issue for CJK laungages

### DIFF
--- a/AsyncDisplayKit/TextKit/ASTextKitContext.mm
+++ b/AsyncDisplayKit/TextKit/ASTextKitContext.mm
@@ -39,12 +39,13 @@
     __instanceLock__ = std::make_shared<ASDN::Mutex>();
     
     // Create the TextKit component stack with our default configuration.
-    _textStorage = (attributedString ? [[NSTextStorage alloc] initWithAttributedString:attributedString] : [[NSTextStorage alloc] init]);
+    
+    _textStorage = [[NSTextStorage alloc] init];
     _layoutManager = [[ASLayoutManager alloc] init];
     _layoutManager.usesFontLeading = NO;
     [_textStorage addLayoutManager:_layoutManager];
     
-    // Set attributed string again(_textStorage has just been init by the same atttributedString), so this should bring no side effect, while magically fix text layout issue for CJK languages.
+    // Instead of calling [NSTextStorage initWithAttributedString:], setting attributedString just after calling addlayoutManager can fix CJK language layout issues.
     // See https://github.com/facebook/AsyncDisplayKit/issues/2894
     if (attributedString) {
       [_textStorage setAttributedString:attributedString];

--- a/AsyncDisplayKit/TextKit/ASTextKitContext.mm
+++ b/AsyncDisplayKit/TextKit/ASTextKitContext.mm
@@ -43,6 +43,13 @@
     _layoutManager = [[ASLayoutManager alloc] init];
     _layoutManager.usesFontLeading = NO;
     [_textStorage addLayoutManager:_layoutManager];
+    
+    // Set attributed string again(_textStorage has just been init by the same atttributedString), so this should bring no side effect, while magically fix text layout issue for CJK languages.
+    // See https://github.com/facebook/AsyncDisplayKit/issues/2894
+    if (attributedString) {
+      [_textStorage setAttributedString:attributedString];
+    }
+    
     _textContainer = [[NSTextContainer alloc] initWithSize:constrainedSize];
     // We want the text laid out up to the very edges of the container.
     _textContainer.lineFragmentPadding = 0;


### PR DESCRIPTION
A quick fix for CJK language layout issue, which is supposed to bring no side effect. Has been tested in our production for one month.
See https://github.com/facebook/AsyncDisplayKit/issues/2894