### PR TITLE
Initial Work for Range Controller to Support Supplementary Elements

### DIFF
--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -98,7 +98,7 @@
 		509E68611B3AEDA0009B9150 /* ASAbstractLayoutController.h in Headers */ = {isa = PBXBuildFile; fileRef = 205F0E171B37339C007741D0 /* ASAbstractLayoutController.h */; };
 		509E68621B3AEDA5009B9150 /* ASAbstractLayoutController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 205F0E181B37339C007741D0 /* ASAbstractLayoutController.mm */; };
 		509E68631B3AEDB4009B9150 /* ASCollectionViewLayoutController.h in Headers */ = {isa = PBXBuildFile; fileRef = 205F0E1B1B373A2C007741D0 /* ASCollectionViewLayoutController.h */; };
-		509E68641B3AEDB7009B9150 /* ASCollectionViewLayoutController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 205F0E1C1B373A2C007741D0 /* ASCollectionViewLayoutController.mm */; };
+		509E68641B3AEDB7009B9150 /* ASCollectionViewLayoutController.m in Sources */ = {isa = PBXBuildFile; fileRef = 205F0E1C1B373A2C007741D0 /* ASCollectionViewLayoutController.m */; };
 		509E68651B3AEDC5009B9150 /* CoreGraphics+ASConvenience.h in Headers */ = {isa = PBXBuildFile; fileRef = 205F0E1F1B376416007741D0 /* CoreGraphics+ASConvenience.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		509E68661B3AEDD7009B9150 /* CoreGraphics+ASConvenience.m in Sources */ = {isa = PBXBuildFile; fileRef = 205F0E201B376416007741D0 /* CoreGraphics+ASConvenience.m */; };
 		636EA1A41C7FF4EC00EE152F /* NSArray+Diffing.m in Sources */ = {isa = PBXBuildFile; fileRef = DBC452DA1C5BF64600B16017 /* NSArray+Diffing.m */; };
@@ -490,7 +490,7 @@
 		205F0E171B37339C007741D0 /* ASAbstractLayoutController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASAbstractLayoutController.h; sourceTree = "<group>"; };
 		205F0E181B37339C007741D0 /* ASAbstractLayoutController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASAbstractLayoutController.mm; sourceTree = "<group>"; };
 		205F0E1B1B373A2C007741D0 /* ASCollectionViewLayoutController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASCollectionViewLayoutController.h; sourceTree = "<group>"; };
-		205F0E1C1B373A2C007741D0 /* ASCollectionViewLayoutController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASCollectionViewLayoutController.mm; sourceTree = "<group>"; };
+		205F0E1C1B373A2C007741D0 /* ASCollectionViewLayoutController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASCollectionViewLayoutController.m; sourceTree = "<group>"; };
 		205F0E1F1B376416007741D0 /* CoreGraphics+ASConvenience.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "CoreGraphics+ASConvenience.h"; sourceTree = "<group>"; };
 		205F0E201B376416007741D0 /* CoreGraphics+ASConvenience.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "CoreGraphics+ASConvenience.m"; sourceTree = "<group>"; };
 		242995D21B29743C00090100 /* ASBasicImageDownloaderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASBasicImageDownloaderTests.m; sourceTree = "<group>"; };
@@ -1071,7 +1071,7 @@
 				68C215561DE10D330019C4BC /* ASCollectionViewLayoutInspector.h */,
 				68C215571DE10D330019C4BC /* ASCollectionViewLayoutInspector.m */,
 				205F0E1B1B373A2C007741D0 /* ASCollectionViewLayoutController.h */,
-				205F0E1C1B373A2C007741D0 /* ASCollectionViewLayoutController.mm */,
+				205F0E1C1B373A2C007741D0 /* ASCollectionViewLayoutController.m */,
 				696F01EA1DD2AF450049FBD5 /* ASEventLog.h */,
 				696F01EB1DD2AF450049FBD5 /* ASEventLog.mm */,
 				4640521B1A3F83C40061C0BA /* ASTableLayoutController.h */,
@@ -1861,7 +1861,7 @@
 				69CB62AE1CB8165900024920 /* _ASDisplayViewAccessiblity.mm in Sources */,
 				CC034A021E5FAF9700626263 /* ASElementMap.m in Sources */,
 				B35061F61B010EFD0018CF92 /* ASCollectionView.mm in Sources */,
-				509E68641B3AEDB7009B9150 /* ASCollectionViewLayoutController.mm in Sources */,
+				509E68641B3AEDB7009B9150 /* ASCollectionViewLayoutController.m in Sources */,
 				B35061F91B010EFD0018CF92 /* ASControlNode.mm in Sources */,
 				8021EC1F1D2B00B100799119 /* UIImage+ASConvenience.m in Sources */,
 				B35062181B010EFD0018CF92 /* ASDataController.mm in Sources */,

--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -1676,13 +1676,51 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
   return _rangeController;
 }
 
