### PR TITLE
Add a concurrent flag to ASStackLayoutSpec that is off by default

### DIFF
--- a/Source/Layout/ASStackLayoutSpec.h
+++ b/Source/Layout/ASStackLayoutSpec.h
@@ -59,10 +59,13 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) ASStackLayoutJustifyContent justifyContent;
 /** Orientation of children along cross axis. Defaults to ASStackLayoutAlignItemsStretch */
 @property (nonatomic, assign) ASStackLayoutAlignItems alignItems;
-//TODO documentation. Defaults to ASStackLayoutFlexWrapNoWrap
+/** Whether children are stacked into a single or multiple lines. Defaults to single line (ASStackLayoutFlexWrapNoWrap) */
 @property (nonatomic, assign) ASStackLayoutFlexWrap flexWrap;
-//TODO documentation. Defaults to ASStackLayoutAlignContentStart
+/** Orientation of lines along cross axis if there are multiple lines. Defaults to ASStackLayoutAlignContentStart */
 @property (nonatomic, assign) ASStackLayoutAlignContent alignContent;
+
+/** Whether this stack can dispatch to other threads, regardless of which thread it's running on */
+@property (nonatomic, assign, getter=isConcurrent) BOOL concurrent;
 
 - (instancetype)init;
 
@@ -84,8 +87,9 @@ NS_ASSUME_NONNULL_BEGIN
  @param spacing The spacing between the children
  @param justifyContent If no children are flexible, this describes how to fill any extra space
  @param alignItems Orientation of the children along the cross axis
+ @param flexWrap Whether children are stacked into a single or multiple lines
+ @param alignContent Orientation of lines along cross axis if there are multiple lines
  @param children ASLayoutElement children to be positioned.
- TODO documentation flex wrap and align content
  */
 + (instancetype)stackLayoutSpecWithDirection:(ASStackLayoutDirection)direction
                                      spacing:(CGFloat)spacing

--- a/Source/Layout/ASStackLayoutSpec.mm
+++ b/Source/Layout/ASStackLayoutSpec.mm
@@ -136,7 +136,7 @@
   
   const ASStackLayoutSpecStyle style = {.direction = _direction, .spacing = _spacing, .justifyContent = _justifyContent, .alignItems = _alignItems, .flexWrap = _flexWrap, .alignContent = _alignContent};
   
-  const auto unpositionedLayout = ASStackUnpositionedLayout::compute(stackChildren, style, constrainedSize);
+  const auto unpositionedLayout = ASStackUnpositionedLayout::compute(stackChildren, style, constrainedSize, _concurrent);
   const auto positionedLayout = ASStackPositionedLayout::compute(unpositionedLayout, style, constrainedSize);
   
   if (style.direction == ASStackLayoutDirectionVertical) {

--- a/Source/Private/Layout/ASStackUnpositionedLayout.h
+++ b/Source/Private/Layout/ASStackUnpositionedLayout.h
@@ -58,7 +58,8 @@ struct ASStackUnpositionedLayout {
   /** Given a set of children, computes the unpositioned layouts for those children. */
   static ASStackUnpositionedLayout compute(const std::vector<ASStackLayoutSpecChild> &children,
                                            const ASStackLayoutSpecStyle &style,
-                                           const ASSizeRange &sizeRange);
+                                           const ASSizeRange &sizeRange,
+                                           const BOOL concurrent);
   
   static CGFloat baselineForItem(const ASStackLayoutSpecStyle &style,
                                  const ASStackLayoutSpecItem &l);


### PR DESCRIPTION
- The current locking situation of `ASDisplayNode` unfortunately causes deadlocks if a stack spec is concurrent. While the concurrency has proven to be beneficial, enabling it by default is too risky.
- Once `ASDisplayNode` has a transactional layout system and/or its locking strategy has improved, we definitely should reconsider this option.