### PR TITLE
Fix Pager Node Issues

### DIFF
--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -327,6 +327,10 @@
 		CC4C2A791D88E3BF0039ACAB /* ASTraceEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = CC4C2A761D88E3BF0039ACAB /* ASTraceEvent.m */; };
 		CC54A81C1D70079800296A24 /* ASDispatch.h in Headers */ = {isa = PBXBuildFile; fileRef = CC54A81B1D70077A00296A24 /* ASDispatch.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CC54A81E1D7008B300296A24 /* ASDispatchTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CC54A81D1D7008B300296A24 /* ASDispatchTests.m */; };
+		CC55A70D1E529FA200594372 /* UIResponder+AsyncDisplayKit.h in Headers */ = {isa = PBXBuildFile; fileRef = CC55A70B1E529FA200594372 /* UIResponder+AsyncDisplayKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CC55A70E1E529FA200594372 /* UIResponder+AsyncDisplayKit.m in Sources */ = {isa = PBXBuildFile; fileRef = CC55A70C1E529FA200594372 /* UIResponder+AsyncDisplayKit.m */; };
+		CC55A7111E52A0F200594372 /* ASResponderChainEnumerator.h in Headers */ = {isa = PBXBuildFile; fileRef = CC55A70F1E52A0F200594372 /* ASResponderChainEnumerator.h */; };
+		CC55A7121E52A0F200594372 /* ASResponderChainEnumerator.m in Sources */ = {isa = PBXBuildFile; fileRef = CC55A7101E52A0F200594372 /* ASResponderChainEnumerator.m */; };
 		CC57EAF71E3939350034C595 /* ASCollectionView+Undeprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = CC2E317F1DAC353700EEE891 /* ASCollectionView+Undeprecated.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CC57EAF81E3939450034C595 /* ASTableView+Undeprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = CC512B841DAC45C60054848E /* ASTableView+Undeprecated.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CC58AA4B1E398E1D002C8CB4 /* ASBlockTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = CC58AA4A1E398E1D002C8CB4 /* ASBlockTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -711,6 +715,10 @@
 		CC512B841DAC45C60054848E /* ASTableView+Undeprecated.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ASTableView+Undeprecated.h"; sourceTree = "<group>"; };
 		CC54A81B1D70077A00296A24 /* ASDispatch.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ASDispatch.h; sourceTree = "<group>"; };
 		CC54A81D1D7008B300296A24 /* ASDispatchTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = ASDispatchTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
+		CC55A70B1E529FA200594372 /* UIResponder+AsyncDisplayKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIResponder+AsyncDisplayKit.h"; sourceTree = "<group>"; };
+		CC55A70C1E529FA200594372 /* UIResponder+AsyncDisplayKit.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIResponder+AsyncDisplayKit.m"; sourceTree = "<group>"; };
+		CC55A70F1E52A0F200594372 /* ASResponderChainEnumerator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASResponderChainEnumerator.h; sourceTree = "<group>"; };
+		CC55A7101E52A0F200594372 /* ASResponderChainEnumerator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASResponderChainEnumerator.m; sourceTree = "<group>"; };
 		CC57EAF91E394EA40034C595 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		CC58AA4A1E398E1D002C8CB4 /* ASBlockTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASBlockTypes.h; sourceTree = "<group>"; };
 		CC7FD9DC1BB5E962005CCB2B /* ASPhotosFrameworkImageRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASPhotosFrameworkImageRequest.h; sourceTree = "<group>"; };
@@ -927,6 +935,8 @@
 				DB55C2651C641AE4004EDCF5 /* ASContextTransitioning.h */,
 				68FC85E71CE29C7D00EDD713 /* ASVisibilityProtocols.h */,
 				68FC85E81CE29C7D00EDD713 /* ASVisibilityProtocols.m */,
+				CC55A70B1E529FA200594372 /* UIResponder+AsyncDisplayKit.h */,
+				CC55A70C1E529FA200594372 /* UIResponder+AsyncDisplayKit.m */,
 				690ED5911E36D118000627C0 /* tvOS */,
 				DE89C1691DCEB9CC00D49D74 /* Debug */,
 				058D09E1195D050800B7D73C /* Details */,
@@ -1120,6 +1130,8 @@
 		058D0A01195D050800B7D73C /* Private */ = {
 			isa = PBXGroup;
 			children = (
+				CC55A70F1E52A0F200594372 /* ASResponderChainEnumerator.h */,
+				CC55A7101E52A0F200594372 /* ASResponderChainEnumerator.m */,
 				6947B0BB1E36B4E30007C478 /* Layout */,
 				CCE04B2A1E313EDA006AEBBB /* Collection Data Adapter */,
 				058D0A03195D050800B7D73C /* _ASCoreAnimationExtras.h */,
@@ -1398,6 +1410,7 @@
 				B35062151B010EFD0018CF92 /* ASBatchContext.h in Headers */,
 				B35061F31B010EFD0018CF92 /* ASCellNode.h in Headers */,
 				34EFC7631B701CBF00AD841F /* ASCenterLayoutSpec.h in Headers */,
+				CC55A7111E52A0F200594372 /* ASResponderChainEnumerator.h in Headers */,
 				18C2ED7F1B9B7DE800F627B3 /* ASCollectionNode.h in Headers */,
 				B35061F51B010EFD0018CF92 /* ASCollectionView.h in Headers */,
 				ACE87A2C1D73696800D7FF06 /* ASSectionContext.h in Headers */,
@@ -1441,6 +1454,7 @@
 				254C6B771BF94DF4003EC431 /* ASTextKitAttributes.h in Headers */,
 				254C6B7D1BF94DF4003EC431 /* ASTextKitShadower.h in Headers */,
 				690ED58E1E36BCA6000627C0 /* ASLayoutElementStylePrivate.h in Headers */,
+				CC55A70D1E529FA200594372 /* UIResponder+AsyncDisplayKit.h in Headers */,
 				254C6B731BF94DF4003EC431 /* ASTextKitCoreTextAdditions.h in Headers */,
 				254C6B7A1BF94DF4003EC431 /* ASTextKitRenderer.h in Headers */,
 				69CB62AC1CB8165900024920 /* _ASDisplayViewAccessiblity.h in Headers */,
@@ -1827,6 +1841,7 @@
 				18C2ED831B9B7DE800F627B3 /* ASCollectionNode.mm in Sources */,
 				E55D86331CA8A14000A0C26F /* ASLayoutElement.mm in Sources */,
 				68FC85EC1CE29C7D00EDD713 /* ASVisibilityProtocols.m in Sources */,
+				CC55A7121E52A0F200594372 /* ASResponderChainEnumerator.m in Sources */,
 				68B8A4E41CBDB958007E4543 /* ASWeakProxy.m in Sources */,
 				9C70F20A1CDBE949007D6C76 /* ASTableNode.mm in Sources */,
 				69CB62AE1CB8165900024920 /* _ASDisplayViewAccessiblity.mm in Sources */,
@@ -1905,6 +1920,7 @@
 				254C6B871BF94F8A003EC431 /* ASTextKitEntityAttribute.m in Sources */,
 				34566CB31BC1213700715E6B /* ASPhotosFrameworkImageRequest.m in Sources */,
 				254C6B831BF94F8A003EC431 /* ASTextKitCoreTextAdditions.m in Sources */,
+				CC55A70E1E529FA200594372 /* UIResponder+AsyncDisplayKit.m in Sources */,
 				697796611D8AC8D3007E93D7 /* ASLayoutSpec+Subclasses.mm in Sources */,
 				B350623B1B010EFD0018CF92 /* NSMutableAttributedString+TextKitAdditions.m in Sources */,
 				044284FD1BAA365100D16268 /* UICollectionViewLayout+ASConvenience.m in Sources */,

--- a/AsyncDisplayKit/ASCollectionView.h
+++ b/AsyncDisplayKit/ASCollectionView.h
@@ -111,6 +111,10 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, assign) BOOL inverted;
 
+@end
+
+@interface ASCollectionView (Deprecated)
+
 /**
  * Forces the .contentInset to be UIEdgeInsetsZero.
  *
@@ -119,11 +123,7 @@ NS_ASSUME_NONNULL_BEGIN
  * automaticallyAdjustsScrollViewInsets, which may not be accessible.  ASPagerNode uses this to ensure
  * its flow layout behaves predictably and does not log undefined layout warnings.
  */
-@property (nonatomic) BOOL zeroContentInsets;
-
-@end
-
-@interface ASCollectionView (Deprecated)
+@property (nonatomic) BOOL zeroContentInsets ASDISPLAYNODE_DEPRECATED_MSG("Set automaticallyAdjustsScrollViewInsets=NO on your view controller instead.");
 
 /**
  * The object that acts as the asynchronous delegate of the collection view

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -36,6 +36,7 @@
 #import <AsyncDisplayKit/ASRunLoopQueue.h>
 #import <AsyncDisplayKit/ASTraitCollection.h>
 #import <AsyncDisplayKit/ASWeakProxy.h>
+#import <AsyncDisplayKit/ASResponderChainEnumerator.h>
 
 /**
  * Assert if the current thread owns a mutex.
@@ -3782,6 +3783,20 @@ ASDISPLAYNODE_INLINE BOOL nodeIsInRasterizedTree(ASDisplayNode *node) {
   CGRect windowFrame = [self _frameInWindow];
   if (CGRectIsNull(windowFrame) == NO) {
     [result addObject:@{ @"frameInWindow" : [NSValue valueWithCGRect:windowFrame] }];
+  }
+  
+  // Attempt to find view controller.
+  // Note that the convenience method asdk_associatedViewController has an assertion
+  // that it's run on main. Since this is a debug method, let's bypass the assertion
+  // and run up the chain ourselves.
+  if (_view != nil) {
+    for (UIResponder *responder in [_view asdk_responderChainEnumerator]) {
+      UIViewController *vc = ASDynamicCast(responder, UIViewController);
+      if (vc) {
+        [result addObject:@{ @"viewController" : ASObjectDescriptionMakeTiny(vc) }];
+        break;
+      }
+    }
   }
   
   if (_view != nil) {

--- a/AsyncDisplayKit/ASPagerNode.h
+++ b/AsyncDisplayKit/ASPagerNode.h
@@ -120,6 +120,24 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (NSInteger)indexOfPageWithNode:(ASCellNode *)node;
 
+/**
+ * Tells the pager node to allow its view controller to automatically adjust its content insets.
+ *
+ * @see UIViewController.automaticallyAdjustsScrollViewInsets
+ *
+ * @discussion ASPagerNode should usually not have its content insets automatically adjusted
+ * because it scrolls horizontally, and flow layout will log errors because the pages
+ * do not fit between the top & bottom insets of the collection view.
+ *
+ * The default value is NO, which means that ASPagerNode expects that its view controller will
+ * have automaticallyAdjustsScrollViewInsets=NO.
+ *
+ * If this property is NO, but your view controller has automaticallyAdjustsScrollViewInsets=YES,
+ * the pager node will set the property to NO and log a warning message. In the future,
+ * the pager node will just log the warning, and you'll need to configure your view controller on your own.
+ */
+@property (nonatomic, assign) BOOL allowsAutomaticInsetsAdjustment;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/AsyncDisplayKit/ASPagerNode.m
+++ b/AsyncDisplayKit/ASPagerNode.m
@@ -208,17 +208,21 @@
   [self setDelegate:nil];
 }
 
-- (void)enterHierarchyState:(ASHierarchyState)hierarchyState
+- (void)didEnterVisibleState
 {
-  [super enterHierarchyState:hierarchyState];
-  
-  if (_allowsAutomaticInsetsAdjustment == NO && hierarchyState == ASHierarchyStateNormal) {
-    UIViewController *vc = [self.view asdk_associatedViewController];
-    if (vc.automaticallyAdjustsScrollViewInsets) {
-      NSLog(@"AsyncDisplayKit: ASPagerNode is setting automaticallyAdjustsScrollViewInsets=NO on its owning view controller %@. This automatic behavior will be disabled in the future. Set allowsAutomaticInsetsAdjustment=YES on the pager node to silence this warning.", vc);
-      vc.automaticallyAdjustsScrollViewInsets = NO;
-    }
-  }
+	[super didEnterVisibleState];
+
+	// Check that our view controller does not automatically set our content insets
+	// It would be better to have a -didEnterHierarchy hook to put this in, but
+	// such a hook doesn't currently exist, and in every use case I can imagine,
+	// the pager is not hosted inside a range-managed node.
+	if (_allowsAutomaticInsetsAdjustment == NO) {
+		UIViewController *vc = [self.view asdk_associatedViewController];
+		if (vc.automaticallyAdjustsScrollViewInsets) {
+			NSLog(@"AsyncDisplayKit: ASPagerNode is setting automaticallyAdjustsScrollViewInsets=NO on its owning view controller %@. This automatic behavior will be disabled in the future. Set allowsAutomaticInsetsAdjustment=YES on the pager node to suppress this behavior.", vc);
+			vc.automaticallyAdjustsScrollViewInsets = NO;
+		}
+	}
 }
 
 @end

--- a/AsyncDisplayKit/AsyncDisplayKit.h
+++ b/AsyncDisplayKit/AsyncDisplayKit.h
@@ -106,6 +106,7 @@
 #import <AsyncDisplayKit/UIImage+ASConvenience.h>
 #import <AsyncDisplayKit/NSArray+Diffing.h>
 #import <AsyncDisplayKit/ASObjectDescriptionHelpers.h>
+#import <AsyncDisplayKit/UIResponder+AsyncDisplayKit.h>
 
 #import <AsyncDisplayKit/AsyncDisplayKit+Debug.h>
 #import <AsyncDisplayKit/ASDisplayNode+Deprecated.h>

--- a/AsyncDisplayKit/Private/ASResponderChainEnumerator.h
+++ b/AsyncDisplayKit/Private/ASResponderChainEnumerator.h
@@ -1,0 +1,22 @@
+//
+//  ASResponderChainEnumerator.h
+//  AsyncDisplayKit
+//
+//  Created by Adlai Holler on 2/13/17.
+//  Copyright © 2017 Facebook. All rights reserved.
+//
+
+#import <UIKit/UIResponder.h>
+#import <AsyncDisplayKit/ASBaseDefines.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+AS_SUBCLASSING_RESTRICTED
+@interface ASResponderChainEnumerator : NSEnumerator
+
+- (instancetype)initWithResponder:(UIResponder *)responder;
+
+@end
+
+
+NS_ASSUME_NONNULL_END

--- a/AsyncDisplayKit/Private/ASResponderChainEnumerator.h
+++ b/AsyncDisplayKit/Private/ASResponderChainEnumerator.h
@@ -18,5 +18,11 @@ AS_SUBCLASSING_RESTRICTED
 
 @end
 
+@interface UIResponder (ASResponderChainEnumerator)
+
+- (ASResponderChainEnumerator *)asdk_responderChainEnumerator;
+
+@end
+
 
 NS_ASSUME_NONNULL_END

--- a/AsyncDisplayKit/Private/ASResponderChainEnumerator.m
+++ b/AsyncDisplayKit/Private/ASResponderChainEnumerator.m
@@ -1,0 +1,32 @@
+//
+//  ASResponderChainEnumerator.m
+//  AsyncDisplayKit
+//
+//  Created by Adlai Holler on 2/13/17.
+//  Copyright © 2017 Facebook. All rights reserved.
+//
+
+#import "ASResponderChainEnumerator.h"
+
+@implementation ASResponderChainEnumerator {
+  UIResponder *_currentResponder;
+}
+
+- (instancetype)initWithResponder:(UIResponder *)responder
+{
+  if (self = [super init]) {
+    _currentResponder = responder;
+  }
+  return self;
+}
+
+#pragma mark - NSEnumerator
+
+- (id)nextObject
+{
+  id result = [_currentResponder nextResponder];
+  _currentResponder = result;
+  return result;
+}
+
+@end

--- a/AsyncDisplayKit/Private/ASResponderChainEnumerator.m
+++ b/AsyncDisplayKit/Private/ASResponderChainEnumerator.m
@@ -30,3 +30,12 @@
 }
 
 @end
