### PR TITLE
Add Production Workarounds for Missing Elements

### DIFF
--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -1737,14 +1737,22 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
   // Visible items
   for (NSIndexPath *indexPath in self.indexPathsForVisibleItems) {
     ASCollectionElement *element = [map elementForItemAtIndexPath:indexPath];
-    [result addObject:element];
+    if (element != nil) {
+      [result addObject:element];
+    } else {
+      ASDisplayNodeFailAssert(@"Couldn't find 'visible' item at index path %@ in map %@", indexPath, map);
+    }
   }
 
   // Visible supplementary elements
   for (NSString *kind in map.supplementaryElementKinds) {
     for (NSIndexPath *indexPath in [self asdk_indexPathsForVisibleSupplementaryElementsOfKind:kind]) {
       ASCollectionElement *element = [map supplementaryElementOfKind:kind atIndexPath:indexPath];
-      [result addObject:element];
+      if (element != nil) {
+        [result addObject:element];
+      } else {
+        ASDisplayNodeFailAssert(@"Couldn't find 'visible' supplementary element of kind %@ at index path %@ in map %@", kind, indexPath, map);
+      }
     }
   }
   return result;

--- a/Source/Private/ASElementMap.m
+++ b/Source/Private/ASElementMap.m
@@ -13,8 +13,9 @@
 #import <AsyncDisplayKit/ASMutableElementMap.h>
 #import <AsyncDisplayKit/ASSection.h>
 #import <AsyncDisplayKit/NSIndexSet+ASHelpers.h>
+#import <AsyncDisplayKit/ASObjectDescriptionHelpers.h>
 
-@interface ASElementMap ()
+@interface ASElementMap () <ASDescriptionProvider>
 
 @property (nonatomic, strong, readonly) NSArray<ASSection *> *sections;
 
@@ -153,6 +154,21 @@
 - (NSUInteger)countByEnumeratingWithState:(NSFastEnumerationState *)state objects:(id  _Nullable __unsafe_unretained [])buffer count:(NSUInteger)len
 {
   return [_elementToIndexPathMap countByEnumeratingWithState:state objects:buffer count:len];
+}
+
+#pragma mark - ASDescriptionProvider
+
+- (NSString *)description
+{
+  return ASObjectDescriptionMake(self, [self propertiesForDescription]);
+}
+
+- (NSMutableArray<NSDictionary *> *)propertiesForDescription
+{
+  NSMutableArray *result = [NSMutableArray array];
+  [result addObject:@{ @"items" : _sectionsOfItems }];
+  [result addObject:@{ @"supplementaryElements" : _supplementaryElements }];
+  return result;
 }
 
 @end


### PR DESCRIPTION
Not sure what's causing this yet, but we're sometimes seeing visible supplementary elements reported by the collection view that don't exist in the element map.

It's possible that these are leftover from an animation that's inflight or something, so we may not want to be as strict as an assertion. Let's get the production crashes out of the way and revisit.