### PR TITLE
Allow users to set child directly on overlay and background specs

### DIFF
--- a/Source/Layout/ASBackgroundLayoutSpec.mm
+++ b/Source/Layout/ASBackgroundLayoutSpec.mm
@@ -33,9 +33,7 @@ static NSUInteger const kBackgroundChildIndex = 1;
   if (!(self = [super init])) {
     return nil;
   }
-  
-  ASDisplayNodeAssertNotNil(child, @"Child cannot be nil");
-  [self setChild:child atIndex:kForegroundChildIndex];
+  self.child = child;
   self.background = background;
   return self;
 }
@@ -49,7 +47,7 @@ static NSUInteger const kBackgroundChildIndex = 1;
                      restrictedToSize:(ASLayoutElementSize)size
                  relativeToParentSize:(CGSize)parentSize
 {
-  ASLayout *contentsLayout = [[super childAtIndex:kForegroundChildIndex] layoutThatFits:constrainedSize parentSize:parentSize];
+  ASLayout *contentsLayout = [self.child layoutThatFits:constrainedSize parentSize:parentSize];
 
   NSMutableArray *sublayouts = [NSMutableArray arrayWithCapacity:2];
   if (self.background) {
@@ -66,6 +64,17 @@ static NSUInteger const kBackgroundChildIndex = 1;
 }
 
 #pragma mark - Background
+
+- (void)setChild:(id<ASLayoutElement>)child
+{
+  ASDisplayNodeAssertNotNil(child, @"Child cannot be nil");
+  [super setChild:child atIndex:kForegroundChildIndex];
+}
+
+- (id<ASLayoutElement>)child
+{
+  return [super childAtIndex:kForegroundChildIndex];
+}
 
 - (void)setBackground:(id<ASLayoutElement>)background
 {

--- a/Source/Layout/ASLayoutSpec.h
+++ b/Source/Layout/ASLayoutSpec.h
@@ -34,10 +34,10 @@ NS_ASSUME_NONNULL_BEGIN
  * only require a single child.
  *
  * For layout specs that require a known number of children (ASBackgroundLayoutSpec, for example)
- * a subclass should use this method to set the "primary" child. It can then use setChild:forIdentifier:
+ * a subclass should use this method to set the "primary" child. It can then use setChild:atIndex:
  * to set any other required children. Ideally a subclass would hide this from the user, and use the
- * setChild:forIdentifier: internally. For example, ASBackgroundLayoutSpec exposes a backgroundChild
- * property that behind the scenes is calling setChild:forIdentifier:.
+ * setChild:atIndex: internally. For example, ASBackgroundLayoutSpec exposes a "background"
+ * property that behind the scenes is calling setChild:atIndex:.
  */
 @property (nullable, strong, nonatomic) id<ASLayoutElement> child;
 

--- a/Source/Layout/ASOverlayLayoutSpec.mm
+++ b/Source/Layout/ASOverlayLayoutSpec.mm
@@ -31,13 +31,23 @@ static NSUInteger const kOverlayChildIndex = 1;
   if (!(self = [super init])) {
     return nil;
   }
-  ASDisplayNodeAssertNotNil(child, @"Child that will be overlayed on shouldn't be nil");
-  [self setChild:child atIndex:kUnderlayChildIndex];
+  self.child = child;
   self.overlay = overlay;
   return self;
 }
 
 #pragma mark - Setter / Getter
+
+- (void)setChild:(id<ASLayoutElement>)child
+{
+  ASDisplayNodeAssertNotNil(child, @"Child that will be overlayed on shouldn't be nil");
+  [super setChild:child atIndex:kUnderlayChildIndex];
+}
+
+- (id<ASLayoutElement>)child
+{
+  return [super childAtIndex:kUnderlayChildIndex];
+}
 
 - (void)setOverlay:(id<ASLayoutElement>)overlay
 {
@@ -59,7 +69,7 @@ static NSUInteger const kOverlayChildIndex = 1;
                      restrictedToSize:(ASLayoutElementSize)size
                  relativeToParentSize:(CGSize)parentSize
 {
-  ASLayout *contentsLayout = [[super childAtIndex:kUnderlayChildIndex] layoutThatFits:constrainedSize parentSize:parentSize];
+  ASLayout *contentsLayout = [self.child layoutThatFits:constrainedSize parentSize:parentSize];
   contentsLayout.position = CGPointZero;
   NSMutableArray *sublayouts = [NSMutableArray arrayWithObject:contentsLayout];
   if (self.overlay) {


### PR DESCRIPTION
Current calling `layoutSpec.child` on a background or overlay layout spec would cause assertion: 
```
Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'This layout spec does not support more than one child. Use the setChildren: or the setChild:AtIndex: API'
```

This is inconvenient to users because it forbids them from doing something like below and instead have to rely on initializers of these specs:
```Objective-C
    ASOverlayLayoutSpec *containerSpec = [[ASOverlayLayoutSpec alloc] init];
    containerSpec.overlay = titleSpec;
    containerSpec.child = self.imageNode;
```

[Reported within Pinterest](https://pinterest.slack.com/archives/ios-help/p1487814286000839). Inconvenient no more!