+
+@implementation UIResponder (ASResponderChainEnumerator)
+
+- (NSEnumerator *)asdk_responderChainEnumerator
+{
+  return [[ASResponderChainEnumerator alloc] initWithResponder:self];
+}
+
+@end

--- a/AsyncDisplayKit/UIResponder+AsyncDisplayKit.h
+++ b/AsyncDisplayKit/UIResponder+AsyncDisplayKit.h
@@ -1,0 +1,24 @@
+//
+//  UIResponder+AsyncDisplayKit.h
+//  AsyncDisplayKit
+//
+//  Created by Adlai Holler on 2/13/17.
+//  Copyright © 2017 Facebook. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface UIResponder (AsyncDisplayKit)
+
+/**
+ * The nearest view controller above this responder, if one exists.
+ *
+ * This property must be accessed on the main thread.
+ */
+@property (nonatomic, nullable, readonly) __kindof UIViewController *asdk_associatedViewController;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/AsyncDisplayKit/UIResponder+AsyncDisplayKit.m
+++ b/AsyncDisplayKit/UIResponder+AsyncDisplayKit.m
@@ -1,0 +1,36 @@
+//
+//  UIResponder+AsyncDisplayKit.m
+//  AsyncDisplayKit
+//
+//  Created by Adlai Holler on 2/13/17.
+//  Copyright © 2017 Facebook. All rights reserved.
+//
+
+#import "UIResponder+AsyncDisplayKit.h"
+
+#import <AsyncDisplayKit/ASAssert.h>
+#import <AsyncDisplayKit/ASBaseDefines.h>
+#import <AsyncDisplayKit/ASResponderChainEnumerator.h>
+
+@implementation UIResponder (AsyncDisplayKit)
+
+- (__kindof UIViewController *)asdk_associatedViewController
+{
+  ASDisplayNodeAssertMainThread();
+  
+  for (UIResponder *responder in [self asdk_responderChainEnumerator]) {
+    UIViewController *vc = ASDynamicCast(responder, UIViewController);
+    if (vc) {
+      return vc;
+    }
+  }
+  return nil;
+}
+
+- (NSEnumerator *)asdk_responderChainEnumerator
+{
+  return [[ASResponderChainEnumerator alloc] initWithResponder:self];
+}
+
+@end
+

