### PR TITLE
Avoid adding nil element which represents an unsupported decoration view

### DIFF
--- a/Source/Details/ASCollectionViewLayoutController.m
+++ b/Source/Details/ASCollectionViewLayoutController.m
@@ -85,10 +85,10 @@ typedef struct ASRangeGeometry ASRangeGeometry;
     
     // Avoid excessive retains and releases, as well as property calls. We know the element is kept alive by map.
     __unsafe_unretained ASCollectionElement *e = [map elementForLayoutAttributes:la];
-    if (intersectsDisplay) {
+    if (e != nil && intersectsDisplay) {
       [display addObject:e];
     }
-    if (intersectsPreload) {
+    if (e != nil && intersectsPreload) {
       [preload addObject:e];
     }
   }


### PR DESCRIPTION
Stack-trace:

```
[Thread 0] Fatal Exception: NSInvalidArgumentException
*** -[__NSSetM addObject:]: object cannot be nil
  0 CoreFoundation                 6465999288 __exceptionPreprocess + 0
  1 libobjc.A.dylib                6443156828 objc_exception_throw + 0
  2 CoreFoundation                 6464833564 -[__NSCFString fastestEncoding] + 0
> 3 Pinterest                      4302733028 -[ASCollectionViewLayoutController allElementsForScrolling:rangeMode:displaySet:preloadSet:map:] (ASCollectionViewLayoutController.m:89)
  4 Pinterest                      4303028176 -[ASRangeController _updateVisibleNodeIndexPaths] (ASRangeController.mm:255)
  5 Pinterest                      4302712760 -[ASCollectionView layoutSubviews] (ASCollectionView.mm:1424)
  6 UIKit                          6565268096 -[UIView(CALayerDelegate) layoutSublayersOfLayer:] + 0
  7 QuartzCore                     6519843288 -[CALayer layoutSublayers] + 0
```