### PR TITLE
Remove macOS Support

### DIFF
--- a/Source/Base/ASAvailability.h
+++ b/Source/Base/ASAvailability.h
@@ -23,9 +23,6 @@
 #define AS_AT_LEAST_IOS9   (kCFCoreFoundationVersionNumber >= kCFCoreFoundationVersionNumber_iOS_9_0)
 #define AS_AT_LEAST_IOS10  (kCFCoreFoundationVersionNumber >= kCFCoreFoundationVersionNumber_iOS_10_0)
 
-#define AS_TARGET_OS_OSX (!(TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_WATCH))
-#define AS_TARGET_OS_IOS TARGET_OS_IPHONE
-
 // If Yoga is available, make it available anywhere we use ASAvailability.
 // This reduces Yoga-specific code in other files.
 #ifndef YOGA_HEADER_PATH
@@ -34,47 +31,4 @@
 
 #ifndef YOGA
   #define YOGA __has_include(YOGA_HEADER_PATH)
-#endif
-
-#if AS_TARGET_OS_OSX
-
-#define UIEdgeInsets NSEdgeInsets
-#define NSStringFromCGSize NSStringFromSize
-#define NSStringFromCGPoint NSStringFromPoint
-
-#import <Foundation/Foundation.h>
-
-@interface NSValue (ASAvailability)
-+ (NSValue *)valueWithCGPoint:(CGPoint)point;
-+ (NSValue *)valueWithCGSize:(CGSize)size;
-- (CGRect)CGRectValue;
-- (CGPoint)CGPointValue;
-- (CGSize)CGSizeValue;
-@end
-
-@implementation NSValue(ASAvailability)
-+ (NSValue *)valueWithCGPoint:(CGPoint)point
-{
-  return [self valueWithPoint:point];
-}
-+ (NSValue *)valueWithCGSize:(CGSize)size
-{
-  return [self valueWithSize:size];
-}
-- (CGRect)CGRectValue
-{
-  return self.rectValue;
-}
-
-- (CGPoint)CGPointValue
-{
-  return self.pointValue;
-}
-
-- (CGSize)CGSizeValue
-{
-  return self.sizeValue;
-}
-@end
-
 #endif

--- a/Source/Details/ASObjectDescriptionHelpers.m
+++ b/Source/Details/ASObjectDescriptionHelpers.m
@@ -9,11 +9,7 @@
 #import <AsyncDisplayKit/ASAvailability.h>
 #import <AsyncDisplayKit/ASObjectDescriptionHelpers.h>
 
-#if AS_TARGET_OS_IOS
 #import <UIKit/UIGeometry.h>
-#else
-#import <Foundation/NSGeometry.h>
-#endif
 
 #import <AsyncDisplayKit/NSIndexSet+ASHelpers.h>
 

--- a/Source/Details/ASTraitCollection.h
+++ b/Source/Details/ASTraitCollection.h
@@ -10,8 +10,6 @@
 
 #import <AsyncDisplayKit/ASAvailability.h>
 
-#if AS_TARGET_OS_IOS
-
 #import <UIKit/UIKit.h>
 #import <AsyncDisplayKit/ASBaseDefines.h>
 
@@ -158,9 +156,3 @@ AS_SUBCLASSING_RESTRICTED
 @end
 
 NS_ASSUME_NONNULL_END
-
-#else
-
-// Non iOS
-
-#endif

--- a/Source/Details/ASTraitCollection.m
+++ b/Source/Details/ASTraitCollection.m
@@ -11,9 +11,6 @@
 //
 
 #import <AsyncDisplayKit/ASTraitCollection.h>
-
-#if AS_TARGET_OS_IOS
-
 #import <AsyncDisplayKit/ASObjectDescriptionHelpers.h>
 #import <AsyncDisplayKit/ASLayoutElement.h>
 
@@ -196,9 +193,3 @@ NSString *NSStringFromASPrimitiveTraitCollection(ASPrimitiveTraitCollection trai
 }
 
 @end
-
-#else
-
-// Non iOS
-
-#endif

--- a/Source/Details/NSIndexSet+ASHelpers.m
+++ b/Source/Details/NSIndexSet+ASHelpers.m
@@ -8,11 +8,8 @@
 
 #import <AsyncDisplayKit/ASAvailability.h>
 
-#if AS_TARGET_OS_IOS
-  #import <UIKit/UIKit.h>
-#else
-  #import <Cocoa/Cocoa.h>
-#endif
+// UIKit indexPath helpers
+#import <UIKit/UIKit.h>
 
 #import <AsyncDisplayKit/NSIndexSet+ASHelpers.h>
 

