### PR TITLE
Don't Skip Remeasurement On First Layout Pass

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -89,7 +89,6 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
   ASBatchContext *_batchContext;
   
   CGSize _lastBoundsSizeUsedForMeasuringNodes;
-  BOOL _ignoreNextBoundsSizeChangeForMeasuringNodes;
   
   NSMutableSet *_registeredSupplementaryKinds;
   
@@ -272,9 +271,6 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
   _superIsPendingDataLoad = YES;
   
   _lastBoundsSizeUsedForMeasuringNodes = self.bounds.size;
-  // If the initial size is 0, expect a size change very soon which is part of the initial configuration
-  // and should not trigger a relayout.
-  _ignoreNextBoundsSizeChangeForMeasuringNodes = CGSizeEqualToSize(_lastBoundsSizeUsedForMeasuringNodes, CGSizeZero);
   
   _layoutFacilitator = layoutFacilitator;
   
@@ -1904,31 +1900,22 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
   }
   _lastBoundsSizeUsedForMeasuringNodes = newBounds.size;
 
-  // First size change occurs during initial configuration. An expensive relayout pass is unnecessary at that time
-  // and should be avoided, assuming that the initial data loading automatically runs shortly afterward.
-  if (_ignoreNextBoundsSizeChangeForMeasuringNodes) {
-    _ignoreNextBoundsSizeChangeForMeasuringNodes = NO;
-  } else {
-    // Laying out all nodes is expensive, and performing an empty update may be unsafe
-    // if the data source has pending changes that it hasn't reported yet – the collection
-    // view will requery the new counts and expect them to match the previous counts.
-    //
-    // We only need to do this if the bounds changed in the non-scrollable direction.
-    // If, for example, a vertical flow layout has its height changed due to a status bar
-    // appearance update, we do not need to relayout all nodes.
-    // For a more permanent fix to the unsafety mentioned above, see https://github.com/facebook/AsyncDisplayKit/pull/2182
-    ASScrollDirection scrollDirection = self.scrollableDirections;
-    BOOL fixedVertically = (ASScrollDirectionContainsVerticalDirection(scrollDirection) == NO);
-    BOOL fixedHorizontally = (ASScrollDirectionContainsHorizontalDirection(scrollDirection) == NO);
+  // Laying out all nodes is expensive.
+  // We only need to do this if the bounds changed in the non-scrollable direction.
+  // If, for example, a vertical flow layout has its height changed due to a status bar
+  // appearance update, we do not need to relayout all nodes.
+  // For a more permanent fix to the unsafety mentioned above, see https://github.com/facebook/AsyncDisplayKit/pull/2182
+  ASScrollDirection scrollDirection = self.scrollableDirections;
+  BOOL fixedVertically = (ASScrollDirectionContainsVerticalDirection(scrollDirection) == NO);
+  BOOL fixedHorizontally = (ASScrollDirectionContainsHorizontalDirection(scrollDirection) == NO);
 
-    BOOL changedInNonScrollingDirection = (fixedHorizontally && newBounds.size.width != lastUsedSize.width) || (fixedVertically && newBounds.size.height != lastUsedSize.height);
+  BOOL changedInNonScrollingDirection = (fixedHorizontally && newBounds.size.width != lastUsedSize.width) || (fixedVertically && newBounds.size.height != lastUsedSize.height);
 
-    if (changedInNonScrollingDirection) {
-      [_dataController relayoutAllNodes];
-      [_dataController waitUntilAllUpdatesAreCommitted];
-      // We need to ensure the size requery is done before we update our layout.
-      [self.collectionViewLayout invalidateLayout];
-    }
+  if (changedInNonScrollingDirection) {
+    [_dataController relayoutAllNodes];
+    [_dataController waitUntilAllUpdatesAreCommitted];
+    // We need to ensure the size requery is done before we update our layout.
+    [self.collectionViewLayout invalidateLayout];
   }
 }
 

--- a/AsyncDisplayKitTests/ASTableViewTests.mm
+++ b/AsyncDisplayKitTests/ASTableViewTests.mm
@@ -395,29 +395,6 @@
   [self triggerSizeChangeAndAssertRelayoutAllNodesForTableView:tableView newSize:tableViewFinalSize];
 }
 
-- (void)testRelayoutAllNodesWithZeroSizeInitially
-{
-  // Initial width of the table view is 0. The first size change is part of the initial config.
-  // Any subsequence size change after that must trigger a relayout.
-  CGSize tableViewFinalSize = CGSizeMake(100, 500);
-  ASTestTableView *tableView = [[ASTestTableView alloc] __initWithFrame:CGRectZero
-                                                                style:UITableViewStylePlain];
-  ASTableViewFilledDataSource *dataSource = [ASTableViewFilledDataSource new];
-
-  tableView.asyncDelegate = dataSource;
-  tableView.asyncDataSource = dataSource;
-  
-  // Initial configuration
-  UIView *superview = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 500, 500)];
-  [superview addSubview:tableView];
-  // Width and height are swapped so that a later size change will simulate a rotation
-  tableView.frame = CGRectMake(0, 0, tableViewFinalSize.height, tableViewFinalSize.width);
-  [tableView layoutIfNeeded];
-  
-  XCTAssertEqual(tableView.testDataController.numberOfAllNodesRelayouts, 0);
-  [self triggerSizeChangeAndAssertRelayoutAllNodesForTableView:tableView newSize:tableViewFinalSize];
-}
-
 - (void)testRelayoutVisibleRowsWhenEditingModeIsChanged
 {
   CGSize tableViewSize = CGSizeMake(100, 500);


### PR DESCRIPTION
Fixes the rest of #2955 

The logic behind this flag is pretty nonsensical. The only reason we would ever get `layoutSubviews` before our size is "final" is if someone calls `layoutIfNeeded` specifically on us, which they might do I guess.

But in the normal case, we get `layoutSubviews` after our superview gets `layoutSubviews` and sets our frame to e.g. `(375, 667)` or whatever our final frame is. Silly silly silly!