### PR TITLE
[ASDisplayNode] Fix node is showing up as black box if wrapping an UIActivityIndicatorView

### DIFF
--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -587,10 +587,18 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
     view = [[_viewClass alloc] init];
   }
   
-  // Update flags related to special handling of UIImageView layers. More details on the flags
-  if (_flags.synchronous && ([_viewClass isSubclassOfClass:[UIImageView class]] || [_viewClass isSubclassOfClass:[UIActivityIndicatorView class]])) {
-    _flags.canClearContentsOfLayer = NO;
-    _flags.canCallSetNeedsDisplayOfLayer = NO;
+  // Special handling of wrapping UIKit components
+  if (_flags.synchronous) {
+    // UIImageView layers. More details on the flags
+    if ([_viewClass isSubclassOfClass:[UIImageView class]]) {
+      _flags.canClearContentsOfLayer = NO;
+      _flags.canCallSetNeedsDisplayOfLayer = NO;
+    }
+      
+    // UIActivityIndicator
+    if ([_viewClass isSubclassOfClass:[UIActivityIndicatorView class]]) {
+      self.opaque = NO;
+    }
   }
 
   return view;

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -596,7 +596,8 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
     }
       
     // UIActivityIndicator
-    if ([_viewClass isSubclassOfClass:[UIActivityIndicatorView class]]) {
+    if ([_viewClass isSubclassOfClass:[UIActivityIndicatorView class]]
+        || [_viewClass isSubclassOfClass:[UIVisualEffectView class]]) {
       self.opaque = NO;
     }
   }


### PR DESCRIPTION
Set the node to not opaque if it’s wrapping an UIActivityIndicatorView. It's reproducible in the Swift example.