### PR TITLE
ASDataController: Adopt ASElementMap

### DIFF
--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -301,6 +301,8 @@
 		B350625D1B0111740018CF92 /* Photos.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 051943141A1575670030A7D0 /* Photos.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		B350625E1B0111780018CF92 /* AssetsLibrary.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 051943121A1575630030A7D0 /* AssetsLibrary.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		C78F7E2B1BF7809800CDEAFC /* ASTableNode.h in Headers */ = {isa = PBXBuildFile; fileRef = B0F880581BEAEC7500D17647 /* ASTableNode.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CC034A011E5FAF9700626263 /* ASElementMap.h in Headers */ = {isa = PBXBuildFile; fileRef = CC0349FF1E5FAF9700626263 /* ASElementMap.h */; };
+		CC034A021E5FAF9700626263 /* ASElementMap.m in Sources */ = {isa = PBXBuildFile; fileRef = CC034A001E5FAF9700626263 /* ASElementMap.m */; };
 		CC051F1F1D7A286A006434CB /* ASCALayerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CC051F1E1D7A286A006434CB /* ASCALayerTests.m */; };
 		CC0AEEA41D66316E005D1C78 /* ASUICollectionViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CC0AEEA31D66316E005D1C78 /* ASUICollectionViewTests.m */; };
 		CC0F885B1E42807F00576FED /* ASCollectionViewFlowLayoutInspector.m in Sources */ = {isa = PBXBuildFile; fileRef = CC0F88591E42807F00576FED /* ASCollectionViewFlowLayoutInspector.m */; };