-- (NSArray *)visibleNodeIndexPathsForRangeController:(ASRangeController *)rangeController
+/// The UIKit version of this method is only available on iOS >= 9
+- (NSArray<NSIndexPath *> *)asdk_indexPathsForVisibleSupplementaryElementsOfKind:(NSString *)kind
 {
-  ASDisplayNodeAssertMainThread();
-  // Calling -indexPathsForVisibleItems will trigger UIKit to call reloadData if it never has, which can result
-  // in incorrect layout if performed at zero size.  We can use the fact that nothing can be visible at zero size to return fast.
-  BOOL isZeroSized = CGSizeEqualToSize(self.bounds.size, CGSizeZero);
-  return isZeroSized ? @[] : [self indexPathsForVisibleItems];
+  if (NSFoundationVersionNumber >= NSFoundationVersionNumber_iOS_9_0) {
+    return [self indexPathsForVisibleSupplementaryElementsOfKind:kind];
+  }
+
+  // iOS 8 workaround
+  // We cannot use willDisplaySupplementaryView/didEndDisplayingSupplementaryView
+  // because those methods send index paths for _deleted items_ (invalid index paths)
+  [self layoutIfNeeded];
+  NSArray<UICollectionViewLayoutAttributes *> *visibleAttributes = [self.collectionViewLayout layoutAttributesForElementsInRect:self.bounds];
+  NSMutableArray *result = [NSMutableArray array];
+  for (UICollectionViewLayoutAttributes *attributes in visibleAttributes) {
+    if (attributes.representedElementCategory == UICollectionElementCategorySupplementaryView
+        && [attributes.representedElementKind isEqualToString:kind]) {
+      [result addObject:attributes.indexPath];
+    }
+  }
+  return result;
+}
+
+- (NSArray<ASCollectionElement *> *)visibleElementsForRangeController:(ASRangeController *)rangeController
+{
+  if (CGRectIsEmpty(self.bounds)) {
+    return @[];
+  }
+
+  ASElementMap *map = _dataController.visibleMap;
+  NSMutableArray<ASCollectionElement *> *result = [NSMutableArray array];
+
+  // Visible items
+  for (NSIndexPath *indexPath in self.indexPathsForVisibleItems) {
+    ASCollectionElement *element = [map elementForItemAtIndexPath:indexPath];
+    [result addObject:element];
+  }
+
+  // Visible supplementary elements
+  for (NSString *kind in map.supplementaryElementKinds) {
+    for (NSIndexPath *indexPath in [self asdk_indexPathsForVisibleSupplementaryElementsOfKind:kind]) {
+      ASCollectionElement *element = [map supplementaryElementOfKind:kind atIndexPath:indexPath];
+      [result addObject:element];
+    }
+  }
+  return result;
 }
 
 - (ASElementMap *)elementMapForRangeController:(ASRangeController *)rangeController

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -649,18 +649,8 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
 
 - (NSArray<ASCellNode *> *)visibleNodes
 {
-  NSArray *indexPaths = [self visibleNodeIndexPathsForRangeController:_rangeController];
-  
-  NSMutableArray<ASCellNode *> *visibleNodes = [NSMutableArray array];
-  for (NSIndexPath *indexPath in indexPaths) {
-    ASCellNode *node = [self nodeForRowAtIndexPath:indexPath];
-    if (node) {
-      // It is possible for UITableView to return indexPaths before the node is completed.
-      [visibleNodes addObject:node];
-    }
-  }
-  
-  return visibleNodes;
+  NSArray<ASCollectionElement *> *elements = [self visibleElementsForRangeController:_rangeController];
+  return ASArrayByFlatMapping(elements, ASCollectionElement *e, e.node);
 }
 
 - (void)beginUpdates
