### PR TITLE
Add Support for IGListKit > 2.1, Without IGListCollectionView

### DIFF
--- a/ASDKListKit/Podfile
+++ b/ASDKListKit/Podfile
@@ -3,7 +3,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '8.0'
 target 'ASDKListKitTests' do
 	pod 'AsyncDisplayKit/IGListKit', :path => '..'
-	pod 'IGListKit', :git => 'https://github.com/Instagram/IGListKit', :commit => '5eca718'
+	pod 'IGListKit', :git => 'https://github.com/Instagram/IGListKit', :commit => 'e9e09d7'
 	pod 'JGMethodSwizzler', :git => 'https://github.com/JonasGessner/JGMethodSwizzler', :branch => 'master'
 end
 

--- a/Source/AsyncDisplayKit-Prefix.pch
+++ b/Source/AsyncDisplayKit-Prefix.pch
@@ -21,4 +21,10 @@
 
 #ifndef IG_LIST_KIT
   #define IG_LIST_KIT __has_include(<IGListKit/IGListKit.h>)
+
+  /**
+   * For IGListKit versions < 3.0, you have to use IGListCollectionView.
+   * For 3.0 and later, that class is removed and you use UICollectionView.
+   */
+  #define IG_LIST_COLLECTION_VIEW __has_include(<IGListKit/IGListCollectionView.h>)
 #endif

--- a/Source/IGListAdapter+AsyncDisplayKit.m
+++ b/Source/IGListAdapter+AsyncDisplayKit.m
@@ -36,9 +36,12 @@
   collectionNode.delegate = dataSource;
   __weak IGListAdapter *weakSelf = self;
   [collectionNode onDidLoad:^(__kindof ASCollectionNode * _Nonnull collectionNode) {
-    // We manually set the superclass of ASCollectionView to IGListCollectionView at runtime.
-    // Issue tracked at https://github.com/Instagram/IGListKit/issues/409
+#if IG_LIST_COLLECTION_VIEW
+    // We manually set the superclass of ASCollectionView to IGListCollectionView at runtime if needed.
     weakSelf.collectionView = (IGListCollectionView *)collectionNode.view;
+#else
+    weakSelf.collectionView = collectionNode.view;
+#endif
   }];
 }
 

--- a/Source/Private/ASIGListAdapterBasedDataSource.m
+++ b/Source/Private/ASIGListAdapterBasedDataSource.m
@@ -42,7 +42,7 @@ typedef struct {
  * and then we use it and clear it in beginBatchFetchWithContext: (on default queue).
  *
  * It is safe to use it without a lock in this limited way, since those two methods will
- * never execute in parallel.6
+ * never execute in parallel.
  */
 @property (nonatomic, weak) ASIGSectionController *sectionControllerForBatchFetching;
 @end
@@ -52,7 +52,9 @@ typedef struct {
 - (instancetype)initWithListAdapter:(IGListAdapter *)listAdapter
 {
   if (self = [super init]) {
+#if IG_LIST_COLLECTION_VIEW
     [ASIGListAdapterBasedDataSource setASCollectionViewSuperclass];
+#endif
     [ASIGListAdapterBasedDataSource configureUpdater:listAdapter.updater];
 
     ASDisplayNodeAssert([listAdapter conformsToProtocol:@protocol(UICollectionViewDataSource)], @"Expected IGListAdapter to conform to UICollectionViewDataSource.");
@@ -244,12 +246,8 @@ typedef struct {
   return ctrl;
 }
 
-/**
- * Set ASCollectionView's superclass to IGListCollectionView.
- * Scary! If IGListKit removed the subclassing restriction, we could
- * use #if in the @interface to choose the superclass based on
- * whether we have IGListKit available.
- */
+/// If needed, set ASCollectionView's superclass to IGListCollectionView (IGListKit < 3.0).
+#if IG_LIST_COLLECTION_VIEW
 + (void)setASCollectionViewSuperclass
 {
 #pragma clang diagnostic push
@@ -260,6 +258,7 @@ typedef struct {
   });
 #pragma clang diagnostic pop
 }
+#endif
 
 /// Ensure updater won't call reloadData on us.
 + (void)configureUpdater:(id<IGListUpdatingDelegate>)updater


### PR DESCRIPTION
In IGListKit <=2.1, you have to use IGListCollectionView. In later versions, you can just use plain UICollectionView 🙌 . This diff lets us support both cases pretty cleanly.