### PR TITLE
Fix the Initialization Hierarchy

### DIFF
--- a/Source/ASCollectionNode.h
+++ b/Source/ASCollectionNode.h
@@ -29,6 +29,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface ASCollectionNode : ASDisplayNode <ASRangeControllerUpdateRangeProtocol>
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /**
  * Initializes an ASCollectionNode
  *

--- a/Source/ASCollectionNode.mm
+++ b/Source/ASCollectionNode.mm
@@ -138,8 +138,7 @@
   if (self = [super init]) {
     __weak __typeof__(self) weakSelf = self;
     [self setViewBlock:^{
-      // Variable will be unused if event logging is off.
-      __unused __typeof__(self) strongSelf = weakSelf;
+      __typeof__(self) strongSelf = weakSelf;
       return [[[strongSelf collectionViewClass] alloc] _initWithFrame:frame collectionViewLayout:layout layoutFacilitator:layoutFacilitator eventLog:ASDisplayNodeGetEventLog(strongSelf)];
     }];
   }

--- a/Source/ASCollectionNode.mm
+++ b/Source/ASCollectionNode.mm
@@ -123,14 +123,6 @@
   }
 }
 
-- (instancetype)init
-{
-  ASDISPLAYNODE_NOT_DESIGNATED_INITIALIZER();
-  UICollectionViewLayout *nilLayout = nil;
-  self = [self initWithCollectionViewLayout:nilLayout]; // Will throw an exception for lacking a UICV Layout.
-  return nil;
-}
-
 - (instancetype)initWithCollectionViewLayout:(UICollectionViewLayout *)layout
 {
   return [self initWithFrame:CGRectZero collectionViewLayout:layout layoutFacilitator:nil];
@@ -143,17 +135,15 @@
 
 - (instancetype)initWithFrame:(CGRect)frame collectionViewLayout:(UICollectionViewLayout *)layout layoutFacilitator:(id<ASCollectionViewLayoutFacilitatorProtocol>)layoutFacilitator
 {
-  __weak __typeof__(self) weakSelf = self;
-  ASDisplayNodeViewBlock collectionViewBlock = ^UIView *{
-    // Variable will be unused if event logging is off.
-    __unused __typeof__(self) strongSelf = weakSelf;
-    return [[[strongSelf collectionViewClass] alloc] _initWithFrame:frame collectionViewLayout:layout layoutFacilitator:layoutFacilitator eventLog:ASDisplayNodeGetEventLog(strongSelf)];
-  };
-
-  if (self = [super initWithViewBlock:collectionViewBlock didLoadBlock:nil]) {
-    return self;
+  if (self = [super init]) {
+    __weak __typeof__(self) weakSelf = self;
+    [self setViewBlock:^{
+      // Variable will be unused if event logging is off.
+      __unused __typeof__(self) strongSelf = weakSelf;
+      return [[[strongSelf collectionViewClass] alloc] _initWithFrame:frame collectionViewLayout:layout layoutFacilitator:layoutFacilitator eventLog:ASDisplayNodeGetEventLog(strongSelf)];
+    }];
   }
-  return nil;
+  return self;
 }
 
 #pragma mark ASDisplayNode

--- a/Source/ASDisplayNode.h
+++ b/Source/ASDisplayNode.h
@@ -125,7 +125,7 @@ extern NSInteger const ASDefaultDrawingPriority;
  * @return An ASDisplayNode instance whose view will be a subclass that enables asynchronous rendering, and passes 
  * through -layout and touch handling methods.
  */
-- (instancetype)init;
+- (instancetype)init NS_DESIGNATED_INITIALIZER;
 
 
 /**
@@ -182,6 +182,28 @@ extern NSInteger const ASDefaultDrawingPriority;
  *    that has `shouldRasterizeDescendants=YES`, and is unloaded, this block will not be called if it is loaded again.
  */
 - (void)onDidLoad:(ASDisplayNodeDidLoadBlock)body;
