### PR TITLE
Fix cell selection state issues

### DIFF
--- a/Source/ASCellNode.h
+++ b/Source/ASCellNode.h
@@ -182,10 +182,10 @@ typedef NS_ENUM(NSUInteger, ASCellNodeVisibilityEvent) {
  */
 @property (nonatomic) UITableViewCellAccessoryType accessoryType;
 
-/* @abstract The seperator inset of the cell seperator line
+/* @abstract The inset of the cell separator line
  * ASTableView uses these properties when configuring UITableViewCells that host ASCellNodes.
  */
-@property (nonatomic) UIEdgeInsets seperatorInset;
+@property (nonatomic) UIEdgeInsets separatorInset;
 
 @end
 

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -79,11 +79,19 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
 {
   _node = node;
   
-  self.backgroundColor = node.backgroundColor;
-  self.selectionStyle = node.selectionStyle;
-  self.accessoryType = node.accessoryType;
-  self.separatorInset = node.seperatorInset;
-  self.clipsToBounds = node.clipsToBounds;
+  if (node) {
+    self.backgroundColor = node.backgroundColor;
+    self.selectionStyle = node.selectionStyle;
+    self.selectedBackgroundView = node.selectedBackgroundView;
+    self.separatorInset = node.separatorInset;
+    self.selectionStyle = node.selectionStyle;
+    self.accessoryType = node.accessoryType;
+    
+    // the following ensures that we clip the entire cell to it's bounds if node.clipsToBounds is set (the default)
+    // This is actually a workaround for a bug we are seeing in some rare cases (selected background view
+    // overlaps other cells if size of ASCellNode has changed.)
+    self.clipsToBounds = node.clipsToBounds;
+  }
   
   [node __setSelectedFromUIKit:self.selected];
   [node __setHighlightedFromUIKit:self.highlighted];
@@ -864,7 +872,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     [_rangeController configureContentView:cell.contentView forCellNode:node];
 
     cell.node = node;
-    cell.selectedBackgroundView = node.selectedBackgroundView;
   }
 
   return cell;

--- a/Source/Details/_ASCollectionViewCell.m
+++ b/Source/Details/_ASCollectionViewCell.m
@@ -17,8 +17,7 @@
   ASDisplayNodeAssertMainThread();
   node.layoutAttributes = _layoutAttributes;
   _node = node;
-  self.backgroundColor = node.backgroundColor;
-  self.clipsToBounds = node.clipsToBounds;
+  
   [node __setSelectedFromUIKit:self.selected];
   [node __setHighlightedFromUIKit:self.highlighted];
 }


### PR DESCRIPTION
Resolves #3037

This is a do-over of c85aa11, with the following differences:
- Fixed `_ASTableViewCell` properties **always** being mutated to match corresponding `ASCellNode` passthrough properties, even when the hosted `ASCellNode` is currently `nil`. Now only inheriting passthrough properties when there’s an actual instance of `ASCellNode` to read them from.
- Corrected spelling of `ASCellNode`’s `separatorInset` property.
- Reverted `_ASCollectionViewCell` inheriting the hosted cell node’s `backgroundColor` & `clipsToBounds` properties. This seems to be surprising and unwanted behavior to some, as seen in #3053 and #3044.
- Moved passthrough of `UITableViewCell`’s `selectedBackgroundView` into `_ASTableViewCell`’s `-setNode:` method for consistency.