### PR TITLE
Majorly Simplify ASTableLayoutController

### DIFF
--- a/Source/Details/ASLayoutController.h
+++ b/Source/Details/ASLayoutController.h
@@ -40,8 +40,6 @@ ASDISPLAYNODE_EXTERN_C_END
 
 @optional
 
-- (void)setVisibleNodeIndexPaths:(NSArray<NSIndexPath *> *)indexPaths;
-
 - (void)setViewportSize:(CGSize)viewportSize;
 - (CGSize)viewportSize;
 

--- a/Source/Details/ASRangeController.mm
+++ b/Source/Details/ASRangeController.mm
@@ -34,7 +34,6 @@
 {
   BOOL _rangeIsValid;
   BOOL _needsRangeUpdate;
-  BOOL _layoutControllerImplementsSetVisibleIndexPaths;
   BOOL _layoutControllerImplementsSetViewportSize;
   NSSet<NSIndexPath *> *_allPreviousIndexPaths;
   ASWeakSet<ASCellNode *> *_visibleNodes;
@@ -165,7 +164,6 @@ static UIApplicationState __ApplicationState = UIApplicationStateActive;
 - (void)setLayoutController:(id<ASLayoutController>)layoutController
 {
   _layoutController = layoutController;
-  _layoutControllerImplementsSetVisibleIndexPaths = [layoutController respondsToSelector:@selector(setVisibleNodeIndexPaths:)];
   _layoutControllerImplementsSetViewportSize = [layoutController respondsToSelector:@selector(setViewportSize:)];
   if (layoutController && _dataSource) {
     [self updateIfNeeded];
@@ -231,11 +229,6 @@ static UIApplicationState __ApplicationState = UIApplicationStateActive;
 
   if (_layoutControllerImplementsSetViewportSize) {
     [_layoutController setViewportSize:[_dataSource viewportSizeForRangeController:self]];
-  }
-  
-  // the layout controller needs to know what the current visible indices are to calculate range offsets
-  if (_layoutControllerImplementsSetVisibleIndexPaths) {
-    [_layoutController setVisibleNodeIndexPaths:visibleNodePaths];
   }
   
   ASInterfaceState selfInterfaceState = [self interfaceState];

--- a/Source/Details/ASTableLayoutController.m
+++ b/Source/Details/ASTableLayoutController.m
@@ -15,8 +15,6 @@
 #import <AsyncDisplayKit/ASAssert.h>
 
 @interface ASTableLayoutController()
-@property (nonatomic, strong) NSIndexPath *minVisibleIndexPath;
-@property (nonatomic, strong) NSIndexPath *maxVisibleIndexPath;
 @end
 
 @implementation ASTableLayoutController
@@ -30,13 +28,7 @@
   return self;
 }
 
-#pragma mark - Visible Indices
-
-- (void)setVisibleNodeIndexPaths:(NSArray *)indexPaths
-{
-  _minVisibleIndexPath = [ASTableLayoutController fastArrayMin:indexPaths];
-  _maxVisibleIndexPath = [ASTableLayoutController fastArrayMax:indexPaths];
-}
+#pragma mark - ASLayoutController
 
 /**
  * IndexPath array for the element in the working range.
@@ -44,24 +36,11 @@
 
 - (NSSet *)indexPathsForScrolling:(ASScrollDirection)scrollDirection rangeMode:(ASLayoutRangeMode)rangeMode rangeType:(ASLayoutRangeType)rangeType
 {
-  if (_minVisibleIndexPath == nil) {
-    return [NSSet set];
-  }
-
-  CGSize viewportSize = [self viewportSize];
-
+  CGRect bounds = _tableView.bounds;
   ASRangeTuningParameters tuningParameters = [self tuningParametersForRangeMode:rangeMode rangeType:rangeType];
-
-  ASDirectionalScreenfulBuffer directionalBuffer = ASDirectionalScreenfulBufferVertical(scrollDirection, tuningParameters);
-  
-  NSIndexPath *startPath = [self findIndexPathAtDistance:(-directionalBuffer.negativeDirection * viewportSize.height)
-                                          fromIndexPath:_minVisibleIndexPath];
-  
-  NSIndexPath *endPath   = [self findIndexPathAtDistance:(directionalBuffer.positiveDirection * viewportSize.height)
-                                          fromIndexPath:_maxVisibleIndexPath];
-
-  NSSet *indexPaths = [self indexPathsFromIndexPath:startPath toIndexPath:endPath];
-  return indexPaths;
+  CGRect rangeBounds = CGRectExpandToRangeWithScrollableDirections(bounds, tuningParameters, ASScrollDirectionVerticalDirections, scrollDirection);
+  NSArray *array = [_tableView indexPathsForRowsInRect:rangeBounds];
+  return [NSSet setWithArray:array];
 }
 
 - (void)allIndexPathsForScrolling:(ASScrollDirection)scrollDirection rangeMode:(ASLayoutRangeMode)rangeMode displaySet:(NSSet **)displaySet preloadSet:(NSSet **)preloadSet
@@ -73,139 +52,6 @@
   *displaySet = [self indexPathsForScrolling:scrollDirection rangeMode:rangeMode rangeType:ASLayoutRangeTypeDisplay];
   *preloadSet = [self indexPathsForScrolling:scrollDirection rangeMode:rangeMode rangeType:ASLayoutRangeTypePreload];
   return;
-}
-
-#pragma mark - Utility
-
-- (NSIndexPath *)findIndexPathAtDistance:(CGFloat)distance fromIndexPath:(NSIndexPath *)start
-{
-  BOOL downward = (distance >= 0);
-  CGRect startRowRect = [_tableView rectForRowAtIndexPath:start];
-  CGFloat targetY = distance + (downward ? CGRectGetMaxY(startRowRect) : CGRectGetMinY(startRowRect));
-
-  // Before first row.
-  NSIndexPath *firstIndexPath = [self firstIndexPathInTableView];
-  if (targetY <= CGRectGetMaxY([_tableView rectForRowAtIndexPath:firstIndexPath])) {
-    return firstIndexPath;
-  }
-
-  // After last row.
-  NSIndexPath *lastIndexPath = [self lastIndexPathInTableView];
-  if (targetY >= CGRectGetMinY([_tableView rectForRowAtIndexPath:lastIndexPath])) {
-    return lastIndexPath;
-  }
-
-  /**
-   * There may not be a row at any given EXACT point, for these possible reasons:
-   * - There is a section header/footer at that point.
-   * - That point is beyond the start/end of the table content. (Handled above)
-   *
-   * Solution: Make a search rect, and if we don't
-   * find any rows, keep doubling its height and searching again. In practice,
-   * this will virtually always find a row on the first try (unless you have a 
-   * tall section header and we land near the middle.)
-   */
-  NSIndexPath *result = nil;
-  for (CGRect searchRect = [ASTableLayoutController initialSearchRectDownward:downward targetY:targetY];
-       // continue while result is nil
-       result == nil;
-       // grow search rect after each loop
-       searchRect = [ASTableLayoutController growSearchRect:searchRect downward:downward]) {
-    NSArray *rows = [_tableView indexPathsForRowsInRect:searchRect];
-    if (downward) {
-      result = [ASTableLayoutController fastArrayMin:rows];
-    } else {
-      result = [ASTableLayoutController fastArrayMax:rows];
-    }
-  }
-  return result;
-}
-
-- (NSSet<NSIndexPath *> *)indexPathsFromIndexPath:(NSIndexPath *)startIndexPath toIndexPath:(NSIndexPath *)endIndexPath
-{
-  ASDisplayNodeAssert([startIndexPath compare:endIndexPath] != NSOrderedDescending, @"Index paths must be in nondescending order. Start: %@, end %@", startIndexPath, endIndexPath);
-
-  NSMutableSet *result = [NSMutableSet set];
-  NSInteger const endSection = endIndexPath.section;
-  NSInteger i = startIndexPath.row;
-  for (NSInteger s = startIndexPath.section; s <= endSection; s++) {
-    // If end section, row <= end.item. Otherwise (row <= sectionRowCount - 1).
-    NSInteger const rowLimit = (s == endSection ? endIndexPath.row : ([_tableView numberOfRowsInSection:s] - 1));
-    for (; i <= rowLimit; i++) {
-      [result addObject:[NSIndexPath indexPathForRow:i inSection:s]];
-    }
-    i = 0;
-  }
-  return result;
-}
-
-- (nullable NSIndexPath *)firstIndexPathInTableView
-{
-  NSInteger sectionCount = _tableView.numberOfSections;
-  for (NSInteger s = 0; s < sectionCount; s++) {
-    if ([_tableView numberOfRowsInSection:s] > 0) {
-      return [NSIndexPath indexPathForRow:0 inSection:s];
-    }
-  }
-  return nil;
-}
-
-- (nullable NSIndexPath *)lastIndexPathInTableView
-{
-  NSInteger lastSectionWithAnyRows = _tableView.numberOfSections;
-  NSInteger rowCount = 0;
-  while (rowCount == 0) {
-    lastSectionWithAnyRows -= 1;
-    if (lastSectionWithAnyRows < 0) {
-      return nil;
-    }
-    rowCount = [_tableView numberOfRowsInSection:lastSectionWithAnyRows];
-  }
-  return [NSIndexPath indexPathForRow:rowCount - 1 inSection:lastSectionWithAnyRows];
-}
-
-// Same as valueForKeyPath:@"@min.self" but faster
-+ (nullable id)fastArrayMin:(NSArray *)array ASDISPLAYNODE_CONST
-{
-  id min = nil;
-  for (id obj in array) {
-    if (min == nil || [obj compare:min] == NSOrderedAscending) {
-      min = obj;
-    }
-  }
-  return min;
-}
-
-// Same as valueForKeyPath:@"@max.self" but faster
-+ (nullable id)fastArrayMax:(NSArray *)array ASDISPLAYNODE_CONST
-{
-  id max = nil;
-  for (id obj in array) {
-    if (max == nil || [max compare:obj] == NSOrderedAscending) {
-      max = obj;
-    }
-  }
-  return max;
-}
-
-+ (CGRect)initialSearchRectDownward:(BOOL)downward targetY:(CGFloat)targetY ASDISPLAYNODE_CONST
-{
-  static CGFloat const kInitialRowSearchHeight = 100;
-  CGRect result = CGRectMake(0, targetY, 1, kInitialRowSearchHeight);
-  if (!downward) {
-    result.origin.y -= result.size.height;
-  }
-  return result;
-}
-
-+ (CGRect)growSearchRect:(CGRect)searchRect downward:(BOOL)downward ASDISPLAYNODE_CONST
-{
-  CGRect result = searchRect;
-  if (!downward) {
-    result.origin.y -= result.size.height;
-  }
-  result.size.height *= 2;
-  return result;
 }
 
 @end


### PR DESCRIPTION
We previously:

- Waited for `setVisibleNodexIndexPaths:`.
- Found the min row and max row.
- Measured the range bounds distance from the min row and max row.
- Searched in rects at that distance away from the min row and max row, growing our search rect until we found one.

We now:

- Ask the table view for the index paths of the rows in the specified rect.