### PR TITLE
Improve locking situation in ASDisplayNode subclasses

### DIFF
--- a/Source/ASButtonNode.mm
+++ b/Source/ASButtonNode.mm
@@ -172,6 +172,7 @@
   if ((_imageNode != nil || newImage != nil) && newImage != self.imageNode.image) {
     _imageNode.image = newImage;
     __instanceLock__.unlock();
+
     [self setNeedsLayout];
     return;
   }
@@ -196,11 +197,13 @@
     newTitle = _normalAttributedTitle;
   }
 
-  if ((_titleNode != nil || newTitle.length > 0) && [self.titleNode.attributedText isEqualToAttributedString:newTitle] == NO) {
-    _titleNode.attributedText = newTitle;
+  ASTextNode *titleNode = _titleNode;
+  
+  if ((titleNode != nil || newTitle.length > 0) && [titleNode.attributedText isEqualToAttributedString:newTitle] == NO) {
+    titleNode.attributedText = newTitle;
     __instanceLock__.unlock();
     
-    self.accessibilityLabel = _titleNode.accessibilityLabel;
+    self.accessibilityLabel = titleNode.accessibilityLabel;
     [self setNeedsLayout];
     return;
   }
@@ -333,8 +336,7 @@
     NSForegroundColorAttributeName : color ? : [UIColor blackColor]
   };
     
-  NSAttributedString *string = [[NSAttributedString alloc] initWithString:title
-                                                               attributes:attributes];
+  NSAttributedString *string = [[NSAttributedString alloc] initWithString:title attributes:attributes];
   [self setAttributedTitle:string forState:state];
 }
 #endif

