### PR TITLE
[ASControlNode] Align touch and tracking system in ASControlNode to UIControl

### DIFF
--- a/Source/ASControlNode.mm
+++ b/Source/ASControlNode.mm
@@ -265,13 +265,14 @@ CGRect _ASControlNodeGetExpandedBounds(ASControlNode *controlNode);
 }
 
 #pragma mark - Action Messages
+
 - (void)addTarget:(id)target action:(SEL)action forControlEvents:(ASControlNodeEvent)controlEventMask
 {
   NSParameterAssert(action);
   NSParameterAssert(controlEventMask != 0);
-  // This assertion would likely be helpful to users who aren't familiar with the implications of layer-backing.
-  // However, it would represent an API change (in debug) as it did not used to assert.
-  // ASDisplayNodeAssert(!self.isLayerBacked, @"ASControlNode is layer backed, will never be able to call target in target:action: pair.");
+  
+  // ASControlNode cannot be layer backed if adding a target
+  ASDisplayNodeAssert(!self.isLayerBacked, @"ASControlNode is layer backed, will never be able to call target in target:action: pair.");
   
   ASDN::MutexLocker l(_controlLock);
 

--- a/Source/ASControlNode.mm
+++ b/Source/ASControlNode.mm
@@ -116,7 +116,7 @@ CGRect _ASControlNodeGetExpandedBounds(ASControlNode *controlNode);
   
   // If a control node is exit the hierarchy and is tracking we have to cancel it
   if (self.tracking) {
-    [self _cancelTrackingForControlEvents:ASControlNodeEventTouchCancel withEvent:nil];
+    [self _cancelTrackingWithEvent:nil];
   }
 }
 
@@ -138,13 +138,10 @@ CGRect _ASControlNodeGetExpandedBounds(ASControlNode *controlNode);
     return;
   }
 
-  ASControlNodeEvent controlEventMask = 0;
-
   // If we get more than one touch down on us, cancel.
   // Additionally, if we're already tracking a touch, a second touch beginning is cause for cancellation.
   if (touches.count > 1 || self.tracking) {
-    controlEventMask |= ASControlNodeEventTouchCancel;
-    [self _cancelTrackingForControlEvents:controlEventMask withEvent:event];
+    [self _cancelTrackingWithEvent:event];
   } else {
     // Otherwise, begin tracking.
     self.tracking = YES;
@@ -154,8 +151,7 @@ CGRect _ASControlNodeGetExpandedBounds(ASControlNode *controlNode);
     self.highlighted = YES;
 
     // Send the appropriate touch-down control event depending on how many times we've been tapped.
-    controlEventMask |= (theTouch.tapCount == 1) ? ASControlNodeEventTouchDown : ASControlNodeEventTouchDownRepeat;
-
+    ASControlNodeEvent controlEventMask = (theTouch.tapCount == 1) ? ASControlNodeEventTouchDown : ASControlNodeEventTouchDownRepeat;
     [self sendActionsForControlEvents:controlEventMask withEvent:event];
   }
 }
@@ -199,7 +195,7 @@ CGRect _ASControlNodeGetExpandedBounds(ASControlNode *controlNode);
   }
 
   // Note that we've cancelled tracking.
-  [self _cancelTrackingForControlEvents:ASControlNodeEventTouchCancel withEvent:event];
+  [self _cancelTrackingWithEvent:event];
 }
 
 - (void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event
@@ -238,7 +234,7 @@ CGRect _ASControlNodeGetExpandedBounds(ASControlNode *controlNode);
                           withEvent:event];
 }
 
-- (void)_cancelTrackingForControlEvents:(ASControlNodeEvent)controlEventMask withEvent:(UIEvent *)event
+- (void)_cancelTrackingWithEvent:(UIEvent *)event
 {
   // We're no longer tracking and there is no touch to be inside.
   self.tracking = NO;
@@ -246,7 +242,7 @@ CGRect _ASControlNodeGetExpandedBounds(ASControlNode *controlNode);
   self.highlighted = NO;
   
   // Send the cancel event.
-  [self sendActionsForControlEvents:controlEventMask withEvent:event];
+  [self sendActionsForControlEvents:ASControlNodeEventTouchCancel withEvent:event];
 }
 
 #pragma clang diagnostic pop


### PR DESCRIPTION
Currently the touch and tracking system of ASControlNode does not align with the system of UIControl. ASControlNode does not even consider `beginTrackingWithTouch:withEvent:` or `continueTrackingWithTouch:withEvent:`.

This commit will change the ASControlNode logic around touch event handling and tracking to align with UIControl after diving a bit into the assembly and the way UIControl is working.

This PR also uncomments the assertion that if adding a target action to an `ASControlNode` that is layer backed it will throw an assertion.

Resolves #3139 