### PR TITLE
[ASImageProtocols] Fix nullables to avoid bridging crashes

### DIFF
--- a/Source/ASMultiplexImageNode.mm
+++ b/Source/ASMultiplexImageNode.mm
@@ -203,7 +203,10 @@ typedef void(^ASMultiplexImageLoadCompletionBlock)(UIImage *image, id imageIdent
   [self _setDownloadIdentifier:nil];
   
   if (_cacheSupportsClearing && self.loadedImageIdentifier != nil) {
-    [_cache clearFetchedImageFromCacheWithURL:[_dataSource multiplexImageNode:self URLForImageIdentifier:self.loadedImageIdentifier]];
+    NSURL *URL = [_dataSource multiplexImageNode:self URLForImageIdentifier:self.loadedImageIdentifier];
+    if (URL != nil) {
+      [_cache clearFetchedImageFromCacheWithURL:URL];
+    }
   }
 
   // setting this to nil makes the node fetch images the next time its display starts

--- a/Source/ASNetworkImageNode.mm
+++ b/Source/ASNetworkImageNode.mm
@@ -450,7 +450,7 @@ static const CGSize kMinReleaseImageOnBackgroundSize = {20.0, 20.0};
 {
   [self _cancelImageDownload];
   [self _clearImage];
-  if (_cacheFlags.cacheSupportsClearing) {
+  if (_cacheFlags.cacheSupportsClearing && _URL != nil) {
     [_cache clearFetchedImageFromCacheWithURL:_URL];
   }
 }
@@ -527,7 +527,9 @@ static const CGSize kMinReleaseImageOnBackgroundSize = {20.0, 20.0};
     }
     
     if (cancelAndReattempt) {
-      [_downloader cancelImageDownloadForIdentifier:downloadIdentifier];
+      if (downloadIdentifier != nil) {
+        [_downloader cancelImageDownloadForIdentifier:downloadIdentifier];
+      }
       [self _downloadImageWithCompletion:finished];
       return;
     }

--- a/Source/Details/ASBasicImageDownloader.mm
+++ b/Source/Details/ASBasicImageDownloader.mm
@@ -266,10 +266,6 @@ static const char *kContextKey = NSStringFromClass(ASBasicImageDownloaderContext
 
 - (void)cancelImageDownloadForIdentifier:(id)downloadIdentifier
 {
-  if (!downloadIdentifier) {
-    return;
-  }
-
   ASDisplayNodeAssert([downloadIdentifier isKindOfClass:ASBasicImageDownloaderContext.class], @"unexpected downloadIdentifier");
   ASBasicImageDownloaderContext *context = (ASBasicImageDownloaderContext *)downloadIdentifier;
 

--- a/Source/Details/ASImageProtocols.h
+++ b/Source/Details/ASImageProtocols.h
@@ -46,11 +46,11 @@ typedef void(^ASImageCacherCompletion)(id <ASImageContainerProtocol> _Nullable i
  is called to attempt to get the image out of the cache synchronously. This allows drawing to occur on the main thread
  if displaysAsynchronously is set to NO or recursivelyEnsureDisplaySynchronously: has been called.
  
- If `URL` is nil, `completion` will be invoked immediately with a nil image. This method *should* block
- the calling thread to fetch the image from a fast memory cache. It is OK to return nil from this method and instead
- support only cachedImageWithURL:callbackQueue:completion: however, synchronous rendering will not be possible.
+ This method *should* block the calling thread to fetch the image from a fast memory cache. It is OK to return nil from
+ this method and instead support only cachedImageWithURL:callbackQueue:completion: however, synchronous rendering will
+ not be possible.
  */
-- (nullable id <ASImageContainerProtocol>)synchronouslyFetchedCachedImageWithURL:(nullable NSURL *)URL;
+- (nullable id <ASImageContainerProtocol>)synchronouslyFetchedCachedImageWithURL:(NSURL *)URL;
 
 /**
  @abstract Called during clearPreloadedData. Allows the cache to optionally trim items.

--- a/Source/Details/ASPINRemoteImageDownloader.m
+++ b/Source/Details/ASPINRemoteImageDownloader.m
@@ -244,10 +244,6 @@ static ASPINRemoteImageDownloader *sharedDownloader = nil;
 
 - (void)cancelImageDownloadForIdentifier:(id)downloadIdentifier
 {
-  if (!downloadIdentifier) {
-    return;
-  }
-
   ASDisplayNodeAssert([downloadIdentifier isKindOfClass:[NSUUID class]], @"downloadIdentifier must be NSUUID");
   [[self sharedPINRemoteImageManager] cancelTaskWithUUID:downloadIdentifier];
 }


### PR DESCRIPTION
Hi guys,

Following #3112 I'm submitting this PR to solve the bridging crashes I was experiencing when implementing `ASImageCacheProtocol` in Swift.
A sample project showcasing the problem can be found here: https://github.com/flovouin/ASDK-ASImageCacheProtocolBridge
The problem is that `clearFetchedImageFromCacheWithURL` is sometimes called with a `nil` URL when it shouldn't.

So I double checked all the calls to `ASImageCacheProtocol` and `ASImageDownloaderProtocol` in the ASDK codebase and came up with the following PR.

- The first commit ensures that the image nodes never call the image protocols methods with a `nil` URL / identifier when they shouldn't. The only place where I am not entirely sure whether the URL can be `nil` is in the [ASNetworkImageNode](https://github.com/flovouin/AsyncDisplayKit/blob/d1e7759e7835521b2b1b9b00a9fae7bea7a70185/Source/ASNetworkImageNode.mm#L505). It would seem that `_downloadImageWithCompletion` is only called if `_URL != nil`, but as there's some multi thread funkyness happening, I'm not sure it is safe to assume. If someone who has more experience than me could review this part, that'd be nice :-)
- The second commit removes unnecessary checks for `nil` identifiers in image downloaders, as they are declared as `nonnull` in the protocol definitions.

@maicki was suggesting in #3112 to have `synchronouslyFetchedCachedImageWithURL` accept a `nullable` URL, which is actually already the case, although I'm not sure it really makes sense: why would you ask for the resource corresponding to a `nil` URL, especially if you already know the result? Also, this method is currently only called with a (explicitly checked) non-nil URL in the codebase. Finally, its documentation seems outdated as it references a `completion` block that does not exist in the method prototype. However I did not amend it for the time being, please tell me if you want me to do so :-) I personally would be in favour of making the URL argument `nonnull`.

This PR solves the crashes demonstrated by the sample project, but I'm willing to make more changes if you have any remarks!

Cheers,
Flo