### PR TITLE
Fix crashes in ASElementMap and ASMutableElementMap

### DIFF
--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -548,7 +548,7 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
 {
   // If this is a section index path, we don't currently have a method
   // to do a mapping.
-  if (indexPath.row == NSNotFound) {
+  if (indexPath == nil || indexPath.row == NSNotFound) {
     return indexPath;
   } else {
     NSIndexPath *viewIndexPath = [_dataController.visibleMap convertIndexPath:indexPath fromMap:_dataController.pendingMap];

--- a/Source/Private/ASElementMap.m
+++ b/Source/Private/ASElementMap.m
@@ -54,8 +54,8 @@
       }
       s++;
     }
-    for (NSDictionary *supsOfKind in [_supplementaryElements objectEnumerator]) {
-      [supsOfKind enumerateKeysAndObjectsUsingBlock:^(NSIndexPath *_Nonnull indexPath, ASCollectionElement * _Nonnull element, BOOL * _Nonnull stop) {
+    for (NSDictionary *supplementariesForKind in [_supplementaryElements objectEnumerator]) {
+      [supplementariesForKind enumerateKeysAndObjectsUsingBlock:^(NSIndexPath *_Nonnull indexPath, ASCollectionElement * _Nonnull element, BOOL * _Nonnull stop) {
         [_elementToIndexPathMap setObject:indexPath forKey:element];
       }];
     }
@@ -90,7 +90,7 @@
 
 - (nullable ASCollectionElement *)elementForItemAtIndexPath:(NSIndexPath *)indexPath
 {
-  return ASGetElementInTwoDimensionalArray(_sectionsOfItems, indexPath);
+  return (indexPath != nil) ? ASGetElementInTwoDimensionalArray(_sectionsOfItems, indexPath) : nil;
 }
 
 - (nullable ASCollectionElement *)supplementaryElementOfKind:(NSString *)supplementaryElementKind atIndexPath:(NSIndexPath *)indexPath

--- a/Source/Private/ASMultidimensionalArrayUtils.mm
+++ b/Source/Private/ASMultidimensionalArrayUtils.mm
@@ -226,6 +226,7 @@ NSArray *ASIndexPathsForMultidimensionalArray(NSArray *multidimensionalArray)
 
 id ASGetElementInTwoDimensionalArray(NSArray *array, NSIndexPath *indexPath)
 {
+  ASDisplayNodeCAssertNotNil(indexPath, @"Expected non-nil index path");
   ASDisplayNodeCAssert(indexPath.length == 2, @"Expected index path of length 2. Index path: %@", indexPath);
   NSInteger section = indexPath.section;
   if (array.count <= section) {

--- a/Source/Private/ASMutableElementMap.m
+++ b/Source/Private/ASMutableElementMap.m
@@ -72,8 +72,8 @@ typedef NSMutableDictionary<NSString *, NSMutableDictionary<NSIndexPath *, ASCol
     [_sectionsOfItems removeObjectsAtIndexes:sections];
   } else {
     // Supplementaries
-    NSMutableDictionary *supsForKind = _supplementaryElements[kind];
-    [supsForKind removeObjectsForKeys:[sections as_filterIndexPathsBySection:supsForKind]];
+    NSMutableDictionary *supplementariesForKind = _supplementaryElements[kind];
+    [supplementariesForKind removeObjectsForKeys:[sections as_filterIndexPathsBySection:supplementariesForKind]];
   }
 }
 
@@ -90,7 +90,12 @@ typedef NSMutableDictionary<NSString *, NSMutableDictionary<NSIndexPath *, ASCol
   if (kind == nil) {
     [_sectionsOfItems[indexPath.section] insertObject:element atIndex:indexPath.item];
   } else {
-    _supplementaryElements[kind][indexPath] = element;
+    NSMutableDictionary *supplementariesForKind = _supplementaryElements[kind];
+    if (supplementariesForKind == nil) {
+      supplementariesForKind = [NSMutableDictionary dictionary];
+      _supplementaryElements[kind] = supplementariesForKind;
+    }
+    supplementariesForKind[indexPath] = element;
   }
 }
 

--- a/Tests/ASCollectionViewTests.mm
+++ b/Tests/ASCollectionViewTests.mm
@@ -1031,7 +1031,7 @@
     r;
   });
   CGFloat expectedHeight = cn.bounds.size.height * 3;
-  XCTAssertEqualWithAccuracy(CGRectGetHeight(preloadBounds), expectedHeight, 100);
+  XCTAssertEqualWithAccuracy(CGRectGetHeight(preloadBounds), expectedHeight, expectedHeight * 0.1);
   XCTAssertEqual([[cn valueForKeyPath:@"rangeController.currentRangeMode"] integerValue], ASLayoutRangeModeMinimum, @"Expected range mode to be minimum before scrolling begins.");
 }
 


### PR DESCRIPTION
- Fix the crash reported by @appleguy in #3074. It occurs because we never create a dictionary that holds supplementaries of a new kind ([here](https://github.com/facebook/AsyncDisplayKit/compare/master...nguyenhuy:HNASElementMapCras?expand=1#diff-1f7bf759dcd5f7e05395f0e53842b26eR93)).
- Fix the crash reported by @maicki on [Slack](https://asyncdisplaykit.slack.com/files/maicki/F4ALP7M2R/-.swift). We just need to gratefully handle `nil` index path internally.