### PR TITLE
Simplify composedTruncationText Logic

### DIFF
--- a/Source/ASTextNode.mm
+++ b/Source/ASTextNode.mm
@@ -177,7 +177,6 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
     self.needsDisplayOnBoundsChange = YES;
 
     _truncationMode = NSLineBreakByWordWrapping;
-    _composedTruncationText = DefaultTruncationAttributedString();
 
     // The common case is for a text node to be non-opaque and blended over some background.
     self.opaque = NO;
@@ -288,7 +287,7 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
   
   return {
     .attributedString = _attributedText,
-    .truncationAttributedString = _composedTruncationText,
+    .truncationAttributedString = [self _locked_composedTruncationText],
     .lineBreakMode = _truncationMode,
     .maximumNumberOfLines = _maximumNumberOfLines,
     .exclusionPaths = _exclusionPaths,
@@ -401,7 +400,7 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
   // Sync the truncation string with attributes from the updated _attributedString
   // Without this, the size calculation of the text with truncation applied will
   // not take into account the attributes of attributedText in the last line
-  [self _updateComposedTruncationText];
+  [self _invalidateTruncationText];
   
   NSUInteger length = attributedText.length;
   if (length > 0) {
@@ -1248,16 +1247,13 @@ static NSAttributedString *DefaultTruncationAttributedString()
 
 #pragma mark - Truncation Message
 
-- (void)_updateComposedTruncationText
-{
-  ASDN::MutexLocker l(__instanceLock__);
-  
-  _composedTruncationText = [self _locked_prepareTruncationStringForDrawing:[self _locked_composedTruncationText]];
-}
-
 - (void)_invalidateTruncationText
 {
-  [self _updateComposedTruncationText];
+  {
+    ASDN::MutexLocker l(__instanceLock__);
+    _composedTruncationText = nil;
+  }
+
   [self setNeedsDisplay];
 }
 
@@ -1290,25 +1286,22 @@ static NSAttributedString *DefaultTruncationAttributedString()
  */
 - (NSAttributedString *)_locked_composedTruncationText
 {
-  //If we have neither return the default
-  if (!_additionalTruncationMessage && !_truncationAttributedText) {
-    return DefaultTruncationAttributedString();
+  if (_composedTruncationText == nil) {
+    if (_truncationAttributedText != nil && _additionalTruncationMessage != nil) {
+      NSMutableAttributedString *newComposedTruncationString = [[NSMutableAttributedString alloc] initWithAttributedString:_truncationAttributedText];
+      [newComposedTruncationString.mutableString appendString:@" "];
+      [newComposedTruncationString appendAttributedString:_additionalTruncationMessage];
+      _composedTruncationText = newComposedTruncationString;
+    } else if (_truncationAttributedText != nil) {
+      _composedTruncationText = _truncationAttributedText;
+    } else if (_additionalTruncationMessage != nil) {
+      _composedTruncationText = _additionalTruncationMessage;
+    } else {
+      _composedTruncationText = DefaultTruncationAttributedString();
+    }
+    _composedTruncationText = [self _locked_prepareTruncationStringForDrawing:_composedTruncationText];
   }
-  // Short circuit if we only have one or the other.
-  if (!_additionalTruncationMessage) {
-    return _truncationAttributedText;
-  }
-  if (!_truncationAttributedText) {
-    return _additionalTruncationMessage;
-  }
-
-  // If we've reached this point, both _additionalTruncationMessage and
-  // _truncationAttributedText are present.  Compose them.
-
-  NSMutableAttributedString *newComposedTruncationString = [[NSMutableAttributedString alloc] initWithAttributedString:_truncationAttributedText];
-  [newComposedTruncationString replaceCharactersInRange:NSMakeRange(newComposedTruncationString.length, 0) withString:@" "];
-  [newComposedTruncationString appendAttributedString:_additionalTruncationMessage];
-  return newComposedTruncationString;
+  return _composedTruncationText;
 }
 
 /**

--- a/Source/ASTextNode.mm
+++ b/Source/ASTextNode.mm
@@ -397,9 +397,7 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
 #endif
   }
     
-  // Sync the truncation string with attributes from the updated _attributedString
-  // Without this, the size calculation of the text with truncation applied will
-  // not take into account the attributes of attributedText in the last line
+  // Since truncation text matches style of attributedText, invalidate it now.
   [self _invalidateTruncationText];
   
   NSUInteger length = attributedText.length;


### PR DESCRIPTION
- `_locked_composedTruncationText` is a lazy getter for the ivar `_composedTruncationText`
- When it changes, call `_invalidateTruncationText`
- Never access `_composedTruncationText` ivar directly.