@@ -1358,7 +1348,7 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     return _rangeController;
 }
 
-- (NSArray *)visibleNodeIndexPathsForRangeController:(ASRangeController *)rangeController
+- (NSArray<ASCollectionElement *> *)visibleElementsForRangeController:(ASRangeController *)rangeController
 {
   ASDisplayNodeAssertMainThread();
   
@@ -1383,7 +1373,8 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     }]];
   }
 
-  return visibleIndexPaths;
+  ASElementMap *map = _dataController.visibleMap;
+  return ASArrayByFlatMapping(visibleIndexPaths, NSIndexPath *indexPath, [map elementForItemAtIndexPath:indexPath]);
 }
 
 - (ASScrollDirection)scrollDirectionForRangeController:(ASRangeController *)rangeController

--- a/Source/Base/ASBaseDefines.h
+++ b/Source/Base/ASBaseDefines.h
@@ -217,3 +217,31 @@
   id __val = x;\
   ((c *) ([__val isKindOfClass:[c class]] ? __val : nil));\
 })
+
+/**
+ * Create a new set by mapping `collection` over `work`, ignoring nil.
+ */
+#define ASSetByFlatMapping(collection, decl, work) ({ \
+  NSMutableSet *s = [NSMutableSet set]; \
+  for (decl in collection) {\
+    id result = work; \
+    if (result != nil) { \
+      [s addObject:result]; \
+    } \
+  } \
+  s; \
+})
+
+/**
+ * Create a new array by mapping `collection` over `work`, ignoring nil.
+ */
+#define ASArrayByFlatMapping(collection, decl, work) ({ \
+  NSMutableArray *a = [NSMutableArray array]; \
+  for (decl in collection) {\
+    id result = work; \
+    if (result != nil) { \
+      [a addObject:result]; \
+    } \
+  } \
+  a; \
+})

