### PR TITLE
[ASVideoPlayerNode] Fixes and improvements

### DIFF
--- a/Source/ASVideoPlayerNode.h
+++ b/Source/ASVideoPlayerNode.h
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, assign) BOOL controlsDisabled;
 
-@property (nonatomic, assign, readonly) BOOL loadAssetWhenNodeBecomesVisible;
+@property (nonatomic, assign, readonly) BOOL loadAssetWhenNodeBecomesVisible ASDISPLAYNODE_DEPRECATED_MSG("Asset is always loaded when this node enters preload state. This flag does nothing.");
 
 #pragma mark - ASVideoNode property proxy
 /**
@@ -52,6 +52,16 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign, readonly) ASVideoNodePlayerState playerState;
 @property (nonatomic, assign, readwrite) BOOL shouldAggressivelyRecoverFromStall;
 @property (nullable, nonatomic, strong, readwrite) NSURL *placeholderImageURL;
+
+@property (nullable, nonatomic, strong, readwrite) AVAsset *asset;
+/**
+ ** @abstract The URL with which the asset was initialized.
+ ** @discussion Setting the URL will override the current asset with a newly created AVURLAsset created from the given URL, and AVAsset *asset will point to that newly created AVURLAsset.  Please don't set both assetURL and asset.
+ ** @return Current URL the asset was initialized or nil if no URL was given.
+ **/
+@property (nullable, nonatomic, strong, readwrite) NSURL *assetURL;
+
+/// You should never set any value on the backing video node. Use exclusivively the video player node to set properties
 @property (nonatomic, strong, readonly) ASVideoNode *videoNode;
 
 //! Defaults to 100
@@ -59,12 +69,16 @@ NS_ASSUME_NONNULL_BEGIN
 //! Defaults to AVLayerVideoGravityResizeAspect
 @property (nonatomic, copy) NSString *gravity;
 
-- (instancetype)initWithUrl:(NSURL*)url;
-- (instancetype)initWithAsset:(AVAsset*)asset;
+#pragma mark - Lifecycle
+- (instancetype)initWithURL:(NSURL *)URL;
+- (instancetype)initWithAsset:(AVAsset *)asset;
 - (instancetype)initWithAsset:(AVAsset *)asset videoComposition:(AVVideoComposition *)videoComposition audioMix:(AVAudioMix *)audioMix;
-- (instancetype)initWithUrl:(NSURL *)url loadAssetWhenNodeBecomesVisible:(BOOL)loadAssetWhenNodeBecomesVisible;
-- (instancetype)initWithAsset:(AVAsset *)asset loadAssetWhenNodeBecomesVisible:(BOOL)loadAssetWhenNodeBecomesVisible;
-- (instancetype)initWithAsset:(AVAsset *)asset videoComposition:(AVVideoComposition *)videoComposition audioMix:(AVAudioMix *)audioMix loadAssetWhenNodeBecomesVisible:(BOOL)loadAssetWhenNodeBecomesVisible;
+
+#pragma mark Lifecycle Deprecated
+- (instancetype)initWithUrl:(NSURL *)url ASDISPLAYNODE_DEPRECATED_MSG("Asset is always loaded when this node enters preload state, therefore loadAssetWhenNodeBecomesVisible is deprecated and not used anymore.");
+- (instancetype)initWithUrl:(NSURL *)url loadAssetWhenNodeBecomesVisible:(BOOL)loadAssetWhenNodeBecomesVisible ASDISPLAYNODE_DEPRECATED_MSG("Asset is always loaded when this node enters preload state, therefore loadAssetWhenNodeBecomesVisible is deprecated and not used anymore.");
+- (instancetype)initWithAsset:(AVAsset *)asset loadAssetWhenNodeBecomesVisible:(BOOL)loadAssetWhenNodeBecomesVisible ASDISPLAYNODE_DEPRECATED_MSG("Asset is always loaded when this node enters preload state, therefore loadAssetWhenNodeBecomesVisible is deprecated and not used anymore.");
+- (instancetype)initWithAsset:(AVAsset *)asset videoComposition:(AVVideoComposition *)videoComposition audioMix:(AVAudioMix *)audioMix loadAssetWhenNodeBecomesVisible:(BOOL)loadAssetWhenNodeBecomesVisible ASDISPLAYNODE_DEPRECATED_MSG("Asset is always loaded when this node enters preload state, therefore loadAssetWhenNodeBecomesVisible is deprecated and not used anymore.");
 
 #pragma mark - Public API
 - (void)seekToTime:(CGFloat)percentComplete;

