### PR TITLE
[ASTextNode] Reset _composedTruncationText when attributedText is updated

### DIFF
--- a/Source/ASTextNode.mm
+++ b/Source/ASTextNode.mm
@@ -392,7 +392,6 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
       return;
     }
 
-    _composedTruncationText = DefaultTruncationAttributedString();
     _attributedText = ASCleanseAttributedStringOfCoreTextAttributes(attributedText);
 #if AS_TEXTNODE_RECORD_ATTRIBUTED_STRINGS
 	  [ASTextNode _registerAttributedText:_attributedText];
@@ -1293,7 +1292,7 @@ static NSAttributedString *DefaultTruncationAttributedString()
 {
   //If we have neither return the default
   if (!_additionalTruncationMessage && !_truncationAttributedText) {
-    return _composedTruncationText;
+    return DefaultTruncationAttributedString();
   }
   // Short circuit if we only have one or the other.
   if (!_additionalTruncationMessage) {

--- a/Source/ASTextNode.mm
+++ b/Source/ASTextNode.mm
@@ -392,6 +392,7 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
       return;
     }
 
+    _composedTruncationText = DefaultTruncationAttributedString();
     _attributedText = ASCleanseAttributedStringOfCoreTextAttributes(attributedText);
 #if AS_TEXTNODE_RECORD_ATTRIBUTED_STRINGS
 	  [ASTextNode _registerAttributedText:_attributedText];


### PR DESCRIPTION
Current issue:
1) Set `attributedText` in `ASTextNode` with whiteColor
2) `_composedTruncationText` gets updated to take on this new color attribute
3) Set the `attributedText` with greenColor
4) The `_composedTruncationText` gets updated with the new attributes, but does NOT overwrite any existing attributes — i.e., does not overwrite the white color with green. Comment from `_locked_prepareTruncationStringForDrawing:`:
```
// Add any of the original string's attributes to the truncation string,
// but don't overwrite any of the truncation string's attributes
```