--- a/Source/Details/ASAbstractLayoutController.mm
+++ b/Source/Details/ASAbstractLayoutController.mm
@@ -167,13 +167,13 @@ extern CGRect CGRectExpandToRangeWithScrollableDirections(CGRect rect, ASRangeTu
 
 #pragma mark - Abstract Index Path Range Support
 
-- (NSSet *)indexPathsForScrolling:(ASScrollDirection)scrollDirection rangeMode:(ASLayoutRangeMode)rangeMode rangeType:(ASLayoutRangeType)rangeType
+- (NSSet<ASCollectionElement *> *)elementsForScrolling:(ASScrollDirection)scrollDirection rangeMode:(ASLayoutRangeMode)rangeMode rangeType:(ASLayoutRangeType)rangeType map:(ASElementMap *)map
 {
   ASDisplayNodeAssertNotSupported();
   return nil;
 }
 
-- (void)allIndexPathsForScrolling:(ASScrollDirection)scrollDirection rangeMode:(ASLayoutRangeMode)rangeMode displaySet:(NSSet *__autoreleasing  _Nullable *)displaySet preloadSet:(NSSet *__autoreleasing  _Nullable *)preloadSet
+- (void)allElementsForScrolling:(ASScrollDirection)scrollDirection rangeMode:(ASLayoutRangeMode)rangeMode displaySet:(NSSet<ASCollectionElement *> *__autoreleasing  _Nullable *)displaySet preloadSet:(NSSet<ASCollectionElement *> *__autoreleasing  _Nullable *)preloadSet map:(ASElementMap *)map
 {
   ASDisplayNodeAssertNotSupported();
 }

--- a/Source/Details/ASLayoutController.h
+++ b/Source/Details/ASLayoutController.h
@@ -16,7 +16,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class ASCellNode;
+@class ASCollectionElement, ASElementMap;
 
 ASDISPLAYNODE_EXTERN_C_BEGIN
 
@@ -34,9 +34,9 @@ ASDISPLAYNODE_EXTERN_C_END
 
 - (ASRangeTuningParameters)tuningParametersForRangeMode:(ASLayoutRangeMode)rangeMode rangeType:(ASLayoutRangeType)rangeType;
 
-- (NSSet<NSIndexPath *> *)indexPathsForScrolling:(ASScrollDirection)scrollDirection rangeMode:(ASLayoutRangeMode)rangeMode rangeType:(ASLayoutRangeType)rangeType;
+- (NSSet<ASCollectionElement *> *)elementsForScrolling:(ASScrollDirection)scrollDirection rangeMode:(ASLayoutRangeMode)rangeMode rangeType:(ASLayoutRangeType)rangeType map:(ASElementMap *)map;
 
-- (void)allIndexPathsForScrolling:(ASScrollDirection)scrollDirection rangeMode:(ASLayoutRangeMode)rangeMode displaySet:(NSSet * _Nullable * _Nullable)displaySet preloadSet:(NSSet * _Nullable * _Nullable)preloadSet;
+- (void)allElementsForScrolling:(ASScrollDirection)scrollDirection rangeMode:(ASLayoutRangeMode)rangeMode displaySet:(NSSet<ASCollectionElement *> * _Nullable * _Nullable)displaySet preloadSet:(NSSet<ASCollectionElement *> * _Nullable * _Nullable)preloadSet map:(ASElementMap *)map;
 
 @optional
 

--- a/Source/Details/ASRangeController.h
+++ b/Source/Details/ASRangeController.h
@@ -107,9 +107,9 @@ AS_SUBCLASSING_RESTRICTED
 /**
  * @param rangeController Sender.
  *
- * @return an array of index paths corresponding to the nodes currently visible onscreen (i.e., the visible range).
+ * @return an array of elements corresponding to the data currently visible onscreen (i.e., the visible range).
  */
-- (NSArray<NSIndexPath *> *)visibleNodeIndexPathsForRangeController:(ASRangeController *)rangeController;
+- (NSArray<ASCollectionElement *> *)visibleElementsForRangeController:(ASRangeController *)rangeController;
 
 /**
  * @param rangeController Sender.

--- a/Source/Details/ASRangeController.mm
+++ b/Source/Details/ASRangeController.mm
@@ -274,9 +274,9 @@ static UIApplicationState __ApplicationState = UIApplicationStateActive;
   }
   
   // For now we are only interested in items. Filter-map out from element to item-index-path.
-  NSSet<NSIndexPath *> *visibleIndexPaths = ASSetByFlatMapping(visibleElements, ASCollectionElement *element, [map indexPathForElementIfItem:element]);
-  NSSet<NSIndexPath *> *displayIndexPaths = ASSetByFlatMapping(displayElements, ASCollectionElement *element, [map indexPathForElementIfItem:element]);
-  NSSet<NSIndexPath *> *preloadIndexPaths = ASSetByFlatMapping(preloadElements, ASCollectionElement *element, [map indexPathForElementIfItem:element]);
+  NSSet<NSIndexPath *> *visibleIndexPaths = ASSetByFlatMapping(visibleElements, ASCollectionElement *element, [map indexPathForElementIfCell:element]);
+  NSSet<NSIndexPath *> *displayIndexPaths = ASSetByFlatMapping(displayElements, ASCollectionElement *element, [map indexPathForElementIfCell:element]);
+  NSSet<NSIndexPath *> *preloadIndexPaths = ASSetByFlatMapping(preloadElements, ASCollectionElement *element, [map indexPathForElementIfCell:element]);
 
   // Prioritize the order in which we visit each.  Visible nodes should be updated first so they are enqueued on
   // the network or display queues before preloading (offscreen) nodes are enqueued.

--- a/Source/Details/ASTableLayoutController.m
+++ b/Source/Details/ASTableLayoutController.m
@@ -13,6 +13,7 @@
 #import <UIKit/UIKit.h>
 
 #import <AsyncDisplayKit/ASAssert.h>
+#import <AsyncDisplayKit/ASElementMap.h>
 
 @interface ASTableLayoutController()
 @end
@@ -30,28 +31,24 @@
 
 #pragma mark - ASLayoutController
 
-/**
- * IndexPath array for the element in the working range.
- */
-
-- (NSSet *)indexPathsForScrolling:(ASScrollDirection)scrollDirection rangeMode:(ASLayoutRangeMode)rangeMode rangeType:(ASLayoutRangeType)rangeType
+- (NSSet<ASCollectionElement *> *)elementsForScrolling:(ASScrollDirection)scrollDirection rangeMode:(ASLayoutRangeMode)rangeMode rangeType:(ASLayoutRangeType)rangeType map:(ASElementMap *)map
 {
   CGRect bounds = _tableView.bounds;
 
   ASRangeTuningParameters tuningParameters = [self tuningParametersForRangeMode:rangeMode rangeType:rangeType];
   CGRect rangeBounds = CGRectExpandToRangeWithScrollableDirections(bounds, tuningParameters, ASScrollDirectionVerticalDirections, scrollDirection);
   NSArray *array = [_tableView indexPathsForRowsInRect:rangeBounds];
-  return [NSSet setWithArray:array];
+  return ASSetByFlatMapping(array, NSIndexPath *indexPath, [map elementForItemAtIndexPath:indexPath]);
 }
 
-- (void)allIndexPathsForScrolling:(ASScrollDirection)scrollDirection rangeMode:(ASLayoutRangeMode)rangeMode displaySet:(NSSet **)displaySet preloadSet:(NSSet **)preloadSet
+- (void)allElementsForScrolling:(ASScrollDirection)scrollDirection rangeMode:(ASLayoutRangeMode)rangeMode displaySet:(NSSet<ASCollectionElement *> *__autoreleasing  _Nullable *)displaySet preloadSet:(NSSet<ASCollectionElement *> *__autoreleasing  _Nullable *)preloadSet map:(ASElementMap *)map
 {
   if (displaySet == NULL || preloadSet == NULL) {
     return;
   }
 
-  *displaySet = [self indexPathsForScrolling:scrollDirection rangeMode:rangeMode rangeType:ASLayoutRangeTypeDisplay];
-  *preloadSet = [self indexPathsForScrolling:scrollDirection rangeMode:rangeMode rangeType:ASLayoutRangeTypePreload];
+  *displaySet = [self elementsForScrolling:scrollDirection rangeMode:rangeMode rangeType:ASLayoutRangeTypeDisplay map:map];
+  *preloadSet = [self elementsForScrolling:scrollDirection rangeMode:rangeMode rangeType:ASLayoutRangeTypePreload map:map];
   return;
 }
 

--- a/Source/Private/ASElementMap.h
+++ b/Source/Private/ASElementMap.h
@@ -60,9 +60,9 @@ AS_SUBCLASSING_RESTRICTED
 - (nullable NSIndexPath *)indexPathForElement:(ASCollectionElement *)element;
 
 /**
- * Returns the index path for the given element, if it represents an item. O(1)
+ * Returns the index path for the given element, if it represents a cell. O(1)
  */
-- (nullable NSIndexPath *)indexPathForElementIfItem:(ASCollectionElement *)element;
+- (nullable NSIndexPath *)indexPathForElementIfCell:(ASCollectionElement *)element;
 
 /**
  * Returns the item-element at the given index path. O(1)

--- a/Source/Private/ASElementMap.h
+++ b/Source/Private/ASElementMap.h
@@ -11,7 +11,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class ASCollectionElement, ASSection;
+@class ASCollectionElement, ASSection, UICollectionViewLayoutAttributes;
 @protocol ASSectionContext;
 
 /**
@@ -26,6 +26,11 @@ AS_SUBCLASSING_RESTRICTED
  * The number of sections (of items) in this map.
  */
 @property (readonly) NSInteger numberOfSections;
+
+/**
+ * The kinds of supplementary elements present in this map. O(1)
+ */
+@property (copy, readonly) NSArray<NSString *> *supplementaryElementKinds;
 
 /**
  * Returns number of items in the given section. O(1)
@@ -55,6 +60,11 @@ AS_SUBCLASSING_RESTRICTED
 - (nullable NSIndexPath *)indexPathForElement:(ASCollectionElement *)element;
 
 /**
+ * Returns the index path for the given element, if it represents an item. O(1)
+ */
+- (nullable NSIndexPath *)indexPathForElementIfItem:(ASCollectionElement *)element;
+
+/**
  * Returns the item-element at the given index path. O(1)
  */
 - (nullable ASCollectionElement *)elementForItemAtIndexPath:(NSIndexPath *)indexPath;
@@ -64,6 +74,13 @@ AS_SUBCLASSING_RESTRICTED
  */
 - (nullable ASCollectionElement *)supplementaryElementOfKind:(NSString *)supplementaryElementKind atIndexPath:(NSIndexPath *)indexPath;
 
+/**
+ * Returns the element that corresponds to the given layout attributes, if any.
+ *
+ * NOTE: This method only regards the category, kind, and index path of the attributes object. Elements do not
+ * have any concept of size/position.
+ */
+- (nullable ASCollectionElement *)elementForLayoutAttributes:(UICollectionViewLayoutAttributes *)layoutAttributes;
 
 #pragma mark - Initialization -- Only Useful to ASDataController
 

--- a/Source/Private/ASElementMap.m
+++ b/Source/Private/ASElementMap.m
@@ -73,6 +73,11 @@
   return _sectionsOfItems.count;
 }
 
