### PR TITLE
Fix locking situation of layout transition

### DIFF
--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -1305,13 +1305,18 @@ ASLayoutElementFinalLayoutElementDefault
 - (void)_setCalculatedDisplayNodeLayout:(std::shared_ptr<ASDisplayNodeLayout>)displayNodeLayout
 {
   ASDN::MutexLocker l(__instanceLock__);
-  
+  [self _locked_setCalculatedDisplayNodeLayout:displayNodeLayout];
+}
+
+- (void)_locked_setCalculatedDisplayNodeLayout:(std::shared_ptr<ASDisplayNodeLayout>)displayNodeLayout
+{
   ASDisplayNodeAssertTrue(displayNodeLayout->layout.layoutElement == self);
   ASDisplayNodeAssertTrue(displayNodeLayout->layout.size.width >= 0.0);
   ASDisplayNodeAssertTrue(displayNodeLayout->layout.size.height >= 0.0);
   
   _calculatedDisplayNodeLayout = displayNodeLayout;
 }
+
 
 - (CGSize)calculatedSize
 {
@@ -1533,22 +1538,35 @@ ASLayoutElementFinalLayoutElementDefault
     }
     
     ASPerformBlockOnMainThread(^{
-      // Grab __instanceLock__ here to make sure this transition isn't invalidated
-      // right after it passed the validation test and before it proceeds
-      ASDN::MutexLocker l(__instanceLock__);
-
-      if ([self _shouldAbortTransitionWithID:transitionID]) {
-        return;
+      ASLayoutTransition *pendingLayoutTransition;
+      _ASTransitionContext *pendingLayoutTransitionContext;
+      {
+        // Grab __instanceLock__ here to make sure this transition isn't invalidated
+        // right after it passed the validation test and before it proceeds
+        ASDN::MutexLocker l(__instanceLock__);
+        
+        if ([self _locked_shouldAbortTransitionWithID:transitionID]) {
+          return;
+        }
+        
+        // Update calculated layout
+        auto previousLayout = _calculatedDisplayNodeLayout;
+        auto pendingLayout = std::make_shared<ASDisplayNodeLayout>(
+                                                                   newLayout,
+                                                                   constrainedSize,
+                                                                   constrainedSize.max
+                                                                   );
+        [self _locked_setCalculatedDisplayNodeLayout:pendingLayout];
+        
+        // Setup pending layout transition for animation
+        _pendingLayoutTransition = pendingLayoutTransition = [[ASLayoutTransition alloc] initWithNode:self
+                                                                                        pendingLayout:pendingLayout
+                                                                                       previousLayout:previousLayout];
+        // Setup context for pending layout transition. we need to hold a strong reference to the context
+        _pendingLayoutTransitionContext = pendingLayoutTransitionContext = [[_ASTransitionContext alloc] initWithAnimation:animated
+                                                                                                            layoutDelegate:_pendingLayoutTransition
+                                                                                                        completionDelegate:self];
       }
-
-      // Update calculated layout
-      auto previousLayout = _calculatedDisplayNodeLayout;
-      auto pendingLayout = std::make_shared<ASDisplayNodeLayout>(
-        newLayout,
-        constrainedSize,
-        constrainedSize.max
-      );
-      [self _setCalculatedDisplayNodeLayout:pendingLayout];
       
       // Apply complete layout transitions for all subnodes
       ASDisplayNodePerformBlockOnEverySubnode(self, NO, ^(ASDisplayNode * _Nonnull node) {
@@ -1563,20 +1581,11 @@ ASLayoutElementFinalLayoutElementDefault
         completion();
       }
       
-      // Setup pending layout transition for animation
-      _pendingLayoutTransition = [[ASLayoutTransition alloc] initWithNode:self
-                                                            pendingLayout:pendingLayout
-                                                           previousLayout:previousLayout];
-      // Setup context for pending layout transition. we need to hold a strong reference to the context
-      _pendingLayoutTransitionContext = [[_ASTransitionContext alloc] initWithAnimation:animated
-                                                                         layoutDelegate:_pendingLayoutTransition
-                                                                     completionDelegate:self];
-      
       // Apply the subnode insertion immediately to be able to animate the nodes
-      [_pendingLayoutTransition applySubnodeInsertions];
+      [pendingLayoutTransition applySubnodeInsertions];
       
       // Kick off animating the layout transition
-      [self animateLayoutTransition:_pendingLayoutTransitionContext];
+      [self animateLayoutTransition:pendingLayoutTransitionContext];
       
       // Mark transaction as finished
       [self _finishOrCancelTransition];
@@ -1662,6 +1671,11 @@ ASLayoutElementFinalLayoutElementDefault
 - (BOOL)_shouldAbortTransitionWithID:(int32_t)transitionID
 {
   ASDN::MutexLocker l(__instanceLock__);
+  return [self _locked_shouldAbortTransitionWithID:transitionID];
+}
+
+- (BOOL)_locked_shouldAbortTransitionWithID:(int32_t)transitionID
+{
   return (!_transitionInProgress || _transitionID != transitionID);
 }
 


### PR DESCRIPTION
- It's not safe to hold the lock of a supernode and:
  - Edit states of its subnodes
  - Call subclass hooks
  - Run completion block
  - Run animation, which can trigger layout passes on subnodes. Especially dangerous if one of them is a collection view because the layout pass can cause a change set update if it's the first pass.

This should fix https://jira.pinadmin.com/browse/BUG-53093

```
[Thread 0] Crashed: com.apple.main-thread
SIGABRT ABORT 0x000000001dc1f89c
  0 libsystem_kernel.dylib         499251356  semaphore_wait_trap + 8
  1 libdispatch.dylib              498348313  _dispatch_group_wait_slow + 234
> 2 Pinterest                      6453191    -[ASDataController updateWithChangeSet:] (ASDataController.mm:444)
  3 Pinterest                      6389189    -[ASCollectionView endUpdatesAnimated:completion:] (ASCollectionView.mm:791)
  4 Pinterest                      6389441    -[ASCollectionView performBatchAnimated:updates:completion:] (ASCollectionView.mm:803)
  5 Pinterest                      6389689    -[ASCollectionView performBatchUpdates:completion:] (ASCollectionView.mm:809)
  6 Pinterest                      6376343    -[ASCollectionView reloadDataWithCompletion:] (ASCollectionView.mm:330)
  7 UIKit                          594195201  -[UICollectionView numberOfSections] + 22
  8 UIKit                          601801303  -[UICollectionViewFlowLayout _getSizingInfosWithExistingSizingDictionary:] + 750
  9 UIKit                          601809707  -[UICollectionViewFlowLayout _fetchItemsInfoForRect:] + 136
 10 UIKit                          594194993  -[UICollectionViewFlowLayout prepareLayout] + 224
 11 UIKit                          593058551  -[UICollectionViewData _prepareToLoadData] + 164
 12 UIKit                          593055787  -[UICollectionViewData validateLayoutInRect:] + 72
 13 UIKit                          593054129  -[UICollectionView layoutSubviews] + 296
 14 Pinterest                      6408361    -[ASCollectionView layoutSubviews] (ASCollectionView.mm:1414)
 15 UIKit                          592666029  -[UIView(CALayerDelegate) layoutSublayersOfLayer:] + 1290
 16 QuartzCore                     557094977  -[CALayer layoutSublayers] + 126
 17 Pinterest                      6249269    -[_ASDisplayLayer layoutSublayers] (_ASDisplayLayer.mm:132)
 18 QuartzCore                     557045647  CA::Layer::layout_if_needed(CA::Transaction*) + 354
 19 QuartzCore                     557045279  CA::Layer::layout_and_display_if_needed(CA::Transaction*) + 16
 20 QuartzCore                     556589763  CA::Context::commit_transaction(CA::Transaction*) + 370
 21 QuartzCore                     556714933  CA::Transaction::commit() + 564
 22 UIKit                          597521413  __68+[UIScreen _beginDisableScreenUpdatesForSnapshotUsingSnapshotCover:]_block_invoke + 32
 23 UIKit                          595347643  -[UIApplication _performWithUICACommitStateSnapshotting:] + 738
 24 UIKit                          597521349  +[UIScreen _beginDisableScreenUpdatesForSnapshotUsingSnapshotCover:] + 426
 25 UIKit                          595713583  __73-[UIView resizableSnapshotViewFromRect:afterScreenUpdates:withCapInsets:]_block_invoke + 86
 26 UIKit                          595797737  +[_UIReplicantView _pendingSnapshotOfTarget:snapshotBlock:] + 398
 27 UIKit                          595713301  -[UIView resizableSnapshotViewFromRect:afterScreenUpdates:withCapInsets:] + 240
 28 UIKit                          595713051  -[UIView snapshotViewAfterScreenUpdates:] + 102
 29 Pinterest                      4973667    +[PIBasicLayoutTransitionController animateLayoutTransition:forNode:] (PIBasicLayoutTransitionController.m:33)
 30 Pinterest                      2754339    -[PIPinCloseupMetadataNode animateLayoutTransition:] (PIPinCloseupMetadataNode.m:388)
```