### PR TITLE
Remove ASTableView's pendingVisibleIndexPath System

### DIFF
--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -136,8 +136,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
 
   ASBatchContext *_batchContext;
 
-  NSIndexPath *_pendingVisibleIndexPath;
-
   // When we update our data controller in response to an interactive move,
   // we don't want to tell the table view about the change (it knows!)
   BOOL _updatingInResponseToInteractiveMove;
@@ -949,8 +947,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
 
 - (void)tableView:(UITableView *)tableView willDisplayCell:(_ASTableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath
 {
-  _pendingVisibleIndexPath = indexPath;
-  
   ASCellNode *cellNode = [cell node];
   cellNode.scrollView = tableView;
 
@@ -977,10 +973,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
 
 - (void)tableView:(UITableView *)tableView didEndDisplayingCell:(_ASTableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath
 {
-  if (ASObjectIsEqual(_pendingVisibleIndexPath, indexPath)) {
-    _pendingVisibleIndexPath = nil;
-  }
-  
   ASCellNode *cellNode = [cell node];
 
   [_rangeController setNeedsUpdate];
@@ -1377,9 +1369,7 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     return @[];
   }
 
-  NSMutableArray *visibleIndexPaths = [self.indexPathsForVisibleRows mutableCopy];
-
-  [visibleIndexPaths sortUsingSelector:@selector(compare:)];
+  NSArray *visibleIndexPaths = self.indexPathsForVisibleRows;
 
   // In some cases (grouped-style tables with particular geometry) indexPathsForVisibleRows will return extra index paths.
   // This is a very serious issue because we rely on the fact that any node that is marked Visible is hosted inside of a cell,
@@ -1388,29 +1378,11 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
   // It would be possible to cache this NSPredicate as an ivar, but that would require unsafeifying self and calling @c bounds
   // for each item. Since the performance cost is pretty small, prefer simplicity.
   if (self.style == UITableViewStyleGrouped && visibleIndexPaths.count != self.visibleCells.count) {
-    [visibleIndexPaths filterUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(NSIndexPath *indexPath, NSDictionary<NSString *,id> * _Nullable bindings) {
+    visibleIndexPaths = [visibleIndexPaths filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(NSIndexPath *indexPath, NSDictionary<NSString *,id> * _Nullable bindings) {
       return CGRectIntersectsRect(bounds, [self rectForRowAtIndexPath:indexPath]);
     }]];
   }
 
-  NSIndexPath *pendingVisibleIndexPath = _pendingVisibleIndexPath;
-  if (pendingVisibleIndexPath == nil) {
-    return visibleIndexPaths;
-  }
-
-  BOOL isPendingIndexPathVisible = (NSNotFound != [visibleIndexPaths indexOfObject:pendingVisibleIndexPath inSortedRange:NSMakeRange(0, visibleIndexPaths.count) options:kNilOptions usingComparator:^(id  _Nonnull obj1, id  _Nonnull obj2) {
-    return [obj1 compare:obj2];
-  }]);
-  
-  if (isPendingIndexPathVisible) {
-    _pendingVisibleIndexPath = nil; // once it has shown up in visibleIndexPaths, we can stop tracking it
-  } else if ([self isIndexPath:visibleIndexPaths.firstObject immediateSuccessorOfIndexPath:pendingVisibleIndexPath]) {
-    [visibleIndexPaths insertObject:pendingVisibleIndexPath atIndex:0];
-  } else if ([self isIndexPath:pendingVisibleIndexPath immediateSuccessorOfIndexPath:visibleIndexPaths.lastObject]) {
-    [visibleIndexPaths addObject:pendingVisibleIndexPath];
-  } else {
-    _pendingVisibleIndexPath = nil; // not contiguous, ignore.
-  }
   return visibleIndexPaths;
 }
 
@@ -1823,31 +1795,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     }
   }
   return 0;
-}
-
-/// @note This should be a UIKit index path.
-- (BOOL)isIndexPath:(NSIndexPath *)indexPath immediateSuccessorOfIndexPath:(NSIndexPath *)anchor
-{
-  if (!anchor || !indexPath) {
-    return NO;
-  }
-  if (indexPath.section == anchor.section) {
-    return (indexPath.row == anchor.row+1); // assumes that indexes are valid
-    
-  } else if (indexPath.section > anchor.section && indexPath.row == 0) {
-    if (anchor.row != [self numberOfRowsInSection:anchor.section] -1) {
-      return NO;  // anchor is not at the end of the section
-    }
-    
-    NSInteger nextSection = anchor.section+1;
-    while([self numberOfRowsInSection:nextSection] == 0) {
-      ++nextSection;
-    }
-    
-    return indexPath.section == nextSection;
-  }
-  
-  return NO;
 }
 
 #pragma mark - _ASDisplayView behavior substitutions


### PR DESCRIPTION
This was added in #430. Since then it's grown and grown in complexity probably due to other issues encountered along the way. 😱 

Back then we would flush the range controller (queued in the run loop), and now we synchronously flush it (if it's invalidated):

- At the end of the layout pass
- After calling endUpdates
- When we enter the window

The original rationale was that "we depend on -indexPathsForVisibleRows to be correct immediately after willDisplayCell:, but it isn't." But I don't think it's true that we depend on it being correct at that time… we depend on it being correct later, asynchronously. Could be interesting to see if `indexPathsForVisibleRows` calls `layoutIfNeeded` or equivalent.

@eanagel What are your thoughts on this? You mentioned that not having it caused issues with programmatic scrolling – do I need to do anything specific to repro?