### PR TITLE
_setImage wasn't calling correct implementation

### DIFF
--- a/Source/ASNetworkImageNode.mm
+++ b/Source/ASNetworkImageNode.mm
@@ -133,10 +133,11 @@ static const CGSize kMinReleaseImageOnBackgroundSize = {20.0, 20.0};
   [self _locked__setImage:image];
 }
 
-/// Setter for private image property. See @c setImage why this is needed
+/// Setter for private image property. See @c _locked_setImage why this is needed
 - (void)_setImage:(UIImage *)image
 {
-  super.image = image;
+  ASDN::MutexLocker l(__instanceLock__);
+  [self _locked__setImage:image];
 }
 
 - (void)_locked__setImage:(UIImage *)image


### PR DESCRIPTION
`_setImage` is intended to call the super version of the method,
however with the adoption of the new `_locked_ prefix`, ASImageNode's
implementation would call back into ASNetworkImageNode's implementation.
This restore the intent of the `_setImage` method.