### PR TITLE
When Converting Index Paths in Tables, Only Wait if Asked

### DIFF
--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -562,7 +562,7 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     return indexPath;
   } else {
     NSIndexPath *viewIndexPath = [_dataController.visibleMap convertIndexPath:indexPath fromMap:_dataController.pendingMap];
-    if (viewIndexPath == nil) {
+    if (viewIndexPath == nil && wait) {
       [self waitUntilAllUpdatesAreCommitted];
       return [self convertIndexPathFromTableNode:indexPath waitingIfNeeded:NO];
     }


### PR DESCRIPTION
This avoids a possible infinite loop.