### PR TITLE
[Yoga] Fix ASLayout hierarchy to only include immediate subnodes.

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode+Beta.h
+++ b/AsyncDisplayKit/ASDisplayNode+Beta.h
@@ -14,7 +14,7 @@
 #import <AsyncDisplayKit/ASEventLog.h>
 
 #if YOGA
-#import <Yoga/Yoga.h>
+  #import YOGA_HEADER_PATH
 #endif
 
 NS_ASSUME_NONNULL_BEGIN
@@ -156,15 +156,19 @@ typedef struct {
 
 #if YOGA
 
+extern void ASDisplayNodePerformBlockOnEveryYogaChild(ASDisplayNode * _Nullable node, void(^block)(ASDisplayNode *node));
+
 @interface ASDisplayNode (Yoga)
 
 @property (nonatomic, strong) NSArray *yogaChildren;
+@property (nonatomic, strong) ASLayout *yogaCalculatedLayout;
 
 - (void)addYogaChild:(ASDisplayNode *)child;
 - (void)removeYogaChild:(ASDisplayNode *)child;
 
-// This method should not normally be called directly.
-- (ASLayout *)calculateLayoutFromYogaRoot:(ASSizeRange)rootConstrainedSize;
+// These methods should not normally be called directly.
+- (void)invalidateCalculatedYogaLayout;
+- (void)calculateLayoutFromYogaRoot:(ASSizeRange)rootConstrainedSize;
 
 @end
 

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -915,6 +915,10 @@ ASLayoutElementFinalLayoutElementDefault
   if (_pendingDisplayNodeLayout != nullptr) {
     _pendingDisplayNodeLayout->invalidate();
   }
+
+#if YOGA
+  [self invalidateCalculatedYogaLayout];
+#endif
 }
 
 - (void)__layout
@@ -1081,7 +1085,11 @@ ASLayoutElementFinalLayoutElementDefault
   if (ASHierarchyStateIncludesYogaLayoutEnabled(_hierarchyState) == YES &&
       ASHierarchyStateIncludesYogaLayoutMeasuring(_hierarchyState) == NO) {
     ASDN::MutexUnlocker ul(__instanceLock__);
-    return [self calculateLayoutFromYogaRoot:constrainedSize];
+    [self calculateLayoutFromYogaRoot:constrainedSize];
+  }
+
+  if (ASHierarchyStateIncludesYogaLayoutEnabled(_hierarchyState) == YES && self.yogaCalculatedLayout) {
+    return self.yogaCalculatedLayout;
   }
 #endif /* YOGA */
 

--- a/AsyncDisplayKit/AsyncDisplayKit-Prefix.pch
+++ b/AsyncDisplayKit/AsyncDisplayKit-Prefix.pch
@@ -22,7 +22,3 @@
 #ifndef IG_LIST_KIT
   #define IG_LIST_KIT __has_include(<IGListKit/IGListKit.h>)
 #endif
-
-#ifndef YOGA
-  #define YOGA __has_include(<Yoga/Yoga.h>)
-#endif

--- a/AsyncDisplayKit/Layout/ASDimension.h
+++ b/AsyncDisplayKit/Layout/ASDimension.h
@@ -215,6 +215,8 @@ typedef struct {
   ASDimension right;
 } ASEdgeInsets;
 
+extern ASEdgeInsets const ASEdgeInsetsZero;
+
 #pragma mark - ASSizeRange
 
 /**

--- a/AsyncDisplayKit/Layout/ASDimension.mm
+++ b/AsyncDisplayKit/Layout/ASDimension.mm
@@ -64,6 +64,9 @@ NSString *NSStringFromASDimension(ASDimension dimension)
 
 ASLayoutSize const ASLayoutSizeAuto = {ASDimensionAuto, ASDimensionAuto};
 
+#pragma mark - ASEdgeInsets
+
+ASEdgeInsets const ASEdgeInsetsZero = {};
 
 #pragma mark - ASSizeRange
 

--- a/AsyncDisplayKit/Layout/ASLayoutElement.mm
+++ b/AsyncDisplayKit/Layout/ASLayoutElement.mm
@@ -20,7 +20,7 @@
 #import <atomic>
 
 #if YOGA
-  #import <Yoga/Yoga.h>
+  #import YOGA_HEADER_PATH
 #endif
 
 extern void ASLayoutElementPerformBlockOnEveryElement(id<ASLayoutElement> element, void(^block)(id<ASLayoutElement> element))

--- a/AsyncDisplayKit/Layout/ASStackLayoutDefines.h
+++ b/AsyncDisplayKit/Layout/ASStackLayoutDefines.h
@@ -66,6 +66,7 @@ typedef NS_ENUM(NSUInteger, ASStackLayoutAlignItems) {
   ASStackLayoutAlignItemsBaselineFirst,
   /** Children align to their last baseline. Only available for horizontal stack spec */
   ASStackLayoutAlignItemsBaselineLast,
+  ASStackLayoutAlignItemsNotSet
 };
 
 /**

--- a/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
+++ b/AsyncDisplayKit/Private/ASDisplayNodeInternal.h
@@ -180,6 +180,7 @@ FOUNDATION_EXPORT NSString * const ASRenderingEngineDidDisplayNodesScheduledBefo
   YGNodeRef _yogaNode;
   ASDisplayNode *_yogaParent;
   NSMutableArray<ASDisplayNode *> *_yogaChildren;
+  ASLayout *_yogaCalculatedLayout;
 #endif
 
 #if TIME_DISPLAYNODE_OPS

--- a/AsyncDisplayKit/Private/Layout/ASStackPositionedLayout.mm
+++ b/AsyncDisplayKit/Private/Layout/ASStackPositionedLayout.mm
@@ -31,6 +31,7 @@ static CGFloat crossOffset(const ASStackLayoutSpecStyle &style,
       return baseline - ASStackUnpositionedLayout::baselineForItem(style, l);
     case ASStackLayoutAlignItemsStart:
     case ASStackLayoutAlignItemsStretch:
+    case ASStackLayoutAlignItemsNotSet:
       return 0;
   }
 }

--- a/Base/ASAvailability.h
+++ b/Base/ASAvailability.h
@@ -27,9 +27,13 @@
 #define AS_TARGET_OS_IOS TARGET_OS_IPHONE
 
 // If Yoga is available, make it available anywhere we use ASAvailability.
-// This reduces Yoga-specific code in other files.// If Yoga is available, make it available anywhere we use ASAvailability.
-#if __has_include(<Yoga/Yoga.h>)
-#define YOGA 1
+// This reduces Yoga-specific code in other files.
+#ifndef YOGA_HEADER_PATH
+  #define YOGA_HEADER_PATH <Yoga/Yoga.h>
+#endif
+
+#ifndef YOGA
+  #define YOGA __has_include(YOGA_HEADER_PATH)
 #endif
 
 #if AS_TARGET_OS_OSX


### PR DESCRIPTION
This patch also adds ASEdgeInsetsZero, and one fix to passthrough of UIKit Supplementary Views.

The core team shouldn't spend any time supporting this, though.  If there is an upcoming refactor in a file like ASDisplayNode or ASLayoutElement, please feel free to delete the integration points.

Because almost all of the implementation is contained within ASDisplayNode+Yoga.mm, I'm very comfortable with re-implementing the integration points if any refactoring effort removes them.

There is now pretty good testing of this feature. I believe there won't be any significant new integration points (like the #if gating), so this should be the level of impact on ASDisplayNode.mm's main file.