--- a/AsyncDisplayKit/UIResponder+AsyncDisplayKit.m
+++ b/AsyncDisplayKit/UIResponder+AsyncDisplayKit.m
@@ -27,10 +27,5 @@
   return nil;
 }
 
-- (NSEnumerator *)asdk_responderChainEnumerator
-{
-  return [[ASResponderChainEnumerator alloc] initWithResponder:self];
-}
-
 @end
 

--- a/examples/PagerNode/Sample/PageNode.m
+++ b/examples/PagerNode/Sample/PageNode.m
@@ -21,9 +21,9 @@
 
 @implementation PageNode
 
-- (ASLayout *)calculateLayoutThatFits:(ASSizeRange)constrainedSize
+- (CGSize)calculateSizeThatFits:(CGSize)constrainedSize
 {
-  return [ASLayout layoutWithLayoutElement:self size:constrainedSize.max];
+  return constrainedSize;
 }
 
 - (void)fetchData

--- a/examples/PagerNode/Sample/ViewController.m
+++ b/examples/PagerNode/Sample/ViewController.m
@@ -46,7 +46,7 @@ static UIColor *randomColor() {
   
   self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@"Next" style:UIBarButtonItemStylePlain target:self action:@selector(scrollToNextPage:)];
   self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@"Previous" style:UIBarButtonItemStylePlain target:self action:@selector(scrollToPreviousPage:)];
