### PR TITLE
Bump .cartfile versions to match .Podspec

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "pinterest/PINRemoteImage" "3.0.0-beta.6"
-github "pinterest/PINCache" "3.0.1-beta.2"
+github "pinterest/PINRemoteImage" "3.0.0-beta.8"
+github "pinterest/PINCache" "3.0.1-beta.4"


### PR DESCRIPTION
Podspec was bumped in 75fddb1, this bumps the cartfile to match

Still using Xcode 8.2.1 so not suffering from the issues as part of #2983. Would be nice if we could bump the versions independently of fixing the Xcode 8.3 issues