### PR TITLE
ASDataController can bail early if a change set is empty

### DIFF
--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -793,9 +793,11 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
   [_changeSet addCompletionHandler:completion];
   
   if (_batchUpdateCount == 0) {
-    _changeSet.animated = animated;
-    [_dataController updateWithChangeSet:_changeSet];
+    _ASHierarchyChangeSet *changeSet = _changeSet;
+    // Nil out _changeSet before forwarding to _dataController to allow the change set to cause subsequent batch updates on the same run loop
     _changeSet = nil;
+    changeSet.animated = animated;
+    [_dataController updateWithChangeSet:changeSet];
   }
 }
 

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -693,9 +693,11 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
   [_changeSet addCompletionHandler:completion];
 
   if (_batchUpdateCount == 0) {
-    _changeSet.animated = animated;
-    [_dataController updateWithChangeSet:_changeSet];
+    _ASHierarchyChangeSet *changeSet = _changeSet;
+    // Nil out _changeSet before forwarding to _dataController to allow the change set to cause subsequent batch updates on the same run loop
     _changeSet = nil;
+    changeSet.animated = animated;
+    [_dataController updateWithChangeSet:changeSet];
   } 
 }
 

--- a/Source/Details/ASDataController.mm
+++ b/Source/Details/ASDataController.mm
@@ -442,12 +442,9 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCollectionElement *> *
   
   dispatch_group_wait(_editingTransactionGroup, DISPATCH_TIME_FOREVER);
   
-  /**
-   * If the initial reloadData has not been called, just bail because we don't have
-   * our old data source counts.
-   * See ASUICollectionViewTests.testThatIssuingAnUpdateBeforeInitialReloadIsUnacceptable
-   * For the issue that UICollectionView has that we're choosing to workaround.
-   */
+  // If the initial reloadData has not been called, just bail because we don't have our old data source counts.
+  // See ASUICollectionViewTests.testThatIssuingAnUpdateBeforeInitialReloadIsUnacceptable
+  // for the issue that UICollectionView has that we're choosing to workaround.
   if (!_initialReloadDataHasBeenCalled) {
     [changeSet executeCompletionHandlerWithFinished:YES];
     return;
@@ -455,6 +452,7 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCollectionElement *> *
   
   [self invalidateDataSourceItemCounts];
   
+  // Log events
   ASDataControllerLogEvent(self, @"triggeredUpdate: %@", changeSet);
 #if ASEVENTLOG_ENABLE
   NSString *changeSetDescription = ASObjectDescriptionMakeTiny(changeSet);
@@ -476,13 +474,22 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCollectionElement *> *
       @throw e;
     }
   }
-
+  
+  // Since we waited for _editingTransactionGroup at the beginning of this method, at this point we can guarantee that _pendingMap equals to _visibleMap.
+  // So if the change set is empty, we don't need to modify data and can safely schedule to notify the delegate.
+  if (changeSet.isEmpty) {
+    [_mainSerialQueue performBlockOnMainThread:^{
+      [_delegate dataController:self willUpdateWithChangeSet:changeSet];
+      [_delegate dataController:self didUpdateWithChangeSet:changeSet];
+    }];
+    return;
+  }
+  
   // Mutable copy of current data.
   ASMutableElementMap *mutableMap = [_pendingMap mutableCopy];
   
   // Step 1: update the mutable copies to match the data source's state
   [self _updateSectionContextsInMap:mutableMap changeSet:changeSet];
-  //TODO If _elements is the same, use a fast path
   __weak id<ASTraitEnvironment> environment = [self.environmentDelegate dataControllerEnvironment];
   __weak ASDisplayNode *owningNode = (ASDisplayNode *)environment; // This is gross!
   ASPrimitiveTraitCollection existingTraitCollection = [environment primitiveTraitCollection];
@@ -496,7 +503,6 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCollectionElement *> *
   dispatch_group_async(_editingTransactionGroup, _editingTransactionQueue, ^{
     // Step 3: Layout **all** new elements without batching in background.
     NSArray<ASCollectionElement *> *unmeasuredElements = [ASDataController unmeasuredElementsFromMap:newMap];
-    // TODO layout in batches, esp reloads
     [self batchLayoutNodesFromContexts:unmeasuredElements batchSize:unmeasuredElements.count batchCompletion:^(id, id) {
       ASSERT_ON_EDITING_QUEUE;
       [_mainSerialQueue performBlockOnMainThread:^{
@@ -531,11 +537,7 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCollectionElement *> *
     return;
   }
   
-  // TODO if the change set includes solely section reloads that together are equivalent to reloadData (i.e reload the only section),
-  // do a reloadData here as an optimization.
-  
   if (changeSet.includesReloadData) {
-
     [map removeAllSectionContexts];
     
     NSUInteger sectionCount = [self itemCountsFromDataSource].size();
@@ -579,9 +581,6 @@ typedef void (^ASDataControllerCompletionBlock)(NSArray<ASCollectionElement *> *
              traitCollection:(ASPrimitiveTraitCollection)traitCollection
 {
   ASDisplayNodeAssertMainThread();
-  
-  // TODO if the change set includes solely section reloads that together are equivalent to reloadData (i.e reload the only section),
-  // do a reloadData here as an optimization.
   
   if (changeSet.includesReloadData) {
     [map removeAllElements];

--- a/Source/Private/_ASHierarchyChangeSet.mm
+++ b/Source/Private/_ASHierarchyChangeSet.mm
@@ -149,6 +149,11 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
 
 #pragma mark External API
 
+- (BOOL)isEmpty
+{
+  return (! _includesReloadData) && (! [self _includesPerItemOrSectionChanges]);
+}
+
 - (void)addCompletionHandler:(void (^)(BOOL))completion
 {
   [self _ensureNotCompleted];
@@ -423,13 +428,10 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
 
 - (void)_validateUpdate
 {
-  // Assert that if reloadData exists, it's the only change
-  // TODO: remove this and be lenient on them?
+  // If reloadData exists, ignore other changes
   if (_includesReloadData) {
-    if (0 < (_originalDeleteSectionChanges.count + _originalDeleteItemChanges.count
-             +_originalInsertSectionChanges.count + _originalInsertItemChanges.count
-             + _reloadSectionChanges.count + _reloadItemChanges.count)) {
-      ASFailUpdateValidation(@"Attempt to reload data in conjuntion with other updates.");
+    if ([self _includesPerItemOrSectionChanges]) {
+      NSLog(@"Warning: A reload data shouldn't be used in conjuntion with other updates.");
     }
     return;
   }
@@ -542,6 +544,13 @@ NSString *NSStringFromASHierarchyChangeType(_ASHierarchyChangeType changeType)
       return;
     }
   }
+}
+
+- (BOOL)_includesPerItemOrSectionChanges
+{
+  return 0 < (_originalDeleteSectionChanges.count + _originalDeleteItemChanges.count
+              +_originalInsertSectionChanges.count + _originalInsertItemChanges.count
+              + _reloadSectionChanges.count + _reloadItemChanges.count);
 }
 
 #pragma mark - Debugging (Private)


### PR DESCRIPTION
Also, I took this opportunity to reorganize `_ASHierarchyChangeSet.h`.