### PR TITLE
Improve designated initializer usage

### DIFF
--- a/Source/ASCellNode.h
+++ b/Source/ASCellNode.h
@@ -191,9 +191,8 @@ typedef NS_ENUM(NSUInteger, ASCellNodeVisibilityEvent) {
 
 @interface ASCellNode (Unavailable)
 
-- (instancetype)initWithLayerBlock:(ASDisplayNodeLayerBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock __unavailable;
-
-- (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock __unavailable;
+- (instancetype)initWithLayerBlock:(ASDisplayNodeLayerBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock NS_UNAVAILABLE;
+- (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock NS_UNAVAILABLE;
 
 - (void)setLayerBacked:(BOOL)layerBacked AS_UNAVAILABLE("ASCellNode does not support layer-backing");
 
@@ -208,7 +207,7 @@ typedef NS_ENUM(NSUInteger, ASCellNodeVisibilityEvent) {
 /**
  * Initializes a text cell with given text attributes and text insets
  */
-- (instancetype)initWithAttributes:(NSDictionary *)textAttributes insets:(UIEdgeInsets)textInsets;
+- (instancetype)initWithAttributes:(NSDictionary *)textAttributes insets:(UIEdgeInsets)textInsets NS_DESIGNATED_INITIALIZER;
 
 /**
  * Text to display.

--- a/Source/ASCellNode.h
+++ b/Source/ASCellNode.h
@@ -192,6 +192,7 @@ typedef NS_ENUM(NSUInteger, ASCellNodeVisibilityEvent) {
 @interface ASCellNode (Unavailable)
 
 - (instancetype)initWithLayerBlock:(ASDisplayNodeLayerBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock NS_UNAVAILABLE;
+
 - (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock NS_UNAVAILABLE;
 
 - (void)setLayerBacked:(BOOL)layerBacked AS_UNAVAILABLE("ASCellNode does not support layer-backing");

--- a/Source/ASDisplayNode.h
+++ b/Source/ASDisplayNode.h
@@ -125,7 +125,7 @@ extern NSInteger const ASDefaultDrawingPriority;
  * @return An ASDisplayNode instance whose view will be a subclass that enables asynchronous rendering, and passes 
  * through -layout and touch handling methods.
  */
-- (instancetype)init;
+- (instancetype)init NS_DESIGNATED_INITIALIZER;
 
 
 /**
@@ -147,7 +147,7 @@ extern NSInteger const ASDefaultDrawingPriority;
  * @return An ASDisplayNode instance that loads its view with the given block that is guaranteed to run on the main
  * queue. The view will render synchronously and -layout and touch handling methods on the node will not be called.
  */
-- (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock;
+- (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock NS_DESIGNATED_INITIALIZER;
 
 /**
  * @abstract Alternative initializer with a block to create the backing layer.
@@ -168,7 +168,7 @@ extern NSInteger const ASDefaultDrawingPriority;
  * @return An ASDisplayNode instance that loads its layer with the given block that is guaranteed to run on the main
  * queue. The layer will render synchronously and -layout and touch handling methods on the node will not be called.
  */
-- (instancetype)initWithLayerBlock:(ASDisplayNodeLayerBlock)layerBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock;
+- (instancetype)initWithLayerBlock:(ASDisplayNodeLayerBlock)layerBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock NS_DESIGNATED_INITIALIZER;
 
 /**
  * @abstract Add a block of work to be performed on the main thread when the node's view or layer is loaded. Thread safe.

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -316,12 +316,11 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
 
 - (instancetype)initWithViewClass:(Class)viewClass
 {
-  if (!(self = [super init]))
+  if (!(self = [self init]))
     return nil;
 
   ASDisplayNodeAssert([viewClass isSubclassOfClass:[UIView class]], @"should initialize with a subclass of UIView");
 
-  [self _initializeInstance];
   _viewClass = viewClass;
   _flags.synchronous = ![viewClass isSubclassOfClass:[_ASDisplayView class]];
 
@@ -330,12 +329,11 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
 
 - (instancetype)initWithLayerClass:(Class)layerClass
 {
-  if (!(self = [super init]))
+  if (!(self = [self init]))
     return nil;
 
   ASDisplayNodeAssert([layerClass isSubclassOfClass:[CALayer class]], @"should initialize with a subclass of CALayer");
 
-  [self _initializeInstance];
   _layerClass = layerClass;
   _flags.synchronous = ![layerClass isSubclassOfClass:[_ASDisplayLayer class]];
   _flags.layerBacked = YES;

--- a/Source/ASEditableTextNode.h
+++ b/Source/ASEditableTextNode.h
@@ -137,6 +137,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ASEditableTextNode (Unavailable)
 
 - (instancetype)initWithLayerBlock:(ASDisplayNodeLayerBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock NS_UNAVAILABLE;
+
 - (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock NS_UNAVAILABLE;
 
 @end

--- a/Source/ASEditableTextNode.h
+++ b/Source/ASEditableTextNode.h
@@ -136,9 +136,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ASEditableTextNode (Unavailable)
 
-- (instancetype)initWithLayerBlock:(ASDisplayNodeLayerBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock __unavailable;
-
-- (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock __unavailable;
+- (instancetype)initWithLayerBlock:(ASDisplayNodeLayerBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock NS_UNAVAILABLE;
+- (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock NS_UNAVAILABLE;
 
 @end
 

--- a/Source/ASMultiplexImageNode.h
+++ b/Source/ASMultiplexImageNode.h
@@ -134,6 +134,15 @@ typedef NS_ENUM(NSUInteger, ASMultiplexImageNodeErrorCode) {
 #endif
 @end
 
+#pragma mark - 
+
+@interface ASMultiplexImageNode (Unavailable)
+
+- (instancetype)initWithLayerBlock:(ASDisplayNodeLayerBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock NS_UNAVAILABLE;
+- (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock NS_UNAVAILABLE;
+
+@end
+
 
 #pragma mark -
 /**

--- a/Source/ASMultiplexImageNode.h
+++ b/Source/ASMultiplexImageNode.h
@@ -139,6 +139,7 @@ typedef NS_ENUM(NSUInteger, ASMultiplexImageNodeErrorCode) {
 @interface ASMultiplexImageNode (Unavailable)
 
 - (instancetype)initWithLayerBlock:(ASDisplayNodeLayerBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock NS_UNAVAILABLE;
+
 - (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock NS_UNAVAILABLE;
 
 @end

--- a/Source/ASMultiplexImageNode.mm
+++ b/Source/ASMultiplexImageNode.mm
@@ -149,7 +149,8 @@ typedef void(^ASMultiplexImageLoadCompletionBlock)(UIImage *image, id imageIdent
 
 @implementation ASMultiplexImageNode
 
-#pragma mark - Getting Started / Tearing Down
+#pragma mark - Lifecycle
+
 - (instancetype)initWithCache:(id<ASImageCacheProtocol>)cache downloader:(id<ASImageDownloaderProtocol>)downloader
 {
   if (!(self = [super init]))
@@ -177,6 +178,18 @@ typedef void(^ASMultiplexImageLoadCompletionBlock)(UIImage *image, id imageIdent
 #else
   return [self initWithCache:nil downloader:[ASBasicImageDownloader sharedImageDownloader]];
 #endif
+}
+
+- (instancetype)initWithLayerBlock:(ASDisplayNodeLayerBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock
+{
+  ASDISPLAYNODE_NOT_DESIGNATED_INITIALIZER();
+  return [self init];
+}
+
+- (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock
+{
+  ASDISPLAYNODE_NOT_DESIGNATED_INITIALIZER();
+  return [self init];
 }
 
 - (void)dealloc

--- a/Source/ASNetworkImageNode.h
+++ b/Source/ASNetworkImageNode.h
@@ -112,6 +112,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+#pragma mark -
+
+@interface ASNetworkImageNode (Unavailable)
+
+- (instancetype)initWithLayerBlock:(ASDisplayNodeLayerBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock NS_UNAVAILABLE;
+- (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock NS_UNAVAILABLE;
+
+@end
 
 #pragma mark -
 /**

--- a/Source/ASNetworkImageNode.h
+++ b/Source/ASNetworkImageNode.h
@@ -117,6 +117,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ASNetworkImageNode (Unavailable)
 
 - (instancetype)initWithLayerBlock:(ASDisplayNodeLayerBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock NS_UNAVAILABLE;
+
 - (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock NS_UNAVAILABLE;
 
 @end

--- a/Source/ASNetworkImageNode.mm
+++ b/Source/ASNetworkImageNode.mm
@@ -102,6 +102,18 @@ static const CGSize kMinReleaseImageOnBackgroundSize = {20.0, 20.0};
 #endif
 }
 
+- (instancetype)initWithLayerBlock:(ASDisplayNodeLayerBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock
+{
+  ASDISPLAYNODE_NOT_DESIGNATED_INITIALIZER();
+  return [self init];
+}
+
+- (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock
+{
+  ASDISPLAYNODE_NOT_DESIGNATED_INITIALIZER();
+  return [self init];
+}
+
 - (void)dealloc
 {
   [self _cancelImageDownload];

--- a/Source/ASScrollNode.mm
+++ b/Source/ASScrollNode.mm
@@ -64,7 +64,7 @@
 
 - (instancetype)init
 {
-  return [super initWithViewBlock:^UIView *{ return [[ASScrollView alloc] init]; }];
+  return [super initWithViewBlock:^UIView *{ return [[ASScrollView alloc] init]; } didLoadBlock:nil];
 }
 
 - (ASLayout *)calculateLayoutThatFits:(ASSizeRange)constrainedSize

--- a/Source/ASTextNode.h
+++ b/Source/ASTextNode.h
@@ -283,6 +283,7 @@ typedef NS_ENUM(NSUInteger, ASTextNodeHighlightStyle) {
 @interface ASTextNode (Unavailable)
 
 - (instancetype)initWithLayerBlock:(ASDisplayNodeLayerBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock NS_UNAVAILABLE;
+
 - (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock NS_UNAVAILABLE;
 
 @end

--- a/Source/ASTextNode.h
+++ b/Source/ASTextNode.h
@@ -283,7 +283,6 @@ typedef NS_ENUM(NSUInteger, ASTextNodeHighlightStyle) {
 @interface ASTextNode (Unavailable)
 
 - (instancetype)initWithLayerBlock:(ASDisplayNodeLayerBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock NS_UNAVAILABLE;
-
 - (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock NS_UNAVAILABLE;
 
 @end

--- a/Source/ASTextNode.h
+++ b/Source/ASTextNode.h
@@ -282,9 +282,9 @@ typedef NS_ENUM(NSUInteger, ASTextNodeHighlightStyle) {
 
 @interface ASTextNode (Unavailable)
 
-- (instancetype)initWithLayerBlock:(ASDisplayNodeLayerBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock __unavailable;
+- (instancetype)initWithLayerBlock:(ASDisplayNodeLayerBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock NS_UNAVAILABLE;
 
-- (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock __unavailable;
+- (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock NS_UNAVAILABLE;
 
 @end
 

--- a/Source/ASVideoNode.h
+++ b/Source/ASVideoNode.h
@@ -146,6 +146,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ASVideoNode (Unavailable)
 
 - (instancetype)initWithLayerBlock:(ASDisplayNodeLayerBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock NS_UNAVAILABLE;
+
 - (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock NS_UNAVAILABLE;
 
 @end

--- a/Source/ASVideoNode.h
+++ b/Source/ASVideoNode.h
@@ -143,4 +143,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+@interface ASVideoNode (Unavailable)
+
+- (instancetype)initWithLayerBlock:(ASDisplayNodeLayerBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock NS_UNAVAILABLE;
+- (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock NS_UNAVAILABLE;
+
+@end
+
+
 NS_ASSUME_NONNULL_END

--- a/Source/ASVideoNode.h
+++ b/Source/ASVideoNode.h
@@ -143,10 +143,4 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface ASVideoNode (Unavailable)
-
-- (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock didLoadBlock:(nullable ASDisplayNodeDidLoadBlock)didLoadBlock __unavailable;
-
-@end
-
 NS_ASSUME_NONNULL_END

--- a/Source/Details/ASAbstractLayoutController.h
+++ b/Source/Details/ASAbstractLayoutController.h
@@ -29,9 +29,9 @@ ASDISPLAYNODE_EXTERN_C_END
 
 @interface ASAbstractLayoutController (Unavailable)
 
-- (NSSet *)indexPathsForScrolling:(ASScrollDirection)scrollDirection rangeMode:(ASLayoutRangeMode)rangeMode rangeType:(ASLayoutRangeType)rangeType __unavailable;
+- (NSSet *)indexPathsForScrolling:(ASScrollDirection)scrollDirection rangeMode:(ASLayoutRangeMode)rangeMode rangeType:(ASLayoutRangeType)rangeType NS_UNAVAILABLE;
 
-- (void)allIndexPathsForScrolling:(ASScrollDirection)scrollDirection rangeMode:(ASLayoutRangeMode)rangeMode displaySet:(NSSet * _Nullable * _Nullable)displaySet preloadSet:(NSSet * _Nullable * _Nullable)preloadSet __unavailable;
+- (void)allIndexPathsForScrolling:(ASScrollDirection)scrollDirection rangeMode:(ASLayoutRangeMode)rangeMode displaySet:(NSSet * _Nullable * _Nullable)displaySet preloadSet:(NSSet * _Nullable * _Nullable)preloadSet NS_UNAVAILABLE;
 
 @end
 

--- a/Source/Layout/ASLayout.h
+++ b/Source/Layout/ASLayout.h
@@ -144,7 +144,7 @@ ASDISPLAYNODE_EXTERN_C_END
 
 @interface ASLayout (Unavailable)
 
-- (instancetype)init __unavailable;
+- (instancetype)init NS_UNAVAILABLE;
 
 @end
 

--- a/Source/Layout/ASLayoutSpec+Subclasses.mm
+++ b/Source/Layout/ASLayoutSpec+Subclasses.mm
@@ -14,7 +14,7 @@
 #pragma mark - ASNullLayoutSpec
 
 @interface ASNullLayoutSpec : ASLayoutSpec
-- (instancetype)init __unavailable;
+- (instancetype)init NS_UNAVAILABLE;
 + (ASNullLayoutSpec *)null;
 @end
 

--- a/Source/Layout/ASLayoutSpec.h
+++ b/Source/Layout/ASLayoutSpec.h
@@ -84,7 +84,7 @@ NS_ASSUME_NONNULL_BEGIN
 /*
  * Init not available for ASWrapperLayoutSpec
  */
-- (instancetype)init __unavailable;
+- (instancetype)init NS_UNAVAILABLE;
 
 @end
 

--- a/Source/Private/ASCollectionViewFlowLayoutInspector.h
+++ b/Source/Private/ASCollectionViewFlowLayoutInspector.h
@@ -28,7 +28,9 @@ AS_SUBCLASSING_RESTRICTED
 @end
 
 @interface ASCollectionViewFlowLayoutInspector (Unavailable)
+
 - (instancetype)init NS_UNAVAILABLE;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/Private/ASCollectionViewFlowLayoutInspector.h
+++ b/Source/Private/ASCollectionViewFlowLayoutInspector.h
@@ -23,9 +23,12 @@ AS_SUBCLASSING_RESTRICTED
 
 @property (nonatomic, weak, readonly) UICollectionViewFlowLayout *layout;
 
-- (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithFlowLayout:(UICollectionViewFlowLayout *)flowLayout NS_DESIGNATED_INITIALIZER;
 
+@end
+
+@interface ASCollectionViewFlowLayoutInspector (Unavailable)
+- (instancetype)init NS_UNAVAILABLE;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/Private/ASCollectionViewFlowLayoutInspector.h
+++ b/Source/Private/ASCollectionViewFlowLayoutInspector.h
@@ -23,13 +23,9 @@ AS_SUBCLASSING_RESTRICTED
 
 @property (nonatomic, weak, readonly) UICollectionViewFlowLayout *layout;
 
-- (instancetype)initWithFlowLayout:(UICollectionViewFlowLayout *)flowLayout NS_DESIGNATED_INITIALIZER;
-
-@end
-
-@interface ASCollectionViewFlowLayoutInspector (Unavailable)
-
 - (instancetype)init NS_UNAVAILABLE;
+
+- (instancetype)initWithFlowLayout:(UICollectionViewFlowLayout *)flowLayout NS_DESIGNATED_INITIALIZER;
 
 @end
 

--- a/Source/Private/ASLayoutTransition.h
+++ b/Source/Private/ASLayoutTransition.h
@@ -93,7 +93,7 @@ AS_SUBCLASSING_RESTRICTED
 
 @interface ASLayoutTransition (Unavailable)
 
-- (instancetype)init __unavailable;
+- (instancetype)init NS_UNAVAILABLE;
 
 @end
 

--- a/Source/Private/ASMutableElementMap.h
+++ b/Source/Private/ASMutableElementMap.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 AS_SUBCLASSING_RESTRICTED
 @interface ASMutableElementMap : NSObject <NSCopying>
 
-- (instancetype)init __unavailable;
+- (instancetype)init NS_UNAVAILABLE;
 
 - (instancetype)initWithSections:(NSArray<ASSection *> *)sections items:(ASCollectionElementTwoDimensionalArray *)items supplementaryElements:(ASSupplementaryElementDictionary *)supplementaryElements;
 

--- a/Source/Private/ASMutableElementMap.h
+++ b/Source/Private/ASMutableElementMap.h
@@ -21,8 +21,6 @@ NS_ASSUME_NONNULL_BEGIN
 AS_SUBCLASSING_RESTRICTED
 @interface ASMutableElementMap : NSObject <NSCopying>
 
-- (instancetype)init NS_UNAVAILABLE;
-
 - (instancetype)initWithSections:(NSArray<ASSection *> *)sections items:(ASCollectionElementTwoDimensionalArray *)items supplementaryElements:(ASSupplementaryElementDictionary *)supplementaryElements;
 
 - (void)insertSection:(ASSection *)section atIndex:(NSInteger)index;
@@ -47,6 +45,12 @@ AS_SUBCLASSING_RESTRICTED
 @end
 
 @interface ASElementMap (MutableCopying) <NSMutableCopying>
+@end
+
+@interface ASMutableElementMap (Unavailable)
+
+- (instancetype)init NS_UNAVAILABLE;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/Private/ASSection.h
+++ b/Source/Private/ASSection.h
@@ -19,7 +19,7 @@
 @property (nonatomic, assign, readonly) NSInteger sectionID;
 @property (nonatomic, strong, nullable, readonly) id<ASSectionContext> context;
 
-- (nullable instancetype)init __unavailable;
+- (nullable instancetype)init NS_UNAVAILABLE;
 - (nullable instancetype)initWithSectionID:(NSInteger)sectionID context:(nullable id<ASSectionContext>)context NS_DESIGNATED_INITIALIZER;
 
 @end


### PR DESCRIPTION
- Improve designated initializer attributions for `ASDisplayNode` and subclasses
- Move initializer in `ASNetworkImageNode`, `ASMultiplexImageNode` and `ASVideoNode` to unavailable
- Use `NS_UNAVAILABLE` instead of `__unavailable`

Fixes:
-  In `ASScrollView` it's now possible to overwrite `init` and call super without any crash
- In `ASTextCellNode` overwrite of `init` did crash calling `super.init`. Now it's actually prevented to overwrite `init` an otherwise it is recommended to overwrite the designated initializer `initWithAttributes:insets:` and just calling super with the passed in parameters to initialize