### PR TITLE
[ASCollectionView] Gratefully handle unavailable headers and footers

### DIFF
--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -611,6 +611,9 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
 - (CGSize)sizeForElement:(ASCollectionElement *)element
 {
   ASDisplayNodeAssertMainThread();
+  if (element == nil) {
+    return CGSizeZero;
+  }
 
   NSString *supplementaryKind = element.supplementaryElementKind;
   NSIndexPath *indexPath = [_dataController.visibleMap indexPathForElement:element];


### PR DESCRIPTION
- `UICollectionViewFlowLayout` asks its delegate, which is `ASCollectionView`, for reference size of headers and footers. If a header or footer is unavailable, its backing collection element will be nil and a zero size should be returned immediately.
- Same deal for unknown items.