### PR TITLE
Add Support for the Run Loop Queue to be Weak

### DIFF
--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -2066,7 +2066,8 @@ NSString * const ASRenderingEngineDidDisplayNodesScheduledBeforeTimestamp = @"AS
   static ASRunLoopQueue<ASDisplayNode *> *renderQueue;
   dispatch_once(&onceToken, ^{
     renderQueue = [[ASRunLoopQueue<ASDisplayNode *> alloc] initWithRunLoop:CFRunLoopGetMain()
-                                                                andHandler:^(ASDisplayNode * _Nonnull dequeuedItem, BOOL isQueueDrained) {
+                                                             retainObjects:NO
+                                                                   handler:^(ASDisplayNode * _Nonnull dequeuedItem, BOOL isQueueDrained) {
       [dequeuedItem _recursivelyTriggerDisplayAndBlock:NO];
       if (isQueueDrained) {
         CFTimeInterval timestamp = CACurrentMediaTime();

--- a/Source/ASDisplayNodeExtras.mm
+++ b/Source/ASDisplayNodeExtras.mm
@@ -24,7 +24,7 @@ extern void ASPerformMainThreadDeallocation(_Nullable id object)
   static ASRunLoopQueue *queue;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
-    queue = [[ASRunLoopQueue alloc] initWithRunLoop:CFRunLoopGetMain() andHandler:nil];
+    queue = [[ASRunLoopQueue alloc] initWithRunLoop:CFRunLoopGetMain() retainObjects:YES handler:nil];
     queue.batchSize = 10;
   });
   if (object != nil) {

--- a/Source/ASRunLoopQueue.h
+++ b/Source/ASRunLoopQueue.h
@@ -22,6 +22,7 @@ AS_SUBCLASSING_RESTRICTED
  * Create a new queue with the given run loop and handler.
  *
  * @param runloop The run loop that will drive this queue.
+ * @param retainsObjects Whether the queue should retain its objects.
  * @param handlerBlock An optional block to be run for each enqueued object.
  *
  * @discussion You may pass @c nil for the handler if you simply want the objects to
@@ -30,7 +31,8 @@ AS_SUBCLASSING_RESTRICTED
  * worker thread with its own run loop.
  */
 - (instancetype)initWithRunLoop:(CFRunLoopRef)runloop
-                     andHandler:(nullable void(^)(ObjectType dequeuedItem, BOOL isQueueDrained))handlerBlock;
+                  retainObjects:(BOOL)retainsObjects
+                        handler:(nullable void(^)(ObjectType dequeuedItem, BOOL isQueueDrained))handlerBlock;
 
 - (void)enqueue:(ObjectType)object;
 

--- a/Source/ASRunLoopQueue.mm
+++ b/Source/ASRunLoopQueue.mm
@@ -256,8 +256,8 @@ static void runLoopSourceCallback(void *info) {
 
     /**
      * For each item in the next batch, if it's non-nil then NULL it out
-     * and if itemsToProcess != nil (that is, we have an execution block)
-     * then add it in. This could be written a bunch of different ways but
+     * and if we have an execution block then add it in.
+     * This could be written a bunch of different ways but
      * this particular one nicely balances readability, safety, and efficiency.
      */
     NSInteger foundItemCount = 0;


### PR DESCRIPTION
- Save resources when nodes are discarded before being displayed.
- Fixes crashes when table nodes/collection nodes are laid out after their dataSource/delegate are deallocated. We could fix this at a lower level, but this is a good place to do it.