### PR TITLE
Avoid multiple initial data loads being issued by UICollectionView/UITableView

### DIFF
--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -141,6 +141,8 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
    */
   NSInteger _batchUpdateCount;
   
+  BOOL _initialReloadDataHasBeenCalled;
+  
   struct {
     unsigned int scrollViewDidScroll:1;
     unsigned int scrollViewWillBeginDragging:1;
@@ -316,6 +318,13 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
 - (void)reloadDataWithCompletion:(void (^)())completion
 {
   ASDisplayNodeAssertMainThread();
+  
+  if (! _initialReloadDataHasBeenCalled) {
+    // If this is the first reload, forward to super immediately to prevent it from triggering more "initial" loads while our data controller is working.
+    _initialReloadDataHasBeenCalled = YES;
+    _superIsPendingDataLoad = YES;
+    [super reloadData];
+  }
   
   void (^batchUpdatesCompletion)(BOOL);
   if (completion) {

--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -141,8 +141,6 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
    */
   NSInteger _batchUpdateCount;
   
-  BOOL _initialReloadDataHasBeenCalled;
-  
   struct {
     unsigned int scrollViewDidScroll:1;
     unsigned int scrollViewWillBeginDragging:1;
@@ -319,9 +317,8 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
 {
   ASDisplayNodeAssertMainThread();
   
-  if (! _initialReloadDataHasBeenCalled) {
+  if (! _dataController.initialReloadDataHasBeenCalled) {
     // If this is the first reload, forward to super immediately to prevent it from triggering more "initial" loads while our data controller is working.
-    _initialReloadDataHasBeenCalled = YES;
     _superIsPendingDataLoad = YES;
     [super reloadData];
   }

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -181,8 +181,6 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
    */
   NSInteger _batchUpdateCount;
   
-  BOOL _initialReloadDataHasBeenCalled;
-  
   struct {
     unsigned int scrollViewDidScroll:1;
     unsigned int scrollViewWillBeginDragging:1;
@@ -485,9 +483,8 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
 {
   ASDisplayNodeAssertMainThread();
   
-  if (! _initialReloadDataHasBeenCalled) {
+  if (! _dataController.initialReloadDataHasBeenCalled) {
     // If this is the first reload, forward to super immediately to prevent it from triggering more "initial" loads while our data controller is working. 
-    _initialReloadDataHasBeenCalled = YES;
     [super reloadData];
   }
   

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -181,6 +181,8 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
    */
   NSInteger _batchUpdateCount;
   
+  BOOL _initialReloadDataHasBeenCalled;
+  
   struct {
     unsigned int scrollViewDidScroll:1;
     unsigned int scrollViewWillBeginDragging:1;
@@ -482,6 +484,12 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
 - (void)reloadDataWithCompletion:(void (^)())completion
 {
   ASDisplayNodeAssertMainThread();
+  
+  if (! _initialReloadDataHasBeenCalled) {
+    // If this is the first reload, forward to super immediately to prevent it from triggering more "initial" loads while our data controller is working. 
+    _initialReloadDataHasBeenCalled = YES;
+    [super reloadData];
+  }
   
   void (^batchUpdatesCompletion)(BOOL);
   if (completion) {

--- a/Tests/ASTableViewTests.mm
+++ b/Tests/ASTableViewTests.mm
@@ -608,7 +608,8 @@
 
   // Assert that the beginning of the call pattern is correct.
   // There is currently noise that comes after that we will allow for this test.
-  NSArray *expectedSelectors = @[ NSStringFromSelector(@selector(reloadData)) ];
+  NSArray *expectedSelectors = @[ NSStringFromSelector(@selector(reloadData)),
+                                  NSStringFromSelector(@selector(reloadData)) ];
   XCTAssertEqualObjects(selectors, expectedSelectors);
 
   [UITableView deswizzleAllInstanceMethods];

--- a/Tests/ASTableViewTests.mm
+++ b/Tests/ASTableViewTests.mm
@@ -606,8 +606,8 @@
   [node waitUntilAllUpdatesAreCommitted];
   XCTAssertGreaterThan(node.view.numberOfSections, 0);
 
-  // Assert that the beginning of the call pattern is correct.
-  // There is currently noise that comes after that we will allow for this test.
+  // The first reloadData call helps prevent UITableView from calling it multiple times while ASDataController is working.
+  // The second reloadData call is the real one.
   NSArray *expectedSelectors = @[ NSStringFromSelector(@selector(reloadData)),
                                   NSStringFromSelector(@selector(reloadData)) ];
   XCTAssertEqualObjects(selectors, expectedSelectors);


### PR DESCRIPTION
- Currently, there is a gap between the moment UICollectionView/UITableView triggers its first data load and when ASDataController finishes processing it. During this gap, the view keeps issuing "initial" loads by calling reloadData and causes its data controller to reload multiple times.
- Fix by immediately forward the first reloadData call to UICollectionView/UITableView before letting its data controller to handle it for real. During the gap, the view thinks that it loaded initial data but is empty, and thus stops triggering initial loads. Once the data controller finished loading, it will call another reloadData on the view which causes the view to swap to a correct state.