--- a/Source/ASButtonNode.mm
+++ b/Source/ASButtonNode.mm
@@ -154,7 +154,7 @@
 
 - (void)updateImage
 {
-  ASDN::MutexLocker l(__instanceLock__);
+  __instanceLock__.lock();
 
   UIImage *newImage;
   if (self.enabled == NO && _disabledImage) {
@@ -171,13 +171,18 @@
   
   if ((_imageNode != nil || newImage != nil) && newImage != self.imageNode.image) {
     _imageNode.image = newImage;
+    __instanceLock__.unlock();
     [self setNeedsLayout];
+    return;
   }
+  
+  __instanceLock__.unlock();
 }
 
 - (void)updateTitle
 {
-  ASDN::MutexLocker l(__instanceLock__);
+  __instanceLock__.lock();
+
   NSAttributedString *newTitle;
   if (self.enabled == NO && _disabledAttributedTitle) {
     newTitle = _disabledAttributedTitle;
@@ -193,14 +198,19 @@
 
   if ((_titleNode != nil || newTitle.length > 0) && [self.titleNode.attributedText isEqualToAttributedString:newTitle] == NO) {
     _titleNode.attributedText = newTitle;
+    __instanceLock__.unlock();
+    
     self.accessibilityLabel = _titleNode.accessibilityLabel;
     [self setNeedsLayout];
+    return;
   }
+  
+  __instanceLock__.unlock();
 }
 
 - (void)updateBackgroundImage
 {
-  ASDN::MutexLocker l(__instanceLock__);
+  __instanceLock__.lock();
   
   UIImage *newImage;
   if (self.enabled == NO && _disabledBackgroundImage) {
@@ -217,8 +227,13 @@
   
   if ((_backgroundImageNode != nil || newImage != nil) && newImage != self.backgroundImageNode.image) {
     _backgroundImageNode.image = newImage;
+    __instanceLock__.unlock();
+    
     [self setNeedsLayout];
+    return;
   }
+  
+  __instanceLock__.unlock();
 }
 
 - (CGFloat)contentSpacing
@@ -229,11 +244,15 @@
 
 - (void)setContentSpacing:(CGFloat)contentSpacing
 {
-  ASDN::MutexLocker l(__instanceLock__);
-  if (contentSpacing == _contentSpacing)
-    return;
-  
-  _contentSpacing = contentSpacing;
+  {
+    ASDN::MutexLocker l(__instanceLock__);
+    if (contentSpacing == _contentSpacing) {
+      return;
+    }
+    
+    _contentSpacing = contentSpacing;
+  }
+
   [self setNeedsLayout];
 }
 
@@ -245,11 +264,15 @@
 
 - (void)setLaysOutHorizontally:(BOOL)laysOutHorizontally
 {
-  ASDN::MutexLocker l(__instanceLock__);
-  if (laysOutHorizontally == _laysOutHorizontally)
-    return;
+  {
+    ASDN::MutexLocker l(__instanceLock__);
+    if (laysOutHorizontally == _laysOutHorizontally) {
+      return;
+    }
   
-  _laysOutHorizontally = laysOutHorizontally;
+    _laysOutHorizontally = laysOutHorizontally;
+  }
+
   [self setNeedsLayout];
 }
 
@@ -306,9 +329,9 @@
 - (void)setTitle:(NSString *)title withFont:(UIFont *)font withColor:(UIColor *)color forState:(UIControlState)state
 {
   NSDictionary *attributes = @{
-                               NSFontAttributeName: font ? : [UIFont systemFontOfSize:[UIFont buttonFontSize]],
-                               NSForegroundColorAttributeName : color ? : [UIColor blackColor]
-                               };
+    NSFontAttributeName: font ? : [UIFont systemFontOfSize:[UIFont buttonFontSize]],
+    NSForegroundColorAttributeName : color ? : [UIColor blackColor]
+  };
     
   NSAttributedString *string = [[NSAttributedString alloc] initWithString:title
                                                                attributes:attributes];
@@ -342,30 +365,32 @@
 
 - (void)setAttributedTitle:(NSAttributedString *)title forState:(UIControlState)state
 {
-  ASDN::MutexLocker l(__instanceLock__);
-  switch (state) {
-    case UIControlStateNormal:
-      _normalAttributedTitle = [title copy];
-      break;
-      
-    case UIControlStateHighlighted:
-      _highlightedAttributedTitle = [title copy];
-      break;
-      
-    case UIControlStateSelected:
-      _selectedAttributedTitle = [title copy];
-      break;
-          
-    case UIControlStateSelected | UIControlStateHighlighted:
-      _selectedHighlightedAttributedTitle = [title copy];
-      break;
-      
-    case UIControlStateDisabled:
-      _disabledAttributedTitle = [title copy];
-      break;
-      
-    default:
-      break;
+  {
+    ASDN::MutexLocker l(__instanceLock__);
+    switch (state) {
+      case UIControlStateNormal:
+        _normalAttributedTitle = [title copy];
+        break;
+        
+      case UIControlStateHighlighted:
+        _highlightedAttributedTitle = [title copy];
+        break;
+        
+      case UIControlStateSelected:
+        _selectedAttributedTitle = [title copy];
+        break;
+            
+      case UIControlStateSelected | UIControlStateHighlighted:
+        _selectedHighlightedAttributedTitle = [title copy];
+        break;
+        
+      case UIControlStateDisabled:
+        _disabledAttributedTitle = [title copy];
+        break;
+        
+      default:
+        break;
+    }
   }
 
   [self updateTitle];
@@ -397,31 +422,34 @@
 
 - (void)setImage:(UIImage *)image forState:(UIControlState)state
 {
-  ASDN::MutexLocker l(__instanceLock__);
-  switch (state) {
-    case UIControlStateNormal:
-      _normalImage = image;
-      break;
+  {
+    ASDN::MutexLocker l(__instanceLock__);
+    switch (state) {
+      case UIControlStateNormal:
+        _normalImage = image;
+        break;
+        
+      case UIControlStateHighlighted:
+        _highlightedImage = image;
+        break;
+        
+      case UIControlStateSelected:
+        _selectedImage = image;
+        break;
       
-    case UIControlStateHighlighted:
-      _highlightedImage = image;
-      break;
-      
-    case UIControlStateSelected:
-      _selectedImage = image;
-      break;
-    
-    case UIControlStateSelected | UIControlStateHighlighted:
-      _selectedHighlightedImage = image;
-      break;
-          
-    case UIControlStateDisabled:
-      _disabledImage = image;
-      break;
-      
-    default:
-      break;
+      case UIControlStateSelected | UIControlStateHighlighted:
+        _selectedHighlightedImage = image;
+        break;
+            
+      case UIControlStateDisabled:
+        _disabledImage = image;
+        break;
+        
+      default:
+        break;
+    }
   }
+
   [self updateImage];
 }
 
@@ -451,31 +479,34 @@
 
 - (void)setBackgroundImage:(UIImage *)image forState:(UIControlState)state
 {
-  ASDN::MutexLocker l(__instanceLock__);
-  switch (state) {
-    case UIControlStateNormal:
-      _normalBackgroundImage = image;
-      break;
-      
-    case UIControlStateHighlighted:
-      _highlightedBackgroundImage = image;
-      break;
-      
-    case UIControlStateSelected:
-      _selectedBackgroundImage = image;
-      break;
-          
-    case UIControlStateSelected | UIControlStateHighlighted:
-      _selectedHighlightedBackgroundImage = image;
-      break;
-      
-    case UIControlStateDisabled:
-      _disabledBackgroundImage = image;
-      break;
-      
-    default:
-      break;
+  {
+    ASDN::MutexLocker l(__instanceLock__);
+    switch (state) {
+      case UIControlStateNormal:
+        _normalBackgroundImage = image;
+        break;
+        
+      case UIControlStateHighlighted:
+        _highlightedBackgroundImage = image;
+        break;
+        
+      case UIControlStateSelected:
+        _selectedBackgroundImage = image;
+        break;
+            
+      case UIControlStateSelected | UIControlStateHighlighted:
+        _selectedHighlightedBackgroundImage = image;
+        break;
+        
+      case UIControlStateDisabled:
+        _disabledBackgroundImage = image;
+        break;
+        
+      default:
+        break;
+    }
   }
+
   [self updateBackgroundImage];
 }
 

--- a/Source/ASImageNode.mm
+++ b/Source/ASImageNode.mm
@@ -560,11 +560,10 @@ static ASDN::Mutex cacheLock;
 - (void)clearContents
 {
   [super clearContents];
-  
-  {
-    ASDN::MutexLocker l(__instanceLock__);
+    
+  __instanceLock__.lock();
     _weakCacheEntry = nil;  // release contents from the cache.
-  }
+  __instanceLock__.unlock();
 }
 
 #pragma mark - Cropping
@@ -591,7 +590,7 @@ static ASDN::Mutex cacheLock;
   _cropEnabled = cropEnabled;
   _cropDisplayBounds = cropBounds;
   
-  UIImage *image = self.image;
+  UIImage *image = _image;
   __instanceLock__.unlock();
 
   // If we have an image to display, display it, respecting our recrop flag.

--- a/Source/ASImageNode.mm
+++ b/Source/ASImageNode.mm
@@ -208,37 +208,46 @@ struct ASImageNodeDrawParameters {
 
 - (CGSize)calculateSizeThatFits:(CGSize)constrainedSize
 {
-  ASDN::MutexLocker l(__instanceLock__);
+  __instanceLock__.lock();
+  UIImage *image = _image;
+  __instanceLock__.unlock();
 
-  if (_image == nil) {
+  if (image == nil) {
     return [super calculateSizeThatFits:constrainedSize];
   }
 
-  return _image.size;
+  return image.size;
 }
 
 #pragma mark - Setter / Getter
 
 - (void)setImage:(UIImage *)image
 {
-  ASDN::MutexLocker l(__instanceLock__);
-  if (!ASObjectIsEqual(_image, image)) {
-    _image = image;
-    
-    [self setNeedsLayout];
-    if (image) {
-      [self setNeedsDisplay];
-      
-      if ([ASImageNode shouldShowImageScalingOverlay] && _debugLabelNode == nil) {
-        ASPerformBlockOnMainThread(^{
-          _debugLabelNode = [[ASTextNode alloc] init];
-          _debugLabelNode.layerBacked = YES;
-          [self addSubnode:_debugLabelNode];
-        });
-      }
-    } else {
-      self.contents = nil;
+  {
+    ASDN::MutexLocker l(__instanceLock__);
+    if (ASObjectIsEqual(_image, image)) {
+      return;
     }
+
+    _image = image;
+  }
+  
+  [self setNeedsLayout];
+
+  if (image) {
+    [self setNeedsDisplay];
+    
+    // Debugging
+    if ([ASImageNode shouldShowImageScalingOverlay] && _debugLabelNode == nil) {
+      ASPerformBlockOnMainThread(^{
+        _debugLabelNode = [[ASTextNode alloc] init];
+        _debugLabelNode.layerBacked = YES;
+        [self addSubnode:_debugLabelNode];
+      });
+    }
+
+  } else {
+    self.contents = nil;
   }
 }
 
@@ -536,9 +545,11 @@ static ASDN::Mutex cacheLock;
   }
 
   // Stash the block and call-site queue. We'll invoke it in -displayDidFinish.
-  ASDN::MutexLocker l(__instanceLock__);
-  if (_displayCompletionBlock != displayCompletionBlock) {
-    _displayCompletionBlock = displayCompletionBlock;
+  {
+    ASDN::MutexLocker l(__instanceLock__);
+    if (_displayCompletionBlock != displayCompletionBlock) {
+      _displayCompletionBlock = displayCompletionBlock;
+    }
   }
 
   [self setNeedsDisplay];
@@ -549,10 +560,11 @@ static ASDN::Mutex cacheLock;
 - (void)clearContents
 {
   [super clearContents];
-    
-  __instanceLock__.lock();
+  
+  {
+    ASDN::MutexLocker l(__instanceLock__);
     _weakCacheEntry = nil;  // release contents from the cache.
-  __instanceLock__.unlock();
+  }
 }
 
 #pragma mark - Cropping
@@ -570,16 +582,20 @@ static ASDN::Mutex cacheLock;
 
 - (void)setCropEnabled:(BOOL)cropEnabled recropImmediately:(BOOL)recropImmediately inBounds:(CGRect)cropBounds
 {
-  ASDN::MutexLocker l(__instanceLock__);
-  if (_cropEnabled == cropEnabled)
+  __instanceLock__.lock();
+  if (_cropEnabled == cropEnabled) {
+    __instanceLock__.unlock();
     return;
+  }
 
   _cropEnabled = cropEnabled;
   _cropDisplayBounds = cropBounds;
+  
+  UIImage *image = self.image;
+  __instanceLock__.unlock();
 
   // If we have an image to display, display it, respecting our recrop flag.
-  if (self.image)
-  {
+  if (image != nil) {
     ASPerformBlockOnMainThread(^{
       if (recropImmediately)
         [self displayImmediately];
@@ -597,11 +613,14 @@ static ASDN::Mutex cacheLock;
 
 - (void)setCropRect:(CGRect)cropRect
 {
-  ASDN::MutexLocker l(__instanceLock__);
-  if (CGRectEqualToRect(_cropRect, cropRect))
-    return;
+  {
+    ASDN::MutexLocker l(__instanceLock__);
+    if (CGRectEqualToRect(_cropRect, cropRect)) {
+      return;
+    }
 
-  _cropRect = cropRect;
+    _cropRect = cropRect;
+  }
 
   // TODO: this logic needs to be updated to respect cropRect.
   CGSize boundsSize = self.bounds.size;

--- a/Source/ASTextNode.mm
+++ b/Source/ASTextNode.mm
@@ -398,11 +398,12 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
 #if AS_TEXTNODE_RECORD_ATTRIBUTED_STRINGS
 	  [ASTextNode _registerAttributedText:_attributedText];
 #endif
-    // Sync the truncation string with attributes from the updated _attributedString
-    // Without this, the size calculation of the text with truncation applied will
-    // not take into account the attributes of attributedText in the last line
-    [self _updateComposedTruncationText];
   }
+    
+  // Sync the truncation string with attributes from the updated _attributedString
+  // Without this, the size calculation of the text with truncation applied will
+  // not take into account the attributes of attributedText in the last line
+  [self _updateComposedTruncationText];
   
   NSUInteger length = attributedText.length;
   if (length > 0) {

--- a/Source/ASTextNode.mm
+++ b/Source/ASTextNode.mm
@@ -1253,7 +1253,7 @@ static NSAttributedString *DefaultTruncationAttributedString()
 {
   ASDN::MutexLocker l(__instanceLock__);
   
-  _composedTruncationText = [self _prepareTruncationStringForDrawing:[self _composedTruncationText]];
+  _composedTruncationText = [self _locked_prepareTruncationStringForDrawing:[self _locked_composedTruncationText]];
 }
 
 - (void)_invalidateTruncationText
@@ -1289,10 +1289,8 @@ static NSAttributedString *DefaultTruncationAttributedString()
  * additional truncation message and a truncation attributed string, they will
  * be properly composed.
  */
-- (NSAttributedString *)_composedTruncationText
+- (NSAttributedString *)_locked_composedTruncationText
 {
-  ASDN::MutexLocker l(__instanceLock__);
-  
   //If we have neither return the default
   if (!_additionalTruncationMessage && !_truncationAttributedText) {
     return _composedTruncationText;
@@ -1319,10 +1317,8 @@ static NSAttributedString *DefaultTruncationAttributedString()
  * - Adds whole-string attributes so the truncation message matches the styling
  * of the body text
  */
-- (NSAttributedString *)_prepareTruncationStringForDrawing:(NSAttributedString *)truncationString
+- (NSAttributedString *)_locked_prepareTruncationStringForDrawing:(NSAttributedString *)truncationString
 {
-  ASDN::MutexLocker l(__instanceLock__);
-  
   truncationString = ASCleanseAttributedStringOfCoreTextAttributes(truncationString);
   NSMutableAttributedString *truncationMutableString = [truncationString mutableCopy];
   // Grab the attributes from the full string

--- a/Source/ASVideoNode.mm
+++ b/Source/ASVideoNode.mm
@@ -434,17 +434,15 @@ static NSString * const kRate = @"rate";
 {
   [super didEnterVisibleState];
   
+  __instanceLock__.lock();
   BOOL shouldPlay = NO;
-
-  {
-    ASDN::MutexLocker l(__instanceLock__);
-    if (_shouldBePlaying || _shouldAutoplay) {
-      if (_player != nil && CMTIME_IS_VALID(_lastPlaybackTime)) {
-        [_player seekToTime:_lastPlaybackTime];
-      }
-      shouldPlay = YES;
+  if (_shouldBePlaying || _shouldAutoplay) {
+    if (_player != nil && CMTIME_IS_VALID(_lastPlaybackTime)) {
+      [_player seekToTime:_lastPlaybackTime];
     }
+    shouldPlay = YES;
   }
+  __instanceLock__.unlock();
   
   if (shouldPlay) {
     [self play];
@@ -778,11 +776,10 @@ static NSString * const kRate = @"rate";
 
 - (void)setPlayerNode:(ASDisplayNode *)playerNode
 {
-  {
-    ASDN::MutexLocker l(__instanceLock__);
-    _playerNode = playerNode;
-  }
-  
+  __instanceLock__.lock();
+  _playerNode = playerNode;
+  __instanceLock__.unlock();
+
   [self setNeedsLayout];
 }
 

--- a/Source/ASVideoNode.mm
+++ b/Source/ASVideoNode.mm
@@ -238,7 +238,10 @@ static NSString * const kRate = @"rate";
 
 - (CGSize)calculateSizeThatFits:(CGSize)constrainedSize
 {
-  ASDN::MutexLocker l(__instanceLock__);
+  __instanceLock__.lock();
+  ASDisplayNode *playerNode = _playerNode;
+  __instanceLock__.unlock();
+
   CGSize calculatedSize = constrainedSize;
   
   // Prevent crashes through if infinite width or height
@@ -247,9 +250,9 @@ static NSString * const kRate = @"rate";
     calculatedSize = CGSizeZero;
   }
   
-  if (_playerNode) {
-    _playerNode.style.preferredSize = calculatedSize;
-    [_playerNode layoutThatFits:ASSizeRangeMake(CGSizeZero, calculatedSize)];
+  if (playerNode != nil) {
+    playerNode.style.preferredSize = calculatedSize;
+    [playerNode layoutThatFits:ASSizeRangeMake(CGSizeZero, calculatedSize)];
   }
   
   return calculatedSize;
@@ -298,9 +301,12 @@ static NSString * const kRate = @"rate";
 
 - (void)setVideoPlaceholderImage:(UIImage *)image
 {
-  ASDN::MutexLocker l(__instanceLock__);
+  __instanceLock__.lock();
+  NSString *gravity = _gravity;
+  __instanceLock__.unlock();
+  
   if (image != nil) {
-    self.contentMode = ASContentModeFromVideoGravity(_gravity);
+    self.contentMode = ASContentModeFromVideoGravity(gravity);
   }
   self.image = image;
 }
@@ -428,12 +434,19 @@ static NSString * const kRate = @"rate";
 {
   [super didEnterVisibleState];
   
-  ASDN::MutexLocker l(__instanceLock__);
-  
-  if (_shouldBePlaying || _shouldAutoplay) {
-    if (_player != nil && CMTIME_IS_VALID(_lastPlaybackTime)) {
-      [_player seekToTime:_lastPlaybackTime];
+  BOOL shouldPlay = NO;
+
+  {
+    ASDN::MutexLocker l(__instanceLock__);
+    if (_shouldBePlaying || _shouldAutoplay) {
+      if (_player != nil && CMTIME_IS_VALID(_lastPlaybackTime)) {
+        [_player seekToTime:_lastPlaybackTime];
+      }
+      shouldPlay = YES;
     }
+  }
+  
+  if (shouldPlay) {
     [self play];
   }
 }
@@ -765,9 +778,11 @@ static NSString * const kRate = @"rate";
 
 - (void)setPlayerNode:(ASDisplayNode *)playerNode
 {
-  ASDN::MutexLocker l(__instanceLock__);
-  _playerNode = playerNode;
-    
+  {
+    ASDN::MutexLocker l(__instanceLock__);
+    _playerNode = playerNode;
+  }
+  
   [self setNeedsLayout];
 }
 

--- a/Source/ASVideoPlayerNode.mm
+++ b/Source/ASVideoPlayerNode.mm
@@ -272,22 +272,22 @@ static void *ASVideoPlayerNodeContext = &ASVideoPlayerNodeContext;
       ASVideoPlayerNodeControlType type = (ASVideoPlayerNodeControlType)[object integerValue];
       switch (type) {
         case ASVideoPlayerNodeControlTypePlaybackButton:
-          [self createPlaybackButton];
+          [self _locked_createPlaybackButton];
           break;
         case ASVideoPlayerNodeControlTypeElapsedText:
-          [self createElapsedTextField];
+          [self _locked_createElapsedTextField];
           break;
         case ASVideoPlayerNodeControlTypeDurationText:
-          [self createDurationTextField];
+          [self _locked_createDurationTextField];
           break;
         case ASVideoPlayerNodeControlTypeScrubber:
-          [self createScrubber];
+          [self _locked_createScrubber];
           break;
         case ASVideoPlayerNodeControlTypeFullScreenButton:
-          [self createFullScreenButton];
+          [self _locked_createFullScreenButton];
           break;
         case ASVideoPlayerNodeControlTypeFlexGrowSpacer:
-          [self createControlFlexGrowSpacer];
+          [self _locked_createControlFlexGrowSpacer];
           break;
         default:
           break;
@@ -345,7 +345,7 @@ static void *ASVideoPlayerNodeContext = &ASVideoPlayerNodeContext;
   _scrubberNode = nil;
 }
 
-- (void)createPlaybackButton
+- (void)_locked_createPlaybackButton
 {
   if (_playbackButtonNode == nil) {
     _playbackButtonNode = [[ASDefaultPlaybackButton alloc] init];
@@ -368,7 +368,7 @@ static void *ASVideoPlayerNodeContext = &ASVideoPlayerNodeContext;
   [self addSubnode:_playbackButtonNode];
 }
 
-- (void)createFullScreenButton
+- (void)_locked_createFullScreenButton
 {
   if (_fullScreenButtonNode == nil) {
     _fullScreenButtonNode = [[ASButtonNode alloc] init];
@@ -385,7 +385,7 @@ static void *ASVideoPlayerNodeContext = &ASVideoPlayerNodeContext;
   [self addSubnode:_fullScreenButtonNode];
 }
 
-- (void)createElapsedTextField
+- (void)_locked_createElapsedTextField
 {
   if (_elapsedTextNode == nil) {
     _elapsedTextNode = [[ASTextNode alloc] init];
@@ -398,7 +398,7 @@ static void *ASVideoPlayerNodeContext = &ASVideoPlayerNodeContext;
   [self addSubnode:_elapsedTextNode];
 }
 
-- (void)createDurationTextField
+- (void)_locked_createDurationTextField
 {
   if (_durationTextNode == nil) {
     _durationTextNode = [[ASTextNode alloc] init];
@@ -412,7 +412,7 @@ static void *ASVideoPlayerNodeContext = &ASVideoPlayerNodeContext;
   [self addSubnode:_durationTextNode];
 }
 
-- (void)createScrubber
+- (void)_locked_createScrubber
 {
   if (_scrubberNode == nil) {
     __weak __typeof__(self) weakSelf = self;
@@ -456,7 +456,7 @@ static void *ASVideoPlayerNodeContext = &ASVideoPlayerNodeContext;
   [self addSubnode:_scrubberNode];
 }
 
-- (void)createControlFlexGrowSpacer
+- (void)_locked_createControlFlexGrowSpacer
 {
   if (_controlFlexGrowSpacerSpec == nil) {
     _controlFlexGrowSpacerSpec = [[ASStackLayoutSpec alloc] init];


### PR DESCRIPTION
To be able to enable asynchronous stack layout spec computation again as well as planned work around layout calculations within `ASDispayNode`, we need to improve our locking situation. This is a first small step by reviewing most of the `ASDisplayNode` subclasses and remove not needed locking.

Especially it's important to remove the lock calling superclass methods like `setNeedsLayout` and `setNeedsDisplay` etc.