+
+/**
+ * Set the block that should be used to load this node's view.
+ *
+ * @param viewBlock The block that creates a view for this node.
+ *
+ * @precondition The node is not yet loaded.
+ *
+ * @note You will usually NOT call this. See the limitations documented in @c initWithViewBlock:
+ */
+- (void)setViewBlock:(ASDisplayNodeViewBlock)viewBlock;
+
+/**
+ * Set the block that should be used to load this node's layer.
+ *
+ * @param viewBlock The block that creates a layer for this node.
+ *
+ * @precondition The node is not yet loaded.
+ *
+ * @note You will usually NOT call this. See the limitations documented in @c initWithLayerBlock:
+ */
+- (void)setLayerBlock:(ASDisplayNodeLayerBlock)layerBlock;
 
 /** 
  * @abstract Returns whether the node is synchronous.

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -316,12 +316,11 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
 
 - (instancetype)initWithViewClass:(Class)viewClass
 {
-  if (!(self = [super init]))
+  if (!(self = [self init]))
     return nil;
 
   ASDisplayNodeAssert([viewClass isSubclassOfClass:[UIView class]], @"should initialize with a subclass of UIView");
 
-  [self _initializeInstance];
   _viewClass = viewClass;
   _flags.synchronous = ![viewClass isSubclassOfClass:[_ASDisplayView class]];
 
@@ -330,13 +329,12 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
 
 - (instancetype)initWithLayerClass:(Class)layerClass
 {
-  if (!(self = [super init])) {
+  if (!(self = [self init])) {
     return nil;
   }
 
   ASDisplayNodeAssert([layerClass isSubclassOfClass:[CALayer class]], @"should initialize with a subclass of CALayer");
 
-  [self _initializeInstance];
   _layerClass = layerClass;
   _flags.synchronous = ![layerClass isSubclassOfClass:[_ASDisplayLayer class]];
   _flags.layerBacked = YES;
@@ -346,26 +344,18 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
 
 - (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock
 {
-  return [self _initWithViewBlock:viewBlock didLoadBlock:nil];
-}
-- (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock didLoadBlock:(ASDisplayNodeDidLoadBlock)didLoadBlock
-{
-  return [self _initWithViewBlock:viewBlock didLoadBlock:didLoadBlock];
+  return [self initWithViewBlock:viewBlock didLoadBlock:nil];
 }
 
-- (instancetype)_initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock didLoadBlock:(ASDisplayNodeDidLoadBlock)didLoadBlock
+- (instancetype)initWithViewBlock:(ASDisplayNodeViewBlock)viewBlock didLoadBlock:(ASDisplayNodeDidLoadBlock)didLoadBlock
 {
-  if (!(self = [super init])) {
+  if (!(self = [self init])) {
     return nil;
   }
-  
-  ASDisplayNodeAssertNotNil(viewBlock, @"should initialize with a valid block that returns a UIView");
-  
-  [self _initializeInstance];
-  _viewBlock = viewBlock;
-  _flags.synchronous = YES;
+
+  [self setViewBlock:viewBlock];
   if (didLoadBlock != nil) {
-    _onDidLoadBlocks = [NSMutableArray arrayWithObject:didLoadBlock];
+    [self onDidLoad:didLoadBlock];
   }
   
   return self;
@@ -373,31 +363,40 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
 
 - (instancetype)initWithLayerBlock:(ASDisplayNodeLayerBlock)layerBlock
 {
-  return [self _initWithLayerBlock:layerBlock didLoadBlock:nil];
+  return [self initWithLayerBlock:layerBlock didLoadBlock:nil];
 }
 
 - (instancetype)initWithLayerBlock:(ASDisplayNodeLayerBlock)layerBlock didLoadBlock:(ASDisplayNodeDidLoadBlock)didLoadBlock
 {
-  return [self _initWithLayerBlock:layerBlock didLoadBlock:didLoadBlock];
-}
-
-- (instancetype)_initWithLayerBlock:(ASDisplayNodeLayerBlock)layerBlock didLoadBlock:(ASDisplayNodeDidLoadBlock)didLoadBlock
-{
-  if (!(self = [super init])) {
+  if (!(self = [self init])) {
     return nil;
   }
   
-  ASDisplayNodeAssertNotNil(layerBlock, @"should initialize with a valid block that returns a CALayer");
-  
-  [self _initializeInstance];
-  _layerBlock = layerBlock;
-  _flags.synchronous = YES;
-  _flags.layerBacked = YES;
+  [self setLayerBlock:layerBlock];
   if (didLoadBlock != nil) {
-    _onDidLoadBlocks = [NSMutableArray arrayWithObject:didLoadBlock];
+    [self onDidLoad:didLoadBlock];
   }
   
   return self;
+}
+
+- (void)setViewBlock:(ASDisplayNodeViewBlock)viewBlock
+{
+  ASDisplayNodeAssertFalse(self.nodeLoaded);
+  ASDisplayNodeAssertNotNil(viewBlock, @"should initialize with a valid block that returns a UIView");
+
+  _viewBlock = viewBlock;
+  _flags.synchronous = YES;
+}
+
+- (void)setLayerBlock:(ASDisplayNodeLayerBlock)layerBlock
+{
+  ASDisplayNodeAssertFalse(self.nodeLoaded);
+  ASDisplayNodeAssertNotNil(layerBlock, @"should initialize with a valid block that returns a CALayer");
+
+  _layerBlock = layerBlock;
+  _flags.synchronous = YES;
+  _flags.layerBacked = YES;
 }
 
 - (void)onDidLoad:(ASDisplayNodeDidLoadBlock)body

--- a/Source/ASScrollNode.mm
+++ b/Source/ASScrollNode.mm
@@ -64,7 +64,10 @@
 
 - (instancetype)init
 {
-  return [super initWithViewBlock:^UIView *{ return [[ASScrollView alloc] init]; }];
+  if (self = [super init]) {
+    [self setViewBlock:^UIView *{ return [[ASScrollView alloc] init]; }];
+  }
+  return self;
 }
 
 - (ASLayout *)calculateLayoutThatFits:(ASSizeRange)constrainedSize

--- a/Source/ASTableNode.h
+++ b/Source/ASTableNode.h
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ASTableNode : ASDisplayNode <ASRangeControllerUpdateRangeProtocol>
 
 - (instancetype)init; // UITableViewStylePlain
-- (instancetype)initWithStyle:(UITableViewStyle)style;
+- (instancetype)initWithStyle:(UITableViewStyle)style NS_DESIGNATED_INITIALIZER;
 
 @property (strong, nonatomic, readonly) ASTableView *view;
 

--- a/Source/ASTableNode.mm
+++ b/Source/ASTableNode.mm
@@ -72,40 +72,22 @@
 
 #pragma mark Lifecycle
 
-- (instancetype)_initWithTableView:(ASTableView *)tableView
-{
-  // Avoid a retain cycle.  In this case, the ASTableView is creating us, and strongly retains us.
-  ASTableView * __weak weakTableView = tableView;
-  if (self = [super initWithViewBlock:^UIView *{ return weakTableView; }]) {
-    __unused __weak ASTableView *view = [self view];
-    return self;
-  }
-  return nil;
-}
-
-- (instancetype)_initWithFrame:(CGRect)frame style:(UITableViewStyle)style dataControllerClass:(Class)dataControllerClass
-{
-  __weak __typeof__(self) weakSelf = self;
-  ASDisplayNodeViewBlock tableViewBlock = ^UIView *{
-    // Variable will be unused if event logging is off.
-    __unused __typeof__(self) strongSelf = weakSelf;
-    return [[ASTableView alloc] _initWithFrame:frame style:style dataControllerClass:dataControllerClass eventLog:ASDisplayNodeGetEventLog(strongSelf)];
-  };
-
-  if (self = [super initWithViewBlock:tableViewBlock]) {
-    return self;
-  }
-  return nil;
-}
-
 - (instancetype)initWithStyle:(UITableViewStyle)style
 {
-  return [self _initWithFrame:CGRectZero style:style dataControllerClass:nil];
+  if (self = [super init]) {
+    __weak __typeof__(self) weakSelf = self;
+    [self setViewBlock:^{
+      // Variable will be unused if event logging is off.
+      __unused __typeof__(self) strongSelf = weakSelf;
+      return [[ASTableView alloc] _initWithFrame:CGRectZero style:style dataControllerClass:nil eventLog:ASDisplayNodeGetEventLog(strongSelf)];
+    }];
+  }
+  return self;
 }
 
 - (instancetype)init
 {
-  return [self _initWithFrame:CGRectZero style:UITableViewStylePlain dataControllerClass:nil];
+  return [self initWithStyle:UITableViewStylePlain];
 }
 
 #pragma mark ASDisplayNode

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -121,10 +121,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
 #pragma mark -
 #pragma mark ASTableView
 
-@interface ASTableNode ()
-- (instancetype)_initWithTableView:(ASTableView *)tableView;
-@end
-
 @interface ASTableView () <ASRangeControllerDataSource, ASRangeControllerDelegate, ASDataControllerSource, _ASTableViewCellDelegate, ASCellNodeInteractionDelegate, ASDelegateProxyInterceptor, ASBatchFetchingScrollView, ASDataControllerEnvironmentDelegate>
 {
   ASTableViewProxy *_proxyDataSource;

--- a/Source/Private/ASDisplayNodeInternal.h
+++ b/Source/Private/ASDisplayNodeInternal.h
@@ -240,10 +240,10 @@ FOUNDATION_EXPORT NSString * const ASRenderingEngineDidDisplayNodesScheduledBefo
 - (void)displayImmediately;
 
 /// Alternative initialiser for backing with a custom view class.  Supports asynchronous display with _ASDisplayView subclasses.
-- (nullable instancetype)initWithViewClass:(Class)viewClass;
+- (instancetype)initWithViewClass:(Class)viewClass;
 
 /// Alternative initialiser for backing with a custom layer class.  Supports asynchronous display with _ASDisplayLayer subclasses.
-- (nullable instancetype)initWithLayerClass:(Class)layerClass;
+- (instancetype)initWithLayerClass:(Class)layerClass;
 
 @property (nonatomic, assign) CGFloat contentsScaleForDisplay;
 

--- a/examples/Swift/Sample/TailLoadingCellNode.swift
+++ b/examples/Swift/Sample/TailLoadingCellNode.swift
@@ -55,7 +55,10 @@ final class SpinnerNode: ASDisplayNode {
   }
 
   override init() {
-    super.init(viewBlock: { UIActivityIndicatorView(activityIndicatorStyle: .Gray) }, didLoadBlock: nil)
+    super.init()
+    setViewBlock {
+        UIActivityIndicatorView(activityIndicatorStyle: .Gray)
+    }
     
     // Set spinner node to default size of the activitiy indicator view
     self.style.preferredSize = CGSizeMake(20.0, 20.0)


### PR DESCRIPTION
- Make `init` the designated initializer for `ASDisplayNode`.
- Add `setViewBlock:` and `setLayerBlock:` methods so that subclasses don't have to call `[super initWithNodeBlock:]` since now they are not allowed to.
- In the future we could deprecate `initWithViewBlock:` and `initWithLayerBlock:` since they now just call `setViewBlock:` and since the `didLoad:` argument can be replaced by calling `onDidLoad:` immediately after.
- Breaks anyone who calls `[super initWithViewBlock:]` but they can easily just replace with `[super init]; [self setViewBlock:]`.