### PR TITLE
Tiny: Make the Run Loop Source Context on Stack, Not Heap

### DIFF
--- a/Source/ASRunLoopQueue.mm
+++ b/Source/ASRunLoopQueue.mm
@@ -189,16 +189,13 @@ static void runLoopSourceCallback(void *info) {
     
     // It is not guaranteed that the runloop will turn if it has no scheduled work, and this causes processing of
     // the queue to stop. Attaching a custom loop source to the run loop and signal it if new work needs to be done
-    CFRunLoopSourceContext *runLoopSourceContext = (CFRunLoopSourceContext *)calloc(1, sizeof(CFRunLoopSourceContext));
-    if (runLoopSourceContext) {
-      runLoopSourceContext->perform = runLoopSourceCallback;
+    CFRunLoopSourceContext sourceContext = {};
+    sourceContext.perform = runLoopSourceCallback;
 #if ASRunLoopQueueLoggingEnabled
-      runLoopSourceContext->info = (__bridge void *)self;
+    sourceContext.info = (__bridge void *)self;
 #endif
-      _runLoopSource = CFRunLoopSourceCreate(NULL, 0, runLoopSourceContext);
-      CFRunLoopAddSource(runloop, _runLoopSource, kCFRunLoopCommonModes);
-      free(runLoopSourceContext);
-    }
+    _runLoopSource = CFRunLoopSourceCreate(NULL, 0, &sourceContext);
+    CFRunLoopAddSource(runloop, _runLoopSource, kCFRunLoopCommonModes);
 
 #if ASRunLoopQueueLoggingEnabled
     _runloopQueueLoggingTimer = [NSTimer timerWithTimeInterval:1.0 target:self selector:@selector(checkRunLoop) userInfo:nil repeats:YES];


### PR DESCRIPTION
Just saw this while working on another problem. Little freebie.