--- a/Source/Layout/ASDimension.mm
+++ b/Source/Layout/ASDimension.mm
@@ -10,11 +10,7 @@
 
 #import <AsyncDisplayKit/ASDimension.h>
 
-#if AS_TARGET_OS_IOS
 #import <UIKit/UIGeometry.h>
-#else
-#import <Foundation/NSGeometry.h>
-#endif
 
 #import <AsyncDisplayKit/CoreGraphics+ASConvenience.h>
 
@@ -108,13 +104,7 @@ ASSizeRange ASSizeRangeIntersect(ASSizeRange sizeRange, ASSizeRange otherSizeRan
 
 NSString *NSStringFromASSizeRange(ASSizeRange sizeRange)
 {
-#if AS_TARGET_OS_IOS
   return [NSString stringWithFormat:@"<ASSizeRange: min=%@, max=%@>",
           NSStringFromCGSize(sizeRange.min),
           NSStringFromCGSize(sizeRange.max)];
-#else
-  return [NSString stringWithFormat:@"<ASSizeRange: min=%@, max=%@>",
-          NSStringFromRect(NSRectFromCGRect(sizeRange.min)),
-          NSStringFromRect(NSRectFromCGRect(sizeRange.max))];
-#endif
 }

--- a/Source/Layout/ASLayoutElement.h
+++ b/Source/Layout/ASLayoutElement.h
@@ -14,15 +14,13 @@
 #import <AsyncDisplayKit/ASDimensionInternal.h>
 #import <AsyncDisplayKit/ASStackLayoutElement.h>
 #import <AsyncDisplayKit/ASAbsoluteLayoutElement.h>
+#import <AsyncDisplayKit/ASTraitCollection.h>
 
 @class ASLayout;
 @class ASLayoutSpec;
 @protocol ASLayoutElementStylability;
 
-#if AS_TARGET_OS_IOS
-#import "ASTraitCollection.h"
 @protocol ASTraitEnvironment;
-#endif
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -66,11 +64,7 @@ ASDISPLAYNODE_EXTERN_C_END
  * access to the options via convenience properties. If you are creating custom layout spec, then you can
  * extend the backing layout options class to accommodate any new layout options.
  */
-#if AS_TARGET_OS_IOS
 @protocol ASLayoutElement <ASLayoutElementExtensibility, ASLayoutElementFinalLayoutElement, ASTraitEnvironment>
-#else
-@protocol ASLayoutElement <ASLayoutElementExtensibility, ASLayoutElementFinalLayoutElement>
-#endif
 
 #pragma mark - Getter
 

--- a/Source/Layout/ASLayoutElementExtensibility.h
+++ b/Source/Layout/ASLayoutElementExtensibility.h
@@ -10,11 +10,7 @@
 //  of patent rights can be found in the PATENTS file in the same directory.
 //
 
-#if AS_TARGET_OS_IOS
 #import <UIKit/UIGeometry.h>
-#else
-#import <Foundation/NSGeometry.h>
-#endif
 
 #import <objc/runtime.h>
 

--- a/Source/Layout/ASLayoutElementPrivate.h
+++ b/Source/Layout/ASLayoutElementPrivate.h
@@ -10,12 +10,7 @@
 
 #import <AsyncDisplayKit/ASAvailability.h>
 #import <AsyncDisplayKit/ASDimension.h>
-
-#if AS_TARGET_OS_IOS
 #import <UIKit/UIGeometry.h>
-#else
-#import <Foundation/NSGeometry.h>
-#endif
 
 @protocol ASLayoutElement;
 @class ASLayoutElementStyle;

--- a/Source/Layout/ASLayoutSpec+Subclasses.mm
+++ b/Source/Layout/ASLayoutSpec+Subclasses.mm
@@ -54,9 +54,7 @@
   if (self.isFinalLayoutElement == NO) {
     id<ASLayoutElement> finalLayoutElement = [child finalLayoutElement];
     if (finalLayoutElement != child) {
-#if AS_TARGET_OS_IOS
       finalLayoutElement.primitiveTraitCollection = child.primitiveTraitCollection;
-#endif
       return finalLayoutElement;
     }
   }

--- a/Source/Layout/ASLayoutSpec.mm
+++ b/Source/Layout/ASLayoutSpec.mm
@@ -49,9 +49,7 @@
   }
   
   _isMutable = YES;