+- (NSArray<NSString *> *)supplementaryElementKinds
+{
+  return _supplementaryElements.allKeys;
+}
+
 - (NSInteger)numberOfItemsInSection:(NSInteger)section
 {
   return _sectionsOfItems[section].count;
@@ -88,6 +93,15 @@
   return [_elementToIndexPathMap objectForKey:element];
 }
 
+- (nullable NSIndexPath *)indexPathForElementIfItem:(ASCollectionElement *)element
+{
+  if (element.supplementaryElementKind == nil) {
+    return [self indexPathForElement:element];
+  } else {
+    return nil;
+  }
+}
+
 - (nullable ASCollectionElement *)elementForItemAtIndexPath:(NSIndexPath *)indexPath
 {
   return (indexPath != nil) ? ASGetElementInTwoDimensionalArray(_sectionsOfItems, indexPath) : nil;
@@ -96,6 +110,21 @@
 - (nullable ASCollectionElement *)supplementaryElementOfKind:(NSString *)supplementaryElementKind atIndexPath:(NSIndexPath *)indexPath
 {
   return _supplementaryElements[supplementaryElementKind][indexPath];
+}
+
+- (ASCollectionElement *)elementForLayoutAttributes:(UICollectionViewLayoutAttributes *)layoutAttributes
+{
+  switch (layoutAttributes.representedElementCategory) {
+    case UICollectionElementCategoryCell:
+      // Cell
+      return [self elementForItemAtIndexPath:layoutAttributes.indexPath];
+    case UICollectionElementCategorySupplementaryView:
+      // Supplementary element.
+      return [self supplementaryElementOfKind:layoutAttributes.representedElementKind atIndexPath:layoutAttributes.indexPath];
+    case UICollectionElementCategoryDecorationView:
+      // No support for decoration views.
+      return nil;
+  }
 }
 
 - (NSIndexPath *)convertIndexPath:(NSIndexPath *)indexPath fromMap:(ASElementMap *)map

--- a/Source/Private/ASElementMap.m
+++ b/Source/Private/ASElementMap.m
@@ -93,7 +93,7 @@
   return [_elementToIndexPathMap objectForKey:element];
 }
 
-- (nullable NSIndexPath *)indexPathForElementIfItem:(ASCollectionElement *)element
+- (nullable NSIndexPath *)indexPathForElementIfCell:(ASCollectionElement *)element
 {
   if (element.supplementaryElementKind == nil) {
     return [self indexPathForElement:element];


### PR DESCRIPTION
This doesn't actually change any behavior, but it lays the groundwork for range controllers to deal with supplementary elements.

After this diff, we provide elements of other kinds to the range controller, but before it starts its core work it filter-maps supplementary elements into item index paths, and continues behaving as before.

We should review this and once it's landed we can change the core range controller algorithm to deal with supplementary elements and items alike.