### PR TITLE
[ASControlNode]Add action with block

### DIFF
--- a/Source/ASControlNode.h
+++ b/Source/ASControlNode.h
@@ -14,6 +14,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class ASControlNode;
+
 /**
   @abstract Kinds of events possible for control nodes.
   @discussion These events are identical to their UIControl counterparts.
@@ -56,6 +58,12 @@ static UIControlState const ASControlStateNormal ASDISPLAYNODE_DEPRECATED_MSG("U
 static UIControlState const ASControlStateDisabled ASDISPLAYNODE_DEPRECATED_MSG("Use UIControlStateDisabled.") = UIControlStateDisabled;
 static UIControlState const ASControlStateHighlighted ASDISPLAYNODE_DEPRECATED_MSG("Use UIControlStateHighlighted.") = UIControlStateHighlighted;
 static UIControlState const ASControlStateSelected ASDISPLAYNODE_DEPRECATED_MSG("Use UIControlStateSelected.") = UIControlStateSelected;
+
+/**
+ @abstract Block type for event handling.
+ @discussion Mainly used for addTarget with block.
+ */
+typedef void(^ASControlBlock)(ASControlNode *sender);
 
 /**
   @abstract ASControlNode is the base class for control nodes (such as buttons), or nodes that track touches to invoke targets with action messages.
@@ -105,6 +113,14 @@ static UIControlState const ASControlStateSelected ASDISPLAYNODE_DEPRECATED_MSG(
   @discussion You may call this method multiple times, and you may specify multiple target-action pairs for a particular event. Targets are held weakly.
  */
 - (void)addTarget:(nullable id)target action:(SEL)action forControlEvents:(ASControlNodeEvent)controlEvents;
+
+/**
+ @abstract Adds a block action for a particular event (or events).
+ @param action A block for event handler. May not be NULL.
+ @param controlEvents A bitmask specifying the control events for which the action message is sent. May not be 0. See "Control Events" for bitmask constants.
+ @discussion You may call this method multiple times, and you may specify multiple target-action pairs for a particular event. Targets are held weakly.
+ */
+- (void)addAction:(ASControlBlock)action forControlEvents:(ASControlNodeEvent)controlEvents;
 
 /**
   @abstract Returns the actions that are associated with a target and a particular control event.

--- a/Source/ASControlNode.h
+++ b/Source/ASControlNode.h
@@ -116,11 +116,11 @@ typedef void(^ASControlBlock)(ASControlNode *sender);
 
 /**
  @abstract Adds a block action for a particular event (or events).
- @param action A block for event handler. May not be NULL.
+ @param actionBlock A block for event handler. May not be NULL.
  @param controlEvents A bitmask specifying the control events for which the action message is sent. May not be 0. See "Control Events" for bitmask constants.
  @discussion You may call this method multiple times, and you may specify multiple target-action pairs for a particular event. Targets are held weakly.
  */
