### PR TITLE
Prevent Adding View-Backed Nodes to Layer-Backed Hierarchies

### DIFF
--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -2255,7 +2255,7 @@ static const char *ASDisplayNodeDrawingPriorityKey = "ASDrawingPriority";
   }
 
   ASDisplayNodeAssert(_flags.layerBacked, @"We shouldn't get called back here if there is no layer");
-  return (id)kCFNull;
+  return nil;
 }
 
 #pragma mark - Error Handling
@@ -2551,6 +2551,11 @@ ASDISPLAYNODE_INLINE BOOL nodeIsInRasterizedTree(ASDisplayNode *node) {
     return;
   }
   
+  if (self.layerBacked && !subnode.layerBacked) {
+    ASDisplayNodeFailAssert(@"Cannot to add a view-backed node as a subnode of a layer-backed node. Supernode: %@, subnode: %@", self, subnode);
+    return;
+  }
+
   __instanceLock__.lock();
     NSUInteger subnodesCount = _subnodes.count;
   __instanceLock__.unlock();
@@ -3177,7 +3182,7 @@ ASDISPLAYNODE_INLINE BOOL nodeIsInRasterizedTree(ASDisplayNode *node) {
     ASDisplayNodeAssert(_flags.synchronous == NO, @"Node created using -initWithViewBlock:/-initWithLayerBlock: cannot be added to subtree of node with shouldRasterizeDescendants=YES. Node: %@", self);
   }
   
-  // Entered or exited contents rendering state.
+  // Entered or exited range managed state.
   if ((newState & ASHierarchyStateRangeManaged) != (oldState & ASHierarchyStateRangeManaged)) {
     if (newState & ASHierarchyStateRangeManaged) {
       [self enterInterfaceState:self.supernode.interfaceState];

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -2552,7 +2552,7 @@ ASDISPLAYNODE_INLINE BOOL nodeIsInRasterizedTree(ASDisplayNode *node) {
   }
   
   if (self.layerBacked && !subnode.layerBacked) {
-    ASDisplayNodeFailAssert(@"Cannot to add a view-backed node as a subnode of a layer-backed node. Supernode: %@, subnode: %@", self, subnode);
+    ASDisplayNodeFailAssert(@"Cannot add a view-backed node as a subnode of a layer-backed node. Supernode: %@, subnode: %@", self, subnode);
     return;
   }
 

--- a/AsyncDisplayKit/ASDisplayNode.mm
+++ b/AsyncDisplayKit/ASDisplayNode.mm
@@ -2255,7 +2255,7 @@ static const char *ASDisplayNodeDrawingPriorityKey = "ASDrawingPriority";
   }
 
   ASDisplayNodeAssert(_flags.layerBacked, @"We shouldn't get called back here if there is no layer");
-  return nil;
+  return (id)kCFNull;
 }
 
 #pragma mark - Error Handling

--- a/AsyncDisplayKitTests/ASDisplayNodeTests.mm
+++ b/AsyncDisplayKitTests/ASDisplayNodeTests.mm
@@ -1098,31 +1098,32 @@ static inline BOOL _CGPointEqualToPointWithEpsilon(CGPoint point1, CGPoint point
 
 - (void)testReplaceSubnodeNoView
 {
-  [self checkReplaceSubnodeWithView:NO layerBacked:NO];
+  [self checkReplaceSubnodeLoaded:NO layerBacked:NO];
 }
 
 - (void)testReplaceSubnodeNoLayer
 {
-  [self checkReplaceSubnodeWithView:NO layerBacked:YES];
+  [self checkReplaceSubnodeLoaded:NO layerBacked:YES];
 }
 
 - (void)testReplaceSubnodeView
 {
-  [self checkReplaceSubnodeWithView:YES layerBacked:NO];
+  [self checkReplaceSubnodeLoaded:YES layerBacked:NO];
 }
 
 - (void)testReplaceSubnodeLayer
 {
-  [self checkReplaceSubnodeWithView:YES layerBacked:YES];
+  [self checkReplaceSubnodeLoaded:YES layerBacked:YES];
 }
 
 
-- (void)checkReplaceSubnodeWithView:(BOOL)loaded layerBacked:(BOOL)isLayerBacked
+- (void)checkReplaceSubnodeLoaded:(BOOL)loaded layerBacked:(BOOL)isLayerBacked
 {
   DeclareNodeNamed(parent);
   DeclareNodeNamed(a);
   DeclareNodeNamed(b);
   DeclareNodeNamed(c);
+  DeclareNodeNamed(d);
 
   for (ASDisplayNode *n in @[parent, a, b, c]) {
     n.layerBacked = isLayerBacked;
@@ -1136,7 +1137,6 @@ static inline BOOL _CGPointEqualToPointWithEpsilon(CGPoint point1, CGPoint point
     [parent layer];
   }
 
-  DeclareNodeNamed(d);
   if (loaded) {
     XCTAssertFalse(d.nodeLoaded, @"Should not yet be loaded");
   }

--- a/AsyncDisplayKitTests/ASDisplayNodeTests.mm
+++ b/AsyncDisplayKitTests/ASDisplayNodeTests.mm
@@ -1125,7 +1125,7 @@ static inline BOOL _CGPointEqualToPointWithEpsilon(CGPoint point1, CGPoint point
   DeclareNodeNamed(c);
   DeclareNodeNamed(d);
 
-  for (ASDisplayNode *n in @[parent, a, b, c]) {
+  for (ASDisplayNode *n in @[parent, a, b, c, d]) {
     n.layerBacked = isLayerBacked;
   }
 

--- a/examples/ASDKgram/Sample/CommentsNode.m
+++ b/examples/ASDKgram/Sample/CommentsNode.m
@@ -96,6 +96,7 @@
   for (NSUInteger i = 0; i < numLabelsToAdd; i++) {
     
     ASTextNode *commentLabel   = [[ASTextNode alloc] init];
+    commentLabel.layerBacked = YES;
     commentLabel.maximumNumberOfLines = 3;
     
     [_commentNodes addObject:commentLabel];


### PR DESCRIPTION
Resolves #3038

Doing this will prevent required callbacks like `didMoveToWindow` from getting sent to our view.