### PR TITLE
Don't load collection/table node just to wait for updates to be committed

### DIFF
--- a/Source/ASCollectionNode.mm
+++ b/Source/ASCollectionNode.mm
@@ -519,7 +519,10 @@
 
 - (void)waitUntilAllUpdatesAreCommitted
 {
-  [self.view waitUntilAllUpdatesAreCommitted];
+  ASDisplayNodeAssertMainThread();
+  if (self.nodeLoaded) {
+    [self.view waitUntilAllUpdatesAreCommitted];
+  }
 }
 
 - (void)reloadDataWithCompletion:(void (^)())completion

--- a/Source/ASTableNode.mm
+++ b/Source/ASTableNode.mm
@@ -653,7 +653,10 @@ ASLayoutElementCollectionTableSetTraitCollection(_environmentStateLock)
 
 - (void)waitUntilAllUpdatesAreCommitted
 {
-  [self.view waitUntilAllUpdatesAreCommitted];
+  ASDisplayNodeAssertMainThread();
+  if (self.nodeLoaded) {
+    [self.view waitUntilAllUpdatesAreCommitted];
+  }
 }
 
 #pragma mark - Debugging (Private)


### PR DESCRIPTION
Because there would be no update otherwise.
This is a follow up on https://github.com/facebook/AsyncDisplayKit/pull/3120.