-#if AS_TARGET_OS_IOS
   _primitiveTraitCollection = ASPrimitiveTraitCollectionMakeDefault();
-#endif
   _childrenArray = [[NSMutableArray alloc] init];
   
   return self;
@@ -174,8 +172,6 @@ ASLayoutElementFinalLayoutElementDefault
 
 #pragma mark - ASTraitEnvironment
 
-#if AS_TARGET_OS_IOS
-
 - (ASPrimitiveTraitCollection)primitiveTraitCollection
 {
   return _primitiveTraitCollection;
@@ -192,11 +188,7 @@ ASLayoutElementFinalLayoutElementDefault
   return [ASTraitCollection traitCollectionWithASPrimitiveTraitCollection:self.primitiveTraitCollection];
 }
 
-#endif
-
-#if AS_TARGET_OS_IOS
 ASPrimitiveTraitCollectionDeprecatedImplementation
-#endif
 
 #pragma mark - ASLayoutElementStyleExtensibility
 

--- a/Source/Private/ASInternalHelpers.h
+++ b/Source/Private/ASInternalHelpers.h
@@ -10,11 +10,7 @@
 
 #import "ASAvailability.h"
 
-#if AS_TARGET_OS_IOS
 #import <UIKit/UIKit.h>
-#else
-#import <QuartzCore/QuartzCore.h>
-#endif
 
 #import <AsyncDisplayKit/ASBaseDefines.h>
 
@@ -77,14 +73,7 @@ ASDISPLAYNODE_INLINE BOOL ASImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
  */
 ASDISPLAYNODE_INLINE void ASPerformBlockWithoutAnimation(BOOL withoutAnimation, void (^block)()) {
   if (withoutAnimation) {
-#if AS_TARGET_OS_IOS
     [UIView performWithoutAnimation:block];
-#else
-    [CATransaction begin];
-    [CATransaction setDisableActions: YES];
-    block();
-    [CATransaction commit];
-#endif
   } else {
     block();
   }

--- a/Source/Private/ASInternalHelpers.m
+++ b/Source/Private/ASInternalHelpers.m
@@ -10,11 +10,7 @@
 
 #import <AsyncDisplayKit/ASInternalHelpers.h>
 
-#if AS_TARGET_OS_IOS
 #import <UIKit/UIKit.h>
-#else
-#import <AppKit/AppKit.h>
-#endif
 
 #import <objc/runtime.h>
 #import <tgmath.h>
@@ -92,7 +88,6 @@ void ASPerformBackgroundDeallocation(id object)
 
 BOOL ASClassRequiresMainThreadDeallocation(Class c)
 {
-#if AS_TARGET_OS_IOS
   if (c == [UIImage class] || c == [UIColor class]) {
     return NO;
   }
@@ -102,19 +97,6 @@ BOOL ASClassRequiresMainThreadDeallocation(Class c)
       || [c isSubclassOfClass:[UIGestureRecognizer class]]) {
     return YES;
   }
-#else
-  if (c == [NSImage class] || c == [NSColor class]) {
-    return NO;
-  }
-  
-  if ([c isSubclassOfClass:[NSResponder class]]
-      || [c isSubclassOfClass:[CALayer class]]
-      || [c isSubclassOfClass:[NSGestureRecognizer class]]) {
-    return YES;
-  }
-#endif
-
-
 
   const char *name = class_getName(c);
   if (strncmp(name, "UI", 2) == 0 || strncmp(name, "AV", 2) == 0 || strncmp(name, "CA", 2) == 0) {
@@ -152,11 +134,7 @@ CGFloat ASScreenScale()
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
     ASDisplayNodeCAssertMainThread();
-#if AS_TARGET_OS_IOS
     __scale = [[UIScreen mainScreen] scale];
-#else
-    __scale = [[NSScreen mainScreen] backingScaleFactor];
-#endif
   });
   return __scale;
 }

--- a/Source/Private/Layout/ASLayoutSpecPrivate.h
+++ b/Source/Private/Layout/ASLayoutSpecPrivate.h
@@ -18,9 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ASLayoutSpec() {
   ASDN::RecursiveMutex __instanceLock__;
-#if AS_TARGET_OS_IOS
   ASPrimitiveTraitCollection _primitiveTraitCollection;
-#endif
   ASLayoutElementStyle *_style;
   NSMutableArray *_childrenArray;
 }


### PR DESCRIPTION
This is causing #3244 to fail because TARGET_OS_IPHONE isn't defined when running unit tests, and rather than fix that let's remove this and focus on iOS.