### PR TITLE
[ASDisplayNode] Trigger a layout pass whenever a node enters preload state

### DIFF
--- a/Source/ASCollectionNode.mm
+++ b/Source/ASCollectionNode.mm
@@ -207,13 +207,6 @@
   [super didEnterPreloadState];
 }
 
-- (void)didEnterDisplayState
-{
-  [super didEnterDisplayState];
-  // Since an initial data load was triggered when this node enter preloads state, wait for it to finish
-  [self waitUntilAllUpdatesAreCommitted];
-}
-
 #if ASRangeControllerLoggingEnabled
 - (void)didEnterVisibleState
 {

--- a/Source/ASCollectionNode.mm
+++ b/Source/ASCollectionNode.mm
@@ -193,16 +193,25 @@
   [self.rangeController clearContents];
 }
 
-- (void)didExitPreloadState
-{
-  [super didExitPreloadState];
-  [self.rangeController clearPreloadedData];
-}
-
 - (void)interfaceStateDidChange:(ASInterfaceState)newState fromState:(ASInterfaceState)oldState
 {
   [super interfaceStateDidChange:newState fromState:oldState];
   [ASRangeController layoutDebugOverlayIfNeeded];
+}
+
+- (void)didEnterPreloadState
+{
+  // Intentionally allocate the collection view here so that super will trigger a layout pass on it which in turn will loads its intial data.
+  // We can get rid of this later when ASDataController, ASRangeController and the collection layout object can operate without the view.
+  [self view];
+  [super didEnterPreloadState];
+}
+
+- (void)didEnterDisplayState
+{
+  [super didEnterDisplayState];
+  // Since an initial data load was triggered when this node enter preloads state, wait for it to finish
+  [self waitUntilAllUpdatesAreCommitted];
 }
 
 #if ASRangeControllerLoggingEnabled
@@ -218,6 +227,12 @@
   NSLog(@"%@ - visible: NO", self);
 }
 #endif
+
+- (void)didExitPreloadState
+{
+  [super didExitPreloadState];
+  [self.rangeController clearPreloadedData];
+}
 
 #pragma mark Setter / Getter
 

--- a/Source/ASCollectionNode.mm
+++ b/Source/ASCollectionNode.mm
@@ -201,8 +201,8 @@
 
 - (void)didEnterPreloadState
 {
-  // Intentionally allocate the collection view here so that super will trigger a layout pass on it which in turn will loads its intial data.
-  // We can get rid of this later when ASDataController, ASRangeController and the collection layout object can operate without the view.
+  // Intentionally allocate the view here so that super will trigger a layout pass on it which in turn will trigger the intial data load.
+  // We can get rid of this call later when ASDataController, ASRangeController and ASCollectionLayout can operate without the view.
   [self view];
   [super didEnterPreloadState];
 }

--- a/Source/ASDisplayNode.h
+++ b/Source/ASDisplayNode.h
@@ -639,6 +639,11 @@ extern NSInteger const ASDefaultDrawingPriority;
  */
 - (void)setNeedsLayout;
 
