### PR TITLE
[ASCollectionView/ASTableView] Support native item and section reloads

### DIFF
--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -1729,22 +1729,32 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
       
       __block NSUInteger numberOfUpdates = 0;
       [self _superPerformBatchUpdates:^{
-        for (_ASHierarchyItemChange *change in [changeSet itemChangesOfType:_ASHierarchyChangeTypeDelete]) {
+        for (_ASHierarchyItemChange *change in [changeSet itemChangesOfType:_ASHierarchyChangeTypeReload]) {
+          [super reloadItemsAtIndexPaths:change.indexPaths];
+          numberOfUpdates++;
+        }
+        
+        for (_ASHierarchySectionChange *change in [changeSet sectionChangesOfType:_ASHierarchyChangeTypeReload]) {
+          [super reloadSections:change.indexSet];
+          numberOfUpdates++;
+        }
+        
+        for (_ASHierarchyItemChange *change in [changeSet itemChangesOfType:_ASHierarchyChangeTypeOriginalDelete]) {
           [super deleteItemsAtIndexPaths:change.indexPaths];
           numberOfUpdates++;
         }
         
-        for (_ASHierarchySectionChange *change in [changeSet sectionChangesOfType:_ASHierarchyChangeTypeDelete]) {
+        for (_ASHierarchySectionChange *change in [changeSet sectionChangesOfType:_ASHierarchyChangeTypeOriginalDelete]) {
           [super deleteSections:change.indexSet];
           numberOfUpdates++;
         }
         
-        for (_ASHierarchySectionChange *change in [changeSet sectionChangesOfType:_ASHierarchyChangeTypeInsert]) {
+        for (_ASHierarchySectionChange *change in [changeSet sectionChangesOfType:_ASHierarchyChangeTypeOriginalInsert]) {
           [super insertSections:change.indexSet];
           numberOfUpdates++;
         }
         
-        for (_ASHierarchyItemChange *change in [changeSet itemChangesOfType:_ASHierarchyChangeTypeInsert]) {
+        for (_ASHierarchyItemChange *change in [changeSet itemChangesOfType:_ASHierarchyChangeTypeOriginalInsert]) {
           [super insertItemsAtIndexPaths:change.indexPaths];
           numberOfUpdates++;
         }

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -1442,7 +1442,39 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
   LOG(@"--- UITableView beginUpdates");
   [super beginUpdates];
   
-  for (_ASHierarchyItemChange *change in [changeSet itemChangesOfType:_ASHierarchyChangeTypeDelete]) {
+  for (_ASHierarchyItemChange *change in [changeSet itemChangesOfType:_ASHierarchyChangeTypeReload]) {
+    NSArray<NSIndexPath *> *indexPaths = change.indexPaths;
+    UITableViewRowAnimation animationOptions = (UITableViewRowAnimation)change.animationOptions;
+    
+    LOG(@"UITableView reloadRows:%ld rows", indexPaths.count);
+    BOOL preventAnimation = animationOptions == UITableViewRowAnimationNone;
+    ASPerformBlockWithoutAnimation(preventAnimation, ^{
+      if (self.test_enableSuperUpdateCallLogging) {
+        NSLog(@"-[super reloadRowsAtIndexPaths]: %@", indexPaths);
+      }
+      [super reloadRowsAtIndexPaths:indexPaths withRowAnimation:animationOptions];
+    });
+    
+    numberOfUpdates++;
+  }
+  
+  for (_ASHierarchySectionChange *change in [changeSet sectionChangesOfType:_ASHierarchyChangeTypeReload]) {
+    NSIndexSet *sectionIndexes = change.indexSet;
+    UITableViewRowAnimation animationOptions = (UITableViewRowAnimation)change.animationOptions;
+    
+    LOG(@"UITableView reloadSections:%@", sectionIndexes);
+    BOOL preventAnimation = (animationOptions == UITableViewRowAnimationNone);
+    ASPerformBlockWithoutAnimation(preventAnimation, ^{
+      if (self.test_enableSuperUpdateCallLogging) {
+        NSLog(@"-[super reloadSections]: %@", sectionIndexes);
+      }
+      [super reloadSections:sectionIndexes withRowAnimation:animationOptions];
+    });
+    
+    numberOfUpdates++;
+  }
+  
+  for (_ASHierarchyItemChange *change in [changeSet itemChangesOfType:_ASHierarchyChangeTypeOriginalDelete]) {
     NSArray<NSIndexPath *> *indexPaths = change.indexPaths;
     UITableViewRowAnimation animationOptions = (UITableViewRowAnimation)change.animationOptions;
     
@@ -1458,7 +1490,7 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     numberOfUpdates++;
   }
   
-  for (_ASHierarchySectionChange *change in [changeSet sectionChangesOfType:_ASHierarchyChangeTypeDelete]) {
+  for (_ASHierarchySectionChange *change in [changeSet sectionChangesOfType:_ASHierarchyChangeTypeOriginalDelete]) {
     NSIndexSet *sectionIndexes = change.indexSet;
     UITableViewRowAnimation animationOptions = (UITableViewRowAnimation)change.animationOptions;
     
@@ -1474,7 +1506,7 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     numberOfUpdates++;
   }
   
-  for (_ASHierarchySectionChange *change in [changeSet sectionChangesOfType:_ASHierarchyChangeTypeInsert]) {
+  for (_ASHierarchySectionChange *change in [changeSet sectionChangesOfType:_ASHierarchyChangeTypeOriginalInsert]) {
     NSIndexSet *sectionIndexes = change.indexSet;
     UITableViewRowAnimation animationOptions = (UITableViewRowAnimation)change.animationOptions;
     
@@ -1490,7 +1522,7 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     numberOfUpdates++;
   }
   
-  for (_ASHierarchyItemChange *change in [changeSet itemChangesOfType:_ASHierarchyChangeTypeInsert]) {
+  for (_ASHierarchyItemChange *change in [changeSet itemChangesOfType:_ASHierarchyChangeTypeOriginalInsert]) {
     NSArray<NSIndexPath *> *indexPaths = change.indexPaths;
     UITableViewRowAnimation animationOptions = (UITableViewRowAnimation)change.animationOptions;
     

--- a/AsyncDisplayKit/Details/ASDataController.mm
+++ b/AsyncDisplayKit/Details/ASDataController.mm
@@ -512,6 +512,9 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCollectionElement *> *
     return;
   }
   
+  // TODO if the change set includes solely section reloads that together are equivalent to reloadData (i.e reload the only section),
+  // do a reloadData here as an optimization.
+  
   if (changeSet.includesReloadData) {
     [_sections removeAllObjects];
     
@@ -558,6 +561,9 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCollectionElement *> *
   ASDisplayNodeAssertMainThread();
   
   __weak id<ASTraitEnvironment> environment = [self.environmentDelegate dataControllerEnvironment];
+  
+  // TODO if the change set includes solely section reloads that together are equivalent to reloadData (i.e reload the only section),
+  // do a reloadData here as an optimization.
   
   if (changeSet.includesReloadData) {
     [_elements removeAllObjects];


### PR DESCRIPTION
After #3017, it's much easier to support native reloads now. Since updates are already broken down to inserts and deletes by `_ASHierarchyChangeSet`, `ASDataController` can consume these inserts and deletes as is, and then `ASCollectionView`/`ASTableView` forward the original changes to `UICollectionView`/`UITableView`. This resolves #469. 

Demo:
- [Reload item](https://cl.ly/jIkf)
- [Reload section](https://cl.ly/jIC7)