### PR TITLE
[Layout] Check in layout transition if the supernode is still the node that is executing the transition

### DIFF
--- a/Source/Private/ASDisplayNodeInternal.h
+++ b/Source/Private/ASDisplayNodeInternal.h
@@ -224,6 +224,7 @@ FOUNDATION_EXPORT NSString * const ASRenderingEngineDidDisplayNodesScheduledBefo
 - (void)_insertSubnode:(ASDisplayNode *)subnode belowSubnode:(ASDisplayNode *)below;
 - (void)_insertSubnode:(ASDisplayNode *)subnode aboveSubnode:(ASDisplayNode *)above;
 - (void)_insertSubnode:(ASDisplayNode *)subnode atIndex:(NSInteger)idx;
+- (void)_removeFromSupernodeIfEqualTo:(ASDisplayNode *)supernode;
 - (void)_removeFromSupernode;
 
 // Private API for helper functions / unit tests.  Use ASDisplayNodeDisableHierarchyNotifications() to control this.

--- a/Source/Private/ASLayoutTransition.mm
+++ b/Source/Private/ASLayoutTransition.mm
@@ -125,7 +125,10 @@ static inline BOOL ASLayoutCanTransitionAsynchronous(ASLayout *layout) {
 
   ASDisplayNodeLogEvent(_node, @"removeSubnodes: %@", _removedSubnodes);
   for (ASDisplayNode *subnode in _removedSubnodes) {
-    [subnode _removeFromSupernode];
+    // In this case we should only remove the subnode if it's still a subnode of the _node that executes a layout transition.
+    // It can happen that a node already did a layout transition and added this subnode, in this case the subnode
+    // would be removed from the new node instead of _node
+    [subnode _removeFromSupernodeIfEqualTo:_node];
   }
 }
 


### PR DESCRIPTION
We have to check in subnode removals in a layout transition, if the supernode of the subnode is indeed still the node that executes the layout transition. It can happen that a node already did a layout transition and added this subnode, in this case the subnode would would be removed from the new node instead of the old node.

Resolves: #3019