### PR TITLE
Don't Cache ConstrainedSize in ASCollectionView

### DIFF
--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -610,6 +610,8 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
 /// Uses latest size range from data source and -layoutThatFits:.
 - (CGSize)sizeForElement:(ASCollectionElement *)element
 {
+  ASDisplayNodeAssertMainThread();
+
   NSString *supplementaryKind = element.supplementaryElementKind;
   NSIndexPath *indexPath = [_dataController.visibleMap indexPathForElement:element];
   ASSizeRange sizeRange;
@@ -623,6 +625,8 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
 
 - (CGSize)calculatedSizeForNodeAtIndexPath:(NSIndexPath *)indexPath
 {
+  ASDisplayNodeAssertMainThread();
+
   ASCollectionElement *e = [_dataController.visibleMap elementForItemAtIndexPath:indexPath];
   return [self calculatedSizeForElement:e];
 }
@@ -909,6 +913,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
 
 - (CGSize)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout sizeForItemAtIndexPath:(NSIndexPath *)indexPath
 {
+  ASDisplayNodeAssertMainThread();
   ASCellNode *cell = [self nodeForItemAtIndexPath:indexPath];
   if (cell.shouldUseUIKitCell) {
     if ([_asyncDelegate respondsToSelector:@selector(collectionView:layout:sizeForItemAtIndexPath:)]) {
@@ -921,6 +926,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
 
 - (CGSize)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)layout referenceSizeForHeaderInSection:(NSInteger)section
 {
+  ASDisplayNodeAssertMainThread();
   NSIndexPath *indexPath = [NSIndexPath indexPathForItem:0 inSection:section];
   ASCellNode *cell = [self supplementaryNodeForElementKind:UICollectionElementKindSectionHeader
                                                atIndexPath:indexPath];
@@ -935,6 +941,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
 
 - (CGSize)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)layout referenceSizeForFooterInSection:(NSInteger)section
 {
+  ASDisplayNodeAssertMainThread();
   NSIndexPath *indexPath = [NSIndexPath indexPathForItem:0 inSection:section];
   ASCellNode *cell = [self supplementaryNodeForElementKind:UICollectionElementKindSectionFooter
                                                atIndexPath:indexPath];

--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -628,7 +628,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
   ASDisplayNodeAssertMainThread();
 
   ASCollectionElement *e = [_dataController.visibleMap elementForItemAtIndexPath:indexPath];
-  return [self calculatedSizeForElement:e];
+  return [self sizeForElement:e];
 }
 
 - (ASCellNode *)nodeForItemAtIndexPath:(NSIndexPath *)indexPath


### PR DESCRIPTION
- Currently we use `node.calculatedSize` for collection view item sizes
  - Assumes already measured with correct size ranges
  - Currently no API to ask us invalidate the size range
  - We hard-invalidate all size ranges on collection-view-bounds-change (rotation)
  - Flow layout knows when item sizes are invalidated, has API for it
- After this diff, we use the latest size range and rely on `layoutThatFits:` as cache
- In the future we remove the eager remeasure pass on rotation if we convince community not to migrate away from `node.calculatedSize` in their layouts
  - After we remove eager remeasure
  - We have public deprecated method `calculatedSizeForItemAtIndexPath:`
  - Maybe expand on that? Give custom layouts an equivalent to ask us for item sizes like `sizeForSupplementaryElementOfKind:atIndexPath:` etc?
- After we remove the eager remeasure pass, this diff + #3133 ensures flow layout handles rotation naturally
- This diff brings a performance regression. I've thought about how we can cache this result but we would need them to tell us when to invalidate the size range for items which they probably won't do.