-- (void)addAction:(ASControlBlock)action forControlEvents:(ASControlNodeEvent)controlEvents;
+- (void)addActionWithBlock:(ASControlBlock)actionBlock forControlEvents:(ASControlNodeEvent)controlEvents;
 
 /**
   @abstract Returns the actions that are associated with a target and a particular control event.

--- a/Source/ASControlNode.mm
+++ b/Source/ASControlNode.mm
@@ -43,9 +43,9 @@
   // Target action pairs stored in an array for each event type
   // ASControlEvent -> [ASTargetAction0, ASTargetAction1]
   NSMutableDictionary<id<NSCopying>, NSMutableArray<ASControlTargetAction *> *> *_controlEventDispatchTable;
+  
+  NSMutableDictionary<id<NSCopying>, NSMutableArray<ASControlBlock> *> *_controlBlockDispatchTable;
 }
-
-@property (nonatomic, weak) ASControlBlock controlBlock;
 
 // Read-write overrides.
 @property (nonatomic, readwrite, assign, getter=isTracking) BOOL tracking;
@@ -334,9 +334,26 @@ CGRect _ASControlNodeGetExpandedBounds(ASControlNode *controlNode);
   self.userInteractionEnabled = YES;
 }
 
-- (void)addAction:(ASControlBlock)action forControlEvents:(ASControlNodeEvent)controlEvents
+- (void)addActionWithBlock:(ASControlBlock)actionBlock forControlEvents:(ASControlNodeEvent)controlEvents
 {
-  self.controlBlock = action;
+  _ASEnumerateControlEventsIncludedInMaskWithBlock(controlEvents, ^(ASControlNodeEvent anEvent) {
+    if (!_controlBlockDispatchTable) {
+      _controlBlockDispatchTable = [[NSMutableDictionary alloc] initWithCapacity:kASControlNodeActionDispatchTableInitialCapacity];
+    }
+    id<NSCopying> eventKey = _ASControlNodeEventKeyForControlEvent(anEvent);
+    NSMutableArray *actions = _controlBlockDispatchTable[eventKey];
+    if (!actions) {
+      actions = [[NSMutableArray alloc] init];
+    }
+    
+    [actions removeObject:actionBlock];
+    [actions addObject:actionBlock];
+    
+    if (eventKey) {
+      _controlBlockDispatchTable[eventKey] = actions;
+    }
+  });
+  
   [self addTarget:self action:@selector(_handleTargetActionBlock:) forControlEvents:controlEvents];
 }
 
@@ -422,9 +439,11 @@ CGRect _ASControlNodeGetExpandedBounds(ASControlNode *controlNode);
 #pragma mark -
 // Handle target action with block.
 - (void)_handleTargetActionBlock:(ASControlNode *)sender {
-  if (self.controlBlock) {
-    self.controlBlock(sender);
-  }
+  [_controlBlockDispatchTable enumerateKeysAndObjectsUsingBlock:^(id<NSCopying>  _Nonnull key, NSMutableArray<ASControlBlock> * _Nonnull actions, BOOL * _Nonnull stop) {
+    [actions enumerateObjectsUsingBlock:^(ASControlBlock  _Nonnull action, NSUInteger idx, BOOL * _Nonnull stop) {
+      action(sender);
+    }];
+  }];
 }
 
 #pragma mark -

--- a/Source/ASControlNode.mm
+++ b/Source/ASControlNode.mm
@@ -45,6 +45,8 @@
   NSMutableDictionary<id<NSCopying>, NSMutableArray<ASControlTargetAction *> *> *_controlEventDispatchTable;
 }
 
+@property (nonatomic, weak) ASControlBlock controlBlock;
+
 // Read-write overrides.
 @property (nonatomic, readwrite, assign, getter=isTracking) BOOL tracking;
 @property (nonatomic, readwrite, assign, getter=isTouchInside) BOOL touchInside;
@@ -332,6 +334,12 @@ CGRect _ASControlNodeGetExpandedBounds(ASControlNode *controlNode);
   self.userInteractionEnabled = YES;
 }
 
+- (void)addAction:(ASControlBlock)action forControlEvents:(ASControlNodeEvent)controlEvents
+{
+  self.controlBlock = action;
+  [self addTarget:self action:@selector(_handleTargetActionBlock:) forControlEvents:controlEvents];
+}
+
 - (NSArray *)actionsForTarget:(id)target forControlEvent:(ASControlNodeEvent)controlEvent
 {
   NSParameterAssert(target);
@@ -409,6 +417,14 @@ CGRect _ASControlNodeGetExpandedBounds(ASControlNode *controlNode);
         [_controlEventDispatchTable removeObjectForKey:eventKey];
       }
     });
+}
+
+#pragma mark -
+// Handle target action with block.
+- (void)_handleTargetActionBlock:(ASControlNode *)sender {
+  if (self.controlBlock) {
+    self.controlBlock(sender);
+  }
 }
 
 #pragma mark -

--- a/Tests/ASControlNodeTests.m
+++ b/Tests/ASControlNodeTests.m
@@ -112,6 +112,17 @@
   XCTAssert(controller.hits == 1, @"Controller did not receive the action event");
 }
 
+- (void)testActionWithBlock {
+  ASActionSenderController *controller = [[ASActionSenderController alloc] init];
+  ASControlNode *node = [[ASControlNode alloc] init];
+  [node addAction:^(ASControlNode * _Nonnull sender) {
+    [controller action:sender];
+  } forControlEvents:EVENT];
+  [controller.view addSubview:node.view];
+  [node sendActionsForControlEvents:EVENT withEvent:nil];
+  XCTAssert(controller.hits == 1, @"Controller did not receive the action event");
+}
+
 - (void)testRemoveWithoutTargetRemovesTargetlessAction {
   ASActionSenderEventController *controller = [[ASActionSenderEventController alloc] init];
   ASControlNode *node = [[ASControlNode alloc] init];

--- a/Tests/ASControlNodeTests.m
+++ b/Tests/ASControlNodeTests.m
@@ -115,7 +115,7 @@
 - (void)testActionWithBlock {
   ASActionSenderController *controller = [[ASActionSenderController alloc] init];
   ASControlNode *node = [[ASControlNode alloc] init];
-  [node addAction:^(ASControlNode * _Nonnull sender) {
+  [node addActionWithBlock:^(ASControlNode * _Nonnull sender) {
     [controller action:sender];
   } forControlEvents:EVENT];
   [controller.view addSubview:node.view];


### PR DESCRIPTION
When handle actions with `ASControlNode`, it's pretty handy to deal with a block, so here comes `[someControlNode addAction:^(ASControlNode * _Nonnull sender) {
    [weakSelf doSomethingWithOrWithoutSender];
  } forControlEvents:ASControlNodeEventTouchUpInside];`