### PR TITLE
[ASThread] Move thread ownership assertion to ASThread

### DIFF
--- a/Source/Base/ASAssert.h
+++ b/Source/Base/ASAssert.h
@@ -59,19 +59,6 @@
 #define ASDisplayNodeCAssertPositiveReal(description, num) ASDisplayNodeCAssert(num >= 0 && num <= CGFLOAT_MAX, @"%@ must be a real positive integer.", description)
 #define ASDisplayNodeCAssertInfOrPositiveReal(description, num) ASDisplayNodeCAssert(isinf(num) || (num >= 0 && num <= CGFLOAT_MAX), @"%@ must be infinite or a real positive integer.", description)
 
-/**
- * Assert if the current thread owns a mutex.
- * This assertion is useful when you want to indicate and enforce the locking policy/expectation of methods.
- * To determine when and which methods acquired a (recursive) mutex (to debug deadlocks, for example),
- * put breakpoints at some of these assertions. When the breakpoints hit, walk through stack trace frames
- * and check ownership count of the mutex.
- */
-#if CHECK_LOCKING_SAFETY
-#define ASDisplayNodeAssertLockUnownedByCurrentThread(lock) ASDisplayNodeAssertFalse(lock.ownedByCurrentThread())
-#else
-#define ASDisplayNodeAssertLockUnownedByCurrentThread(lock)
-#endif
-
 #define ASDisplayNodeErrorDomain @"ASDisplayNodeErrorDomain"
 #define ASDisplayNodeNonFatalErrorCode 1
 

--- a/Source/Details/ASThread.h
+++ b/Source/Details/ASThread.h
@@ -64,6 +64,18 @@ static inline BOOL ASDisplayNodeThreadIsMain()
   _Pragma("clang diagnostic pop"); \
 } while (0)
 
+/**
+ * Assert if the current thread owns a mutex.
+ * This assertion is useful when you want to indicate and enforce the locking policy/expectation of methods.
+ * To determine when and which methods acquired a (recursive) mutex (to debug deadlocks, for example),
+ * put breakpoints at some of these assertions. When the breakpoints hit, walk through stack trace frames
+ * and check ownership count of the mutex.
+ */
+#if CHECK_LOCKING_SAFETY
+#define ASDisplayNodeAssertLockUnownedByCurrentThread(lock) ASDisplayNodeAssertFalse(lock.ownedByCurrentThread())
+#else
+#define ASDisplayNodeAssertLockUnownedByCurrentThread(lock)
+#endif
 
 namespace ASDN {
   


### PR DESCRIPTION
Fix below warning:
> /Users/engineering/jenkins_root/workspace/AsyncDisplayKit-PRs/Source/Base/ASAssert.h:69:5: 'CHECK_LOCKING_SAFETY' is not defined, evaluates to 0 [-Wundef]