### PR TITLE
[Swift] Fix crashes while subclassing ASDisplayNode and subclasses in Swift

### DIFF
--- a/Source/ASCollectionNode.mm
+++ b/Source/ASCollectionNode.mm
@@ -118,7 +118,7 @@
 
 - (instancetype)initWithCollectionViewLayout:(UICollectionViewLayout *)layout
 {
-  return [self initWithFrame:CGRectZero collectionViewLayout:layout];
+  return [self initWithFrame:CGRectZero collectionViewLayout:layout layoutFacilitator:nil];
 }
 
 - (instancetype)initWithFrame:(CGRect)frame collectionViewLayout:(UICollectionViewLayout *)layout
@@ -135,7 +135,7 @@
     return [[ASCollectionView alloc] _initWithFrame:frame collectionViewLayout:layout layoutFacilitator:layoutFacilitator eventLog:ASDisplayNodeGetEventLog(strongSelf)];
   };
 
-  if (self = [super initWithViewBlock:collectionViewBlock]) {
+  if (self = [super initWithViewBlock:collectionViewBlock didLoadBlock:nil]) {
     return self;
   }
   return nil;

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -330,8 +330,9 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
 
 - (instancetype)initWithLayerClass:(Class)layerClass
 {
-  if (!(self = [super init]))
+  if (!(self = [super init])) {
     return nil;
+  }
 
   ASDisplayNodeAssert([layerClass isSubclassOfClass:[CALayer class]], @"should initialize with a subclass of CALayer");
 
@@ -345,13 +346,18 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
 
 - (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock
 {
-  return [self initWithViewBlock:viewBlock didLoadBlock:nil];
+  return [self _initWithViewBlock:viewBlock didLoadBlock:nil];
 }
-
 - (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock didLoadBlock:(ASDisplayNodeDidLoadBlock)didLoadBlock
 {
-  if (!(self = [super init]))
+  return [self _initWithViewBlock:viewBlock didLoadBlock:didLoadBlock];
+}
+
+- (instancetype)_initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock didLoadBlock:(ASDisplayNodeDidLoadBlock)didLoadBlock
+{
+  if (!(self = [super init])) {
     return nil;
+  }
   
   ASDisplayNodeAssertNotNil(viewBlock, @"should initialize with a valid block that returns a UIView");
   
@@ -367,13 +373,19 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
 
 - (instancetype)initWithLayerBlock:(ASDisplayNodeLayerBlock)layerBlock
 {
-  return [self initWithLayerBlock:layerBlock didLoadBlock:nil];
+  return [self _initWithLayerBlock:layerBlock didLoadBlock:nil];
 }
 
 - (instancetype)initWithLayerBlock:(ASDisplayNodeLayerBlock)layerBlock didLoadBlock:(ASDisplayNodeDidLoadBlock)didLoadBlock
 {
-  if (!(self = [super init]))
+  return [self _initWithLayerBlock:layerBlock didLoadBlock:didLoadBlock];
+}
+
+- (instancetype)_initWithLayerBlock:(ASDisplayNodeLayerBlock)layerBlock didLoadBlock:(ASDisplayNodeDidLoadBlock)didLoadBlock
+{
+  if (!(self = [super init])) {
     return nil;
+  }
   
   ASDisplayNodeAssertNotNil(layerBlock, @"should initialize with a valid block that returns a CALayer");
   


### PR DESCRIPTION
Unfortunately we had to revert #3132 as it would have broke a lot of current code as the designated and convenience initializer in ASDisplayNode are not probably defined at all.

This PR at least fixes crashes if `ASDisplayNode` is subclassed in Swift and certain initializer implemented. This especially fixes known crashes in `ASScrollNode`, `ASCollectionNode` and `ASTableNode`.