--- a/examples/ASDKTube/Sample/Models/VideoModel.m
+++ b/examples/ASDKTube/Sample/Models/VideoModel.m
@@ -24,7 +24,7 @@
 {
   self = [super init];
   if (self) {
-    NSString *videoUrlString = @"https://files.parsetfss.com/8a8a3b0c-619e-4e4d-b1d5-1b5ba9bf2b42/tfss-3045b261-7e93-4492-b7e5-5d6358376c9f-editedLiveAndDie.mov";
+    NSString *videoUrlString = @"https://www.w3schools.com/html/mov_bbb.mp4";
     NSString *avatarUrlString = [NSString stringWithFormat:@"https://api.adorable.io/avatars/50/%@",[[NSProcessInfo processInfo] globallyUniqueString]];
 
     _title      = @"Demo title";

--- a/examples/ASDKTube/Sample/Nodes/VideoContentCell.m
+++ b/examples/ASDKTube/Sample/Nodes/VideoContentCell.m
@@ -69,7 +69,7 @@
     _muteButtonNode.style.height = ASDimensionMakeWithPoints(22.0);
     [_muteButtonNode addTarget:self action:@selector(didTapMuteButton) forControlEvents:ASControlNodeEventTouchUpInside];
 
-    _videoPlayerNode = [[ASVideoPlayerNode alloc] initWithUrl:_videoModel.url loadAssetWhenNodeBecomesVisible:YES];
+    _videoPlayerNode = [[ASVideoPlayerNode alloc] initWithURL:_videoModel.url];
     _videoPlayerNode.delegate = self;
     _videoPlayerNode.backgroundColor = [UIColor blackColor];
     [self addSubnode:_videoPlayerNode];
@@ -142,7 +142,6 @@
 - (void)didTapVideoPlayerNode:(ASVideoPlayerNode *)videoPlayer
 {
   if (_videoPlayerNode.playerState == ASVideoNodePlayerStatePlaying) {
-    NSLog(@"TRANSITION");
     _videoPlayerNode.controlsDisabled = !_videoPlayerNode.controlsDisabled;
     [_videoPlayerNode pause];
   } else {

--- a/examples/ASDKTube/Sample/ViewController.m
+++ b/examples/ASDKTube/Sample/ViewController.m
@@ -87,9 +87,9 @@
     return _videoPlayerNode;
   }
   
-  NSURL *fileUrl = [NSURL URLWithString:@"https://files.parsetfss.com/8a8a3b0c-619e-4e4d-b1d5-1b5ba9bf2b42/tfss-3045b261-7e93-4492-b7e5-5d6358376c9f-editedLiveAndDie.mov"];
+  NSURL *fileUrl = [NSURL URLWithString:@"https://www.w3schools.com/html/mov_bbb.mp4"];
 
-  _videoPlayerNode = [[ASVideoPlayerNode alloc] initWithUrl:fileUrl];
+  _videoPlayerNode = [[ASVideoPlayerNode alloc] initWithURL:fileUrl];
   _videoPlayerNode.delegate = self;
 //  _videoPlayerNode.disableControls = YES;
 //


### PR DESCRIPTION
This PR is building on top of the fabulous work of @nguyenhuy in #3093.

Some problems in ASVideoPlayerNode currently:
* We have two sources of truth. One is the asset within the `ASVideoPlayerNode` and the other one is within the backing `ASVideoNode`. Ideally we only want to have only one final source of truth, therefore this PR will try to use the `ASVideoNode` as final truth of source.
* `_loadAssetWhenNodeBecomesVisible` isn't turned on in the empty initializer. This causes an assertion in #3042 because it's not safe to set an asset on ASVideoNode off main.
* The flag itself is troublesome. It's enabled by default, but even so, "visible" is a bit too late. The asset can be loaded as soon as the player enters preload state, which is what ASVideoNode is doing.
This PR deprecates _loadAssetWhenNodeBecomesVisible and fixes #3042 by letting ASVideoPlayerNode handles its objects automatically.
* The API does not align with UIKit components. Therefore a couple of initializer related to initialization with an URL are deprecated and replaced.

@MarvinNazari Would be great if you can comment and help me to test this PR. Thank you!