### PR TITLE
[ASVideoPlayerNode] Always load asset when it enters preload state

### DIFF
--- a/Source/ASVideoPlayerNode.h
+++ b/Source/ASVideoPlayerNode.h
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, assign) BOOL controlsDisabled;
 
-@property (nonatomic, assign, readonly) BOOL loadAssetWhenNodeBecomesVisible;
+@property (nonatomic, assign, readonly) BOOL loadAssetWhenNodeBecomesVisible ASDISPLAYNODE_DEPRECATED_MSG("Asset is always loaded when this node enters preload state. This flag does nothing.");
 
 #pragma mark - ASVideoNode property proxy
 /**

--- a/Source/ASVideoPlayerNode.mm
+++ b/Source/ASVideoPlayerNode.mm
@@ -72,7 +72,6 @@ static void *ASVideoPlayerNodeContext = &ASVideoPlayerNodeContext;
   ASStackLayoutSpec *_controlFlexGrowSpacerSpec;
   ASDisplayNode *_spinnerNode;
 
-  BOOL _loadAssetWhenNodeBecomesVisible;
   BOOL _isSeeking;
   CMTime _duration;
 
@@ -114,7 +113,6 @@ static void *ASVideoPlayerNodeContext = &ASVideoPlayerNodeContext;
   
   _url = url;
   _asset = [AVAsset assetWithURL:_url];
-  _loadAssetWhenNodeBecomesVisible = YES;
   
   [self _init];
   
@@ -128,7 +126,6 @@ static void *ASVideoPlayerNodeContext = &ASVideoPlayerNodeContext;
   }
 
   _asset = asset;
-  _loadAssetWhenNodeBecomesVisible = YES;
 
   [self _init];
 
@@ -144,7 +141,6 @@ static void *ASVideoPlayerNodeContext = &ASVideoPlayerNodeContext;
   _asset = asset;
   _videoComposition = videoComposition;
   _audioMix = audioMix;
-  _loadAssetWhenNodeBecomesVisible = YES;
 
   [self _init];
 
@@ -159,7 +155,6 @@ static void *ASVideoPlayerNodeContext = &ASVideoPlayerNodeContext;
 
   _url = url;
   _asset = [AVAsset assetWithURL:_url];
-  _loadAssetWhenNodeBecomesVisible = loadAssetWhenNodeBecomesVisible;
 
   [self _init];
 
@@ -173,7 +168,6 @@ static void *ASVideoPlayerNodeContext = &ASVideoPlayerNodeContext;
   }
 
   _asset = asset;
-  _loadAssetWhenNodeBecomesVisible = loadAssetWhenNodeBecomesVisible;
 
   [self _init];
 
@@ -189,7 +183,6 @@ static void *ASVideoPlayerNodeContext = &ASVideoPlayerNodeContext;
   _asset = asset;
   _videoComposition = videoComposition;
   _audioMix = audioMix;
-  _loadAssetWhenNodeBecomesVisible = loadAssetWhenNodeBecomesVisible;
 
   [self _init];
 
@@ -203,11 +196,6 @@ static void *ASVideoPlayerNodeContext = &ASVideoPlayerNodeContext;
 
   _videoNode = [[ASVideoNode alloc] init];
   _videoNode.delegate = self;
-  if (_loadAssetWhenNodeBecomesVisible == NO) {
-    _videoNode.asset = _asset;
-    _videoNode.videoComposition = _videoComposition;
-    _videoNode.audioMix = _audioMix;
-  }
   [self addSubnode:_videoNode];
 }
 
@@ -220,13 +208,11 @@ static void *ASVideoPlayerNodeContext = &ASVideoPlayerNodeContext;
   }
 }
 
-- (void)didEnterVisibleState
+- (void)didEnterPreloadState
 {
-  [super didEnterVisibleState];
-  
-  ASDN::MutexLocker l(__instanceLock__);
-  
-  if (_loadAssetWhenNodeBecomesVisible) {
+  [super didEnterPreloadState];
+  {
+    ASDN::MutexLocker l(__instanceLock__);
     if (_asset != _videoNode.asset) {
       _videoNode.asset = _asset;
     }

--- a/Source/ASVideoPlayerNode.mm
+++ b/Source/ASVideoPlayerNode.mm
@@ -53,11 +53,11 @@ static void *ASVideoPlayerNodeContext = &ASVideoPlayerNodeContext;
     unsigned int delegateVideoPlayerNodeDidRecoverFromStall:1;
   } _delegateFlags;
   
+  // Immutable properties
   NSURL *_url;
   AVAsset *_asset;
   AVVideoComposition *_videoComposition;
   AVAudioMix *_audioMix;
-  
   ASVideoNode *_videoNode;
 
   NSArray *_neededDefaultControls;
@@ -211,17 +211,16 @@ static void *ASVideoPlayerNodeContext = &ASVideoPlayerNodeContext;
 - (void)didEnterPreloadState
 {
   [super didEnterPreloadState];
-  {
-    ASDN::MutexLocker l(__instanceLock__);
-    if (_asset != _videoNode.asset) {
-      _videoNode.asset = _asset;
-    }
-    if (_videoComposition != _videoNode.videoComposition) {
-      _videoNode.videoComposition = _videoComposition;
-    }
-    if (_audioMix != _videoNode.audioMix) {
-      _videoNode.audioMix = _audioMix;
-    }
+  
+  // Don't need to grab instance lock here because all of these properties are immutable.
+  if (_asset != _videoNode.asset) {
+    _videoNode.asset = _asset;
+  }
+  if (_videoComposition != _videoNode.videoComposition) {
+    _videoNode.videoComposition = _videoComposition;
+  }
+  if (_audioMix != _videoNode.audioMix) {
+    _videoNode.audioMix = _audioMix;
   }
 }
 


### PR DESCRIPTION
Some problems in `ASVideoPlayerNode` currently:
- `_loadAssetWhenNodeBecomesVisible` isn't turned on in the empty initializer. This causes an assertion in #3042 because it's not safe to set an asset on ASVideoNode off main.
- The flag itself is troublesome. It's enabled by default, but even so, "visible" is a bit too late. The asset can be loaded as soon as the player enters preload state, which is what ASVideoNode is doing.

This PR deprecates `_loadAssetWhenNodeBecomesVisible` and fixes #3042 by letting `ASVideoPlayerNode` handles its objects automatically.

@MarvinNazari Would be great if you can comment and help me to test this PR. Thank you!