### PR TITLE
Add Support for IGListBindingSectionController

### DIFF
--- a/ASDKListKit/Podfile
+++ b/ASDKListKit/Podfile
@@ -3,6 +3,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '8.0'
 target 'ASDKListKitTests' do
 	pod 'AsyncDisplayKit/IGListKit', :path => '..'
+	pod 'IGListKit', :git => 'https://github.com/Instagram/IGListKit', :commit => '5eca718'
 	pod 'JGMethodSwizzler', :git => 'https://github.com/JonasGessner/JGMethodSwizzler', :branch => 'master'
 end
 

--- a/Source/Details/_ASCollectionViewCell.h
+++ b/Source/Details/_ASCollectionViewCell.h
@@ -7,11 +7,16 @@
 //
 
 #import <UIKit/UIKit.h>
+#import <AsyncDisplayKit/ASBaseDefines.h>
 
 @class ASCellNode;
 
+NS_ASSUME_NONNULL_BEGIN
+
+AS_SUBCLASSING_RESTRICTED
 @interface _ASCollectionViewCell : UICollectionViewCell
 @property (nonatomic, weak) ASCellNode *node;
-@property (nonatomic, strong) UICollectionViewLayoutAttributes *layoutAttributes;
+@property (nonatomic, strong, nullable) UICollectionViewLayoutAttributes *layoutAttributes;
 @end
 
+NS_ASSUME_NONNULL_END

--- a/Source/Details/_ASCollectionViewCell.m
+++ b/Source/Details/_ASCollectionViewCell.m
@@ -71,3 +71,27 @@
 }
 
 @end
+
+/**
+ * A category that makes _ASCollectionViewCell conform to IGListBindable.
+ *
+ * We don't need to do anything to bind the view model – the cell node
+ * serves the same purpose.
+ */
+#if __has_include(<IGListKit/IGListBindable.h>)
+
+#import <IGListKit/IGListBindable.h>
+
+@interface _ASCollectionViewCell (IGListBindable) <IGListBindable>
+@end
+
+@implementation _ASCollectionViewCell (IGListBindable)
+
+- (void)bindViewModel:(id)viewModel
+{
+  // nop
+}
+
+@end
+
+#endif


### PR DESCRIPTION
- Add a category to `_ASCollectionViewCell` that gives it an empty implementation of `bindViewModel:`. We don't need to bind view models because we have cell nodes. 
- Modernize `_ASCollectionViewCell.h` as a ridealong.
- Specify the exact commit of IGListKit in our ASDKListKit project.