-
+  self.automaticallyAdjustsScrollViewInsets = NO;
   return self;
 }
 


### PR DESCRIPTION
Resolves #2974 and other major pager node rotation/content inset issues.

- Deprecates `ASCollectionView.zeroContentInsets`.
  - This flag was added as a hack during development of `ASPagerNode` to "undo" the effects of `UIViewController.automaticallyAdjustsScrollViewInsets`.
  - The flag adds `contentInsets = .zero` into `layoutSubviews`, after `[super layoutSubviews]`
  - This means our `contentInsets` is thrashing around constantly.
  - The view controller _also_ sets `contentOffset` during its insets adjustment, which we didn't account for.
- Adds a flag `ASPagerNode.allowsAutomaticInsetsAdjustment`.
  - Defaults to `NO` since you virtually NEVER want UIVC to adjust pager node insets.
  - If `NO`, finds the owning view controller of the pager and sets `automaticallyAdjustsScrollViewInsets=NO`, and logs a message.
  - In the future, we may remove the automatic setting of this property and just log the message, so users retain control of their view controllers' flags.
  - If they for some reason _want_ automatic insets adjustment from their VC, they can set `allowsAutomaticInsetsAdjustment=YES` on their pager node.
- Adds a public category method `-[UIResponder asdk_associatedViewController]` that safely travels up the responder chain and finds the nearest view controller. This is used above, and it may very well be handy for users especially when debugging. I also put the view controller in the node's `-debugDescription` for fun. I could have left it out to keep this diff smaller.
- Adds a private class `ASResponderChainEnumerator` that is used in implementing above, and may come in handy in other places later.
- Replaces `ASPagerFlowLayout.currentIndexPath` with `ASPagerFlowLayout.currentCellNode` so that we can stay pointing at the same node across inserts/deletes.
- Makes `ASPagerFlowLayout` use `-shouldInvalidateLayoutForBoundsChange:` – which is like the `UICollectionViewLayout` version of `scrollViewDidScroll:` – to update its `currentIndexPath`, rather than using `targetContentOffsetForProposedContentOffset:withScrollingVelocity:`, which is not called during programmatic scrolls.
- When a collection view's bounds change, removes the `performBatchUpdates:` that we placed around `_relayoutAllNodes`. The stated reason for the batch updates was to get the relayout into the data controller's transaction pipeline, but it already _goes_ in that pipeline internally, and we don't need to submit an empty update to trigger a layout invalidation, since we're already manually invalidating the layout on the next line. This avoids triggering `UICollectionViewLayout.targetContentOffsetForProposedContentOffset:` needlessly, which happens on every collection view update, even empty ones.
- Fixes indentation throughout `ASPagerFlowLayout.m`.

In short:
Before:

![](https://media.giphy.com/media/3xgAtLMCukb3q/giphy.gif)

After:


![](https://media.giphy.com/media/zhgNlupeH80RW/giphy.gif)

Note the flashing may look ugly here, but it's intentionally added by flow layout because in a real app, the layout transition is usually going to be bad.