### PR TITLE
[ASDisplayNode] Revert #3063

### DIFF
--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -2312,7 +2312,7 @@ static const char *ASDisplayNodeDrawingPriorityKey = "ASDrawingPriority";
   }
 
   ASDisplayNodeAssert(_flags.layerBacked, @"We shouldn't get called back here unless we are layer-backed.");
-  return nil;
+  return (id)kCFNull;
 }
 
 #pragma mark - Error Handling


### PR DESCRIPTION
`-[ASDisplayNode actionForLayer:forKey:]` should return `nil` to avoid the node being animated by CA when it's being moved from one supernode to another.

This reverts commit 1d21c0bd5545741f284e553d7ed003c69fa6897c introduced by @Adlai-Holler in #3063.