+/**
+ * Performs a layout pass on the node. Convenience for use whether the view / layer is loaded or not. Safe to call from a background thread.
+ */
+- (void)layoutIfNeeded;
+
 @property (nonatomic, strong, nullable) id contents;                           // default=nil
 @property (nonatomic, assign)           BOOL clipsToBounds;                    // default==NO
 @property (nonatomic, getter=isOpaque)  BOOL opaque;                           // default==YES

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -3722,6 +3722,8 @@ ASDISPLAYNODE_INLINE BOOL nodeIsInRasterizedTree(ASDisplayNode *node) {
   ASDisplayNodeAssertLockUnownedByCurrentThread(__instanceLock__);
   [_interfaceStateDelegate didEnterPreloadState];
   
+  [self layoutIfNeeded];
+  
   if (_methodOverrides & ASDisplayNodeMethodOverrideFetchData) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -985,7 +985,7 @@ ASLayoutElementFinalLayoutElementDefault
 
 - (void)__layout
 {
-  ASDisplayNodeAssertMainThread();
+  ASDisplayNodeAssertThreadAffinity(self);
   ASDisplayNodeAssertLockUnownedByCurrentThread(__instanceLock__);
   
   {
@@ -1014,8 +1014,10 @@ ASLayoutElementFinalLayoutElementDefault
     [self _locked_layoutPlaceholderIfNecessary];
   }
   
-  [self layout];
-  [self layoutDidFinish];
+  ASPerformBlockOnMainThread(^{
+    [self layout];
+    [self layoutDidFinish];
+  });
 }
 
 /// Needs to be called with lock held
@@ -1054,7 +1056,7 @@ ASLayoutElementFinalLayoutElementDefault
   std::shared_ptr<ASDisplayNodeLayout> nextLayout = _pendingDisplayNodeLayout;
   #define layoutSizeDifferentFromBounds !CGSizeEqualToSize(nextLayout->layout.size, boundsSizeForLayout)
   
-  // nextLayout was likely created by a call to layoutThatFits:, check if is valid and can be applied.
+  // nextLayout was likely created by a call to layoutThatFits:, check if it is valid and can be applied.
   // If our bounds size is different than it, or invalid, recalculate.  Use #define to avoid nullptr->
   if (nextLayout == nullptr || nextLayout->isDirty() == YES || layoutSizeDifferentFromBounds) {
     // Use the last known constrainedSize passed from a parent during layout (if never, use bounds).

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -3725,6 +3725,8 @@ ASDISPLAYNODE_INLINE BOOL nodeIsInRasterizedTree(ASDisplayNode *node) {
   ASDisplayNodeAssertLockUnownedByCurrentThread(__instanceLock__);
   [_interfaceStateDelegate didEnterPreloadState];
   
+  // Trigger a layout pass to ensure all subnodes have the correct size to preload their content.
+  // This is important for image nodes, as well as collection and table nodes.
   [self layoutIfNeeded];
   
   if (_methodOverrides & ASDisplayNodeMethodOverrideFetchData) {

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -1014,6 +1014,8 @@ ASLayoutElementFinalLayoutElementDefault
     [self _locked_layoutPlaceholderIfNecessary];
   }
   
+  [self _layoutSublayouts];
+  
   ASPerformBlockOnMainThread(^{
     [self layout];
     [self layoutDidFinish];
@@ -1407,12 +1409,13 @@ ASLayoutElementFinalLayoutElementDefault
 
 - (void)layout
 {
-  [self _layoutSublayouts];
+  ASDisplayNodeAssertMainThread();
+  // Subclass hook
 }
 
 - (void)_layoutSublayouts
 {
-  ASDisplayNodeAssertMainThread();
+  ASDisplayNodeAssertThreadAffinity(self);
   ASDisplayNodeAssertLockUnownedByCurrentThread(__instanceLock__);
   
   ASLayout *layout;

--- a/Source/ASTableNode.mm
+++ b/Source/ASTableNode.mm
@@ -126,16 +126,18 @@
   [self.rangeController clearContents];
 }
 
-- (void)didExitPreloadState
-{
-  [super didExitPreloadState];
-  [self.rangeController clearPreloadedData];
-}
-
 - (void)interfaceStateDidChange:(ASInterfaceState)newState fromState:(ASInterfaceState)oldState
 {
   [super interfaceStateDidChange:newState fromState:oldState];
   [ASRangeController layoutDebugOverlayIfNeeded];
+}
+
+- (void)didEnterPreloadState
+{
+  // Intentionally allocate the view here so that super will trigger a layout pass on it which in turn will trigger the intial data load.
+  // We can get rid of this call later when ASDataController, ASRangeController and ASCollectionLayout can operate without the view.
+  [self view];
+  [super didEnterPreloadState];
 }
 
 #if ASRangeControllerLoggingEnabled
@@ -151,6 +153,12 @@
   NSLog(@"%@ - visible: NO", self);
 }
 #endif
+
+- (void)didExitPreloadState
+{
+  [super didExitPreloadState];
+  [self.rangeController clearPreloadedData];
+}
 
 #pragma mark Setter / Getter
 

--- a/Source/Details/UIView+ASConvenience.h
+++ b/Source/Details/UIView+ASConvenience.h
@@ -42,6 +42,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)setNeedsDisplay;
 - (void)setNeedsLayout;
+- (void)layoutIfNeeded;
 
 @end
 

--- a/Source/Details/_ASCollectionViewCell.m
+++ b/Source/Details/_ASCollectionViewCell.m
@@ -58,6 +58,7 @@
  */
 - (void)applyLayoutAttributes:(UICollectionViewLayoutAttributes *)layoutAttributes
 {
+  [super applyLayoutAttributes:layoutAttributes];
   self.layoutAttributes = layoutAttributes;
 }
 

--- a/Source/Private/ASDisplayNode+UIViewBridge.mm
+++ b/Source/Private/ASDisplayNode+UIViewBridge.mm
@@ -331,7 +331,6 @@ if (shouldApply) { _layer.layerProperty = (layerValueExpr); } else { ASDisplayNo
       // which may call -displayIfNeeded. We want to ensure the needsDisplay flag is set now, and then cleared.
       [viewOrLayer setNeedsDisplay];
     } else {
-      // Need to grab the lock here because _ASPendingState itself is not locked at all
       _bridge_prologue_write;
       [ASDisplayNodeGetPendingState(self) setNeedsDisplay];
     }
@@ -361,7 +360,6 @@ if (shouldApply) { _layer.layerProperty = (layerValueExpr); } else { ASDisplayNo
     // The node is loaded but we're not on main.
     // We will call [self __setNeedsLayout] when we apply the pending state.
     // We need to call it on main if the node is loaded to support automatic subnode management.
-    
     _bridge_prologue_write;
     [ASDisplayNodeGetPendingState(self) setNeedsLayout];
   } else {
@@ -390,7 +388,6 @@ if (shouldApply) { _layer.layerProperty = (layerValueExpr); } else { ASDisplayNo
     // The node is loaded but we're not on main.
     // We will call layoutIfNeeded on the view or layer when we apply the pending state. __layout will in turn be called on us (see -[_ASDisplayLayer layoutSublayers]).
     // We need to call it on main if the node is loaded to support automatic subnode management.
-    
     _bridge_prologue_write;
     [ASDisplayNodeGetPendingState(self) layoutIfNeeded];
   } else {

--- a/Source/Private/ASDisplayNode+UIViewBridge.mm
+++ b/Source/Private/ASDisplayNode+UIViewBridge.mm
@@ -40,7 +40,6 @@
 #if DISPLAYNODE_USE_LOCKS
 #define _bridge_prologue_read ASDN::MutexLocker l(__instanceLock__); ASDisplayNodeAssertThreadAffinity(self)
 #define _bridge_prologue_write ASDN::MutexLocker l(__instanceLock__)
-#define _bridge_prologue_write_unlock ASDN::MutexUnlocker u(__instanceLock__)
 #else
 #define _bridge_prologue_read ASDisplayNodeAssertThreadAffinity(self)
 #define _bridge_prologue_write
@@ -78,8 +77,6 @@ if (shouldApply) { _view.viewAndPendingViewStateProperty = (viewAndPendingViewSt
 
 #define _setToLayer(layerProperty, layerValueExpr) BOOL shouldApply = ASDisplayNodeShouldApplyBridgedWriteToView(self); \
 if (shouldApply) { _layer.layerProperty = (layerValueExpr); } else { ASDisplayNodeGetPendingState(self).layerProperty = (layerValueExpr); }
-
-#define _messageToViewOrLayer(viewAndLayerSelector) (_view ? [_view viewAndLayerSelector] : [_layer viewAndLayerSelector])
 
 /**
  * This category implements certain frequently-used properties and methods of UIView and CALayer so that ASDisplayNode clients can just call the view/layer methods on the node,
@@ -301,8 +298,17 @@ if (shouldApply) { _layer.layerProperty = (layerValueExpr); } else { ASDisplayNo
 
 - (void)setNeedsDisplay
 {
-  _bridge_prologue_write;
-  if (_hierarchyState & ASHierarchyStateRasterized) {
+  BOOL isRasterized = NO;
+  BOOL shouldApply = NO;
+  id viewOrLayer = nil;
+  {
+    _bridge_prologue_write;
+    isRasterized = _hierarchyState & ASHierarchyStateRasterized;
+    shouldApply = ASDisplayNodeShouldApplyBridgedWriteToView(self);
+    viewOrLayer = _view ?: _layer;
+  }
+  
+  if (isRasterized) {
     ASPerformBlockOnMainThread(^{
       // The below operation must be performed on the main thread to ensure against an extremely rare deadlock, where a parent node
       // begins materializing the view / layer hierarchy (locking itself or a descendant) while this node walks up
@@ -319,13 +325,14 @@ if (shouldApply) { _layer.layerProperty = (layerValueExpr); } else { ASDisplayNo
       [rasterizedContainerNode setNeedsDisplay];
     });
   } else {
-    BOOL shouldApply = ASDisplayNodeShouldApplyBridgedWriteToView(self);
     if (shouldApply) {
       // If not rasterized, and the node is loaded (meaning we certainly have a view or layer), send a
       // message to the view/layer first. This is because __setNeedsDisplay calls as scheduleNodeForDisplay,
       // which may call -displayIfNeeded. We want to ensure the needsDisplay flag is set now, and then cleared.
-      _messageToViewOrLayer(setNeedsDisplay);
+      [viewOrLayer setNeedsDisplay];
     } else {
+      // Need to grab the lock here because _ASPendingState itself is not locked at all
+      _bridge_prologue_write;
       [ASDisplayNodeGetPendingState(self) setNeedsDisplay];
     }
     [self __setNeedsDisplay];
@@ -334,29 +341,61 @@ if (shouldApply) { _layer.layerProperty = (layerValueExpr); } else { ASDisplayNo
 
 - (void)setNeedsLayout
 {
-  _bridge_prologue_write;
-  BOOL shouldApply = ASDisplayNodeShouldApplyBridgedWriteToView(self);
+  BOOL shouldApply = NO;
+  BOOL loaded = NO;
+  id viewOrLayer = nil;
+  {
+    _bridge_prologue_write;
+    shouldApply = ASDisplayNodeShouldApplyBridgedWriteToView(self);
+    loaded = __loaded(self);
+    viewOrLayer = _view ?: _layer;
+  }
+  
   if (shouldApply) {
     // The node is loaded and we're on main.
     // Quite the opposite of setNeedsDisplay, we must call __setNeedsLayout before messaging
     // the view or layer to ensure that measurement and implicitly added subnodes have been handled.
-    
-    // Calling __setNeedsLayout while holding the property lock can cause deadlocks
-    _bridge_prologue_write_unlock;
     [self __setNeedsLayout];
-    _bridge_prologue_write;
-    _messageToViewOrLayer(setNeedsLayout);
-  } else if (__loaded(self)) {
+    [viewOrLayer setNeedsLayout];
+  } else if (loaded) {
     // The node is loaded but we're not on main.
-    // We will call [self __setNeedsLayout] when we apply
-    // the pending state. We need to call it on main if the node is loaded
-    // to support automatic subnode management.
+    // We will call [self __setNeedsLayout] when we apply the pending state.
+    // We need to call it on main if the node is loaded to support automatic subnode management.
+    
+    _bridge_prologue_write;
     [ASDisplayNodeGetPendingState(self) setNeedsLayout];
   } else {
     // The node is not loaded and we're not on main.
-    _bridge_prologue_write_unlock;
     [self __setNeedsLayout];
+  }
+}
+
+- (void)layoutIfNeeded
+{
+  BOOL shouldApply = NO;
+  BOOL loaded = NO;
+  id viewOrLayer = nil;
+  {
     _bridge_prologue_write;
+    shouldApply = ASDisplayNodeShouldApplyBridgedWriteToView(self);
+    loaded = __loaded(self);
+    viewOrLayer = _view ?: _layer;
+  }
+  
+  if (shouldApply) {
+    // The node is loaded and we're on main.
+    // Message the view or layer which in turn will call __layout on us (see -[_ASDisplayLayer layoutSublayers]).
+    [viewOrLayer layoutIfNeeded];
+  } else if (loaded) {
+    // The node is loaded but we're not on main.
+    // We will call layoutIfNeeded on the view or layer when we apply the pending state. __layout will in turn be called on us (see -[_ASDisplayLayer layoutSublayers]).
+    // We need to call it on main if the node is loaded to support automatic subnode management.
+    
+    _bridge_prologue_write;
+    [ASDisplayNodeGetPendingState(self) layoutIfNeeded];
+  } else {
+    // The node is not loaded and we're not on main.
+    [self __layout];
   }
 }
 

--- a/Source/Private/_ASPendingState.mm
+++ b/Source/Private/_ASPendingState.mm
@@ -24,7 +24,8 @@ typedef struct {
   // Properties
   int needsDisplay:1;
   int needsLayout:1;
-
+  int layoutIfNeeded:1;
+  
   // Flags indicating that a given property should be applied to the view at creation
   int setClipsToBounds:1;
   int setOpaque:1;
@@ -270,6 +271,11 @@ static BOOL defaultAllowsEdgeAntialiasing = NO;
 - (void)setNeedsLayout
 {
   _flags.needsLayout = YES;
+}
+
+- (void)layoutIfNeeded
+{
+  _flags.layoutIfNeeded = YES;
 }
 
 - (void)setClipsToBounds:(BOOL)flag
@@ -761,9 +767,6 @@ static BOOL defaultAllowsEdgeAntialiasing = NO;
   if (flags.setEdgeAntialiasingMask)
     layer.edgeAntialiasingMask = edgeAntialiasingMask;
 
-  if (flags.needsLayout)
-    [layer setNeedsLayout];
-
   if (flags.setAsyncTransactionContainer)
     layer.asyncdisplaykit_asyncTransactionContainer = asyncTransactionContainer;
 
@@ -771,6 +774,12 @@ static BOOL defaultAllowsEdgeAntialiasing = NO;
     ASDisplayNodeAssert(layer.opaque == opaque, @"Didn't set opaque as desired");
 
   ASPendingStateApplyMetricsToLayer(self, layer);
+  
+  if (flags.needsLayout)
+    [layer setNeedsLayout];
+  
+  if (flags.layoutIfNeeded)
+    [layer layoutIfNeeded];
 }
 
 - (void)applyToView:(UIView *)view withSpecialPropertiesHandling:(BOOL)specialPropertiesHandling
@@ -889,9 +898,6 @@ static BOOL defaultAllowsEdgeAntialiasing = NO;
   if (flags.setEdgeAntialiasingMask)
     layer.edgeAntialiasingMask = edgeAntialiasingMask;
 
-  if (flags.needsLayout)
-    [view setNeedsLayout];
-
   if (flags.setAsyncTransactionContainer)
     view.asyncdisplaykit_asyncTransactionContainer = asyncTransactionContainer;
 
@@ -955,6 +961,12 @@ static BOOL defaultAllowsEdgeAntialiasing = NO;
   } else {
     ASPendingStateApplyMetricsToLayer(self, layer);
   }
+  
+  if (flags.needsLayout)
+    [view setNeedsLayout];
+  
+  if (flags.layoutIfNeeded)
+    [view layoutIfNeeded];
 }
 
 // FIXME: Make this more efficient by tracking which properties are set rather than reading everything.


### PR DESCRIPTION
This ensures all subnodes have the correct size to preload their content. This is important for image nodes, as well as collection and table nodes.

For collection node, we can take a step further by telling it load initial data during preload state. Without doing this, the node often loads when it enters display state which is too late. And its cells can't even start prefetching before the loading finishes. [Here](https://www.dropbox.com/s/neqp2juv9l2zi7z/Pin-to-pin%20swiping.mp4?dl=0) is a video on pin-to-pin swiping before (left) and after (right) this diff.

Since ASDisplayNode currently doesn't have a `layoutIfNeeded` implementation, I'd have to allocate its view/layer (or call `__layout` directly) in order to trigger a layout pass. Instead, I went ahead and implement the method. It's more convenient for users and helps them to avoid prematurely allocate the backing store.

I also took the opportunity to revisit the locking situation of some methods inside `ASDisplayNode+UIViewBridge`.



