### PR TITLE
Standardize Dependency Flags for PINRemoteImage, IGListKit

### DIFF
--- a/AsyncDisplayKit.podspec
+++ b/AsyncDisplayKit.podspec
@@ -44,16 +44,12 @@ Pod::Spec.new do |spec|
   end
   
   spec.subspec 'PINRemoteImage' do |pin|
-      # Note: The core.prefix_header_file includes setup of PIN_REMOTE_IMAGE, so the line below could be removed.
-      pin.xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) PIN_REMOTE_IMAGE=1' }
       pin.dependency 'PINRemoteImage/iOS', '= 3.0.0-beta.8'
       pin.dependency 'PINRemoteImage/PINCache'
       pin.dependency 'AsyncDisplayKit/Core'
   end
 
   spec.subspec 'IGListKit' do |igl|
-      # Note: The core.prefix_header_file includes setup of IG_LIST_KIT, so the line below could be removed.
-      igl.xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) IG_LIST_KIT=1' }
       igl.dependency 'IGListKit', '2.1.0'
       igl.dependency 'AsyncDisplayKit/Core'
   end

--- a/BUCK
+++ b/BUCK
@@ -88,7 +88,6 @@ asyncdisplaykit_library(
 for name in ['AsyncDisplayKit', 'AsyncDisplayKit-PINRemoteImage']:
   asyncdisplaykit_library(
     name = name,
-    additional_preprocessor_flags = ['-DPIN_REMOTE_IMAGE=1'],
     deps = [
       '//Pods/PINRemoteImage:PINRemoteImage-PINCache',
     ],

--- a/Source/ASCollectionView.mm
+++ b/Source/ASCollectionView.mm
@@ -9,7 +9,6 @@
 //
 
 #import <AsyncDisplayKit/ASAssert.h>
-#import <AsyncDisplayKit/ASAvailability.h>
 #import <AsyncDisplayKit/ASBatchFetching.h>
 #import <AsyncDisplayKit/ASDelegateProxy.h>
 #import <AsyncDisplayKit/ASCellNode+Internal.h>

--- a/Source/ASDisplayNode+Beta.h
+++ b/Source/ASDisplayNode+Beta.h
@@ -8,7 +8,6 @@
 //  of patent rights can be found in the PATENTS file in the same directory.
 //
 
-#import <AsyncDisplayKit/ASAvailability.h>
 #import <AsyncDisplayKit/ASDisplayNode.h>
 #import <AsyncDisplayKit/ASLayoutRangeType.h>
 #import <AsyncDisplayKit/ASEventLog.h>

--- a/Source/ASDisplayNode+Yoga.mm
+++ b/Source/ASDisplayNode+Yoga.mm
@@ -6,7 +6,6 @@
 //  Copyright © 2017 Facebook. All rights reserved.
 //
 
-#import <AsyncDisplayKit/ASAvailability.h>
 
 #if YOGA /* YOGA */
 

--- a/Source/ASMultiplexImageNode.mm
+++ b/Source/ASMultiplexImageNode.mm
@@ -11,7 +11,6 @@
 #import <AsyncDisplayKit/ASMultiplexImageNode.h>
 #import <AssetsLibrary/AssetsLibrary.h>
 
-#import <AsyncDisplayKit/ASAvailability.h>
 #import <AsyncDisplayKit/ASDisplayNode+FrameworkSubclasses.h>
 #import <AsyncDisplayKit/ASDisplayNodeExtras.h>
 #import <AsyncDisplayKit/ASPhotosFrameworkImageRequest.h>

--- a/Source/ASTableView.mm
+++ b/Source/ASTableView.mm
@@ -14,7 +14,6 @@
 #import <AsyncDisplayKit/_ASDisplayLayer.h>
 #import <AsyncDisplayKit/_ASHierarchyChangeSet.h>
 #import <AsyncDisplayKit/ASAssert.h>
-#import <AsyncDisplayKit/ASAvailability.h>
 #import <AsyncDisplayKit/ASBatchFetching.h>
 #import <AsyncDisplayKit/ASCellNode+Internal.h>
 #import <AsyncDisplayKit/ASCollectionElement.h>

--- a/Source/ASViewController.mm
+++ b/Source/ASViewController.mm
@@ -12,7 +12,6 @@
 
 #import <AsyncDisplayKit/ASViewController.h>
 #import <AsyncDisplayKit/ASAssert.h>
-#import <AsyncDisplayKit/ASAvailability.h>
 #import <AsyncDisplayKit/ASDisplayNode+FrameworkPrivate.h>
 #import <AsyncDisplayKit/ASLayout.h>
 #import <AsyncDisplayKit/ASTraitCollection.h>

--- a/Source/AsyncDisplayKit-Prefix.pch
+++ b/Source/AsyncDisplayKit-Prefix.pch
@@ -8,11 +8,4 @@
   #import <Foundation/Foundation.h>
 #endif
 
-#define PIN_REMOTE_IMAGE __has_include(<PINRemoteImage/PINRemoteImage.h>)
-#define IG_LIST_KIT __has_include(<IGListKit/IGListKit.h>)
-
-/**
- * For IGListKit versions < 3.0, you have to use IGListCollectionView.
- * For 3.0 and later, that class is removed and you use UICollectionView.
- */
-#define IG_LIST_COLLECTION_VIEW __has_include(<IGListKit/IGListCollectionView.h>)
+#import <AsyncDisplayKit/ASAvailability.h>

--- a/Source/AsyncDisplayKit-Prefix.pch
+++ b/Source/AsyncDisplayKit-Prefix.pch
@@ -8,17 +8,8 @@
   #import <Foundation/Foundation.h>
 #endif
 
-// Some build systems (Buck, Bazel, etc) will define these flags manually if the functionality
-// is needed by the app. Carthage in particular, or if a user forgets to set the build flag, benefit from
-// checking if each flag is not defined and then setting it to whether or not the header is accessible.
-
-#ifndef PIN_REMOTE_IMAGE
-  #define PIN_REMOTE_IMAGE __has_include(<PINRemoteImage/PINRemoteImage.h>)
-#endif
-
-#ifndef IG_LIST_KIT
-  #define IG_LIST_KIT __has_include(<IGListKit/IGListKit.h>)
-#endif
+#define PIN_REMOTE_IMAGE __has_include(<PINRemoteImage/PINRemoteImage.h>)
+#define IG_LIST_KIT __has_include(<IGListKit/IGListKit.h>)
 
 /**
  * For IGListKit versions < 3.0, you have to use IGListCollectionView.

--- a/Source/AsyncDisplayKit-Prefix.pch
+++ b/Source/AsyncDisplayKit-Prefix.pch
@@ -8,23 +8,20 @@
   #import <Foundation/Foundation.h>
 #endif
 
-// Some build systems (Cocoapods, Buck, Bazel, etc) will define these flags manually if the functionality
+// Some build systems (Buck, Bazel, etc) will define these flags manually if the functionality
 // is needed by the app. Carthage in particular, or if a user forgets to set the build flag, benefit from
 // checking if each flag is not defined and then setting it to whether or not the header is accessible.
 
 #ifndef PIN_REMOTE_IMAGE
-// For Carthage or manual builds, this will define PIN_REMOTE_IMAGE if the header is available in the
-// search path e.g. they've dragged in the framework (technically this will not be able to detect if
-// a user does not include the framework in the link binary with build step).
   #define PIN_REMOTE_IMAGE __has_include(<PINRemoteImage/PINRemoteImage.h>)
 #endif
 
 #ifndef IG_LIST_KIT
   #define IG_LIST_KIT __has_include(<IGListKit/IGListKit.h>)
-
-  /**
-   * For IGListKit versions < 3.0, you have to use IGListCollectionView.
-   * For 3.0 and later, that class is removed and you use UICollectionView.
-   */
-  #define IG_LIST_COLLECTION_VIEW __has_include(<IGListKit/IGListCollectionView.h>)
 #endif
+
+/**
+ * For IGListKit versions < 3.0, you have to use IGListCollectionView.
+ * For 3.0 and later, that class is removed and you use UICollectionView.
+ */
+#define IG_LIST_COLLECTION_VIEW __has_include(<IGListKit/IGListCollectionView.h>)

--- a/Source/AsyncDisplayKit.h
+++ b/Source/AsyncDisplayKit.h
@@ -8,6 +8,7 @@
 //  of patent rights can be found in the PATENTS file in the same directory.
 //
 
+#import <AsyncDisplayKit/ASAvailability.h>
 #import <AsyncDisplayKit/ASDisplayNode.h>
 #import <AsyncDisplayKit/ASDisplayNode+Convenience.h>
 #import <AsyncDisplayKit/ASDisplayNodeExtras.h>

--- a/Source/AsyncDisplayKit.h
+++ b/Source/AsyncDisplayKit.h
@@ -8,7 +8,6 @@
 //  of patent rights can be found in the PATENTS file in the same directory.
 //
 
-#import <AsyncDisplayKit/ASAvailability.h>
 #import <AsyncDisplayKit/ASDisplayNode.h>
 #import <AsyncDisplayKit/ASDisplayNode+Convenience.h>
 #import <AsyncDisplayKit/ASDisplayNodeExtras.h>
@@ -82,6 +81,7 @@
 #import <AsyncDisplayKit/ASDisplayNode+Beta.h>
 #import <AsyncDisplayKit/ASTextNode+Beta.h>
 #import <AsyncDisplayKit/ASTextNodeTypes.h>
+#import <AsyncDisplayKit/ASAvailability.h>
 #import <AsyncDisplayKit/ASBlockTypes.h>
 #import <AsyncDisplayKit/ASContextTransitioning.h>
 #import <AsyncDisplayKit/ASControlNode+Subclasses.h>

--- a/Source/AsyncDisplayKit.h
+++ b/Source/AsyncDisplayKit.h
@@ -8,6 +8,7 @@
 //  of patent rights can be found in the PATENTS file in the same directory.
 //
 
+#import <AsyncDisplayKit/ASAvailability.h>
 #import <AsyncDisplayKit/ASDisplayNode.h>
 #import <AsyncDisplayKit/ASDisplayNode+Convenience.h>
 #import <AsyncDisplayKit/ASDisplayNodeExtras.h>
@@ -81,7 +82,6 @@
 #import <AsyncDisplayKit/ASDisplayNode+Beta.h>
 #import <AsyncDisplayKit/ASTextNode+Beta.h>
 #import <AsyncDisplayKit/ASTextNodeTypes.h>
-#import <AsyncDisplayKit/ASAvailability.h>
 #import <AsyncDisplayKit/ASBlockTypes.h>
 #import <AsyncDisplayKit/ASContextTransitioning.h>
 #import <AsyncDisplayKit/ASControlNode+Subclasses.h>

--- a/Source/AsyncDisplayKit.h
+++ b/Source/AsyncDisplayKit.h
@@ -81,7 +81,6 @@
 #import <AsyncDisplayKit/ASDisplayNode+Beta.h>
 #import <AsyncDisplayKit/ASTextNode+Beta.h>
 #import <AsyncDisplayKit/ASTextNodeTypes.h>
-#import <AsyncDisplayKit/ASAvailability.h>
 #import <AsyncDisplayKit/ASBlockTypes.h>
 #import <AsyncDisplayKit/ASContextTransitioning.h>
 #import <AsyncDisplayKit/ASControlNode+Subclasses.h>

--- a/Source/Base/ASAvailability.h
+++ b/Source/Base/ASAvailability.h
@@ -32,3 +32,12 @@
 #ifndef YOGA
   #define YOGA __has_include(YOGA_HEADER_PATH)
 #endif
+
+#define PIN_REMOTE_IMAGE __has_include(<PINRemoteImage/PINRemoteImage.h>)
+#define IG_LIST_KIT __has_include(<IGListKit/IGListKit.h>)
+
+/**
+ * For IGListKit versions < 3.0, you have to use IGListCollectionView.
+ * For 3.0 and later, that class is removed and you use UICollectionView.
+ */
+#define IG_LIST_COLLECTION_VIEW __has_include(<IGListKit/IGListCollectionView.h>)

--- a/Source/Base/ASBaseDefines.h
+++ b/Source/Base/ASBaseDefines.h
@@ -12,14 +12,6 @@
 
 #import <AsyncDisplayKit/ASLog.h>
 
-#ifndef PIN_REMOTE_IMAGE
-#if __has_include(<PINRemoteImage/PINRemoteImage.h>)
-#define PIN_REMOTE_IMAGE 1
-#else
-#define PIN_REMOTE_IMAGE 0
-#endif
-#endif
-
 // The C++ compiler mangles C function names. extern "C" { /* your C functions */ } prevents this.
 // You should wrap all C function prototypes declared in headers with ASDISPLAYNODE_EXTERN_C_BEGIN/END, even if
 // they are included only from .m (Objective-C) files. It's common for .m files to start using C++

--- a/Source/Base/ASLog.h
+++ b/Source/Base/ASLog.h
@@ -10,7 +10,6 @@
 
 #pragma once
 
-#import <AsyncDisplayKit/ASAvailability.h>
 
 #define ASMultiplexImageNodeLogDebug(...)
 #define ASMultiplexImageNodeCLogDebug(...)

--- a/Source/Details/ASObjectDescriptionHelpers.m
+++ b/Source/Details/ASObjectDescriptionHelpers.m
@@ -6,7 +6,6 @@
 //  Copyright © 2016 Facebook. All rights reserved.
 //
 
-#import <AsyncDisplayKit/ASAvailability.h>
 #import <AsyncDisplayKit/ASObjectDescriptionHelpers.h>
 
 #import <UIKit/UIGeometry.h>

--- a/Source/Details/ASPhotosFrameworkImageRequest.m
+++ b/Source/Details/ASPhotosFrameworkImageRequest.m
@@ -12,7 +12,6 @@
 
 #import <AsyncDisplayKit/ASPhotosFrameworkImageRequest.h>
 #import <AsyncDisplayKit/ASBaseDefines.h>
-#import <AsyncDisplayKit/ASAvailability.h>
 
 NSString *const ASPhotosURLScheme = @"ph";
 

--- a/Source/Details/ASTraitCollection.h
+++ b/Source/Details/ASTraitCollection.h
@@ -8,7 +8,6 @@
 //  of patent rights can be found in the PATENTS file in the same directory.
 //
 
-#import <AsyncDisplayKit/ASAvailability.h>
 
 #import <UIKit/UIKit.h>
 #import <AsyncDisplayKit/ASBaseDefines.h>

--- a/Source/Details/NSIndexSet+ASHelpers.m
+++ b/Source/Details/NSIndexSet+ASHelpers.m
@@ -6,7 +6,6 @@
 //  Copyright © 2016 Facebook. All rights reserved.
 //
 
-#import <AsyncDisplayKit/ASAvailability.h>
 
 // UIKit indexPath helpers
 #import <UIKit/UIKit.h>

--- a/Source/Layout/ASInsetLayoutSpec.h
+++ b/Source/Layout/ASInsetLayoutSpec.h
@@ -8,7 +8,6 @@
 //  of patent rights can be found in the PATENTS file in the same directory.
 //
 
-#import <AsyncDisplayKit/ASAvailability.h>
 #import <AsyncDisplayKit/ASLayoutSpec.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Source/Layout/ASLayoutElement.h
+++ b/Source/Layout/ASLayoutElement.h
@@ -8,7 +8,6 @@
 //  of patent rights can be found in the PATENTS file in the same directory.
 //
 
-#import <AsyncDisplayKit/ASAvailability.h>
 #import <AsyncDisplayKit/ASLayoutElementPrivate.h>
 #import <AsyncDisplayKit/ASLayoutElementExtensibility.h>
 #import <AsyncDisplayKit/ASDimensionInternal.h>

--- a/Source/Layout/ASLayoutElementPrivate.h
+++ b/Source/Layout/ASLayoutElementPrivate.h
@@ -8,7 +8,6 @@
 //  of patent rights can be found in the PATENTS file in the same directory.
 //
 
-#import <AsyncDisplayKit/ASAvailability.h>
 #import <AsyncDisplayKit/ASDimension.h>
 #import <UIKit/UIGeometry.h>
 

--- a/Source/Layout/ASLayoutSpec.mm
+++ b/Source/Layout/ASLayoutSpec.mm
@@ -16,7 +16,6 @@
 #import <AsyncDisplayKit/ASLayoutElementStylePrivate.h>
 #import <AsyncDisplayKit/ASTraitCollection.h>
 #import <AsyncDisplayKit/ASEqualityHelpers.h>
-#import <AsyncDisplayKit/ASAvailability.h>
 #import <AsyncDisplayKit/ASInternalHelpers.h>
 
 #import <objc/runtime.h>

--- a/Source/Private/Layout/ASLayoutSpecPrivate.h
+++ b/Source/Private/Layout/ASLayoutSpecPrivate.h
@@ -10,7 +10,6 @@
 //  of patent rights can be found in the PATENTS file in the same directory.
 //
 
-#import <AsyncDisplayKit/ASAvailability.h>
 #import <AsyncDisplayKit/ASInternalHelpers.h>
 #import <AsyncDisplayKit/ASThread.h>
 


### PR DESCRIPTION
We are seeing a build warning when using the IGListKit Subspec (which explicitly defines `IG_LIST_KIT` in the podspec) because that causes the `#ifndef` in the prefix header to skip defining the `IG_LIST_COLLECTION_VIEW` macro.

While I'm at it fixing that, I think we should go ahead and standardize that we always define these flags internally, by looking at which headers are available when building AsyncDisplayKit.

This diff:
- Removes the explicit define from the podspec and BUCK files.
- Removes the `#ifndef` from the prefix header.

At the end of the day, if those headers aren't available (`__has_include` would evaluate to false) then the build isn't going to work no matter what you manually define. 