### PR TITLE
ASDataController: Eliminate Mutable State

### DIFF
--- a/AsyncDisplayKit/Details/ASDataController.h
+++ b/AsyncDisplayKit/Details/ASDataController.h
@@ -211,14 +211,6 @@ extern NSString * const ASCollectionInvalidUpdateException;
 
 - (nullable id<ASSectionContext>)contextForSection:(NSInteger)section;
 
-/**
- * Immediately move this item. This is called by ASTableView when the user has finished an interactive
- * item move and the table view is requesting a model update.
- * 
- * This must be called on the main thread.
- */
-- (void)moveCompletedNodeAtIndexPath:(NSIndexPath *)indexPath toIndexPath:(NSIndexPath *)newIndexPath;
-
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
- Before data controller had one mutable & one immutable representation of the data.
- Now data controller has just two immutable data representations: `completedElements` and `pendingElements`
- Mutable representation is never saved – it's created in `updateWithChangeSet:` and provided to methods that are expected to modify it, and then immediately cloned.

This makes the data controller much easier to reason about, and sets the stage for building a custom immutable representation of the state-of-the-world for data controller.