### PR TITLE
Don't Eagerly Trigger Relayout in Wait

### DIFF
--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -362,10 +362,6 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
   }
   
   [_dataController waitUntilAllUpdatesAreCommitted];
-  
-  // reloadData of UICollectionView doesn't requery its data source but defers until the next layout pass.
-  // A forced layout pass is neccessary here to make sure everything is ready after this method returns.
-  [self layoutIfNeeded];
 }
 
 - (void)setDataSource:(id<UICollectionViewDataSource>)dataSource

--- a/Tests/ASCollectionViewTests.mm
+++ b/Tests/ASCollectionViewTests.mm
@@ -827,6 +827,7 @@
 
   ASCollectionNode *cn = testController.collectionNode;
   [cn waitUntilAllUpdatesAreCommitted];
+  [cn.view layoutIfNeeded];
   ASCellNode *node = [cn nodeForItemAtIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]];
   XCTAssertTrue(node.visible);
   testController.asyncDelegate->_itemCounts = {0};
@@ -984,9 +985,13 @@
   window.rootViewController = testController;
 
   [window makeKeyAndVisible];
+  // Trigger the initial reload to start
   [view layoutIfNeeded];
   
+  // Wait for ASDK reload to finish
   [cn waitUntilAllUpdatesAreCommitted];
+  // Force UIKit to read updated data & range controller to update and account for it
+  [cn.view layoutIfNeeded];
   [self waitForExpectationsWithTimeout:60 handler:nil];
   
   CGFloat contentHeight = cn.view.contentSize.height;
@@ -1011,9 +1016,13 @@
   window.rootViewController = testController;
 
   [window makeKeyAndVisible];
+  // Trigger the initial reload to start
   [window layoutIfNeeded];
 
+  // Wait for ASDK reload to finish
   [cn waitUntilAllUpdatesAreCommitted];
+  // Force UIKit to read updated data & range controller to update and account for it
+  [cn.view layoutIfNeeded];
 
   CGRect preloadBounds = ({
     CGRect r = CGRectNull;


### PR DESCRIPTION
This was added in #3017 and it's causing some issues for Pinterest, due to it triggering the initial load of data for collections that are `(0, 0)`. @nguyenhuy Do you remember the details of why this was added?