### PR TITLE
[Trait collection] Correctly handle changes that occur mid-updates

### DIFF
--- a/Source/ASCollectionNode.mm
+++ b/Source/ASCollectionNode.mm
@@ -219,7 +219,7 @@
 
 #pragma mark Setter / Getter
 
-// TODO: Implement this without the view.
+// TODO: Implement this without the view. Then revisit ASLayoutElementCollectionTableSetTraitCollection
 - (ASDataController *)dataController
 {
   return self.view.dataController;

--- a/Source/ASTableNode.mm
+++ b/Source/ASTableNode.mm
@@ -172,7 +172,7 @@
 
 #pragma mark Setter / Getter
 
-// TODO: Implement this without the view.
+// TODO: Implement this without the view. Then revisit ASLayoutElementCollectionTableSetTraitCollection
 - (ASDataController *)dataController
 {
   return self.view.dataController;

--- a/Source/Details/ASDataController.h
+++ b/Source/Details/ASDataController.h
@@ -201,6 +201,16 @@ extern NSString * const ASCollectionInvalidUpdateException;
 
 - (void)waitUntilAllUpdatesAreCommitted;
 
+/**
+ * Notifies the data controller object that its environment has changed. The object will request its environment delegate for new information
+ * and propagate the information to all visible elements, including ones that are being prepared in background.
+ *
+ * @discussion If called before the initial @c reloadData, this method will do nothing and the trait collection of the initial load will be requested from the environment delegate.
+ *
+ * @discussion This method can be called on any threads.
+ */
+- (void)environmentDidChange;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/Details/ASDataController.mm
+++ b/Source/Details/ASDataController.mm
@@ -506,15 +506,6 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCollectionElement *> *
         _visibleMap = newMap;
 
         [_delegate dataController:self didUpdateWithChangeSet:changeSet];
-        
-        // Step 5: If the environment changed mid-update, notify all visible elements
-        __weak id<ASTraitEnvironment> newEnvironment = [self.environmentDelegate dataControllerEnvironment];
-        ASPrimitiveTraitCollection newTraitCollection = [newEnvironment primitiveTraitCollection];
-        if (! ASPrimitiveTraitCollectionIsEqualToASPrimitiveTraitCollection(existingTraitCollection, newTraitCollection)) {
-          for (ASCollectionElement *element in _visibleMap) {
-            element.traitCollection = newTraitCollection;
-          }
-        }
       }];
     }];
   });

--- a/Source/Details/ASTraitCollection.h
+++ b/Source/Details/ASTraitCollection.h
@@ -117,18 +117,12 @@ ASDISPLAYNODE_EXTERN_C_END
 \
   /* Extra Trait Collection Handling */\
 \
-  /* If the node is not loaded  yet don't do anything as otherwise the access of the view will trigger a load*/\
-  if (!self.isNodeLoaded) { return; }\
+  /* If the node is not loaded  yet don't do anything as otherwise the access of the view will trigger a load */\
+  if (! self.isNodeLoaded) { return; }\
 \
   ASPrimitiveTraitCollection currentTraits = self.primitiveTraitCollection;\
   if (ASPrimitiveTraitCollectionIsEqualToASPrimitiveTraitCollection(currentTraits, oldTraits) == NO) {\
-    /* Must dispatch to main for self.view && [self.view.dataController visibleMap]*/\
-    ASPerformBlockOnMainThread(^{\
-      ASElementMap *map = self.view.dataController.visibleMap; \
-      for (ASCollectionElement *element in map) { \
-         ASTraitCollectionPropagateDown(element.nodeIfAllocated, currentTraits); \
-      } \
-    });\
+    [self.dataController environmentDidChange];\
   }\
 }\
 


### PR DESCRIPTION
- Currently, when there is a new trait collection, we correctly propagate it to all visible elements. However, since the propagating block is executed on main thread immediately without waiting for the background editing queue of `ASDataController`, not all elements are updated.
- Then to fix that, we updated ASDataController to handle these changes inside `updateWithChangeSet` (#3200). This works, but it doesn’t address the underlying issue.
- We now delegate the propagating task to `ASDataController` which schedule a block to its main serial queue after waiting for its background editing queue.
- Unit test included.