### PR TITLE
[ASCellNode] Let superclass know if size change happened and it does not have an interaction delegate

### DIFF
--- a/Source/ASCellNode.mm
+++ b/Source/ASCellNode.mm
@@ -122,6 +122,8 @@
 {
   if (_interactionDelegate != nil) {
     [_interactionDelegate nodeDidInvalidateSize:self];
+  } else {
+    [super _locked_rootNodeDidInvalidateSize];
   }
 }
 
@@ -129,6 +131,8 @@
 {
   if (_interactionDelegate != nil) {
     [_interactionDelegate nodeDidInvalidateSize:self];
+  } else {
+    [super _layoutTransitionMeasurementDidFinish];
   }
 }
 


### PR DESCRIPTION
Cell nodes can be used without using it within a collection or table view. In this case if a size change happened we should call super as there is no interactionDelegate