### PR TITLE
Invalidate Pager Flow Metrics on Bounds Change

### DIFF
--- a/Source/ASPagerFlowLayout.m
+++ b/Source/ASPagerFlowLayout.m
@@ -101,4 +101,12 @@
   return [super shouldInvalidateLayoutForBoundsChange:newBounds];
 }
 
+- (UICollectionViewLayoutInvalidationContext *)invalidationContextForBoundsChange:(CGRect)newBounds
+{
+  UICollectionViewFlowLayoutInvalidationContext *ctx = (UICollectionViewFlowLayoutInvalidationContext *)[super invalidationContextForBoundsChange:newBounds];
+  ctx.invalidateFlowLayoutDelegateMetrics = YES;
+  ctx.invalidateFlowLayoutAttributes = YES;
+  return ctx;
+}
+
 @end


### PR DESCRIPTION
Currently rotation works because of a different code path (`nodeDidRelayout:sizeChanged:` -> `invalidateLayoutWithContext:`) but that code path requires multiple invalidations and isn't native. 

This is the native way to get flow layout to ask you for the new sizes on rotation, which we need.