### PR TITLE
Allow creating a ASPINRemoteImageDownloader that ignores caches

### DIFF
--- a/Source/Details/ASPINRemoteImageDownloader.h
+++ b/Source/Details/ASPINRemoteImageDownloader.h
@@ -51,6 +51,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (PINRemoteImageManager *)sharedPINRemoteImageManager;
 
+/**
+ * When downloading images ignore all caches. Defaults to NO.
+ */
+@property (nonatomic, assign) BOOL shouldIgnoreCache;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/Details/ASPINRemoteImageDownloader.m
+++ b/Source/Details/ASPINRemoteImageDownloader.m
@@ -203,7 +203,13 @@ static ASPINRemoteImageDownloader *sharedDownloader = nil;
                    downloadProgress:(ASImageDownloaderProgress)downloadProgress
                          completion:(ASImageDownloaderCompletion)completion;
 {
-  return [[self sharedPINRemoteImageManager] downloadImageWithURL:URL options:PINRemoteImageManagerDownloadOptionsSkipDecode progressDownload:^(int64_t completedBytes, int64_t totalBytes) {
+  PINRemoteImageManagerDownloadOptions options = PINRemoteImageManagerDownloadOptionsSkipDecode;
+  
+  if (_shouldIgnoreCache) {
+    options |= PINRemoteImageManagerDownloadOptionsIgnoreCache;
+  }
+  
+  return [[self sharedPINRemoteImageManager] downloadImageWithURL:URL options:options progressDownload:^(int64_t completedBytes, int64_t totalBytes) {
     if (downloadProgress == nil) { return; }
 
     /// If we're targeting the main queue and we're on the main thread, call immediately.


### PR DESCRIPTION
This is a minimal API change to allow bypassing PINRemoteImage's disk caching.