### PR TITLE
With CALayer, Use Its Internal Storage Instead of objc_associatedObject

### DIFF
--- a/Source/Details/Transactions/_ASAsyncTransactionContainer.m
+++ b/Source/Details/Transactions/_ASAsyncTransactionContainer.m
@@ -13,53 +13,15 @@
 
 #import <AsyncDisplayKit/_ASAsyncTransaction.h>
 #import <AsyncDisplayKit/_ASAsyncTransactionGroup.h>
-#import <objc/runtime.h>
-
-static const char *ASDisplayNodeAssociatedTransactionsKey = "ASAssociatedTransactions";
-static const char *ASDisplayNodeAssociatedCurrentTransactionKey = "ASAssociatedCurrentTransaction";
 
 @implementation CALayer (ASAsyncTransactionContainerTransactions)
-
-- (NSHashTable *)asyncdisplaykit_asyncLayerTransactions
-{
-  return objc_getAssociatedObject(self, ASDisplayNodeAssociatedTransactionsKey);
-}
-
-- (void)asyncdisplaykit_setAsyncLayerTransactions:(NSHashTable *)transactions
-{
-  objc_setAssociatedObject(self, ASDisplayNodeAssociatedTransactionsKey, transactions, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-}
 
 // No-ops in the base class. Mostly exposed for testing.
 - (void)asyncdisplaykit_asyncTransactionContainerWillBeginTransaction:(_ASAsyncTransaction *)transaction {}
 - (void)asyncdisplaykit_asyncTransactionContainerDidCompleteTransaction:(_ASAsyncTransaction *)transaction {}
 @end
 
-static const char *ASAsyncTransactionIsContainerKey = "ASTransactionIsContainer";
-
 @implementation CALayer (ASAsyncTransactionContainer)
-
-- (_ASAsyncTransaction *)asyncdisplaykit_currentAsyncTransaction
-{
-  return objc_getAssociatedObject(self, ASDisplayNodeAssociatedCurrentTransactionKey);
-}
-
-- (void)asyncdisplaykit_setCurrentAsyncTransaction:(_ASAsyncTransaction *)transaction
-{
-  objc_setAssociatedObject(self, ASDisplayNodeAssociatedCurrentTransactionKey, transaction, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-}
-
-- (BOOL)asyncdisplaykit_isAsyncTransactionContainer
-{
-  CFBooleanRef isContainerBool = (__bridge CFBooleanRef)objc_getAssociatedObject(self, ASAsyncTransactionIsContainerKey);
-  BOOL isContainer = (isContainerBool == kCFBooleanTrue);
-  return isContainer;
-}
-
-- (void)asyncdisplaykit_setAsyncTransactionContainer:(BOOL)isContainer
-{
-  objc_setAssociatedObject(self, ASAsyncTransactionIsContainerKey, (id)(isContainer ? kCFBooleanTrue : kCFBooleanFalse), OBJC_ASSOCIATION_ASSIGN);
-}
 
 - (ASAsyncTransactionContainerState)asyncdisplaykit_asyncTransactionContainerState
 {


### PR DESCRIPTION
This works since CALayer will store arbitrary key-value pairs. @appleguy you have the most context around this system. Thoughts?