@@ -684,6 +686,8 @@
 		B30BF6511C5964B0004FCD53 /* ASLayoutManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ASLayoutManager.m; path = TextKit/ASLayoutManager.m; sourceTree = "<group>"; };
 		B35061DA1B010EDF0018CF92 /* AsyncDisplayKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AsyncDisplayKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BDC2D162BD55A807C1475DA5 /* Pods-AsyncDisplayKitTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AsyncDisplayKitTests.profile.xcconfig"; path = "Pods/Target Support Files/Pods-AsyncDisplayKitTests/Pods-AsyncDisplayKitTests.profile.xcconfig"; sourceTree = "<group>"; };
+		CC0349FF1E5FAF9700626263 /* ASElementMap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASElementMap.h; sourceTree = "<group>"; };
+		CC034A001E5FAF9700626263 /* ASElementMap.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASElementMap.m; sourceTree = "<group>"; };
 		CC051F1E1D7A286A006434CB /* ASCALayerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASCALayerTests.m; sourceTree = "<group>"; };
 		CC0AEEA31D66316E005D1C78 /* ASUICollectionViewTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASUICollectionViewTests.m; sourceTree = "<group>"; };
 		CC0F88591E42807F00576FED /* ASCollectionViewFlowLayoutInspector.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASCollectionViewFlowLayoutInspector.m; sourceTree = "<group>"; };
@@ -1124,6 +1128,8 @@
 		058D0A01195D050800B7D73C /* Private */ = {
 			isa = PBXGroup;
 			children = (
+				CC0349FF1E5FAF9700626263 /* ASElementMap.h */,
+				CC034A001E5FAF9700626263 /* ASElementMap.m */,
 				CC55A70F1E52A0F200594372 /* ASResponderChainEnumerator.h */,
 				CC55A7101E52A0F200594372 /* ASResponderChainEnumerator.m */,
 				6947B0BB1E36B4E30007C478 /* Layout */,
@@ -1466,6 +1472,7 @@
 				CC57EAF71E3939350034C595 /* ASCollectionView+Undeprecated.h in Headers */,
 				B35062521B010EFD0018CF92 /* ASDisplayNodeInternal.h in Headers */,
 				AC7A2C181BDE11DF0093FE1A /* ASTableViewInternal.h in Headers */,
+				CC034A011E5FAF9700626263 /* ASElementMap.h in Headers */,
 				B35062531B010EFD0018CF92 /* ASImageNode+CGExtras.h in Headers */,
 				254C6B7F1BF94DF4003EC431 /* ASTextKitTruncating.h in Headers */,
 				CC58AA4B1E398E1D002C8CB4 /* ASBlockTypes.h in Headers */,
@@ -1832,6 +1839,7 @@
 				68B8A4E41CBDB958007E4543 /* ASWeakProxy.m in Sources */,
 				9C70F20A1CDBE949007D6C76 /* ASTableNode.mm in Sources */,
 				69CB62AE1CB8165900024920 /* _ASDisplayViewAccessiblity.mm in Sources */,
+				CC034A021E5FAF9700626263 /* ASElementMap.m in Sources */,
 				B35061F61B010EFD0018CF92 /* ASCollectionView.mm in Sources */,
 				509E68641B3AEDB7009B9150 /* ASCollectionViewLayoutController.mm in Sources */,
 				B35061F91B010EFD0018CF92 /* ASControlNode.mm in Sources */,

--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -315,6 +315,8 @@
 		CC0F886C1E4286FA00576FED /* ReferenceImages_64 in Resources */ = {isa = PBXBuildFile; fileRef = CC0F88691E4286FA00576FED /* ReferenceImages_64 */; };
 		CC0F886D1E4286FA00576FED /* ReferenceImages_iOS_10 in Resources */ = {isa = PBXBuildFile; fileRef = CC0F886A1E4286FA00576FED /* ReferenceImages_iOS_10 */; };
 		CC11F97A1DB181180024D77B /* ASNetworkImageNodeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CC11F9791DB181180024D77B /* ASNetworkImageNodeTests.m */; };
+		CC2F65EE1E5FFB1600DA57C9 /* ASMutableElementMap.h in Headers */ = {isa = PBXBuildFile; fileRef = CC2F65EC1E5FFB1600DA57C9 /* ASMutableElementMap.h */; };
+		CC2F65EF1E5FFB1600DA57C9 /* ASMutableElementMap.m in Sources */ = {isa = PBXBuildFile; fileRef = CC2F65ED1E5FFB1600DA57C9 /* ASMutableElementMap.m */; };
 		CC3B20841C3F76D600798563 /* ASPendingStateController.h in Headers */ = {isa = PBXBuildFile; fileRef = CC3B20811C3F76D600798563 /* ASPendingStateController.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CC3B20861C3F76D600798563 /* ASPendingStateController.mm in Sources */ = {isa = PBXBuildFile; fileRef = CC3B20821C3F76D600798563 /* ASPendingStateController.mm */; };
 		CC3B208A1C3F7A5400798563 /* ASWeakSet.h in Headers */ = {isa = PBXBuildFile; fileRef = CC3B20871C3F7A5400798563 /* ASWeakSet.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -699,6 +701,8 @@
 		CC0F886A1E4286FA00576FED /* ReferenceImages_iOS_10 */ = {isa = PBXFileReference; lastKnownFileType = folder; path = ReferenceImages_iOS_10; sourceTree = "<group>"; };
 		CC11F9791DB181180024D77B /* ASNetworkImageNodeTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASNetworkImageNodeTests.m; sourceTree = "<group>"; };
 		CC2E317F1DAC353700EEE891 /* ASCollectionView+Undeprecated.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ASCollectionView+Undeprecated.h"; sourceTree = "<group>"; };
+		CC2F65EC1E5FFB1600DA57C9 /* ASMutableElementMap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASMutableElementMap.h; sourceTree = "<group>"; };
+		CC2F65ED1E5FFB1600DA57C9 /* ASMutableElementMap.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASMutableElementMap.m; sourceTree = "<group>"; };
 		CC3B20811C3F76D600798563 /* ASPendingStateController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASPendingStateController.h; sourceTree = "<group>"; };
 		CC3B20821C3F76D600798563 /* ASPendingStateController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASPendingStateController.mm; sourceTree = "<group>"; };
 		CC3B20871C3F7A5400798563 /* ASWeakSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASWeakSet.h; sourceTree = "<group>"; };
@@ -1128,6 +1132,8 @@
 		058D0A01195D050800B7D73C /* Private */ = {
 			isa = PBXGroup;
 			children = (
+				CC2F65EC1E5FFB1600DA57C9 /* ASMutableElementMap.h */,
+				CC2F65ED1E5FFB1600DA57C9 /* ASMutableElementMap.m */,
 				CC0349FF1E5FAF9700626263 /* ASElementMap.h */,
 				CC034A001E5FAF9700626263 /* ASElementMap.m */,
 				CC55A70F1E52A0F200594372 /* ASResponderChainEnumerator.h */,
@@ -1505,6 +1511,7 @@
 				9CDC18CD1B910E12004965E2 /* ASLayoutElementPrivate.h in Headers */,
 				B35062201B010EFD0018CF92 /* ASLayoutController.h in Headers */,
 				B35062211B010EFD0018CF92 /* ASLayoutRangeType.h in Headers */,
+				CC2F65EE1E5FFB1600DA57C9 /* ASMutableElementMap.h in Headers */,
 				34EFC76A1B701CE600AD841F /* ASLayoutSpec.h in Headers */,
 				B350625C1B010F070018CF92 /* ASLog.h in Headers */,
 				CC3B208A1C3F7A5400798563 /* ASWeakSet.h in Headers */,
@@ -1865,6 +1872,7 @@
 				B350621E1B010EFD0018CF92 /* ASHighlightOverlayLayer.mm in Sources */,
 				9CC606651D24DF9E006581A0 /* NSIndexSet+ASHelpers.m in Sources */,
 				CC0F885F1E4280B800576FED /* _ASCollectionViewCell.m in Sources */,
+				CC2F65EF1E5FFB1600DA57C9 /* ASMutableElementMap.m in Sources */,
 				B35062541B010EFD0018CF92 /* ASImageNode+CGExtras.m in Sources */,
 				6947B0C01E36B4E30007C478 /* ASStackUnpositionedLayout.mm in Sources */,
 				68355B401CB57A69001D4E68 /* ASImageContainerProtocolCategories.m in Sources */,

--- a/AsyncDisplayKit/ASCellNode+Internal.h
+++ b/AsyncDisplayKit/ASCellNode+Internal.h
@@ -14,6 +14,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class ASCollectionElement;
+
 @protocol ASCellNodeInteractionDelegate <NSObject>
 
 /**
@@ -58,10 +60,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, strong, nullable) UICollectionViewLayoutAttributes *layoutAttributes;
 
-/// readwrite variant of the readonly public property.
-@property (nonatomic, copy, nullable) NSString *supplementaryElementKind;
-
-@property (nonatomic, copy, nullable) NSIndexPath *cachedIndexPath;
+@property (weak, nullable) ASCollectionElement *collectionElement;
 
 @property (nonatomic, weak, nullable) ASDisplayNode *owningNode;
 

--- a/AsyncDisplayKit/ASCellNode.mm
+++ b/AsyncDisplayKit/ASCellNode.mm
@@ -14,6 +14,7 @@
 #import <AsyncDisplayKit/ASInternalHelpers.h>
 #import <AsyncDisplayKit/ASDisplayNode+FrameworkPrivate.h>
 #import <AsyncDisplayKit/ASCollectionView+Undeprecated.h>
+#import <AsyncDisplayKit/ASCollectionElement.h>
 #import <AsyncDisplayKit/ASTableView+Undeprecated.h>
 #import <AsyncDisplayKit/_ASDisplayView.h>
 #import <AsyncDisplayKit/ASDisplayNode+Subclasses.h>
@@ -389,6 +390,12 @@ static NSMutableSet *__cellClassesForVisibilityNotifications = nil; // See +init
 
   return result;
 }
+
+- (NSString *)supplementaryElementKind
+{
+  return self.collectionElement.supplementaryElementKind;
+}
+
 @end
 
 

--- a/AsyncDisplayKit/ASCollectionNode.mm
+++ b/AsyncDisplayKit/ASCollectionNode.mm
@@ -12,6 +12,8 @@
 
 #import <AsyncDisplayKit/ASCollectionNode.h>
 
+#import <AsyncDisplayKit/ASCollectionElement.h>
+#import <AsyncDisplayKit/ASElementMap.h>
 #import <AsyncDisplayKit/ASCollectionInternal.h>
 #import <AsyncDisplayKit/ASCollectionViewLayoutFacilitatorProtocol.h>
 #import <AsyncDisplayKit/ASDisplayNode+Beta.h>
@@ -418,13 +420,13 @@
 - (NSInteger)numberOfItemsInSection:(NSInteger)section
 {
   [self reloadDataInitiallyIfNeeded];
-  return [self.dataController numberOfRowsInSection:section];
+  return [self.dataController.pendingMap numberOfItemsInSection:section];
 }
 
 - (NSInteger)numberOfSections
 {
   [self reloadDataInitiallyIfNeeded];
-  return [self.dataController numberOfSections];
+  return self.dataController.pendingMap.numberOfSections;
 }
 
 - (NSArray<__kindof ASCellNode *> *)visibleNodes
@@ -436,12 +438,12 @@
 - (ASCellNode *)nodeForItemAtIndexPath:(NSIndexPath *)indexPath
 {
   [self reloadDataInitiallyIfNeeded];
-  return [self.dataController nodeAtIndexPath:indexPath];
+  return [self.dataController.pendingMap elementForItemAtIndexPath:indexPath].node;
 }
 
 - (NSIndexPath *)indexPathForNode:(ASCellNode *)cellNode
 {
-  return [self.dataController indexPathForNode:cellNode];
+  return [self.dataController.pendingMap indexPathForElement:cellNode.collectionElement];
 }
 
 - (NSArray<NSIndexPath *> *)indexPathsForVisibleItems
@@ -484,7 +486,7 @@
 - (id<ASSectionContext>)contextForSection:(NSInteger)section
 {
   ASDisplayNodeAssertMainThread();
-  return [self.dataController contextForSection:section];
+  return [self.dataController.pendingMap contextForSection:section];
 }
 
 #pragma mark - Editing

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -606,11 +606,6 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
   return [[self nodeForItemAtIndexPath:indexPath] calculatedSize];
 }
 
-- (ASElementMap *)elementMapForRangeController:(ASRangeController *)rangeController
-{
-  return _dataController.visibleMap;
-}
-
 - (ASCellNode *)nodeForItemAtIndexPath:(NSIndexPath *)indexPath
 {
   return [_dataController.visibleMap elementForItemAtIndexPath:indexPath].node;
@@ -627,8 +622,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
   if (indexPath.item == NSNotFound) {
     return indexPath;
   } else {
-    id element = [_dataController.pendingMap elementForItemAtIndexPath:indexPath];
-    NSIndexPath *viewIndexPath = [_dataController.visibleMap indexPathForElement:element];
+    NSIndexPath *viewIndexPath = [_dataController.visibleMap convertIndexPath:indexPath fromMap:_dataController.pendingMap];
     if (viewIndexPath == nil && wait) {
       [self waitUntilAllUpdatesAreCommitted];
       return [self convertIndexPathFromCollectionNode:indexPath waitingIfNeeded:NO];
@@ -1652,6 +1646,11 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
   // in incorrect layout if performed at zero size.  We can use the fact that nothing can be visible at zero size to return fast.
   BOOL isZeroSized = CGSizeEqualToSize(self.bounds.size, CGSizeZero);
   return isZeroSized ? @[] : [self indexPathsForVisibleItems];
+}
+
+- (ASElementMap *)elementMapForRangeController:(ASRangeController *)rangeController
+{
+  return _dataController.visibleMap;
 }
 
 - (ASScrollDirection)scrollDirectionForRangeController:(ASRangeController *)rangeController

--- a/AsyncDisplayKit/ASCollectionView.mm
+++ b/AsyncDisplayKit/ASCollectionView.mm
@@ -1670,11 +1670,6 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
   return ASInterfaceStateForDisplayNode(self.collectionNode, self.window);
 }
 
-- (ASDisplayNode *)rangeController:(ASRangeController *)rangeController nodeAtIndexPath:(NSIndexPath *)indexPath
-{
-  return [self nodeForItemAtIndexPath:indexPath];
-}
-
 - (NSString *)nameForRangeControllerDataSource
 {
   return self.asyncDataSource ? NSStringFromClass([self.asyncDataSource class]) : NSStringFromClass([self class]);

--- a/AsyncDisplayKit/ASTableNode.mm
+++ b/AsyncDisplayKit/ASTableNode.mm
@@ -11,6 +11,8 @@
 //
 
 #import <AsyncDisplayKit/ASTableNode.h>
+#import <AsyncDisplayKit/ASCollectionElement.h>
+#import <AsyncDisplayKit/ASElementMap.h>
 #import <AsyncDisplayKit/ASTableViewInternal.h>
 #import <AsyncDisplayKit/ASDisplayNode+Subclasses.h>
 #import <AsyncDisplayKit/ASDisplayNode+FrameworkPrivate.h>
@@ -438,14 +440,14 @@ ASLayoutElementCollectionTableSetTraitCollection(_environmentStateLock)
 {
   ASDisplayNodeAssertMainThread();
   [self reloadDataInitiallyIfNeeded];
-  return [self.dataController numberOfRowsInSection:section];
+  return [self.dataController.pendingMap numberOfItemsInSection:section];
 }
 
 - (NSInteger)numberOfSections
 {
   ASDisplayNodeAssertMainThread();
   [self reloadDataInitiallyIfNeeded];
-  return [self.dataController numberOfSections];
+  return [self.dataController.pendingMap numberOfSections];
 }
 
 - (NSArray<__kindof ASCellNode *> *)visibleNodes
@@ -456,13 +458,13 @@ ASLayoutElementCollectionTableSetTraitCollection(_environmentStateLock)
 
 - (NSIndexPath *)indexPathForNode:(ASCellNode *)cellNode
 {
-  return [self.dataController indexPathForNode:cellNode];
+  return [self.dataController.pendingMap indexPathForElement:cellNode.collectionElement];
 }
 
 - (ASCellNode *)nodeForRowAtIndexPath:(NSIndexPath *)indexPath
 {
   [self reloadDataInitiallyIfNeeded];
-  return [self.dataController nodeAtIndexPath:indexPath];
+  return [self.dataController.pendingMap elementForItemAtIndexPath:indexPath].node;
 }
 
 - (CGRect)rectForRowAtIndexPath:(NSIndexPath *)indexPath

--- a/AsyncDisplayKit/ASTableView.mm
+++ b/AsyncDisplayKit/ASTableView.mm
@@ -1397,11 +1397,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
   return self.scrollDirection;
 }
 
-- (ASDisplayNode *)rangeController:(ASRangeController *)rangeController nodeAtIndexPath:(NSIndexPath *)indexPath
-{
-  return [_dataController nodeAtIndexPath:indexPath];
-}
-
 - (CGSize)viewportSizeForRangeController:(ASRangeController *)rangeController
 {
   ASDisplayNodeAssertMainThread();

--- a/AsyncDisplayKit/Details/ASCollectionElement.mm
+++ b/AsyncDisplayKit/Details/ASCollectionElement.mm
@@ -52,8 +52,8 @@
       ASDisplayNodeFailAssert(@"Node block returned nil node!");
       node = [[ASCellNode alloc] init];
     }
-    node.supplementaryElementKind = _supplementaryElementKind;
     node.owningNode = (ASDisplayNode *)_traitEnvironment;
+    node.collectionElement = self;
     ASTraitCollectionPropagateDown(node, [_traitEnvironment primitiveTraitCollection]);
     _node = node;
   }

--- a/AsyncDisplayKit/Details/ASDataController.h
+++ b/AsyncDisplayKit/Details/ASDataController.h
@@ -117,8 +117,14 @@ AS_SUBCLASSING_RESTRICTED
 
 - (instancetype)initWithDataSource:(id<ASDataControllerSource>)dataSource eventLog:(nullable ASEventLog *)eventLog NS_DESIGNATED_INITIALIZER;
 
+/**
+ * The map that is currently displayed. The "UIKit index space."
+ */
 @property (nonatomic, strong, readonly) ASElementMap *visibleMap;
 
+/**
+ * The map that is currently being prepared for display. The "data source index space."
+ */
 @property (nonatomic, strong, readonly) ASElementMap *pendingMap;
 
 /**

--- a/AsyncDisplayKit/Details/ASDataController.h
+++ b/AsyncDisplayKit/Details/ASDataController.h
@@ -120,12 +120,12 @@ AS_SUBCLASSING_RESTRICTED
 /**
  * The map that is currently displayed. The "UIKit index space."
  */
-@property (nonatomic, strong, readonly) ASElementMap *visibleMap;
+@property (nonatomic, nullable, strong, readonly) ASElementMap *visibleMap;
 
 /**
  * The map that is currently being prepared for display. The "data source index space."
  */
-@property (nonatomic, strong, readonly) ASElementMap *pendingMap;
+@property (nonatomic, nullable, strong, readonly) ASElementMap *pendingMap;
 
 /**
  Data source for fetching data info.

--- a/AsyncDisplayKit/Details/ASDataController.h
+++ b/AsyncDisplayKit/Details/ASDataController.h
@@ -120,12 +120,12 @@ AS_SUBCLASSING_RESTRICTED
 /**
  * The map that is currently displayed. The "UIKit index space."
  */
-@property (nonatomic, nullable, strong, readonly) ASElementMap *visibleMap;
+@property (nonatomic, strong, readonly) ASElementMap *visibleMap;
 
 /**
- * The map that is currently being prepared for display. The "data source index space."
+ * The latest map fetched from the data source. May be more recent than @c visibleMap.
  */
-@property (nonatomic, nullable, strong, readonly) ASElementMap *pendingMap;
+@property (nonatomic, strong, readonly) ASElementMap *pendingMap;
 
 /**
  Data source for fetching data info.

--- a/AsyncDisplayKit/Details/ASDataController.h
+++ b/AsyncDisplayKit/Details/ASDataController.h
@@ -28,6 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class ASCellNode;
 @class ASDataController;
+@class ASElementMap;
 @class _ASHierarchyChangeSet;
 @protocol ASTraitEnvironment;
 @protocol ASSectionContext;
@@ -115,6 +116,10 @@ extern NSString * const ASCollectionInvalidUpdateException;
 
 - (instancetype)initWithDataSource:(id<ASDataControllerSource>)dataSource eventLog:(nullable ASEventLog *)eventLog NS_DESIGNATED_INITIALIZER;
 
+@property (nonatomic, strong, readonly) ASElementMap *visibleMap;
+
+@property (nonatomic, strong, readonly) ASElementMap *pendingMap;
+
 /**
  Data source for fetching data info.
  */
@@ -174,42 +179,6 @@ extern NSString * const ASCollectionInvalidUpdateException;
 - (void)relayoutAllNodes;
 
 - (void)waitUntilAllUpdatesAreCommitted;
-
-/** @name Data Querying */
-
-- (NSUInteger)numberOfSections;
-
-- (NSUInteger)numberOfRowsInSection:(NSUInteger)section;
-
-- (nullable ASCellNode *)nodeAtIndexPath:(NSIndexPath *)indexPath;
-
-- (NSUInteger)completedNumberOfSections;
-
-- (NSUInteger)completedNumberOfRowsInSection:(NSUInteger)section;
-
-- (nullable ASCellNode *)nodeAtCompletedIndexPath:(NSIndexPath *)indexPath;
-
-/**
- * @return The index path, in the data source's index space, for the given node.
- */
-- (nullable NSIndexPath *)indexPathForNode:(ASCellNode *)cellNode;
-
-/**
- * @return The index path, in UIKit's index space, for the given node.
- *
- * @discussion @c indexPathForNode: is returns an index path in the data source's index space.
- *   This method is useful for e.g. looking up the cell for a given node.
- */
-- (nullable NSIndexPath *)completedIndexPathForNode:(ASCellNode *)cellNode;
-
-/**
- * Direct access to the nodes that have completed calculation and layout
- */
-- (NSArray<NSArray <ASCellNode *> *> *)completedNodes;
-
-- (nullable ASCellNode *)supplementaryNodeOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath;
-
-- (nullable id<ASSectionContext>)contextForSection:(NSInteger)section;
 
 @end
 

--- a/AsyncDisplayKit/Details/ASDataController.h
+++ b/AsyncDisplayKit/Details/ASDataController.h
@@ -112,6 +112,7 @@ extern NSString * const ASCollectionInvalidUpdateException;
  * will be updated asynchronously. The dataSource must be updated to reflect the changes before these methods has been called.
  * For each data updating, the corresponding methods in delegate will be called.
  */
+AS_SUBCLASSING_RESTRICTED
 @interface ASDataController : NSObject
 
 - (instancetype)initWithDataSource:(id<ASDataControllerSource>)dataSource eventLog:(nullable ASEventLog *)eventLog NS_DESIGNATED_INITIALIZER;

--- a/AsyncDisplayKit/Details/ASDataController.h
+++ b/AsyncDisplayKit/Details/ASDataController.h
@@ -112,7 +112,6 @@ extern NSString * const ASCollectionInvalidUpdateException;
  * will be updated asynchronously. The dataSource must be updated to reflect the changes before these methods has been called.
  * For each data updating, the corresponding methods in delegate will be called.
  */
-AS_SUBCLASSING_RESTRICTED
 @interface ASDataController : NSObject
 
 - (instancetype)initWithDataSource:(id<ASDataControllerSource>)dataSource eventLog:(nullable ASEventLog *)eventLog NS_DESIGNATED_INITIALIZER;

--- a/AsyncDisplayKit/Details/ASDataController.mm
+++ b/AsyncDisplayKit/Details/ASDataController.mm
@@ -98,8 +98,6 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCollectionElement *> *
   _eventLog = eventLog;
 #endif
 
-  _pendingMap = [[ASElementMap alloc] init];
-
   
   _nextSectionID = 0;
   
@@ -462,7 +460,7 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCollectionElement *> *
   }
 
   // Mutable copy of current data.
-  ASMutableElementMap *mutableMap = [_pendingMap mutableCopy];
+  ASMutableElementMap *mutableMap = [_pendingMap mutableCopy] ?: [[ASMutableElementMap alloc] init];
   
   // Step 1: update the mutable copies to match the data source's state
   [self _updateSectionContextsInMap:mutableMap changeSet:changeSet];

--- a/AsyncDisplayKit/Details/ASDataController.mm
+++ b/AsyncDisplayKit/Details/ASDataController.mm
@@ -21,6 +21,7 @@
 #import <AsyncDisplayKit/ASCollectionElement.h>
 #import <AsyncDisplayKit/ASDispatch.h>
 #import <AsyncDisplayKit/ASElementMap.h>
+#import <AsyncDisplayKit/ASMutableElementMap.h>
 #import <AsyncDisplayKit/ASInternalHelpers.h>
 #import <AsyncDisplayKit/ASCellNode+Internal.h>
 #import <AsyncDisplayKit/ASDisplayNode+Subclasses.h>
@@ -51,9 +52,6 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCollectionElement *> *
 #endif
 
 @interface ASDataController () {
-
-  ASElementMap *_pendingMap;
-  ASElementMap *_visibleMap;
 
   NSInteger _nextSectionID;
   
@@ -318,6 +316,7 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCollectionElement *> *
 /**
  * Inserts new elements of a certain kind at some index paths
  *
+ * @param map The map to insert the elements into.
  * @param kind The kind of the elements, e.g ASDataControllerRowNodeKind
  * @param indexPaths The index paths at which new elements should be populated
  * @param environment The trait environment needed to initialize elements

--- a/AsyncDisplayKit/Details/ASDataController.mm
+++ b/AsyncDisplayKit/Details/ASDataController.mm
@@ -98,6 +98,7 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCollectionElement *> *
   _eventLog = eventLog;
 #endif
 
+  _visibleMap = _pendingMap = [[ASElementMap alloc] init];
   
   _nextSectionID = 0;
   
@@ -460,7 +461,7 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCollectionElement *> *
   }
 
   // Mutable copy of current data.
-  ASMutableElementMap *mutableMap = [_pendingMap mutableCopy] ?: [[ASMutableElementMap alloc] init];
+  ASMutableElementMap *mutableMap = [_pendingMap mutableCopy];
   
   // Step 1: update the mutable copies to match the data source's state
   [self _updateSectionContextsInMap:mutableMap changeSet:changeSet];

--- a/AsyncDisplayKit/Details/ASDataController.mm
+++ b/AsyncDisplayKit/Details/ASDataController.mm
@@ -20,6 +20,7 @@
 #import <AsyncDisplayKit/ASThread.h>
 #import <AsyncDisplayKit/ASCollectionElement.h>
 #import <AsyncDisplayKit/ASDispatch.h>
+#import <AsyncDisplayKit/ASElementMap.h>
 #import <AsyncDisplayKit/ASInternalHelpers.h>
 #import <AsyncDisplayKit/ASCellNode+Internal.h>
 #import <AsyncDisplayKit/ASDisplayNode+Subclasses.h>
@@ -32,14 +33,6 @@
 
 #define RETURN_IF_NO_DATASOURCE(val) if (_dataSource == nil) { return val; }
 #define ASSERT_ON_EDITING_QUEUE ASDisplayNodeAssertNotNil(dispatch_get_specific(&kASDataControllerEditingQueueKey), @"%@ must be called on the editing transaction queue.", NSStringFromSelector(_cmd))
-
-#define ASCollectionElementTwoDimensionalMutableArray  NSMutableArray<NSMutableArray<ASCollectionElement *> *>
-#define ASCollectionElementTwoDimensionalArray         NSArray<NSArray<ASCollectionElement *> *>
-
-// Dictionary with each entry is a pair of "kind" key and two dimensional array of elements
-#define ASCollectionElementTwoDimensionalDictionary         NSDictionary<NSString *, ASCollectionElementTwoDimensionalArray *>
-// Mutable dictionary with each entry is a pair of "kind" key and two dimensional array of elements
-#define ASCollectionElementTwoDimensionalMutableDictionary  NSMutableDictionary<NSString *, ASCollectionElementTwoDimensionalMutableArray *>
 
 const static NSUInteger kASDataControllerSizingCountPerProcessor = 5;
 const static char * kASDataControllerEditingQueueKey = "kASDataControllerEditingQueueKey";
@@ -59,11 +52,8 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCollectionElement *> *
 
 @interface ASDataController () {
 
-  ASCollectionElementTwoDimensionalDictionary *_pendingElements;        // Main thread only. These are in the data source's index space
-  NSArray<ASSection *> *_pendingSections;
-
-  ASCollectionElementTwoDimensionalDictionary *_completedElements;        // Main thread only. These are in the UIKit's index space.
-  NSArray<ASSection *> *_completedSections;
+  ASElementMap *_pendingMap;
+  ASElementMap *_completedMap;
 
   NSInteger _nextSectionID;
   
@@ -109,11 +99,8 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCollectionElement *> *
 #if ASEVENTLOG_ENABLE
   _eventLog = eventLog;
 #endif
-  
-  _pendingElements = @{};
-  _pendingSections = @[];
-  _completedElements = @{};
-  _completedSections = @[];
+
+  _pendingMap = [[ASElementMap alloc] init];
   
   _nextSectionID = 0;
   
@@ -281,9 +268,9 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCollectionElement *> *
  * @param originalIndexPaths The index paths belongs to sections whose supplementary nodes need to be repopulated.
  * @param environment The trait environment needed to initialize elements
  */
-- (void)_repopulateSupplementaryNodesIntoDictionary:(ASCollectionElementTwoDimensionalMutableDictionary *)elements
-                    forSectionsContainingIndexPaths:(NSArray<NSIndexPath *> *)originalIndexPaths
-                                        environment:(id<ASTraitEnvironment>)environment
+- (void)_repopulateSupplementaryNodesIntoMap:(ASMutableElementMap *)map
+             forSectionsContainingIndexPaths:(NSArray<NSIndexPath *> *)originalIndexPaths
+                                 environment:(id<ASTraitEnvironment>)environment
 {
   ASDisplayNodeAssertMainThread();
   
@@ -298,11 +285,10 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCollectionElement *> *
     // That way we are sure we removed all the old supplementaries, even if that kind isn't present anymore.
     
     // Step 1: Remove all existing elements of this kind in these sections
-    [elements[kind] enumerateObjectsAtIndexes:sectionIndexes options:0 usingBlock:^(NSMutableArray<ASCollectionElement *> * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
-      [obj removeAllObjects];
-    }];
+    [map removeElementsOfKind:kind inSections:sectionIndexes];
+    
     // Step 2: populate new elements for all index paths in these sections
-    [self _insertElementsIntoDictionary:elements kind:kind forSections:sectionIndexes environment:environment];
+    [self _insertElementsIntoMap:map kind:kind forSections:sectionIndexes environment:environment];
   }
 }
 
@@ -313,10 +299,10 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCollectionElement *> *
  * @param sections The sections that should be populated by new elements
  * @param environment The trait environment needed to initialize elements
  */
-- (void)_insertElementsIntoDictionary:(ASCollectionElementTwoDimensionalMutableDictionary *)elements
-                                 kind:(NSString *)kind
-                          forSections:(NSIndexSet *)sections
-                          environment:(id<ASTraitEnvironment>)environment
+- (void)_insertElementsIntoMap:(ASMutableElementMap *)map
+                          kind:(NSString *)kind
+                   forSections:(NSIndexSet *)sections
+                   environment:(id<ASTraitEnvironment>)environment
 {
   ASDisplayNodeAssertMainThread();
   
@@ -325,7 +311,7 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCollectionElement *> *
   }
   
   NSArray<NSIndexPath *> *indexPaths = [self _allIndexPathsForItemsOfKind:kind inSections:sections];
-  [self _insertElementsIntoDictionary:elements kind:kind atIndexPaths:indexPaths environment:environment];
+  [self _insertElementsIntoMap:map kind:kind atIndexPaths:indexPaths environment:environment];
 }
 
 /**
@@ -335,10 +321,10 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCollectionElement *> *
  * @param indexPaths The index paths at which new elements should be populated
  * @param environment The trait environment needed to initialize elements
  */
-- (void)_insertElementsIntoDictionary:(ASCollectionElementTwoDimensionalMutableDictionary *)elements
-                                 kind:(NSString *)kind
-                         atIndexPaths:(NSArray<NSIndexPath *> *)indexPaths
-                          environment:(id<ASTraitEnvironment>)environment
+- (void)_insertElementsIntoMap:(ASMutableElementMap *)map
+                          kind:(NSString *)kind
+                  atIndexPaths:(NSArray<NSIndexPath *> *)indexPaths
+                   environment:(id<ASTraitEnvironment>)environment
 {
   ASDisplayNodeAssertMainThread();
   
@@ -353,7 +339,6 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCollectionElement *> *
   }
   
   LOG(@"Populating elements of kind: %@, for index paths: %@", kind, indexPaths);
-  NSMutableArray<ASCollectionElement *> *array = [NSMutableArray arrayWithCapacity:indexPaths.count];
   for (NSIndexPath *indexPath in indexPaths) {
     ASCellNodeBlock nodeBlock;
     if (isRowKind) {
@@ -363,13 +348,12 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCollectionElement *> *
     }
     
     ASSizeRange constrainedSize = [self constrainedSizeForNodeOfKind:kind atIndexPath:indexPath];
-    [array addObject:[[ASCollectionElement alloc] initWithNodeBlock:nodeBlock
+    ASCollectionElement *element = [[ASCollectionElement alloc] initWithNodeBlock:nodeBlock
                                            supplementaryElementKind:isRowKind ? nil : kind
                                                     constrainedSize:constrainedSize
-                                                        environment:environment]];
+                                                        environment:environment];
+    [map insertElement:element atIndexPath:indexPath];
   }
-  
-  ASInsertElementsIntoMultidimensionalArrayAtIndexPaths(elements[kind], indexPaths, array);
 }
 
 - (void)invalidateDataSourceItemCounts
@@ -478,34 +462,29 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCollectionElement *> *
   }
 
   // Mutable copy of current data.
-  ASCollectionElementTwoDimensionalMutableDictionary *mutableElements = [ASDataController deepMutableCopyOfElementsDictionary:_pendingElements];
-  NSMutableArray *mutableSections = [_pendingSections mutableCopy];
+  ASMutableElementMap *mutableMap = [_pendingMap mutableCopy];
   
   // Step 1: update the mutable copies to match the data source's state
-  [self _updateSectionContexts:mutableSections changeSet:changeSet];
+  [self _updateSectionContextsInMap:mutableMap changeSet:changeSet];
   //TODO If _elements is the same, use a fast path
-  [self _updateElements:mutableElements changeSet:changeSet];
+  [self _updateElementsInMap:mutableMap changeSet:changeSet];
   
   // Step 2: Clone the new data
-  ASCollectionElementTwoDimensionalDictionary *newElements = [ASDataController deepImmutableCopyOfElementsDictionary:mutableElements];
-  NSArray *newSections = [mutableSections copy];
+  ASElementMap *newMap = [mutableMap copy];
 
-  // Save the pending values as ivars
-  _pendingElements = newElements;
-  _pendingSections = newSections;
+  _pendingMap = newMap;
   
   dispatch_group_async(_editingTransactionGroup, _editingTransactionQueue, ^{
     // Step 3: Layout **all** new elements without batching in background.
-    NSArray<ASCollectionElement *> *unloadedElements = [ASDataController unloadedElementsFromDictionary:newElements];
+    NSArray<ASCollectionElement *> *unmeasuredElements = [ASDataController unmeasuredElementsFromMap:newMap];
     // TODO layout in batches, esp reloads
-    [self batchLayoutNodesFromContexts:unloadedElements batchSize:unloadedElements.count batchCompletion:^(id, id) {
+    [self batchLayoutNodesFromContexts:unmeasuredElements batchSize:unmeasuredElements.count batchCompletion:^(id, id) {
       ASSERT_ON_EDITING_QUEUE;
       [_mainSerialQueue performBlockOnMainThread:^{
         [_delegate dataController:self willUpdateWithChangeSet:changeSet];
-        
+
         // Step 4: Deploy the new data as "completed" and inform delegate
-        _completedElements = newElements;
-        _completedSections = newSections;
+        _completedMap = newMap;
 
         [_delegate dataController:self didUpdateWithChangeSet:changeSet];
       }];
@@ -516,7 +495,7 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCollectionElement *> *
 /**
  * Update sections based on the given change set.
  */
-- (void)_updateSectionContexts:(NSMutableArray<ASSection *> *)sections changeSet:(_ASHierarchyChangeSet *)changeSet
+- (void)_updateSectionContextsInMap:(ASMutableElementMap *)map changeSet:(_ASHierarchyChangeSet *)changeSet
 {
   ASDisplayNodeAssertMainThread();
   
@@ -528,25 +507,26 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCollectionElement *> *
   // do a reloadData here as an optimization.
   
   if (changeSet.includesReloadData) {
-    [sections removeAllObjects];
+
+    [map removeAllSectionContexts];
     
     NSUInteger sectionCount = [self itemCountsFromDataSource].size();
     NSIndexSet *sectionIndexes = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, sectionCount)];
-    [self _insertSectionContextsIntoArray:sections indexes:sectionIndexes];
+    [self _insertSectionContextsIntoMap:map indexes:sectionIndexes];
     // Return immediately because reloadData can't be used in conjuntion with other updates.
     return;
   }
   
   for (_ASHierarchySectionChange *change in [changeSet sectionChangesOfType:_ASHierarchyChangeTypeDelete]) {
-    [sections removeObjectsAtIndexes:change.indexSet];
+    [map removeSectionContextsAtIndexes:change.indexSet];
   }
   
   for (_ASHierarchySectionChange *change in [changeSet sectionChangesOfType:_ASHierarchyChangeTypeInsert]) {
-    [self _insertSectionContextsIntoArray:sections indexes:change.indexSet];
+    [self _insertSectionContextsIntoMap:map indexes:change.indexSet];
   }
 }
 
-- (void)_insertSectionContextsIntoArray:(NSMutableArray<ASSection *> *)sections indexes:(NSIndexSet *)sectionIndexes
+- (void)_insertSectionContextsIntoMap:(ASMutableElementMap *)map indexes:(NSIndexSet *)sectionIndexes
 {
   ASDisplayNodeAssertMainThread();
   
@@ -557,7 +537,7 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCollectionElement *> *
   [sectionIndexes enumerateIndexesUsingBlock:^(NSUInteger idx, BOOL * _Nonnull stop) {
     id<ASSectionContext> context = [_dataSource dataController:self contextForSection:idx];
     ASSection *section = [[ASSection alloc] initWithSectionID:_nextSectionID context:context];
-    [sections insertObject:section atIndex:idx];
+    [map insertSection:section atIndex:idx];
     _nextSectionID++;
   }];
 }
@@ -565,7 +545,7 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCollectionElement *> *
 /**
  * Update elements based on the given change set.
  */
-- (void)_updateElements:(ASCollectionElementTwoDimensionalMutableDictionary *)elements changeSet:(_ASHierarchyChangeSet *)changeSet
+- (void)_updateElementsInMap:(ASMutableElementMap *)map changeSet:(_ASHierarchyChangeSet *)changeSet
 {
   ASDisplayNodeAssertMainThread();
   
@@ -575,12 +555,12 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCollectionElement *> *
   // do a reloadData here as an optimization.
   
   if (changeSet.includesReloadData) {
-    [elements removeAllObjects];
+    [map removeAllElements];
     
     NSUInteger sectionCount = [self itemCountsFromDataSource].size();
     if (sectionCount > 0) {
       NSIndexSet *sectionIndexes = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, sectionCount)];
-      [self _insertElementsIntoDictionary:elements sections:sectionIndexes environment:environment];
+      [self _insertElementsIntoMap:map sections:sectionIndexes environment:environment];
     }
     // Return immediately because reloadData can't be used in conjuntion with other updates.
     return;
@@ -588,10 +568,9 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCollectionElement *> *
   
   for (_ASHierarchyItemChange *change in [changeSet itemChangesOfType:_ASHierarchyChangeTypeDelete]) {
     // FIXME: change.indexPaths is in descending order but ASDeleteElementsInMultidimensionalArrayAtIndexPaths() expects them to be in ascending order
-    NSArray *sortedIndexPaths = [change.indexPaths sortedArrayUsingSelector:@selector(compare:)];
-    ASDeleteElementsInMultidimensionalArrayAtIndexPaths(elements[ASDataControllerRowNodeKind], sortedIndexPaths);
+    [map removeItemsAtIndexPaths:change.indexPaths];
     // Aggressively repopulate supplementary nodes (#1773 & #1629)
-    [self _repopulateSupplementaryNodesIntoDictionary:elements forSectionsContainingIndexPaths:change.indexPaths
+    [self _repopulateSupplementaryNodesIntoMap:map forSectionsContainingIndexPaths:change.indexPaths
                                                               environment:environment];
   }
 
@@ -600,55 +579,39 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCollectionElement *> *
     NSMutableArray<NSString *> *kinds = [NSMutableArray arrayWithObject:ASDataControllerRowNodeKind];
     [kinds addObjectsFromArray:[self supplementaryKindsInSections:sectionIndexes]];
     for (NSString *kind in kinds) {
-      [elements[kind] removeObjectsAtIndexes:sectionIndexes];
+      [map removeElementsOfKind:kind inSections:sectionIndexes];
     }
   }
   
   for (_ASHierarchySectionChange *change in [changeSet sectionChangesOfType:_ASHierarchyChangeTypeInsert]) {
-    [self _insertElementsIntoDictionary:elements sections:change.indexSet environment:environment];
+    [self _insertElementsIntoMap:map sections:change.indexSet environment:environment];
   }
   
   for (_ASHierarchyItemChange *change in [changeSet itemChangesOfType:_ASHierarchyChangeTypeInsert]) {
-    [self _insertElementsIntoDictionary:elements kind:ASDataControllerRowNodeKind atIndexPaths:change.indexPaths environment:environment];
+    [self _insertElementsIntoMap:map kind:ASDataControllerRowNodeKind atIndexPaths:change.indexPaths environment:environment];
     // Aggressively reload supplementary nodes (#1773 & #1629)
-    [self _repopulateSupplementaryNodesIntoDictionary:elements forSectionsContainingIndexPaths:change.indexPaths
+    [self _repopulateSupplementaryNodesIntoMap:map forSectionsContainingIndexPaths:change.indexPaths
                                                               environment:environment];
   }
 }
 
-- (void)_insertElementsIntoDictionary:(ASCollectionElementTwoDimensionalMutableDictionary *)elements
-                             sections:(NSIndexSet *)originalSectionIndexes
-                          environment:(id<ASTraitEnvironment>)environment
+- (void)_insertElementsIntoMap:(ASMutableElementMap *)map
+                      sections:(NSIndexSet *)sectionIndexes
+                   environment:(id<ASTraitEnvironment>)environment
 {
   ASDisplayNodeAssertMainThread();
   
-  if (originalSectionIndexes.count == 0 || _dataSource == nil) {
+  if (sectionIndexes.count == 0 || _dataSource == nil) {
     return;
   }
-  
+
+  [map insertEmptySectionsOfItemsAtIndexes:sectionIndexes];
   NSMutableArray<NSString *> *kinds = [NSMutableArray arrayWithObject:ASDataControllerRowNodeKind];
-  [kinds addObjectsFromArray:[self supplementaryKindsInSections:originalSectionIndexes]];
-  
+  [kinds addObjectsFromArray:[self supplementaryKindsInSections:sectionIndexes]];
+
   for (NSString *kind in kinds) {
-    NSIndexSet *sectionIndexes = originalSectionIndexes;
-    // Step 1: Ensure _elements has enough space for new elements
-    NSMutableArray *nodeContextsOfKind = elements[kind];
-    if (nodeContextsOfKind == nil) {
-      nodeContextsOfKind = [NSMutableArray array];
-      elements[kind] = nodeContextsOfKind;
-      
-      // TODO If this is a new kind, agressively populate elements for all sections including ones that are not inside the originalSectionIndexes.
-      if (sectionIndexes.lastIndex > 0) {
-        sectionIndexes = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, sectionIndexes.lastIndex + 1)];
-      }
-    }
-    NSMutableArray *sectionArray = [NSMutableArray arrayWithCapacity:sectionIndexes.count];
-    for (NSUInteger i = 0; i < sectionIndexes.count; i++) {
-      [sectionArray addObject:[NSMutableArray array]];
-    }
-    [nodeContextsOfKind insertObjects:sectionArray atIndexes:sectionIndexes];
     // Step 2: Populate new elements for all sections
-    [self _insertElementsIntoDictionary:elements kind:kind forSections:sectionIndexes environment:environment];
+    [self _insertElementsIntoMap:map kind:kind forSections:sectionIndexes environment:environment];
   }
 }
 
@@ -668,42 +631,28 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCollectionElement *> *
   // i.e there might be some nodes that were measured using the old constrained size but haven't been added to _completedElements
   dispatch_group_async(_editingTransactionGroup, _editingTransactionQueue, ^{
     [_mainSerialQueue performBlockOnMainThread:^{
-      for (NSString *kind in _completedElements) {
-        [self _relayoutNodesOfKind:kind];
-      }
+      [self _relayoutAllNodes];
     }];
   });
 }
 
-- (void)_relayoutNodesOfKind:(NSString *)kind
+- (void)_relayoutAllNodes
 {
   ASDisplayNodeAssertMainThread();
-  NSArray *elements = _completedElements[kind];
-  if (!elements.count) {
-    return;
-  }
-  
-  NSUInteger sectionIndex = 0;
-  for (NSMutableArray *section in elements) {
-    NSUInteger rowIndex = 0;
-    for (ASCollectionElement *context in section) {
-      RETURN_IF_NO_DATASOURCE();
-      NSIndexPath *indexPath = [NSIndexPath indexPathForRow:rowIndex inSection:sectionIndex];
-      ASSizeRange constrainedSize = [self constrainedSizeForNodeOfKind:kind atIndexPath:indexPath];
-      if (ASSizeRangeHasSignificantArea(constrainedSize)) {
-        context.constrainedSize = constrainedSize;
+  [_completedMap enumerateUsingBlock:^(NSIndexPath * _Nonnull indexPath, ASCollectionElement * _Nonnull element, BOOL * _Nonnull stop) {
+    NSString *kind = element.supplementaryElementKind ?: ASDataControllerRowNodeKind;
+    ASSizeRange constrainedSize = [self constrainedSizeForNodeOfKind:kind atIndexPath:indexPath];
+    if (ASSizeRangeHasSignificantArea(constrainedSize)) {
+      element.constrainedSize = constrainedSize;
 
-        // Node may not be allocated yet (e.g node virtualization or same size optimization)
-        // Call context.nodeIfAllocated here to avoid immature node allocation and layout
-        ASCellNode *node = context.nodeIfAllocated;
-        if (node) {
-          [self _layoutNode:node withConstrainedSize:constrainedSize];
-        }
+      // Node may not be allocated yet (e.g node virtualization or same size optimization)
+      // Call context.nodeIfAllocated here to avoid immature node allocation and layout
+      ASCellNode *node = element.nodeIfAllocated;
+      if (node) {
+        [self _layoutNode:node withConstrainedSize:constrainedSize];
       }
-      rowIndex += 1;
     }
-    sectionIndex += 1;
-  }
+  }];
 }
 
 #pragma mark - Data Querying (External API)
@@ -711,27 +660,25 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCollectionElement *> *
 - (NSUInteger)numberOfSections
 {
   ASDisplayNodeAssertMainThread();
-  return [_pendingElements[ASDataControllerRowNodeKind] count];
+  return _pendingMap.sections.count;
 }
 
 - (NSUInteger)numberOfRowsInSection:(NSUInteger)section
 {
   ASDisplayNodeAssertMainThread();
-  NSArray *contextSections = _pendingElements[ASDataControllerRowNodeKind];
-  return (section < contextSections.count) ? [contextSections[section] count] : 0;
+  return [_pendingMap numberOfItemsInSection:section];
 }
 
 - (NSUInteger)completedNumberOfSections
 {
   ASDisplayNodeAssertMainThread();
-  return [_completedElements[ASDataControllerRowNodeKind] count];
+  return _completedMap.sections.count;
 }
 
 - (NSUInteger)completedNumberOfRowsInSection:(NSUInteger)section
 {
   ASDisplayNodeAssertMainThread();
-  NSArray *completedNodes = _completedElements[ASDataControllerRowNodeKind];
-  return (section < completedNodes.count) ? [completedNodes[section] count] : 0;
+  return [_completedMap numberOfItemsInSection:section];
 }
 
 - (ASCellNode *)nodeAtIndexPath:(NSIndexPath *)indexPath
@@ -740,12 +687,7 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCollectionElement *> *
   if (indexPath == nil) {
     return nil;
   }
-  
-  ASCollectionElement *context = ASGetElementInTwoDimensionalArray(_pendingElements[ASDataControllerRowNodeKind],
-                                                                    indexPath);
-  // Note: Node may not be allocated and laid out yet (e.g node virtualization or same size optimization)
-  // In that case, calling context.node here will force an allocation
-  return context.node;
+  return [_pendingMap elementForItemAtIndexPath:indexPath].node;
 }
 
 - (ASCellNode *)nodeAtCompletedIndexPath:(NSIndexPath *)indexPath
@@ -754,80 +696,26 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCollectionElement *> *
   if (indexPath == nil) {
     return nil;
   }
-
-  ASCollectionElement *context = ASGetElementInTwoDimensionalArray(_completedElements[ASDataControllerRowNodeKind],
-                                                                    indexPath);
-  // Note: Node may not be allocated and laid out yet (e.g node virtualization or same size optimization)
-  // TODO: Force synchronous allocation and layout pass in that case?
-  return context.node;
+  return [_completedMap elementForItemAtIndexPath:indexPath].node;
 }
 
 - (NSIndexPath *)indexPathForNode:(ASCellNode *)cellNode;
 {
   ASDisplayNodeAssertMainThread();
-  return [self _indexPathForNode:cellNode inContexts:_pendingElements];
+  return [_pendingMap indexPathForElement:cellNode.collectionElement];
 }
 
 - (NSIndexPath *)completedIndexPathForNode:(ASCellNode *)cellNode
 {
   ASDisplayNodeAssertMainThread();
-  return [self _indexPathForNode:cellNode inContexts:_completedElements];
-}
-
-- (NSIndexPath *)_indexPathForNode:(ASCellNode *)cellNode inContexts:(ASCollectionElementTwoDimensionalDictionary *)elements
-{
-  ASDisplayNodeAssertMainThread();
-  if (cellNode == nil) {
-    return nil;
-  }
-
-  NSString *kind = cellNode.supplementaryElementKind ?: ASDataControllerRowNodeKind;
-  ASCollectionElementTwoDimensionalArray *sections = elements[kind];
-
-  // Check if the cached index path is still correct.
-  NSIndexPath *indexPath = cellNode.cachedIndexPath;
-  if (indexPath != nil) {
-    ASCollectionElement *context = ASGetElementInTwoDimensionalArray(sections, indexPath);
-    // Use nodeIfAllocated to avoid accidental node allocation and layout
-    if (context.nodeIfAllocated == cellNode) {
-      return indexPath;
-    } else {
-      indexPath = nil;
-    }
-  }
-
-  // Loop through each section to look for the node context
-  NSInteger sectionIdx = 0;
-  for (NSArray<ASCollectionElement *> *section in sections) {
-    NSUInteger item = [section indexOfObjectPassingTest:^BOOL(ASCollectionElement * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
-      return obj.nodeIfAllocated == cellNode;
-    }];
-    if (item != NSNotFound) {
-      indexPath = [NSIndexPath indexPathForItem:item inSection:sectionIdx];
-      break;
-    }
-    sectionIdx += 1;
-  }
-  cellNode.cachedIndexPath = indexPath;
-  return indexPath;
+  return [_completedMap indexPathForElement:cellNode.collectionElement];
 }
 
 /// Returns nodes that can be queried externally.
 - (NSArray *)completedNodes
 {
   ASDisplayNodeAssertMainThread();
-  ASCollectionElementTwoDimensionalArray *sections = _completedElements[ASDataControllerRowNodeKind];
-  NSMutableArray<NSMutableArray<ASCellNode *> *> *completedNodes = [NSMutableArray arrayWithCapacity:sections.count];
-  for (NSArray<ASCollectionElement *> *section in sections) {
-    NSMutableArray<ASCellNode *> *nodesInSection = [NSMutableArray arrayWithCapacity:section.count];
-    for (ASCollectionElement *context in section) {
-      // Note: Node may not be allocated and laid out yet (e.g node virtualization or same size optimization)
-      // TODO: Force synchronous allocation and layout pass in that case?
-      [nodesInSection addObject:context.node];
-    }
-    [completedNodes addObject:nodesInSection];
-  }
-  return completedNodes;
+  return _completedMap.itemNodes;
 }
 
 #pragma mark - External supplementary store and section context querying
@@ -838,50 +726,22 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCollectionElement *> *
   if (kind == nil || indexPath == nil) {
     return nil;
   }
-  
-  ASCollectionElement *context = ASGetElementInTwoDimensionalArray(_completedElements[kind], indexPath);
-  // Note: Node may not be allocated and laid out yet (e.g node virtualization or same size optimization)
-  // TODO: Force synchronous allocation and layout pass in that case?
-  return context.node;
+  return [_completedMap supplementaryElementOfKind:kind atIndexPath:indexPath].node;
 }
 
 - (id<ASSectionContext>)contextForSection:(NSInteger)section
 {
   ASDisplayNodeAssertMainThread();
-  return _pendingSections[section].context;
+  return _pendingMap.sections[section].context;
 }
 
-#pragma mark - elements dictionary
-
-//TODO Move this to somewhere else?
-+ (ASCollectionElementTwoDimensionalDictionary *)deepImmutableCopyOfElementsDictionary:(ASCollectionElementTwoDimensionalDictionary *)originalDict
-{
-  NSMutableDictionary *deepCopy = [NSMutableDictionary dictionaryWithCapacity:originalDict.count];
-  [originalDict enumerateKeysAndObjectsUsingBlock:^(NSString * _Nonnull kind, ASCollectionElementTwoDimensionalArray * _Nonnull obj, BOOL * _Nonnull stop) {
-    deepCopy[kind] = [[NSArray alloc] initWithArray:obj copyItems:YES];
-  }];
-  return deepCopy;
-}
-
-+ (ASCollectionElementTwoDimensionalMutableDictionary *)deepMutableCopyOfElementsDictionary:(ASCollectionElementTwoDimensionalDictionary *)originalDict
-{
-  ASCollectionElementTwoDimensionalMutableDictionary *deepCopy = [NSMutableDictionary dictionaryWithCapacity:originalDict.count];
-  [originalDict enumerateKeysAndObjectsUsingBlock:^(NSString * _Nonnull kind, ASCollectionElementTwoDimensionalArray * _Nonnull obj, BOOL * _Nonnull stop) {
-    deepCopy[kind] = (ASCollectionElementTwoDimensionalMutableArray *)ASTwoDimensionalArrayDeepMutableCopy(obj);
-  }];
-  return deepCopy;
-}
-
-+ (NSArray<ASCollectionElement *> *)unloadedElementsFromDictionary:(ASCollectionElementTwoDimensionalDictionary *)dict
++ (NSArray<ASCollectionElement *> *)unmeasuredElementsFromMap:(ASElementMap *)map
 {
   NSMutableArray<ASCollectionElement *> *unloadedContexts = [NSMutableArray array];
-  [dict enumerateKeysAndObjectsUsingBlock:^(NSString * _Nonnull kind, ASCollectionElementTwoDimensionalArray * _Nonnull allSections, BOOL * _Nonnull stop) {
-    [allSections enumerateObjectsUsingBlock:^(NSArray<ASCollectionElement *> * _Nonnull section, NSUInteger idx, BOOL * _Nonnull stop) {
-      [section enumerateObjectsUsingBlock:^(ASCollectionElement * _Nonnull context, NSUInteger idx, BOOL * _Nonnull stop) {
-        ASCellNode *node = context.nodeIfAllocated;
-        if (node == nil || node.calculatedLayout == nil) [unloadedContexts addObject:context];
-      }];
-    }];
+  [map enumerateUsingBlock:^(NSIndexPath * _Nonnull indexPath, ASCollectionElement * _Nonnull element, BOOL * _Nonnull stop) {
+    if (element.nodeIfAllocated.calculatedLayout == nil) {
+      [unloadedContexts addObject:element];
+    }
   }];
   return unloadedContexts;
 }

--- a/AsyncDisplayKit/Details/ASRangeController.h
+++ b/AsyncDisplayKit/Details/ASRangeController.h
@@ -134,9 +134,7 @@ AS_SUBCLASSING_RESTRICTED
  */
 - (ASInterfaceState)interfaceStateForRangeController:(ASRangeController *)rangeController;
 
-- (ASDisplayNode *)rangeController:(ASRangeController *)rangeController nodeAtIndexPath:(NSIndexPath *)indexPath;
-
-- (NSArray<NSArray <ASCellNode *> *> *)completedNodes;
+- (ASElementMap *)elementMapForRangeController:(ASRangeController *)rangeController;
 
 - (NSString *)nameForRangeControllerDataSource;
 

--- a/AsyncDisplayKit/Details/ASTraitCollection.h
+++ b/AsyncDisplayKit/Details/ASTraitCollection.h
@@ -122,14 +122,12 @@ ASDISPLAYNODE_EXTERN_C_END
 \
   ASPrimitiveTraitCollection currentTraits = self.primitiveTraitCollection;\
   if (ASPrimitiveTraitCollectionIsEqualToASPrimitiveTraitCollection(currentTraits, oldTraits) == NO) {\
-    /* Must dispatch to main for self.view && [self.view.dataController completedNodes]*/\
+    /* Must dispatch to main for self.view && [self.view.dataController visibleMap]*/\
     ASPerformBlockOnMainThread(^{\
-      NSArray<NSArray <ASCellNode *> *> *completedNodes = [self.view.dataController completedNodes];\
-      for (NSArray *sectionArray in completedNodes) {\
-        for (ASCellNode *cellNode in sectionArray) {\
-          ASTraitCollectionPropagateDown(cellNode, currentTraits);\
-        }\
-      }\
+      ASElementMap *map = self.view.dataController.visibleMap; \
+      [map enumerateUsingBlock:^(NSIndexPath * _Nonnull indexPath, ASCollectionElement * _Nonnull element, BOOL * _Nonnull stop) { \
+         ASTraitCollectionPropagateDown(element.nodeIfAllocated, currentTraits); \
+      }]; \
     });\
   }\
 }\

--- a/AsyncDisplayKit/Details/NSIndexSet+ASHelpers.h
+++ b/AsyncDisplayKit/Details/NSIndexSet+ASHelpers.h
@@ -25,4 +25,6 @@
 /// Returns all the section indexes contained in the index paths array.
 + (NSIndexSet *)as_sectionsFromIndexPaths:(NSArray<NSIndexPath *> *)indexPaths;
 
+- (NSArray<NSIndexPath *> *)as_filterIndexPathsBySection:(id<NSFastEnumeration>)indexPaths;
+
 @end

--- a/AsyncDisplayKit/Details/NSIndexSet+ASHelpers.m
+++ b/AsyncDisplayKit/Details/NSIndexSet+ASHelpers.m
@@ -92,4 +92,15 @@
   return result;
 }
 
+- (NSArray<NSIndexPath *> *)as_filterIndexPathsBySection:(id<NSFastEnumeration>)indexPaths
+{
+  NSMutableArray *result = [NSMutableArray array];
+  for (NSIndexPath *indexPath in indexPaths) {
+    if ([self containsIndex:indexPath.section]) {
+      [result addObject:indexPath];
+    }
+  }
+  return result;
+}
+
 @end

--- a/AsyncDisplayKit/Private/ASElementMap.h
+++ b/AsyncDisplayKit/Private/ASElementMap.h
@@ -24,17 +24,6 @@ AS_SUBCLASSING_RESTRICTED
 @interface ASElementMap : NSObject <NSCopying>
 
 /**
- * Create a new element map for this dataset. You probably don't need to use this – ASDataController is the only one who creates these.
- *
- * @param sections The array of ASSection objects.
- * @param items A 2D array of ASCollectionElements, for each item.
- * @param supplementaryElements A dictionary of gathered supplementary elements.
- */
-- (instancetype)initWithSections:(NSArray<ASSection *> *)sections
-                           items:(ASCollectionElementTwoDimensionalArray *)items
-           supplementaryElements:(ASSupplementaryElementDictionary *)supplementaryElements;
-
-/**
  * The number of sections (of items) in this map.
  */
 @property (readonly) NSInteger numberOfSections;
@@ -80,6 +69,17 @@ AS_SUBCLASSING_RESTRICTED
  * Enumerates all the elements in this map, and their index paths.
  */
 - (void)enumerateUsingBlock:(AS_NOESCAPE void(^)(NSIndexPath *indexPath, ASCollectionElement *element, BOOL *stop))block;
+
+/**
+ * Create a new element map for this dataset. You probably don't need to use this – ASDataController is the only one who creates these.
+ *
+ * @param sections The array of ASSection objects.
+ * @param items A 2D array of ASCollectionElements, for each item.
+ * @param supplementaryElements A dictionary of gathered supplementary elements.
+ */
+- (instancetype)initWithSections:(NSArray<ASSection *> *)sections
+                           items:(ASCollectionElementTwoDimensionalArray *)items
+           supplementaryElements:(ASSupplementaryElementDictionary *)supplementaryElements;
 
 @end
 

--- a/AsyncDisplayKit/Private/ASElementMap.h
+++ b/AsyncDisplayKit/Private/ASElementMap.h
@@ -14,8 +14,17 @@ NS_ASSUME_NONNULL_BEGIN
 @class ASCollectionElement, ASSection;
 @protocol ASSectionContext;
 
+typedef NSArray<NSArray<ASCollectionElement *> *> ASCollectionElementTwoDimensionalArray;
+
+// ElementKind -> IndexPath -> Element
+typedef NSDictionary<NSString *, NSDictionary<NSIndexPath *, ASCollectionElement *> *> ASSupplementaryElementDictionary;
+
 AS_SUBCLASSING_RESTRICTED
 @interface ASElementMap : NSObject <NSCopying, NSMutableCopying>
+
+- (instancetype)initWithSections:(NSArray<ASSection *> *)sections
+                           items:(ASCollectionElementTwoDimensionalArray *)items
+           supplementaryElements:(ASSupplementaryElementDictionary *)supplementaryElements;
 
 @property (readonly) NSInteger numberOfSections;
 
@@ -45,32 +54,6 @@ AS_SUBCLASSING_RESTRICTED
 - (nullable ASCollectionElement *)supplementaryElementOfKind:(NSString *)supplementaryElementKind atIndexPath:(NSIndexPath *)indexPath;
 
 - (void)enumerateUsingBlock:(AS_NOESCAPE void(^)(NSIndexPath *indexPath, ASCollectionElement *element, BOOL *stop))block;
-
-@end
-
-/**
- * This mutable version will be removed in the future. It's only here now to keep the diff small
- * as we port data controller to use this.
- */
-AS_SUBCLASSING_RESTRICTED
-@interface ASMutableElementMap : NSObject <NSCopying>
-
-- (void)insertSection:(ASSection *)section atIndex:(NSInteger)index;
-
-- (void)removeAllSectionContexts;
-
-/// Only modifies the array of ASSection * objects
-- (void)removeSectionContextsAtIndexes:(NSIndexSet *)indexes;
-
-- (void)removeAllElements;
-
-- (void)removeItemsAtIndexPaths:(NSArray<NSIndexPath *> *)indexPaths;
-
-- (void)removeElementsOfKind:(NSString *)kind inSections:(NSIndexSet *)sections;
-
-- (void)insertEmptySectionsOfItemsAtIndexes:(NSIndexSet *)sections;
-
-- (void)insertElement:(ASCollectionElement *)element atIndexPath:(NSIndexPath *)indexPath;
 
 @end
 

--- a/AsyncDisplayKit/Private/ASElementMap.h
+++ b/AsyncDisplayKit/Private/ASElementMap.h
@@ -1,0 +1,73 @@
+//
+//  ASElementMap.h
+//  AsyncDisplayKit
+//
+//  Created by Adlai Holler on 2/22/17.
+//  Copyright © 2017 Facebook. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <AsyncDisplayKit/ASBaseDefines.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class ASCollectionElement, ASCellNode, ASSection, _ASHierarchyChangeSet;
+@protocol ASDataControllerSource;
+
+AS_SUBCLASSING_RESTRICTED
+@interface ASElementMap : NSObject <NSCopying, NSMutableCopying>
+
+@property (nonatomic, strong, readonly) NSArray<ASSection *> *sections;
+
+@property (nonatomic, strong, readonly) NSArray<NSArray<ASCellNode *> *> *itemNodes;
+
+- (NSInteger)numberOfItemsInSection:(NSInteger)section;
+
+@property (nonatomic, readonly) NSArray<NSString *> *supplementaryElementKinds;
+
+/**
+ * O(1)
+ */
+- (nullable NSIndexPath *)indexPathForElement:(ASCollectionElement *)element;
+
+/**
+ * O(1)
+ */
+- (nullable ASCollectionElement *)elementForItemAtIndexPath:(NSIndexPath *)indexPath;
+
+/**
+ * O(1)
+ */
+- (nullable ASCollectionElement *)supplementaryElementOfKind:(NSString *)supplementaryElementKind atIndexPath:(NSIndexPath *)indexPath;
+
+- (void)enumerateUsingBlock:(AS_NOESCAPE void(^)(NSIndexPath *indexPath, ASCollectionElement *element, BOOL *stop))block;
+
+@end
+
+/**
+ * This mutable version will be removed in the future. It's only here now to keep the diff small
+ * as we port data controller to use this.
+ */
+AS_SUBCLASSING_RESTRICTED
+@interface ASMutableElementMap : NSObject <NSCopying>
+
+- (void)insertSection:(ASSection *)section atIndex:(NSInteger)index;
+
+- (void)removeAllSectionContexts;
+
+/// Only modifies the array of ASSection * objects
+- (void)removeSectionContextsAtIndexes:(NSIndexSet *)indexes;
+
+- (void)removeAllElements;
+
+- (void)removeItemsAtIndexPaths:(NSArray<NSIndexPath *> *)indexPaths;
+
+- (void)removeElementsOfKind:(NSString *)kind inSections:(NSIndexSet *)sections;
+
+- (void)insertEmptySectionsOfItemsAtIndexes:(NSIndexSet *)sections;
+
+- (void)insertElement:(ASCollectionElement *)element atIndexPath:(NSIndexPath *)indexPath;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/AsyncDisplayKit/Private/ASElementMap.h
+++ b/AsyncDisplayKit/Private/ASElementMap.h
@@ -14,12 +14,6 @@ NS_ASSUME_NONNULL_BEGIN
 @class ASCollectionElement, ASSection;
 @protocol ASSectionContext;
 
-// SectionIndex -> ItemIndex -> Element
-typedef NSArray<NSArray<ASCollectionElement *> *> ASCollectionElementTwoDimensionalArray;
-
-// ElementKind -> IndexPath -> Element
-typedef NSDictionary<NSString *, NSDictionary<NSIndexPath *, ASCollectionElement *> *> ASSupplementaryElementDictionary;
-
 AS_SUBCLASSING_RESTRICTED
 @interface ASElementMap : NSObject <NSCopying>
 
@@ -69,6 +63,16 @@ AS_SUBCLASSING_RESTRICTED
  * Enumerates all the elements in this map, and their index paths.
  */
 - (void)enumerateUsingBlock:(AS_NOESCAPE void(^)(NSIndexPath *indexPath, ASCollectionElement *element, BOOL *stop))block;
+
+
+#pragma mark - Initialization -- Only Useful to ASDataController
+
+
+// SectionIndex -> ItemIndex -> Element
+typedef NSArray<NSArray<ASCollectionElement *> *> ASCollectionElementTwoDimensionalArray;
+
+// ElementKind -> IndexPath -> Element
+typedef NSDictionary<NSString *, NSDictionary<NSIndexPath *, ASCollectionElement *> *> ASSupplementaryElementDictionary;
 
 /**
  * Create a new element map for this dataset. You probably don't need to use this – ASDataController is the only one who creates these.

--- a/AsyncDisplayKit/Private/ASElementMap.h
+++ b/AsyncDisplayKit/Private/ASElementMap.h
@@ -14,45 +14,71 @@ NS_ASSUME_NONNULL_BEGIN
 @class ASCollectionElement, ASSection;
 @protocol ASSectionContext;
 
+// SectionIndex -> ItemIndex -> Element
 typedef NSArray<NSArray<ASCollectionElement *> *> ASCollectionElementTwoDimensionalArray;
 
 // ElementKind -> IndexPath -> Element
 typedef NSDictionary<NSString *, NSDictionary<NSIndexPath *, ASCollectionElement *> *> ASSupplementaryElementDictionary;
 
 AS_SUBCLASSING_RESTRICTED
-@interface ASElementMap : NSObject <NSCopying, NSMutableCopying>
+@interface ASElementMap : NSObject <NSCopying>
 
+/**
+ * Create a new element map for this dataset. You probably don't need to use this – ASDataController is the only one who creates these.
+ *
+ * @param sections The array of ASSection objects.
+ * @param items A 2D array of ASCollectionElements, for each item.
+ * @param supplementaryElements A dictionary of gathered supplementary elements.
+ */
 - (instancetype)initWithSections:(NSArray<ASSection *> *)sections
                            items:(ASCollectionElementTwoDimensionalArray *)items
            supplementaryElements:(ASSupplementaryElementDictionary *)supplementaryElements;
 
+/**
+ * The number of sections (of items) in this map.
+ */
 @property (readonly) NSInteger numberOfSections;
 
+/**
+ * Returns number of items in the given section. O(1)
+ */
 - (NSInteger)numberOfItemsInSection:(NSInteger)section;
 
+/**
+ * Returns the context object for the given section, if any. O(1)
+ */
 - (nullable id<ASSectionContext>)contextForSection:(NSInteger)section;
 
+/**
+ * All the index paths for all the items in this map. O(N)
+ *
+ * This property may be removed in the future, since it doesn't account for supplementary nodes.
+ */
 @property (copy, readonly) NSArray<NSIndexPath *> *itemIndexPaths;
 
-@property (copy, readonly) NSArray<NSString *> *supplementaryElementKinds;
-
-- (NSIndexPath *)convertIndexPath:(NSIndexPath *)indexPath fromMap:(ASElementMap *)map;
+/**
+ * Returns the index path that corresponds to the same element in @c map at the given @c indexPath. O(1)
+ */
+- (nullable NSIndexPath *)convertIndexPath:(NSIndexPath *)indexPath fromMap:(ASElementMap *)map;
 
 /**
- * O(1)
+ * Returns the index path for the given element. O(1)
  */
 - (nullable NSIndexPath *)indexPathForElement:(ASCollectionElement *)element;
 
 /**
- * O(1)
+ * Returns the item-element at the given index path. O(1)
  */
 - (nullable ASCollectionElement *)elementForItemAtIndexPath:(NSIndexPath *)indexPath;
 
 /**
- * O(1)
+ * Returns the element for the supplementary element of the given kind at the given index path. O(1)
  */
 - (nullable ASCollectionElement *)supplementaryElementOfKind:(NSString *)supplementaryElementKind atIndexPath:(NSIndexPath *)indexPath;
 
+/**
+ * Enumerates all the elements in this map, and their index paths.
+ */
 - (void)enumerateUsingBlock:(AS_NOESCAPE void(^)(NSIndexPath *indexPath, ASCollectionElement *element, BOOL *stop))block;
 
 @end

--- a/AsyncDisplayKit/Private/ASElementMap.h
+++ b/AsyncDisplayKit/Private/ASElementMap.h
@@ -11,19 +11,23 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class ASCollectionElement, ASCellNode, ASSection, _ASHierarchyChangeSet;
-@protocol ASDataControllerSource;
+@class ASCollectionElement, ASSection;
+@protocol ASSectionContext;
 
 AS_SUBCLASSING_RESTRICTED
 @interface ASElementMap : NSObject <NSCopying, NSMutableCopying>
 
-@property (nonatomic, strong, readonly) NSArray<ASSection *> *sections;
-
-@property (nonatomic, strong, readonly) NSArray<NSArray<ASCellNode *> *> *itemNodes;
+@property (readonly) NSInteger numberOfSections;
 
 - (NSInteger)numberOfItemsInSection:(NSInteger)section;
 
-@property (nonatomic, readonly) NSArray<NSString *> *supplementaryElementKinds;
+- (nullable id<ASSectionContext>)contextForSection:(NSInteger)section;
+
+@property (copy, readonly) NSArray<NSIndexPath *> *itemIndexPaths;
+
+@property (copy, readonly) NSArray<NSString *> *supplementaryElementKinds;
+
+- (NSIndexPath *)convertIndexPath:(NSIndexPath *)indexPath fromMap:(ASElementMap *)map;
 
 /**
  * O(1)

--- a/AsyncDisplayKit/Private/ASElementMap.m
+++ b/AsyncDisplayKit/Private/ASElementMap.m
@@ -10,16 +10,14 @@
 #import <UIKit/UIKit.h>
 #import <AsyncDisplayKit/ASCollectionElement.h>
 #import <AsyncDisplayKit/ASMultidimensionalArrayUtils.h>
+#import <AsyncDisplayKit/ASMutableElementMap.h>
 #import <AsyncDisplayKit/ASSection.h>
 #import <AsyncDisplayKit/NSIndexSet+ASHelpers.h>
-
-typedef NSMutableArray<NSMutableArray<ASCollectionElement *> *> ASMutableCollectionElementTwoDimensionalArray;
 
 typedef NSArray<NSArray<ASCollectionElement *> *> ASCollectionElementTwoDimensionalArray;
 
 // ElementKind -> IndexPath -> Element
 typedef NSDictionary<NSString *, NSDictionary<NSIndexPath *, ASCollectionElement *> *> ASSupplementaryElementDictionary;
-typedef NSMutableDictionary<NSString *, NSMutableDictionary<NSIndexPath *, ASCollectionElement *> *> ASMutableSupplementaryElementDictionary;
 
 @interface ASElementMap ()
 
@@ -33,10 +31,6 @@ typedef NSMutableDictionary<NSString *, NSMutableDictionary<NSIndexPath *, ASCol
 
 @property (nonatomic, strong, readonly) ASSupplementaryElementDictionary *supplementaryElements;
 
-@end
-
-@interface ASMutableElementMap ()
-- (instancetype)initWithSections:(NSArray<ASSection *> *)sections items:(ASCollectionElementTwoDimensionalArray *)items supplementaryElements:(ASSupplementaryElementDictionary *)supplementaryElements;
 @end
 
 @implementation ASElementMap
@@ -159,95 +153,6 @@ typedef NSMutableDictionary<NSString *, NSMutableDictionary<NSIndexPath *, ASCol
 - (id)mutableCopyWithZone:(NSZone *)zone
 {
   return [[ASMutableElementMap alloc] initWithSections:_sections items:_sectionsOfItems supplementaryElements:_supplementaryElements];
-}
-
-#pragma mark - Helpers
-
-+ (ASMutableSupplementaryElementDictionary *)deepMutableCopyOfElementsDictionary:(ASSupplementaryElementDictionary *)originalDict
-{
-  NSMutableDictionary *deepCopy = [NSMutableDictionary dictionaryWithCapacity:originalDict.count];
-  [originalDict enumerateKeysAndObjectsUsingBlock:^(NSString * _Nonnull key, NSDictionary<NSIndexPath *,ASCollectionElement *> * _Nonnull obj, BOOL * _Nonnull stop) {
-    deepCopy[key] = [obj mutableCopy];
-  }];
-
-  return deepCopy;
-}
-@end
-
-@implementation ASMutableElementMap {
-  ASMutableSupplementaryElementDictionary *_supplementaryElements;
-  NSMutableArray<ASSection *> *_sections;
-  ASMutableCollectionElementTwoDimensionalArray *_sectionsOfItems;
-}
-
-- (instancetype)initWithSections:(NSArray<ASSection *> *)sections items:(ASCollectionElementTwoDimensionalArray *)items supplementaryElements:(ASSupplementaryElementDictionary *)supplementaryElements
-{
-  if (self = [super init]) {
-    _sections = [sections mutableCopy];
-    _sectionsOfItems = (id)ASTwoDimensionalArrayDeepMutableCopy(items);
-    _supplementaryElements = [ASElementMap deepMutableCopyOfElementsDictionary:supplementaryElements];
-  }
-  return self;
-}
-
-- (id)copyWithZone:(NSZone *)zone
-{
-  return [[ASElementMap alloc] initWithSections:_sections items:_sectionsOfItems supplementaryElements:_supplementaryElements];
-}
-
-- (void)removeAllSectionContexts
-{
-  [_sections removeAllObjects];
-}
-
-- (void)insertSection:(ASSection *)section atIndex:(NSInteger)index
-{
-  [_sections insertObject:section atIndex:index];
-}
-
-- (void)removeItemsAtIndexPaths:(NSArray<NSIndexPath *> *)indexPaths
-{
-  indexPaths = [indexPaths sortedArrayUsingSelector:@selector(compare:)];
-  ASDeleteElementsInMultidimensionalArrayAtIndexPaths(_sectionsOfItems, indexPaths);
-}
-
-- (void)removeSectionContextsAtIndexes:(NSIndexSet *)indexes
-{
-  [_sections removeObjectsAtIndexes:indexes];
-}
-
-- (void)removeAllElements
-{
-  [_sectionsOfItems removeAllObjects];
-}
-
-- (void)removeElementsOfKind:(NSString *)kind inSections:(NSIndexSet *)sections
-{
-  if ([kind isEqualToString:ASDataControllerRowNodeKind]) {
-    // Items
-    [_sectionsOfItems removeObjectsAtIndexes:sections];
-  } else {
-    // Supplementaries
-    NSMutableDictionary *supsForKind = _supplementaryElements[kind];
-    [supsForKind removeObjectsForKeys:[sections as_filterIndexPathsBySection:supsForKind]];
-  }
-}
-
-- (void)insertEmptySectionsOfItemsAtIndexes:(NSIndexSet *)sections
-{
-  [sections enumerateIndexesUsingBlock:^(NSUInteger idx, BOOL * _Nonnull stop) {
-    [_sectionsOfItems insertObject:[NSMutableArray array] atIndex:idx];
-  }];
-}
-
-- (void)insertElement:(ASCollectionElement *)element atIndexPath:(NSIndexPath *)indexPath
-{
-  NSString *kind = element.supplementaryElementKind;
-  if (kind == nil) {
-    [_sectionsOfItems[indexPath.section] insertObject:element atIndex:indexPath.item];
-  } else {
-    _supplementaryElements[kind][indexPath] = element;
-  }
 }
 
 @end

--- a/AsyncDisplayKit/Private/ASElementMap.m
+++ b/AsyncDisplayKit/Private/ASElementMap.m
@@ -145,7 +145,7 @@ typedef NSDictionary<NSString *, NSDictionary<NSIndexPath *, ASCollectionElement
   return self;
 }
 
-// NSMutabeCopying conformance is declared in ASMutableElementMap.h, so that most consumers of ASElementMap don't bother with it.
+// NSMutableCopying conformance is declared in ASMutableElementMap.h, so that most consumers of ASElementMap don't bother with it.
 #pragma mark - NSMutableCopying
 
 - (id)mutableCopyWithZone:(NSZone *)zone

--- a/AsyncDisplayKit/Private/ASElementMap.m
+++ b/AsyncDisplayKit/Private/ASElementMap.m
@@ -10,6 +10,7 @@
 #import <UIKit/UIKit.h>
 #import <AsyncDisplayKit/ASCollectionElement.h>
 #import <AsyncDisplayKit/ASMultidimensionalArrayUtils.h>
+#import <AsyncDisplayKit/ASSection.h>
 #import <AsyncDisplayKit/NSIndexSet+ASHelpers.h>
 
 typedef NSMutableArray<NSMutableArray<ASCollectionElement *> *> ASMutableCollectionElementTwoDimensionalArray;
@@ -21,6 +22,8 @@ typedef NSDictionary<NSString *, NSDictionary<NSIndexPath *, ASCollectionElement
 typedef NSMutableDictionary<NSString *, NSMutableDictionary<NSIndexPath *, ASCollectionElement *> *> ASMutableSupplementaryElementDictionary;
 
 @interface ASElementMap ()
+
+@property (nonatomic, strong, readonly) NSArray<ASSection *> *sections;
 
 // Element -> IndexPath
 @property (nonatomic, strong, readonly) NSMapTable<ASCollectionElement *, NSIndexPath *> *elementToIndexPathMap;
@@ -71,6 +74,11 @@ typedef NSMutableDictionary<NSString *, NSMutableDictionary<NSIndexPath *, ASCol
   return self;
 }
 
+- (NSArray<NSIndexPath *> *)itemIndexPaths
+{
+  return ASIndexPathsForTwoDimensionalArray(_sectionsOfItems);
+}
+
 - (NSInteger)numberOfSections
 {
   return _sectionsOfItems.count;
@@ -79,6 +87,11 @@ typedef NSMutableDictionary<NSString *, NSMutableDictionary<NSIndexPath *, ASCol
 - (NSInteger)numberOfItemsInSection:(NSInteger)section
 {
   return _sectionsOfItems[section].count;
+}
+
+- (id<ASSectionContext>)contextForSection:(NSInteger)section
+{
+  return _sections[section].context;
 }
 
 - (NSArray<NSString *> *)supplementaryElementKinds
@@ -99,6 +112,12 @@ typedef NSMutableDictionary<NSString *, NSMutableDictionary<NSIndexPath *, ASCol
 - (nullable ASCollectionElement *)supplementaryElementOfKind:(NSString *)supplementaryElementKind atIndexPath:(NSIndexPath *)indexPath
 {
   return _supplementaryElements[supplementaryElementKind][indexPath];
+}
+
+- (NSIndexPath *)convertIndexPath:(NSIndexPath *)indexPath fromMap:(ASElementMap *)map
+{
+  id element = [map elementForItemAtIndexPath:indexPath];
+  return [self indexPathForElement:element];
 }
 
 - (void)enumerateUsingBlock:(void(^)(NSIndexPath *indexPath, ASCollectionElement *element, BOOL *stop))block

--- a/AsyncDisplayKit/Private/ASElementMap.m
+++ b/AsyncDisplayKit/Private/ASElementMap.m
@@ -1,0 +1,234 @@
+//
+//  ASElementMap.m
+//  AsyncDisplayKit
+//
+//  Created by Adlai Holler on 2/22/17.
+//  Copyright © 2017 Facebook. All rights reserved.
+//
+
+#import "ASElementMap.h"
+#import <UIKit/UIKit.h>
+#import <AsyncDisplayKit/ASCollectionElement.h>
+#import <AsyncDisplayKit/ASMultidimensionalArrayUtils.h>
+#import <AsyncDisplayKit/NSIndexSet+ASHelpers.h>
+
+typedef NSMutableArray<NSMutableArray<ASCollectionElement *> *> ASMutableCollectionElementTwoDimensionalArray;
+
+typedef NSArray<NSArray<ASCollectionElement *> *> ASCollectionElementTwoDimensionalArray;
+
+// ElementKind -> IndexPath -> Element
+typedef NSDictionary<NSString *, NSDictionary<NSIndexPath *, ASCollectionElement *> *> ASSupplementaryElementDictionary;
+typedef NSMutableDictionary<NSString *, NSMutableDictionary<NSIndexPath *, ASCollectionElement *> *> ASMutableSupplementaryElementDictionary;
+
+@interface ASElementMap ()
+
+// Element -> IndexPath
+@property (nonatomic, strong, readonly) NSMapTable<ASCollectionElement *, NSIndexPath *> *elementToIndexPathMap;
+
+// The items, in a 2D array
+@property (nonatomic, strong, readonly) ASCollectionElementTwoDimensionalArray *sectionsOfItems;
+
+@property (nonatomic, strong, readonly) ASSupplementaryElementDictionary *supplementaryElements;
+
+@end
+
+@interface ASMutableElementMap ()
+- (instancetype)initWithSections:(NSArray<ASSection *> *)sections items:(ASCollectionElementTwoDimensionalArray *)items supplementaryElements:(ASSupplementaryElementDictionary *)supplementaryElements;
+@end
+
+@implementation ASElementMap
+
+- (instancetype)init
+{
+  return [self initWithSections:@[] items:@[] supplementaryElements:@{}];
+}
+
+- (instancetype)initWithSections:(NSArray<ASSection *> *)sections items:(ASCollectionElementTwoDimensionalArray *)items supplementaryElements:(ASSupplementaryElementDictionary *)supplementaryElements
+{
+  if (self = [super init]) {
+    _sections = [sections copy];
+    _sectionsOfItems = [[NSArray alloc] initWithArray:items copyItems:YES];
+    _supplementaryElements = [[NSDictionary alloc] initWithDictionary:supplementaryElements copyItems:YES];
+
+    // Setup our index path map
+    _elementToIndexPathMap = [NSMapTable mapTableWithKeyOptions:(NSMapTableStrongMemory | NSMapTableObjectPointerPersonality) valueOptions:NSMapTableCopyIn];
+    NSInteger s = 0;
+    for (NSArray *section in _sectionsOfItems) {
+      NSInteger i = 0;
+      for (ASCollectionElement *element in section) {
+        NSIndexPath *indexPath = [NSIndexPath indexPathForItem:i inSection:s];
+        [_elementToIndexPathMap setObject:indexPath forKey:element];
+        i++;
+      }
+      s++;
+    }
+    for (NSDictionary *supsOfKind in [_supplementaryElements objectEnumerator]) {
+      [supsOfKind enumerateKeysAndObjectsUsingBlock:^(NSIndexPath *_Nonnull indexPath, ASCollectionElement * _Nonnull element, BOOL * _Nonnull stop) {
+        [_elementToIndexPathMap setObject:indexPath forKey:element];
+      }];
+    }
+  }
+  return self;
+}
+
+- (NSInteger)numberOfSections
+{
+  return _sectionsOfItems.count;
+}
+
+- (NSInteger)numberOfItemsInSection:(NSInteger)section
+{
+  return _sectionsOfItems[section].count;
+}
+
+- (NSArray<NSString *> *)supplementaryElementKinds
+{
+  return [_supplementaryElements allKeys] ?: @[];
+}
+
+- (nullable NSIndexPath *)indexPathForElement:(ASCollectionElement *)element
+{
+  return [_elementToIndexPathMap objectForKey:element];
+}
+
+- (nullable ASCollectionElement *)elementForItemAtIndexPath:(NSIndexPath *)indexPath
+{
+  return ASGetElementInTwoDimensionalArray(_sectionsOfItems, indexPath);
+}
+
+- (nullable ASCollectionElement *)supplementaryElementOfKind:(NSString *)supplementaryElementKind atIndexPath:(NSIndexPath *)indexPath
+{
+  return _supplementaryElements[supplementaryElementKind][indexPath];
+}
+
+- (void)enumerateUsingBlock:(void(^)(NSIndexPath *indexPath, ASCollectionElement *element, BOOL *stop))block
+{
+  __block BOOL stop = NO;
+
+  // Do items first
+  for (NSArray *section in _sectionsOfItems) {
+    for (ASCollectionElement *element in section) {
+      NSIndexPath *indexPath = [self indexPathForElement:element];
+      block(indexPath, element, &stop);
+      if (stop) {
+        return;
+      }
+    }
+  }
+
+  // Then supplementaries
+  [_supplementaryElements enumerateKeysAndObjectsUsingBlock:^(NSString * _Nonnull kind, NSDictionary<NSIndexPath *,ASCollectionElement *> * _Nonnull elementsOfKind, BOOL * _Nonnull stop0) {
+    [elementsOfKind enumerateKeysAndObjectsUsingBlock:^(NSIndexPath * _Nonnull indexPath, ASCollectionElement * _Nonnull element, BOOL * _Nonnull stop1) {
+      block(indexPath, element, &stop);
+      if (stop) {
+        *stop1 = YES;
+      }
+    }];
+    if (stop) {
+      *stop0 = YES;
+    }
+  }];
+}
+
+#pragma mark - NSCopying
+
+- (id)copyWithZone:(NSZone *)zone
+{
+  return self;
+}
+
+- (id)mutableCopyWithZone:(NSZone *)zone
+{
+  return [[ASMutableElementMap alloc] initWithSections:_sections items:_sectionsOfItems supplementaryElements:_supplementaryElements];
+}
+
+#pragma mark - Helpers
+
++ (ASMutableSupplementaryElementDictionary *)deepMutableCopyOfElementsDictionary:(ASSupplementaryElementDictionary *)originalDict
+{
+  NSMutableDictionary *deepCopy = [NSMutableDictionary dictionaryWithCapacity:originalDict.count];
+  [originalDict enumerateKeysAndObjectsUsingBlock:^(NSString * _Nonnull key, NSDictionary<NSIndexPath *,ASCollectionElement *> * _Nonnull obj, BOOL * _Nonnull stop) {
+    deepCopy[key] = [obj mutableCopy];
+  }];
+
+  return deepCopy;
+}
+@end
+
+@implementation ASMutableElementMap {
+  ASMutableSupplementaryElementDictionary *_supplementaryElements;
+  NSMutableArray<ASSection *> *_sections;
+  ASMutableCollectionElementTwoDimensionalArray *_sectionsOfItems;
+}
+
+- (instancetype)initWithSections:(NSArray<ASSection *> *)sections items:(ASCollectionElementTwoDimensionalArray *)items supplementaryElements:(ASSupplementaryElementDictionary *)supplementaryElements
+{
+  if (self = [super init]) {
+    _sections = [sections mutableCopy];
+    _sectionsOfItems = (id)ASTwoDimensionalArrayDeepMutableCopy(items);
+    _supplementaryElements = [ASElementMap deepMutableCopyOfElementsDictionary:supplementaryElements];
+  }
+  return self;
+}
+
+- (id)copyWithZone:(NSZone *)zone
+{
+  return [[ASElementMap alloc] initWithSections:_sections items:_sectionsOfItems supplementaryElements:_supplementaryElements];
+}
+
+- (void)removeAllSectionContexts
+{
+  [_sections removeAllObjects];
+}
+
+- (void)insertSection:(ASSection *)section atIndex:(NSInteger)index
+{
+  [_sections insertObject:section atIndex:index];
+}
+
+- (void)removeItemsAtIndexPaths:(NSArray<NSIndexPath *> *)indexPaths
+{
+  indexPaths = [indexPaths sortedArrayUsingSelector:@selector(compare:)];
+  ASDeleteElementsInMultidimensionalArrayAtIndexPaths(_sectionsOfItems, indexPaths);
+}
+
+- (void)removeSectionContextsAtIndexes:(NSIndexSet *)indexes
+{
+  [_sections removeObjectsAtIndexes:indexes];
+}
+
+- (void)removeAllElements
+{
+  [_sectionsOfItems removeAllObjects];
+}
+
+- (void)removeElementsOfKind:(NSString *)kind inSections:(NSIndexSet *)sections
+{
+  if ([kind isEqualToString:ASDataControllerRowNodeKind]) {
+    // Items
+    [_sectionsOfItems removeObjectsAtIndexes:sections];
+  } else {
+    // Supplementaries
+    NSMutableDictionary *supsForKind = _supplementaryElements[kind];
+    [supsForKind removeObjectsForKeys:[sections as_filterIndexPathsBySection:supsForKind]];
+  }
+}
+
+- (void)insertEmptySectionsOfItemsAtIndexes:(NSIndexSet *)sections
+{
+  [sections enumerateIndexesUsingBlock:^(NSUInteger idx, BOOL * _Nonnull stop) {
+    [_sectionsOfItems insertObject:[NSMutableArray array] atIndex:idx];
+  }];
+}
+
+- (void)insertElement:(ASCollectionElement *)element atIndexPath:(NSIndexPath *)indexPath
+{
+  NSString *kind = element.supplementaryElementKind;
+  if (kind == nil) {
+    [_sectionsOfItems[indexPath.section] insertObject:element atIndex:indexPath.item];
+  } else {
+    _supplementaryElements[kind][indexPath] = element;
+  }
+}
+
+@end

--- a/AsyncDisplayKit/Private/ASElementMap.m
+++ b/AsyncDisplayKit/Private/ASElementMap.m
@@ -88,11 +88,6 @@ typedef NSDictionary<NSString *, NSDictionary<NSIndexPath *, ASCollectionElement
   return _sections[section].context;
 }
 
-- (NSArray<NSString *> *)supplementaryElementKinds
-{
-  return [_supplementaryElements allKeys] ?: @[];
-}
-
 - (nullable NSIndexPath *)indexPathForElement:(ASCollectionElement *)element
 {
   return [_elementToIndexPathMap objectForKey:element];
@@ -149,6 +144,9 @@ typedef NSDictionary<NSString *, NSDictionary<NSIndexPath *, ASCollectionElement
 {
   return self;
 }
+
+// NSMutabeCopying conformance is declared in ASMutableElementMap.h, so that most consumers of ASElementMap don't bother with it.
+#pragma mark - NSMutableCopying
 
 - (id)mutableCopyWithZone:(NSZone *)zone
 {

--- a/AsyncDisplayKit/Private/ASElementMap.m
+++ b/AsyncDisplayKit/Private/ASElementMap.m
@@ -14,11 +14,6 @@
 #import <AsyncDisplayKit/ASSection.h>
 #import <AsyncDisplayKit/NSIndexSet+ASHelpers.h>
 
-typedef NSArray<NSArray<ASCollectionElement *> *> ASCollectionElementTwoDimensionalArray;
-
-// ElementKind -> IndexPath -> Element
-typedef NSDictionary<NSString *, NSDictionary<NSIndexPath *, ASCollectionElement *> *> ASSupplementaryElementDictionary;
-
 @interface ASElementMap ()
 
 @property (nonatomic, strong, readonly) NSArray<ASSection *> *sections;

--- a/AsyncDisplayKit/Private/ASMutableElementMap.h
+++ b/AsyncDisplayKit/Private/ASMutableElementMap.h
@@ -42,4 +42,7 @@ AS_SUBCLASSING_RESTRICTED
 
 @end
 
+@interface ASElementMap (MutableCopying) <NSMutableCopying>
+@end
+
 NS_ASSUME_NONNULL_END

--- a/AsyncDisplayKit/Private/ASMutableElementMap.h
+++ b/AsyncDisplayKit/Private/ASMutableElementMap.h
@@ -1,0 +1,45 @@
+//
+//  ASMutableElementMap.h
+//  AsyncDisplayKit
+//
+//  Created by Adlai Holler on 2/23/17.
+//  Copyright © 2017 Facebook. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <AsyncDisplayKit/ASBaseDefines.h>
+#import <AsyncDisplayKit/ASElementMap.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class ASSection, ASCollectionElement;
+
+/**
+ * This mutable version will be removed in the future. It's only here now to keep the diff small
+ * as we port data controller to use ASElementMap.
+ */
+AS_SUBCLASSING_RESTRICTED
+@interface ASMutableElementMap : NSObject <NSCopying>
+
+- (instancetype)initWithSections:(NSArray<ASSection *> *)sections items:(ASCollectionElementTwoDimensionalArray *)items supplementaryElements:(ASSupplementaryElementDictionary *)supplementaryElements;
+
+- (void)insertSection:(ASSection *)section atIndex:(NSInteger)index;
+
+- (void)removeAllSectionContexts;
+
+/// Only modifies the array of ASSection * objects
+- (void)removeSectionContextsAtIndexes:(NSIndexSet *)indexes;
+
+- (void)removeAllElements;
+
+- (void)removeItemsAtIndexPaths:(NSArray<NSIndexPath *> *)indexPaths;
+
+- (void)removeElementsOfKind:(NSString *)kind inSections:(NSIndexSet *)sections;
+
+- (void)insertEmptySectionsOfItemsAtIndexes:(NSIndexSet *)sections;
+
+- (void)insertElement:(ASCollectionElement *)element atIndexPath:(NSIndexPath *)indexPath;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/AsyncDisplayKit/Private/ASMutableElementMap.h
+++ b/AsyncDisplayKit/Private/ASMutableElementMap.h
@@ -21,6 +21,8 @@ NS_ASSUME_NONNULL_BEGIN
 AS_SUBCLASSING_RESTRICTED
 @interface ASMutableElementMap : NSObject <NSCopying>
 
+- (instancetype)init __unavailable;
+
 - (instancetype)initWithSections:(NSArray<ASSection *> *)sections items:(ASCollectionElementTwoDimensionalArray *)items supplementaryElements:(ASSupplementaryElementDictionary *)supplementaryElements;
 
 - (void)insertSection:(ASSection *)section atIndex:(NSInteger)index;

--- a/AsyncDisplayKit/Private/ASMutableElementMap.m
+++ b/AsyncDisplayKit/Private/ASMutableElementMap.m
@@ -1,0 +1,109 @@
+//
+//  ASMutableElementMap.m
+//  AsyncDisplayKit
+//
+//  Created by Adlai Holler on 2/23/17.
+//  Copyright © 2017 Facebook. All rights reserved.
+//
+
+#import "ASMutableElementMap.h"
+
+#import <AsyncDisplayKit/ASCollectionElement.h>
+#import <AsyncDisplayKit/ASDataController.h>
+#import <AsyncDisplayKit/ASElementMap.h>
+#import <AsyncDisplayKit/ASMultidimensionalArrayUtils.h>
+#import <AsyncDisplayKit/NSIndexSet+ASHelpers.h>
+
+typedef NSMutableArray<NSMutableArray<ASCollectionElement *> *> ASMutableCollectionElementTwoDimensionalArray;
+
+typedef NSMutableDictionary<NSString *, NSMutableDictionary<NSIndexPath *, ASCollectionElement *> *> ASMutableSupplementaryElementDictionary;
+
+@implementation ASMutableElementMap {
+  ASMutableSupplementaryElementDictionary *_supplementaryElements;
+  NSMutableArray<ASSection *> *_sections;
+  ASMutableCollectionElementTwoDimensionalArray *_sectionsOfItems;
+}
+
+- (instancetype)initWithSections:(NSArray<ASSection *> *)sections items:(ASCollectionElementTwoDimensionalArray *)items supplementaryElements:(ASSupplementaryElementDictionary *)supplementaryElements
+{
+  if (self = [super init]) {
+    _sections = [sections mutableCopy];
+    _sectionsOfItems = (id)ASTwoDimensionalArrayDeepMutableCopy(items);
+    _supplementaryElements = [ASMutableElementMap deepMutableCopyOfElementsDictionary:supplementaryElements];
+  }
+  return self;
+}
+
+- (id)copyWithZone:(NSZone *)zone
+{
+  return [[ASElementMap alloc] initWithSections:_sections items:_sectionsOfItems supplementaryElements:_supplementaryElements];
+}
+
+- (void)removeAllSectionContexts
+{
+  [_sections removeAllObjects];
+}
+
+- (void)insertSection:(ASSection *)section atIndex:(NSInteger)index
+{
+  [_sections insertObject:section atIndex:index];
+}
+
+- (void)removeItemsAtIndexPaths:(NSArray<NSIndexPath *> *)indexPaths
+{
+  indexPaths = [indexPaths sortedArrayUsingSelector:@selector(compare:)];
+  ASDeleteElementsInMultidimensionalArrayAtIndexPaths(_sectionsOfItems, indexPaths);
+}
+
+- (void)removeSectionContextsAtIndexes:(NSIndexSet *)indexes
+{
+  [_sections removeObjectsAtIndexes:indexes];
+}
+
+- (void)removeAllElements
+{
+  [_sectionsOfItems removeAllObjects];
+}
+
+- (void)removeElementsOfKind:(NSString *)kind inSections:(NSIndexSet *)sections
+{
+  if ([kind isEqualToString:ASDataControllerRowNodeKind]) {
+    // Items
+    [_sectionsOfItems removeObjectsAtIndexes:sections];
+  } else {
+    // Supplementaries
+    NSMutableDictionary *supsForKind = _supplementaryElements[kind];
+    [supsForKind removeObjectsForKeys:[sections as_filterIndexPathsBySection:supsForKind]];
+  }
+}
+
+- (void)insertEmptySectionsOfItemsAtIndexes:(NSIndexSet *)sections
+{
+  [sections enumerateIndexesUsingBlock:^(NSUInteger idx, BOOL * _Nonnull stop) {
+    [_sectionsOfItems insertObject:[NSMutableArray array] atIndex:idx];
+  }];
+}
+
+- (void)insertElement:(ASCollectionElement *)element atIndexPath:(NSIndexPath *)indexPath
+{
+  NSString *kind = element.supplementaryElementKind;
+  if (kind == nil) {
+    [_sectionsOfItems[indexPath.section] insertObject:element atIndex:indexPath.item];
+  } else {
+    _supplementaryElements[kind][indexPath] = element;
+  }
+}
+
+#pragma mark - Helpers
+
++ (ASMutableSupplementaryElementDictionary *)deepMutableCopyOfElementsDictionary:(ASSupplementaryElementDictionary *)originalDict
+{
+  NSMutableDictionary *deepCopy = [NSMutableDictionary dictionaryWithCapacity:originalDict.count];
+  [originalDict enumerateKeysAndObjectsUsingBlock:^(NSString * _Nonnull key, NSDictionary<NSIndexPath *,ASCollectionElement *> * _Nonnull obj, BOOL * _Nonnull stop) {
+    deepCopy[key] = [obj mutableCopy];
+  }];
+  
+  return deepCopy;
+}
+
+@end

--- a/AsyncDisplayKit/Private/ASMutableElementMap.m
+++ b/AsyncDisplayKit/Private/ASMutableElementMap.m
@@ -24,11 +24,6 @@ typedef NSMutableDictionary<NSString *, NSMutableDictionary<NSIndexPath *, ASCol
   ASMutableCollectionElementTwoDimensionalArray *_sectionsOfItems;
 }
 
-- (instancetype)init
-{
-  return [self initWithSections:@[] items:@[] supplementaryElements:@{}];
-}
-
 - (instancetype)initWithSections:(NSArray<ASSection *> *)sections items:(ASCollectionElementTwoDimensionalArray *)items supplementaryElements:(ASSupplementaryElementDictionary *)supplementaryElements
 {
   if (self = [super init]) {

--- a/AsyncDisplayKit/Private/ASMutableElementMap.m
+++ b/AsyncDisplayKit/Private/ASMutableElementMap.m
@@ -24,6 +24,11 @@ typedef NSMutableDictionary<NSString *, NSMutableDictionary<NSIndexPath *, ASCol
   ASMutableCollectionElementTwoDimensionalArray *_sectionsOfItems;
 }
 
+- (instancetype)init
+{
+  return [self initWithSections:@[] items:@[] supplementaryElements:@{}];
+}
+
 - (instancetype)initWithSections:(NSArray<ASSection *> *)sections items:(ASCollectionElementTwoDimensionalArray *)items supplementaryElements:(ASSupplementaryElementDictionary *)supplementaryElements
 {
   if (self = [super init]) {


### PR DESCRIPTION
- Add a new immutable class `ASElementMap` that gives a state-of-the-world for a collection/table.
- Have `ASDataController` vend two maps: one visible and one pending.
- Have `ASTableView ASCollectionView ASRangeController` use the maps directly to answer questions like `numberOfSections` etc.
- Remove `cachedIndexPath` and `supplementaryElementKind` fields from `ASCellNode+Internal`. Add new `collectionElement` field to it.
  - Index path can be efficiently looked up from a given element map.
  - Supplementary element kind can be looked up from new `collectionElement` field.
  - `collectionElement` field added on assumption that if you return an existing cell node in a node block, then it no longer participates in the old collection view.

Plenty more work to do from here! At least now we can reliably move collection view data states around.