### PR TITLE
Remove Declaration of ASPhotosFrameworkImageRequest.isEqual

### DIFF
--- a/Source/Details/ASPhotosFrameworkImageRequest.h
+++ b/Source/Details/ASPhotosFrameworkImageRequest.h
@@ -60,11 +60,6 @@ extern NSString *const ASPhotosURLScheme;
  */
 @property (nonatomic, readonly) NSURL *url;
 
-/**
- @return `YES` if `object` is an equivalent image request, `NO` otherwise.
- */
-- (BOOL)isEqual:(id)object;
-
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
The nullability in this declaration is incorrect (throws warnings under some environments), and honestly it's not needed anyway. Goodbye!