### PR TITLE
Fix failing batch fetch in some cases.

### DIFF
--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -146,6 +146,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
     unsigned int scrollViewWillBeginDragging:1;
     unsigned int scrollViewDidEndDragging:1;
     unsigned int scrollViewWillEndDragging:1;
+    unsigned int scrollViewDidEndDecelerating:1;
     unsigned int collectionViewWillDisplayNodeForItem:1;
     unsigned int collectionViewWillDisplayNodeForItemDeprecated:1;
     unsigned int collectionViewDidEndDisplayingNodeForItem:1;
@@ -482,6 +483,7 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
     
     _asyncDelegateFlags.scrollViewDidScroll = [_asyncDelegate respondsToSelector:@selector(scrollViewDidScroll:)];
     _asyncDelegateFlags.scrollViewWillEndDragging = [_asyncDelegate respondsToSelector:@selector(scrollViewWillEndDragging:withVelocity:targetContentOffset:)];
+    _asyncDelegateFlags.scrollViewDidEndDecelerating = [_asyncDelegate respondsToSelector:@selector(scrollViewDidEndDecelerating:)];
     _asyncDelegateFlags.scrollViewWillBeginDragging = [_asyncDelegate respondsToSelector:@selector(scrollViewWillBeginDragging:)];
     _asyncDelegateFlags.scrollViewDidEndDragging = [_asyncDelegate respondsToSelector:@selector(scrollViewDidEndDragging:willDecelerate:)];
     _asyncDelegateFlags.collectionViewWillDisplayNodeForItem = [_asyncDelegate respondsToSelector:@selector(collectionView:willDisplayNode:forItemAtIndexPath:)];
@@ -1316,6 +1318,15 @@ static NSString * const kReuseIdentifier = @"_ASCollectionReuseIdentifier";
   
   if (_asyncDelegateFlags.scrollViewWillEndDragging) {
     [_asyncDelegate scrollViewWillEndDragging:scrollView withVelocity:velocity targetContentOffset:(targetContentOffset ? : &contentOffset)];
+  }
+}
+
+- (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView
+{
+  _deceleratingVelocity = CGPointZero;
+    
+  if (_asyncDelegateFlags.scrollViewDidEndDecelerating) {
+    [_asyncDelegate scrollViewDidEndDecelerating:scrollView];
   }
 }
 

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -1204,11 +1204,11 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
 
 - (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView
 {
-    _deceleratingVelocity = CGPointZero;
-    
-    if (_asyncDelegateFlags.scrollViewDidEndDecelerating) {
-        [_asyncDelegate scrollViewDidEndDecelerating:scrollView];
-    }
+  _deceleratingVelocity = CGPointZero;
+
+  if (_asyncDelegateFlags.scrollViewDidEndDecelerating) {
+      [_asyncDelegate scrollViewDidEndDecelerating:scrollView];
+  }
 }
 
 - (void)scrollViewWillBeginDragging:(UIScrollView *)scrollView

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -182,6 +182,7 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     unsigned int scrollViewWillBeginDragging:1;
     unsigned int scrollViewDidEndDragging:1;
     unsigned int scrollViewWillEndDragging:1;
+    unsigned int scrollViewDidEndDecelerating:1;
     unsigned int tableNodeWillDisplayNodeForRow:1;
     unsigned int tableViewWillDisplayNodeForRow:1;
     unsigned int tableViewWillDisplayNodeForRowDeprecated:1;
@@ -432,6 +433,7 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
     _asyncDelegateFlags.tableViewDidEndDisplayingNodeForRow = [_asyncDelegate respondsToSelector:@selector(tableView:didEndDisplayingNode:forRowAtIndexPath:)];
     _asyncDelegateFlags.tableNodeDidEndDisplayingNodeForRow = [_asyncDelegate respondsToSelector:@selector(tableNode:didEndDisplayingRowWithNode:)];
     _asyncDelegateFlags.scrollViewWillEndDragging = [_asyncDelegate respondsToSelector:@selector(scrollViewWillEndDragging:withVelocity:targetContentOffset:)];
+    _asyncDelegateFlags.scrollViewDidEndDecelerating = [_asyncDelegate respondsToSelector:@selector(scrollViewDidEndDecelerating:)];
     _asyncDelegateFlags.tableViewWillBeginBatchFetch = [_asyncDelegate respondsToSelector:@selector(tableView:willBeginBatchFetchWithContext:)];
     _asyncDelegateFlags.tableNodeWillBeginBatchFetch = [_asyncDelegate respondsToSelector:@selector(tableNode:willBeginBatchFetchWithContext:)];
     _asyncDelegateFlags.shouldBatchFetchForTableView = [_asyncDelegate respondsToSelector:@selector(shouldBatchFetchForTableView:)];
@@ -1198,6 +1200,15 @@ static NSString * const kCellReuseIdentifier = @"_ASTableViewCell";
   if (_asyncDelegateFlags.scrollViewWillEndDragging) {
     [_asyncDelegate scrollViewWillEndDragging:scrollView withVelocity:velocity targetContentOffset:(targetContentOffset ? : &contentOffset)];
   }
+}
+
+- (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView
+{
+    _deceleratingVelocity = CGPointZero;
+    
+    if (_asyncDelegateFlags.scrollViewDidEndDecelerating) {
+        [_asyncDelegate scrollViewDidEndDecelerating:scrollView];
+    }
 }
 
 - (void)scrollViewWillBeginDragging:(UIScrollView *)scrollView

--- a/Source/Details/ASDelegateProxy.m
+++ b/Source/Details/ASDelegateProxy.m
@@ -54,7 +54,8 @@
           selector == @selector(tableView:didEndDisplayingCell:forRowAtIndexPath:) ||
           
           // used for batch fetching API
-          selector == @selector(scrollViewWillEndDragging:withVelocity:targetContentOffset:)
+          selector == @selector(scrollViewWillEndDragging:withVelocity:targetContentOffset:) ||
+          selector == @selector(scrollViewDidEndDecelerating:)
           );
 }
 
@@ -96,6 +97,7 @@
           
           // used for batch fetching API
           selector == @selector(scrollViewWillEndDragging:withVelocity:targetContentOffset:) ||
+          selector == @selector(scrollViewDidEndDecelerating:) ||
           
           // used for ASCellNode visibility
           selector == @selector(scrollViewDidScroll:) ||


### PR DESCRIPTION
This resolves issue #3056.

Some times the batch fetch is not fired, even though it is `true` on `func shouldBatchFetch(for collectionView: ASCollectionView) -> Bool`.

I noticed that this is happening because `_deceleratingVelocity` is not reset. So I made the changes based on what @Adlai-Holler said and now it is working.