### PR TITLE
Create a Pluggable "Tips" System to Help in Development

### DIFF
--- a/AsyncDisplayKit.podspec
+++ b/AsyncDisplayKit.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |spec|
         'Source/Details/**/*.h',
         'Source/Layout/**/*.h',
         'Source/Base/*.h',
-        'Source/Debug/AsyncDisplayKit+Debug.h',
+        'Source/Debug/**/*.h',
         'Source/TextKit/ASTextNodeTypes.h',
         'Source/TextKit/ASTextKitComponents.h'
     ]

--- a/AsyncDisplayKit.xcodeproj/project.pbxproj
+++ b/AsyncDisplayKit.xcodeproj/project.pbxproj
@@ -342,6 +342,8 @@
 		CC57EAF71E3939350034C595 /* ASCollectionView+Undeprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = CC2E317F1DAC353700EEE891 /* ASCollectionView+Undeprecated.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CC57EAF81E3939450034C595 /* ASTableView+Undeprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = CC512B841DAC45C60054848E /* ASTableView+Undeprecated.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CC58AA4B1E398E1D002C8CB4 /* ASBlockTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = CC58AA4A1E398E1D002C8CB4 /* ASBlockTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CC6AA2DA1E9F03B900978E87 /* ASDisplayNode+Ancestry.h in Headers */ = {isa = PBXBuildFile; fileRef = CC6AA2D81E9F03B900978E87 /* ASDisplayNode+Ancestry.h */; };
+		CC6AA2DB1E9F03B900978E87 /* ASDisplayNode+Ancestry.m in Sources */ = {isa = PBXBuildFile; fileRef = CC6AA2D91E9F03B900978E87 /* ASDisplayNode+Ancestry.m */; };
 		CC7FD9E11BB5F750005CCB2B /* ASPhotosFrameworkImageRequestTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CC7FD9E01BB5F750005CCB2B /* ASPhotosFrameworkImageRequestTests.m */; };
 		CC7FD9E21BB603FF005CCB2B /* ASPhotosFrameworkImageRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = CC7FD9DC1BB5E962005CCB2B /* ASPhotosFrameworkImageRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CC87BB951DA8193C0090E380 /* ASCellNode+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = CC87BB941DA8193C0090E380 /* ASCellNode+Internal.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -349,6 +351,22 @@
 		CC8B05D81D73979700F54286 /* ASTextNodePerformanceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CC8B05D71D73979700F54286 /* ASTextNodePerformanceTests.m */; };
 		CC90E1F41E383C0400FED591 /* AsyncDisplayKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B35061DA1B010EDF0018CF92 /* AsyncDisplayKit.framework */; };
 		CCA221D31D6FA7EF00AF6A0F /* ASViewControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CCA221D21D6FA7EF00AF6A0F /* ASViewControllerTests.m */; };
+		CCA282B41E9EA7310037E8B7 /* ASTipsController.h in Headers */ = {isa = PBXBuildFile; fileRef = CCA282B21E9EA7310037E8B7 /* ASTipsController.h */; };
+		CCA282B51E9EA7310037E8B7 /* ASTipsController.m in Sources */ = {isa = PBXBuildFile; fileRef = CCA282B31E9EA7310037E8B7 /* ASTipsController.m */; };
+		CCA282B81E9EA8E40037E8B7 /* AsyncDisplayKit+Tips.h in Headers */ = {isa = PBXBuildFile; fileRef = CCA282B61E9EA8E40037E8B7 /* AsyncDisplayKit+Tips.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CCA282B91E9EA8E40037E8B7 /* AsyncDisplayKit+Tips.m in Sources */ = {isa = PBXBuildFile; fileRef = CCA282B71E9EA8E40037E8B7 /* AsyncDisplayKit+Tips.m */; };
+		CCA282BC1E9EABDD0037E8B7 /* ASTipProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = CCA282BA1E9EABDD0037E8B7 /* ASTipProvider.h */; };
+		CCA282BD1E9EABDD0037E8B7 /* ASTipProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = CCA282BB1E9EABDD0037E8B7 /* ASTipProvider.m */; };
+		CCA282C01E9EAE010037E8B7 /* ASTip.h in Headers */ = {isa = PBXBuildFile; fileRef = CCA282BE1E9EAE010037E8B7 /* ASTip.h */; };
+		CCA282C11E9EAE010037E8B7 /* ASTip.m in Sources */ = {isa = PBXBuildFile; fileRef = CCA282BF1E9EAE010037E8B7 /* ASTip.m */; };
+		CCA282C41E9EAE630037E8B7 /* ASLayerBackingTipProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = CCA282C21E9EAE630037E8B7 /* ASLayerBackingTipProvider.h */; };
+		CCA282C51E9EAE630037E8B7 /* ASLayerBackingTipProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = CCA282C31E9EAE630037E8B7 /* ASLayerBackingTipProvider.m */; };
+		CCA282C81E9EB64B0037E8B7 /* ASDisplayNodeTipState.h in Headers */ = {isa = PBXBuildFile; fileRef = CCA282C61E9EB64B0037E8B7 /* ASDisplayNodeTipState.h */; };
+		CCA282C91E9EB64B0037E8B7 /* ASDisplayNodeTipState.m in Sources */ = {isa = PBXBuildFile; fileRef = CCA282C71E9EB64B0037E8B7 /* ASDisplayNodeTipState.m */; };
+		CCA282CC1E9EB73E0037E8B7 /* ASTipNode.h in Headers */ = {isa = PBXBuildFile; fileRef = CCA282CA1E9EB73E0037E8B7 /* ASTipNode.h */; };
+		CCA282CD1E9EB73E0037E8B7 /* ASTipNode.m in Sources */ = {isa = PBXBuildFile; fileRef = CCA282CB1E9EB73E0037E8B7 /* ASTipNode.m */; };
+		CCA282D01E9EBF6C0037E8B7 /* ASTipsWindow.h in Headers */ = {isa = PBXBuildFile; fileRef = CCA282CE1E9EBF6C0037E8B7 /* ASTipsWindow.h */; };
+		CCA282D11E9EBF6C0037E8B7 /* ASTipsWindow.m in Sources */ = {isa = PBXBuildFile; fileRef = CCA282CF1E9EBF6C0037E8B7 /* ASTipsWindow.m */; };
 		CCB2F34D1D63CCC6004E6DE9 /* ASDisplayNodeSnapshotTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CCB2F34C1D63CCC6004E6DE9 /* ASDisplayNodeSnapshotTests.m */; };
 		CCF18FF41D2575E300DF5895 /* NSIndexSet+ASHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = CC4981BA1D1C7F65004E13CC /* NSIndexSet+ASHelpers.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DB55C2671C641AE4004EDCF5 /* ASContextTransitioning.h in Headers */ = {isa = PBXBuildFile; fileRef = DB55C2651C641AE4004EDCF5 /* ASContextTransitioning.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -753,6 +771,8 @@
 		CC55A7101E52A0F200594372 /* ASResponderChainEnumerator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASResponderChainEnumerator.m; sourceTree = "<group>"; };
 		CC57EAF91E394EA40034C595 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		CC58AA4A1E398E1D002C8CB4 /* ASBlockTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASBlockTypes.h; sourceTree = "<group>"; };
+		CC6AA2D81E9F03B900978E87 /* ASDisplayNode+Ancestry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "ASDisplayNode+Ancestry.h"; path = "Base/ASDisplayNode+Ancestry.h"; sourceTree = "<group>"; };
+		CC6AA2D91E9F03B900978E87 /* ASDisplayNode+Ancestry.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "ASDisplayNode+Ancestry.m"; path = "Base/ASDisplayNode+Ancestry.m"; sourceTree = "<group>"; };
 		CC7FD9DC1BB5E962005CCB2B /* ASPhotosFrameworkImageRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASPhotosFrameworkImageRequest.h; sourceTree = "<group>"; };
 		CC7FD9DD1BB5E962005CCB2B /* ASPhotosFrameworkImageRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASPhotosFrameworkImageRequest.m; sourceTree = "<group>"; };
 		CC7FD9E01BB5F750005CCB2B /* ASPhotosFrameworkImageRequestTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASPhotosFrameworkImageRequestTests.m; sourceTree = "<group>"; };
@@ -761,6 +781,22 @@
 		CC8B05D51D73836400F54286 /* ASPerformanceTestContext.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASPerformanceTestContext.m; sourceTree = "<group>"; };
 		CC8B05D71D73979700F54286 /* ASTextNodePerformanceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASTextNodePerformanceTests.m; sourceTree = "<group>"; };
 		CCA221D21D6FA7EF00AF6A0F /* ASViewControllerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASViewControllerTests.m; sourceTree = "<group>"; };
+		CCA282B21E9EA7310037E8B7 /* ASTipsController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTipsController.h; sourceTree = "<group>"; };
+		CCA282B31E9EA7310037E8B7 /* ASTipsController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASTipsController.m; sourceTree = "<group>"; };
+		CCA282B61E9EA8E40037E8B7 /* AsyncDisplayKit+Tips.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "AsyncDisplayKit+Tips.h"; sourceTree = "<group>"; };
+		CCA282B71E9EA8E40037E8B7 /* AsyncDisplayKit+Tips.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "AsyncDisplayKit+Tips.m"; sourceTree = "<group>"; };
+		CCA282BA1E9EABDD0037E8B7 /* ASTipProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTipProvider.h; sourceTree = "<group>"; };
+		CCA282BB1E9EABDD0037E8B7 /* ASTipProvider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASTipProvider.m; sourceTree = "<group>"; };
+		CCA282BE1E9EAE010037E8B7 /* ASTip.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTip.h; sourceTree = "<group>"; };
+		CCA282BF1E9EAE010037E8B7 /* ASTip.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASTip.m; sourceTree = "<group>"; };
+		CCA282C21E9EAE630037E8B7 /* ASLayerBackingTipProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASLayerBackingTipProvider.h; sourceTree = "<group>"; };
+		CCA282C31E9EAE630037E8B7 /* ASLayerBackingTipProvider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASLayerBackingTipProvider.m; sourceTree = "<group>"; };
+		CCA282C61E9EB64B0037E8B7 /* ASDisplayNodeTipState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASDisplayNodeTipState.h; sourceTree = "<group>"; };
+		CCA282C71E9EB64B0037E8B7 /* ASDisplayNodeTipState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASDisplayNodeTipState.m; sourceTree = "<group>"; };
+		CCA282CA1E9EB73E0037E8B7 /* ASTipNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTipNode.h; sourceTree = "<group>"; };
+		CCA282CB1E9EB73E0037E8B7 /* ASTipNode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASTipNode.m; sourceTree = "<group>"; };
+		CCA282CE1E9EBF6C0037E8B7 /* ASTipsWindow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTipsWindow.h; sourceTree = "<group>"; };
+		CCA282CF1E9EBF6C0037E8B7 /* ASTipsWindow.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASTipsWindow.m; sourceTree = "<group>"; };
 		CCB2F34C1D63CCC6004E6DE9 /* ASDisplayNodeSnapshotTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASDisplayNodeSnapshotTests.m; sourceTree = "<group>"; };
 		CCBD05DE1E4147B000D18509 /* ASIGListAdapterBasedDataSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASIGListAdapterBasedDataSource.m; sourceTree = "<group>"; };
 		CCBD05DF1E4147B000D18509 /* ASIGListAdapterBasedDataSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASIGListAdapterBasedDataSource.h; sourceTree = "<group>"; };
@@ -956,6 +992,8 @@
 				0516FA3F1A1563D200B4EBED /* ASMultiplexImageNode.mm */,
 				68FC85DC1CE29AB700EDD713 /* ASNavigationController.h */,
 				68FC85DD1CE29AB700EDD713 /* ASNavigationController.m */,
+				CC6AA2D81E9F03B900978E87 /* ASDisplayNode+Ancestry.h */,
+				CC6AA2D91E9F03B900978E87 /* ASDisplayNode+Ancestry.m */,
 				055B9FA61A1C154B00035D6D /* ASNetworkImageNode.h */,
 				055B9FA71A1C154B00035D6D /* ASNetworkImageNode.mm */,
 				698371D91E4379CD00437585 /* ASNodeController+Beta.h */,
@@ -1183,6 +1221,20 @@
 		058D0A01195D050800B7D73C /* Private */ = {
 			isa = PBXGroup;
 			children = (
+				CCA282CE1E9EBF6C0037E8B7 /* ASTipsWindow.h */,
+				CCA282CF1E9EBF6C0037E8B7 /* ASTipsWindow.m */,
+				CCA282C61E9EB64B0037E8B7 /* ASDisplayNodeTipState.h */,
+				CCA282C71E9EB64B0037E8B7 /* ASDisplayNodeTipState.m */,
+				CCA282CA1E9EB73E0037E8B7 /* ASTipNode.h */,
+				CCA282CB1E9EB73E0037E8B7 /* ASTipNode.m */,
+				CCA282BE1E9EAE010037E8B7 /* ASTip.h */,
+				CCA282BF1E9EAE010037E8B7 /* ASTip.m */,
+				CCA282C21E9EAE630037E8B7 /* ASLayerBackingTipProvider.h */,
+				CCA282C31E9EAE630037E8B7 /* ASLayerBackingTipProvider.m */,
+				CCA282BA1E9EABDD0037E8B7 /* ASTipProvider.h */,
+				CCA282BB1E9EABDD0037E8B7 /* ASTipProvider.m */,
+				CCA282B21E9EA7310037E8B7 /* ASTipsController.h */,
+				CCA282B31E9EA7310037E8B7 /* ASTipsController.m */,
 				CC2F65EC1E5FFB1600DA57C9 /* ASMutableElementMap.h */,
 				CC2F65ED1E5FFB1600DA57C9 /* ASMutableElementMap.m */,
 				E5ABAC791E8564EE007AC15C /* ASRectTable.h */,
@@ -1414,6 +1466,8 @@
 		DE89C1691DCEB9CC00D49D74 /* Debug */ = {
 			isa = PBXGroup;
 			children = (
+				CCA282B61E9EA8E40037E8B7 /* AsyncDisplayKit+Tips.h */,
+				CCA282B71E9EA8E40037E8B7 /* AsyncDisplayKit+Tips.m */,
 				764D83D21C8EA515009B4FB8 /* AsyncDisplayKit+Debug.h */,
 				764D83D31C8EA515009B4FB8 /* AsyncDisplayKit+Debug.m */,
 			);
@@ -1477,6 +1531,7 @@
 				B35062111B010EFD0018CF92 /* _ASDisplayView.h in Headers */,
 				9C55866C1BD54A3000B50E3A /* ASAsciiArtBoxCreator.h in Headers */,
 				509E68611B3AEDA0009B9150 /* ASAbstractLayoutController.h in Headers */,
+				CCA282B81E9EA8E40037E8B7 /* AsyncDisplayKit+Tips.h in Headers */,
 				B35062571B010F070018CF92 /* ASAssert.h in Headers */,
 				B35062581B010F070018CF92 /* ASAvailability.h in Headers */,
 				DE84918D1C8FFF2B003D89E9 /* ASRunLoopQueue.h in Headers */,
@@ -1502,6 +1557,7 @@
 				68FC85EA1CE29C7D00EDD713 /* ASVisibilityProtocols.h in Headers */,
 				A37320101C571B740011FC94 /* ASTextNode+Beta.h in Headers */,
 				9C70F2061CDA4F0C007D6C76 /* ASTraitCollection.h in Headers */,
+				CC6AA2DA1E9F03B900978E87 /* ASDisplayNode+Ancestry.h in Headers */,
 				8021EC1D1D2B00B100799119 /* UIImage+ASConvenience.h in Headers */,
 				B35061FD1B010EFD0018CF92 /* ASDisplayNode+Subclasses.h in Headers */,
 				B35061FB1B010EFD0018CF92 /* ASDisplayNode.h in Headers */,
@@ -1559,6 +1615,7 @@
 				E58E9E491E941DA5004CFC59 /* ASCollectionLayout.h in Headers */,
 				254C6B7F1BF94DF4003EC431 /* ASTextKitTruncating.h in Headers */,
 				CC58AA4B1E398E1D002C8CB4 /* ASBlockTypes.h in Headers */,
+				CCA282BC1E9EABDD0037E8B7 /* ASTipProvider.h in Headers */,
 				6977965F1D8AC8D3007E93D7 /* ASLayoutSpec+Subclasses.h in Headers */,
 				692BE8D71E36B65B00C86D87 /* ASLayoutSpecPrivate.h in Headers */,
 				34EFC75D1B701BE900AD841F /* ASInternalHelpers.h in Headers */,
@@ -1591,6 +1648,7 @@
 				B35062211B010EFD0018CF92 /* ASLayoutRangeType.h in Headers */,
 				CC2F65EE1E5FFB1600DA57C9 /* ASMutableElementMap.h in Headers */,
 				34EFC76A1B701CE600AD841F /* ASLayoutSpec.h in Headers */,
+				CCA282D01E9EBF6C0037E8B7 /* ASTipsWindow.h in Headers */,
 				B350625C1B010F070018CF92 /* ASLog.h in Headers */,
 				CC3B208A1C3F7A5400798563 /* ASWeakSet.h in Headers */,
 				B35062041B010EFD0018CF92 /* ASMultiplexImageNode.h in Headers */,
@@ -1598,16 +1656,19 @@
 				B35062241B010EFD0018CF92 /* ASMutableAttributedStringBuilder.h in Headers */,
 				B13CA0F81C519EBA00E031AB /* ASCollectionViewLayoutFacilitatorProtocol.h in Headers */,
 				B35062061B010EFD0018CF92 /* ASNetworkImageNode.h in Headers */,
+				CCA282C81E9EB64B0037E8B7 /* ASDisplayNodeTipState.h in Headers */,
 				34EFC76C1B701CED00AD841F /* ASOverlayLayoutSpec.h in Headers */,
 				E5ABAC7B1E8564EE007AC15C /* ASRectTable.h in Headers */,
 				B35062261B010EFD0018CF92 /* ASRangeController.h in Headers */,
 				34EFC76E1B701CF400AD841F /* ASRatioLayoutSpec.h in Headers */,
 				DB55C2671C641AE4004EDCF5 /* ASContextTransitioning.h in Headers */,
+				CCA282C41E9EAE630037E8B7 /* ASLayerBackingTipProvider.h in Headers */,
 				6900C5F41E8072DA00BCD75C /* ASImageNode+Private.h in Headers */,
 				68B0277B1C1A79D60041016B /* ASDisplayNode+Beta.h in Headers */,
 				B350622D1B010EFD0018CF92 /* ASScrollDirection.h in Headers */,
 				254C6B751BF94DF4003EC431 /* ASTextKitComponents.h in Headers */,
 				B35062081B010EFD0018CF92 /* ASScrollNode.h in Headers */,
+				CCA282CC1E9EB73E0037E8B7 /* ASTipNode.h in Headers */,
 				25E327571C16819500A2170C /* ASPagerNode.h in Headers */,
 				9C70F20E1CDBE9E5007D6C76 /* NSArray+Diffing.h in Headers */,
 				9C49C3701B853961000B0DD5 /* ASStackLayoutElement.h in Headers */,
@@ -1616,7 +1677,9 @@
 				764D83D51C8EA515009B4FB8 /* AsyncDisplayKit+Debug.h in Headers */,
 				CC7FD9E21BB603FF005CCB2B /* ASPhotosFrameworkImageRequest.h in Headers */,
 				254C6B761BF94DF4003EC431 /* ASTextNodeTypes.h in Headers */,
+				CCA282B41E9EA7310037E8B7 /* ASTipsController.h in Headers */,
 				34EFC7711B701CFF00AD841F /* ASStackLayoutSpec.h in Headers */,
+				CCA282C01E9EAE010037E8B7 /* ASTip.h in Headers */,
 				2767E9411BB19BD600EA9B77 /* ASViewController.h in Headers */,
 				92DD2FE81BF4D0A80074C9DD /* ASMapNode.h in Headers */,
 				9C6BB3B31B8CC9C200F13F52 /* ASAbsoluteLayoutElement.h in Headers */,
@@ -1890,10 +1953,12 @@
 				9F98C0261DBE29E000476D92 /* ASControlTargetAction.m in Sources */,
 				9C70F2091CDABA36007D6C76 /* ASViewController.mm in Sources */,
 				3917EBD51E9C2FC400D04A01 /* _ASCollectionReusableView.m in Sources */,
+				CCA282D11E9EBF6C0037E8B7 /* ASTipsWindow.m in Sources */,
 				8BBBAB8D1CEBAF1E00107FC6 /* ASDefaultPlaybackButton.m in Sources */,
 				B30BF6541C59D889004FCD53 /* ASLayoutManager.m in Sources */,
 				690C35671E0567C600069B91 /* ASDimensionDeprecated.mm in Sources */,
 				92DD2FE71BF4D0850074C9DD /* ASMapNode.mm in Sources */,
+				CCA282B91E9EA8E40037E8B7 /* AsyncDisplayKit+Tips.m in Sources */,
 				636EA1A51C7FF4EF00EE152F /* ASDefaultPlayButton.m in Sources */,
 				B350623D1B010EFD0018CF92 /* _ASAsyncTransaction.mm in Sources */,
 				E516FC801E9FE24200714FF4 /* ASEqualityHashHelpers.mm in Sources */,
@@ -1901,14 +1966,17 @@
 				B35062401B010EFD0018CF92 /* _ASAsyncTransactionContainer.m in Sources */,
 				AC026B721BD57DBF00BBC17E /* _ASHierarchyChangeSet.mm in Sources */,
 				B35062421B010EFD0018CF92 /* _ASAsyncTransactionGroup.m in Sources */,
+				CCA282BD1E9EABDD0037E8B7 /* ASTipProvider.m in Sources */,
 				B350624A1B010EFD0018CF92 /* _ASCoreAnimationExtras.mm in Sources */,
 				68EE0DC01C1B4ED300BA1B99 /* ASMainSerialQueue.mm in Sources */,
 				B35062101B010EFD0018CF92 /* _ASDisplayLayer.mm in Sources */,
 				9C55866B1BD54A1900B50E3A /* ASAsciiArtBoxCreator.m in Sources */,
 				B35062121B010EFD0018CF92 /* _ASDisplayView.mm in Sources */,
 				DEFAD8131CC48914000527C4 /* ASVideoNode.mm in Sources */,
+				CCA282C11E9EAE010037E8B7 /* ASTip.m in Sources */,
 				B350624C1B010EFD0018CF92 /* _ASPendingState.mm in Sources */,
 				698371DC1E4379CD00437585 /* ASNodeController+Beta.m in Sources */,
+				CC6AA2DB1E9F03B900978E87 /* ASDisplayNode+Ancestry.m in Sources */,
 				509E68621B3AEDA5009B9150 /* ASAbstractLayoutController.mm in Sources */,
 				254C6B861BF94F8A003EC431 /* ASTextKitContext.mm in Sources */,
 				DBDB83971C6E879900D0098C /* ASPagerFlowLayout.m in Sources */,
@@ -1930,6 +1998,7 @@
 				9C70F20A1CDBE949007D6C76 /* ASTableNode.mm in Sources */,
 				69CB62AE1CB8165900024920 /* _ASDisplayViewAccessiblity.mm in Sources */,
 				B35061F61B010EFD0018CF92 /* ASCollectionView.mm in Sources */,
+				CCA282C51E9EAE630037E8B7 /* ASLayerBackingTipProvider.m in Sources */,
 				509E68641B3AEDB7009B9150 /* ASCollectionViewLayoutController.m in Sources */,
 				B35061F91B010EFD0018CF92 /* ASControlNode.mm in Sources */,
 				8021EC1F1D2B00B100799119 /* UIImage+ASConvenience.m in Sources */,
@@ -1977,6 +2046,7 @@
 				B35062071B010EFD0018CF92 /* ASNetworkImageNode.mm in Sources */,
 				34EFC76D1B701CF100AD841F /* ASOverlayLayoutSpec.mm in Sources */,
 				044285101BAA64EC00D16268 /* ASTwoDimensionalArrayUtils.m in Sources */,
+				CCA282B51E9EA7310037E8B7 /* ASTipsController.m in Sources */,
 				B35062271B010EFD0018CF92 /* ASRangeController.mm in Sources */,
 				0442850A1BAA63FE00D16268 /* ASBatchFetching.m in Sources */,
 				68FC85E61CE29B9400EDD713 /* ASNavigationController.m in Sources */,
@@ -1986,6 +2056,7 @@
 				254C6B851BF94F8A003EC431 /* ASTextKitAttributes.mm in Sources */,
 				90FC784F1E4BFE1B00383C5A /* ASDisplayNode+Yoga.mm in Sources */,
 				E5ABAC7C1E8564EE007AC15C /* ASRectTable.m in Sources */,
+				CCA282C91E9EB64B0037E8B7 /* ASDisplayNodeTipState.m in Sources */,
 				509E68601B3AED8E009B9150 /* ASScrollDirection.m in Sources */,
 				B35062091B010EFD0018CF92 /* ASScrollNode.mm in Sources */,
 				8BDA5FC81CDBDF95007D13B2 /* ASVideoPlayerNode.mm in Sources */,
@@ -2014,6 +2085,7 @@
 				CC55A70E1E529FA200594372 /* UIResponder+AsyncDisplayKit.m in Sources */,
 				697796611D8AC8D3007E93D7 /* ASLayoutSpec+Subclasses.mm in Sources */,
 				B350623B1B010EFD0018CF92 /* NSMutableAttributedString+TextKitAdditions.m in Sources */,
+				CCA282CD1E9EB73E0037E8B7 /* ASTipNode.m in Sources */,
 				044284FD1BAA365100D16268 /* UICollectionViewLayout+ASConvenience.m in Sources */,
 				CC0F885B1E42807F00576FED /* ASCollectionViewFlowLayoutInspector.m in Sources */,
 				690ED5981E36D118000627C0 /* ASControlNode+tvOS.m in Sources */,

--- a/Source/ASCellNode.mm
+++ b/Source/ASCellNode.mm
@@ -368,6 +368,11 @@
   return self.collectionElement.supplementaryElementKind;
 }
 
+- (BOOL)supportsLayerBacking
+{
+  return NO;
+}
+
 @end
 
 

--- a/Source/ASControlNode.mm
+++ b/Source/ASControlNode.mm
@@ -273,6 +273,11 @@ CGRect _ASControlNodeGetExpandedBounds(ASControlNode *controlNode);
   return YES;
 }
 
+- (BOOL)supportsLayerBacking
+{
+  return super.supportsLayerBacking && !self.userInteractionEnabled;
+}
+
 #pragma mark - Action Messages
 
 - (void)addTarget:(id)target action:(SEL)action forControlEvents:(ASControlNodeEvent)controlEventMask
@@ -424,7 +429,7 @@ CGRect _ASControlNodeGetExpandedBounds(ASControlNode *controlNode);
     (ASControlNodeEvent controlEvent)
     {
       // Use a copy to itereate, the action perform could call remove causing a mutation crash.
-      NSMutableArray *eventTargetActionArray = [_controlEventDispatchTable[_ASControlNodeEventKeyForControlEvent(controlEvent)] copy];
+      NSArray *eventTargetActionArray = [_controlEventDispatchTable[_ASControlNodeEventKeyForControlEvent(controlEvent)] copy];
       
       // Iterate on each target action pair
       for (ASControlTargetAction *targetAction in eventTargetActionArray) {

--- a/Source/ASDisplayNode.h
+++ b/Source/ASDisplayNode.h
@@ -592,6 +592,11 @@ extern NSInteger const ASDefaultDrawingPriority;
  */
 - (CGRect)convertRect:(CGRect)rect fromNode:(nullable ASDisplayNode *)node AS_WARN_UNUSED_RESULT;
 
+/**
+ * Whether or not the node would support having .layerBacked = YES.
+ */
+@property (nonatomic, readonly) BOOL supportsLayerBacking;
+
 @end
 
 /**

--- a/Source/ASDisplayNode.mm
+++ b/Source/ASDisplayNode.mm
@@ -37,6 +37,7 @@
 #import <AsyncDisplayKit/ASTraitCollection.h>
 #import <AsyncDisplayKit/ASWeakProxy.h>
 #import <AsyncDisplayKit/ASResponderChainEnumerator.h>
+#import <AsyncDisplayKit/ASTipsController.h>
 
 #if ASDisplayNodeLoggingEnabled
   #define LOG(...) NSLog(__VA_ARGS__)
@@ -245,11 +246,6 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   ASScreenScale();
 }
 
-+ (BOOL)layerBackedNodesEnabled
-{
-  return YES;
-}
-
 + (Class)viewClass
 {
   return [_ASDisplayView class];
@@ -275,6 +271,8 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   _eventLog = [[ASEventLog alloc] initWithObject:self];
 #endif
   
+  _viewClass = [self.class viewClass];
+  _layerClass = [self.class layerClass];
   _contentsScaleForDisplay = ASScreenScale();
   
   _primitiveTraitCollection = ASPrimitiveTraitCollectionMakeDefault();
@@ -574,9 +572,6 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
     _viewBlock = nil;
     _viewClass = [view class];
   } else {
-    if (!_viewClass) {
-      _viewClass = [self.class viewClass];
-    }
     view = [[_viewClass alloc] init];
   }
   
@@ -610,9 +605,6 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
     _layerBlock = nil;
     _layerClass = [layer class];
   } else {
-    if (!_layerClass) {
-      _layerClass = [self.class layerClass];
-    }
     layer = [[_layerClass alloc] init];
   }
 
@@ -805,32 +797,34 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
   return _flags.synchronous;
 }
 
-- (void)setSynchronous:(BOOL)flag
-{
-  ASDN::MutexLocker l(__instanceLock__);
-  _flags.synchronous = flag;
-}
-
 - (void)setLayerBacked:(BOOL)isLayerBacked
 {
-  if (![self.class layerBackedNodesEnabled]) {
+  // Only call this if assertions are enabled – it could be expensive.
+  ASDisplayNodeAssert(!isLayerBacked || self.supportsLayerBacking, @"Node %@ does not support layer backing.", self);
+
+  ASDN::MutexLocker l(__instanceLock__);
+  if (_flags.layerBacked == isLayerBacked) {
+    return;
+  }
+  
+  if ([self _locked_isNodeLoaded]) {
+    ASDisplayNodeFailAssert(@"Cannot change layerBacked after view/layer has loaded.");
     return;
   }
 
-  ASDN::MutexLocker l(__instanceLock__);
-  ASDisplayNodeAssert(!_view && !_layer, @"Cannot change isLayerBacked after layer or view has loaded");
-  ASDisplayNodeAssert(!_viewBlock && !_layerBlock, @"Cannot change isLayerBacked when a layer or view block is provided");
-  ASDisplayNodeAssert(!_viewClass && !_layerClass, @"Cannot change isLayerBacked when a layer or view class is provided");
-
-  if (isLayerBacked != _flags.layerBacked && !_view && !_layer) {
-    _flags.layerBacked = isLayerBacked;
-  }
+  _flags.layerBacked = isLayerBacked;
 }
 
 - (BOOL)isLayerBacked
 {
   ASDN::MutexLocker l(__instanceLock__);
   return _flags.layerBacked;
+}
+
+- (BOOL)supportsLayerBacking
+{
+  ASDN::MutexLocker l(__instanceLock__);
+  return !_flags.synchronous && !_flags.viewEverHadAGestureRecognizerAttached && _viewClass == [_ASDisplayView class] && _layerClass == [_ASDisplayLayer class];
 }
 
 - (BOOL)shouldAnimateSizeChanges
@@ -855,6 +849,12 @@ static ASDisplayNodeMethodOverrides GetASDisplayNodeMethodOverrides(Class c)
 {
   ASDN::MutexLocker l(__instanceLock__);
   _threadSafeBounds = newBounds;
+}
+
+- (void)nodeViewDidAddGestureRecognizer
+{
+  ASDN::MutexLocker l(__instanceLock__);
+  _flags.viewEverHadAGestureRecognizerAttached = YES;
 }
 
 #pragma mark - Layout
@@ -3656,6 +3656,9 @@ ASDISPLAYNODE_INLINE BOOL nodeIsInRasterizedTree(ASDisplayNode *node) {
   ASDisplayNodeAssertMainThread();
   ASDisplayNodeAssertLockUnownedByCurrentThread(__instanceLock__);
   [_interfaceStateDelegate didEnterVisibleState];
+#if AS_ENABLE_TIPS
+  [ASTipsController.shared nodeDidAppear:self];
+#endif
 }
 
 - (void)didExitVisibleState

--- a/Source/ASEditableTextNode.mm
+++ b/Source/ASEditableTextNode.mm
@@ -306,6 +306,11 @@
   [super setLayerBacked:layerBacked];
 }
 
+- (BOOL)supportsLayerBacking
+{
+  return NO;
+}
+
 #pragma mark - Configuration
 @synthesize delegate = _delegate;
 

--- a/Source/ASMapNode.mm
+++ b/Source/ASMapNode.mm
@@ -427,5 +427,11 @@
     }
   }
 }
+
+- (BOOL)supportsLayerBacking
+{
+  return NO;
+}
+
 @end
 #endif

--- a/Source/ASTextNode.mm
+++ b/Source/ASTextNode.mm
@@ -254,6 +254,28 @@ static NSArray *DefaultLinkAttributeNames = @[ NSLinkAttributeName ];
   }
 }
 
+- (BOOL)supportsLayerBacking
+{
+  if (!super.supportsLayerBacking) {
+    return NO;
+  }
+  
+  // If the text contains any links, return NO.
+  NSAttributedString *attributedText = self.attributedText;
+  NSRange range = NSMakeRange(0, attributedText.length);
+  for (NSString *linkAttributeName in _linkAttributeNames) {
+    __block BOOL hasLink = NO;
+    [attributedText enumerateAttribute:linkAttributeName inRange:range options:NSAttributedStringEnumerationLongestEffectiveRangeNotRequired usingBlock:^(id  _Nullable value, NSRange range, BOOL * _Nonnull stop) {
+      hasLink = (value != nil);
+      *stop = YES;
+    }];
+    if (hasLink) {
+      return NO;
+    }
+  }
+  return YES;
+}
+
 #pragma mark - Renderer Management
 
 - (ASTextKitRenderer *)_renderer

--- a/Source/ASVideoPlayerNode.mm
+++ b/Source/ASVideoPlayerNode.mm
@@ -251,6 +251,11 @@ static void *ASVideoPlayerNodeContext = &ASVideoPlayerNodeContext;
   }
 }
 
+- (BOOL)supportsLayerBacking
+{
+  return NO;
+}
+
 #pragma mark - UI
 
 - (void)createControls

--- a/Source/AsyncDisplayKit.h
+++ b/Source/AsyncDisplayKit.h
@@ -115,6 +115,7 @@
 #import <AsyncDisplayKit/UIResponder+AsyncDisplayKit.h>
 
 #import <AsyncDisplayKit/AsyncDisplayKit+Debug.h>
+#import <AsyncDisplayKit/AsyncDisplayKit+Tips.h>
 #import <AsyncDisplayKit/ASDisplayNode+Deprecated.h>
 
 #import <AsyncDisplayKit/ASCollectionNode+Beta.h>

--- a/Source/Base/ASBaseDefines.h
+++ b/Source/Base/ASBaseDefines.h
@@ -104,6 +104,10 @@
 # define ASDISPLAYNODE_NOTHROW
 #endif
 
+#ifndef AS_ENABLE_TIPS
+#define AS_ENABLE_TIPS 0
+#endif
+
 /**
  * The event backtraces take a static 2KB of memory
  * and retain all objects present in all the registers

--- a/Source/Base/ASDisplayNode+Ancestry.h
+++ b/Source/Base/ASDisplayNode+Ancestry.h
@@ -1,0 +1,25 @@
+//
+//  ASNodeAncestorEnumerator.h
+//  AsyncDisplayKit
+//
+//  Created by Adlai Holler on 4/12/17.
+//  Copyright © 2017 Facebook. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <AsyncDisplayKit/ASDisplayNode.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ASDisplayNode (Ancestry)
+
+- (NSEnumerator *)ancestorEnumeratorWithSelf:(BOOL)includeSelf;
+
+/**
+ * e.g. "(<MYTextNode: 0xFFFF>, <MYTextContainingNode: 0xFFFF>, <MYCellNode: 0xFFFF>)"
+ */
+@property (atomic, copy, readonly) NSString *ancestryDescription;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/Base/ASDisplayNode+Ancestry.m
+++ b/Source/Base/ASDisplayNode+Ancestry.m
@@ -1,0 +1,55 @@
+//
+//  ASNodeAncestorEnumerator.m
+//  AsyncDisplayKit
+//
+//  Created by Adlai Holler on 4/12/17.
+//  Copyright © 2017 Facebook. All rights reserved.
+//
+
+#import "ASDisplayNode+Ancestry.h"
+
+AS_SUBCLASSING_RESTRICTED
+@interface ASNodeAncestryEnumerator : NSEnumerator
+@end
+
+@implementation ASNodeAncestryEnumerator {
+  /// Would be nice to use __unsafe_unretained but nodes can be
+  /// deallocated on arbitrary threads so nope.
+  __weak ASDisplayNode * _nextNode;
+}
+
+- (instancetype)initWithNode:(ASDisplayNode *)node
+{
+  if (self = [super init]) {
+    _nextNode = node;
+  }
+  return self;
+}
+
+- (id)nextObject
+{
+  ASDisplayNode *node = _nextNode;
+  _nextNode = [node supernode];
+  return node;
+}
+
+@end
+
+@implementation ASDisplayNode (Ancestry)
+
+- (NSEnumerator *)ancestorEnumeratorWithSelf:(BOOL)includeSelf
+{
+  ASDisplayNode *node = includeSelf ? self : self.supernode;
+  return [[ASNodeAncestryEnumerator alloc] initWithNode:node];
+}
+
+- (NSString *)ancestryDescription
+{
+  NSMutableArray *strings = [NSMutableArray array];
+  for (ASDisplayNode *node in [self ancestorEnumeratorWithSelf:YES]) {
+    [strings addObject:ASObjectDescriptionMakeTiny(node)];
+  }
+  return strings.description;
+}
+
+@end

--- a/Source/Debug/AsyncDisplayKit+Tips.h
+++ b/Source/Debug/AsyncDisplayKit+Tips.h
@@ -1,0 +1,42 @@
+//
+//  AsyncDisplayKit+Tips.h
+//  AsyncDisplayKit
+//
+//  Created by Adlai Holler on 4/12/17.
+//  Copyright © 2017 Facebook. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <AsyncDisplayKit/ASDisplayNode.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef void(^ASTipDisplayBlock)(ASDisplayNode *node, NSString *message);
+
+/**
+ * The methods added to ASDisplayNode to control the tips system.
+ *
+ * To enable tips, define AS_ENABLE_TIPS=1 (e.g. modify ASBaseDefines.h).
+ */
+@interface ASDisplayNode (Tips)
+
+/**
+ * Whether this class should have tips active. Default YES.
+ *
+ * NOTE: This property is for _disabling_ tips on a per-class basis,
+ * if they become annoying or have false-positives. The tips system
+ * is completely disabled unless you define AS_ENABLE_TIPS=1.
+ */
+@property (class) BOOL enableTips;
+
+/**
+ * A block to be run on the main thread to show text when a tip is tapped.
+ *
+ * If nil, the default, the message is just logged to the console with the
+ * ancestry of the node.
+ */
+@property (class, nonatomic, copy, null_resettable) ASTipDisplayBlock tipDisplayBlock; 
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/Debug/AsyncDisplayKit+Tips.m
+++ b/Source/Debug/AsyncDisplayKit+Tips.m
@@ -1,0 +1,47 @@
+//
+//  AsyncDisplayKit+Tips.m
+//  AsyncDisplayKit
+//
+//  Created by Adlai Holler on 4/12/17.
+//  Copyright © 2017 Facebook. All rights reserved.
+//
+
+#import "AsyncDisplayKit+Tips.h"
+#import <AsyncDisplayKit/ASDisplayNode+Ancestry.h>
+
+@implementation ASDisplayNode (Tips)
+
+static char ASDisplayNodeEnableTipsKey;
+static ASTipDisplayBlock _Nullable __tipDisplayBlock;
+
+/**
+ * Use associated objects with NSNumbers. This is a debug property - simplicity is king.
+ */
++ (void)setEnableTips:(BOOL)enableTips
+{
+  objc_setAssociatedObject(self, &ASDisplayNodeEnableTipsKey, @(enableTips), OBJC_ASSOCIATION_COPY);
+}
+
++ (BOOL)enableTips
+{
+  NSNumber *result = objc_getAssociatedObject(self, &ASDisplayNodeEnableTipsKey);
+  if (result == nil) {
+    return YES;
+  }
+  return result.boolValue;
+}
+
+
++ (void)setTipDisplayBlock:(ASTipDisplayBlock)tipDisplayBlock
+{
+  __tipDisplayBlock = tipDisplayBlock;
+}
+
++ (ASTipDisplayBlock)tipDisplayBlock
+{
+  return __tipDisplayBlock ?: ^(ASDisplayNode *node, NSString *string) {
+    NSLog(@"%@. Node ancestry: %@", string, node.ancestryDescription);
+  };
+}
+
+@end

--- a/Source/Details/_ASDisplayView.mm
+++ b/Source/Details/_ASDisplayView.mm
@@ -237,6 +237,12 @@
   node.threadSafeBounds = bounds;
 }
 
+- (void)addGestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
+{
+  [super addGestureRecognizer:gestureRecognizer];
+  [_asyncdisplaykit_node nodeViewDidAddGestureRecognizer];
+}
+
 #pragma mark - Event Handling + UIResponder Overrides
 - (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event
 {

--- a/Source/Private/ASDisplayNodeInternal.h
+++ b/Source/Private/ASDisplayNodeInternal.h
@@ -67,6 +67,7 @@ FOUNDATION_EXPORT NSString * const ASRenderingEngineDidDisplayNodesScheduledBefo
   struct ASDisplayNodeFlags {
     // public properties
     unsigned synchronous:1;
+    unsigned viewEverHadAGestureRecognizerAttached:1;
     unsigned layerBacked:1;
     unsigned displaysAsynchronously:1;
     unsigned shouldRasterizeDescendants:1;
@@ -140,8 +141,8 @@ FOUNDATION_EXPORT NSString * const ASRenderingEngineDidDisplayNodesScheduledBefo
   ASDisplayNodeViewBlock _viewBlock;
   ASDisplayNodeLayerBlock _layerBlock;
   NSMutableArray<ASDisplayNodeDidLoadBlock> *_onDidLoadBlocks;
-  Class _viewClass;
-  Class _layerClass;
+  Class _viewClass; // nil -> _ASDisplayView
+  Class _layerClass; // nil -> _ASDisplayLayer
   
   UIImage *_placeholderImage;
   CALayer *_placeholderLayer;
@@ -282,6 +283,8 @@ FOUNDATION_EXPORT NSString * const ASRenderingEngineDidDisplayNodesScheduledBefo
  * is in ASDisplayNode+Beta.h
  */
 @property (nonatomic, assign) BOOL shouldRasterizeDescendants;
+
+- (void)nodeViewDidAddGestureRecognizer;
 
 @end
 

--- a/Source/Private/ASDisplayNodeTipState.h
+++ b/Source/Private/ASDisplayNodeTipState.h
@@ -1,0 +1,31 @@
+//
+//  ASDisplayNodeTipState.h
+//  AsyncDisplayKit
+//
+//  Created by Adlai Holler on 4/12/17.
+//  Copyright © 2017 Facebook. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <AsyncDisplayKit/ASBaseDefines.h>
+
+@class ASDisplayNode, ASTipNode;
+
+NS_ASSUME_NONNULL_BEGIN
+
+AS_SUBCLASSING_RESTRICTED
+@interface ASDisplayNodeTipState : NSObject
+
+- (instancetype)initWithNode:(ASDisplayNode *)node NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)init NS_UNAVAILABLE;
+
+/// Unsafe because once the node is deallocated, we will not be able to access the tip state.
+@property (nonatomic, unsafe_unretained, readonly) ASDisplayNode *node;
+
+/// Main-thread-only.
+@property (nonatomic, strong, nullable) ASTipNode *tipNode;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/Private/ASDisplayNodeTipState.m
+++ b/Source/Private/ASDisplayNodeTipState.m
@@ -1,0 +1,24 @@
+//
+//  ASDisplayNodeTipState.m
+//  AsyncDisplayKit
+//
+//  Created by Adlai Holler on 4/12/17.
+//  Copyright © 2017 Facebook. All rights reserved.
+//
+
+#import "ASDisplayNodeTipState.h"
+
+@interface ASDisplayNodeTipState ()
+@end
+
+@implementation ASDisplayNodeTipState
+
+- (instancetype)initWithNode:(ASDisplayNode *)node
+{
+  if (self = [super init]) {
+    _node = node;
+  }
+  return self;
+}
+
+@end

--- a/Source/Private/ASLayerBackingTipProvider.h
+++ b/Source/Private/ASLayerBackingTipProvider.h
@@ -1,0 +1,23 @@
+//
+//  ASLayerBackingTipProvider.h
+//  AsyncDisplayKit
+//
+//  Created by Adlai Holler on 4/12/17.
+//  Copyright © 2017 Facebook. All rights reserved.
+//
+
+#import "ASTipProvider.h"
+#import <AsyncDisplayKit/ASBaseDefines.h>
+
+#if AS_ENABLE_TIPS
+
+NS_ASSUME_NONNULL_BEGIN
+
+AS_SUBCLASSING_RESTRICTED
+@interface ASLayerBackingTipProvider : ASTipProvider
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif // AS_ENABLE_TIPS

--- a/Source/Private/ASLayerBackingTipProvider.m
+++ b/Source/Private/ASLayerBackingTipProvider.m
@@ -1,0 +1,44 @@
+//
+//  ASLayerBackingTipProvider.m
+//  AsyncDisplayKit
+//
+//  Created by Adlai Holler on 4/12/17.
+//  Copyright © 2017 Facebook. All rights reserved.
+//
+
+#import "ASLayerBackingTipProvider.h"
+
+#if AS_ENABLE_TIPS
+
+#import <AsyncDisplayKit/ASCellNode.h>
+#import <AsyncDisplayKit/ASControlNode.h>
+#import <AsyncDisplayKit/ASDisplayNode.h>
+#import <AsyncDisplayKit/ASDisplayNodeExtras.h>
+#import <AsyncDisplayKit/ASTip.h>
+
+@implementation ASLayerBackingTipProvider
+
+- (ASTip *)tipForNode:(ASDisplayNode *)node
+{
+  // Already layer-backed.
+  if (node.layerBacked) {
+    return nil;
+  }
+
+  // TODO: Avoid revisiting nodes we already visited
+  ASDisplayNode *failNode = ASDisplayNodeFindFirstNode(node, ^BOOL(ASDisplayNode * _Nonnull node) {
+    return !node.supportsLayerBacking;
+  });
+  if (failNode != nil) {
+    return nil;
+  }
+
+  ASTip *result = [[ASTip alloc] initWithNode:node
+                                         kind:ASTipKindEnableLayerBacking
+                                       format:@"Enable layer backing to improve performance"];
+  return result;
+}
+
+@end
+
+#endif // AS_ENABLE_TIPS

--- a/Source/Private/ASTip.h
+++ b/Source/Private/ASTip.h
@@ -1,0 +1,48 @@
+//
+//  ASTip.h
+//  AsyncDisplayKit
+//
+//  Created by Adlai Holler on 4/12/17.
+//  Copyright © 2017 Facebook. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <AsyncDisplayKit/ASBaseDefines.h>
+
+#if AS_ENABLE_TIPS
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class ASDisplayNode;
+
+typedef NS_ENUM (NSInteger, ASTipKind) {
+  ASTipKindEnableLayerBacking
+};
+
+AS_SUBCLASSING_RESTRICTED
+@interface ASTip : NSObject
+
+- (instancetype)initWithNode:(ASDisplayNode *)node
+                        kind:(ASTipKind)kind
+                      format:(NSString *)format, ... NS_FORMAT_FUNCTION(3, 4);
+
+/**
+ * The kind of tip this is.
+ */
+@property (nonatomic, readonly) ASTipKind kind;
+
+/**
+ * The node that this tip applies to.
+ */
+@property (nonatomic, strong, readonly) ASDisplayNode *node;
+
+/**
+ * The text to show the user.
+ */
+@property (nonatomic, strong, readonly) NSString *text;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif // AS_ENABLE_TIPS

--- a/Source/Private/ASTip.m
+++ b/Source/Private/ASTip.m
@@ -1,0 +1,34 @@
+//
+//  ASTip.m
+//  AsyncDisplayKit
+//
+//  Created by Adlai Holler on 4/12/17.
+//  Copyright © 2017 Facebook. All rights reserved.
+//
+
+#import "ASTip.h"
+
+#if AS_ENABLE_TIPS
+
+#import <AsyncDisplayKit/ASDisplayNode.h>
+
+@implementation ASTip
+
+- (instancetype)initWithNode:(ASDisplayNode *)node
+                        kind:(ASTipKind)kind
+                      format:(NSString *)format, ...
+{
+  if (self = [super init]) {
+    _node = node;
+    _kind = kind;
+    va_list args;
+    va_start(args, format);
+    _text = [[NSString alloc] initWithFormat:format arguments:args];
+    va_end(args);
+  }
+  return self;
+}
+
+@end
+
+#endif // AS_ENABLE_TIPS

--- a/Source/Private/ASTipNode.h
+++ b/Source/Private/ASTipNode.h
@@ -1,0 +1,38 @@
+//
+//  ASTipNode.h
+//  AsyncDisplayKit
+//
+//  Created by Adlai Holler on 4/12/17.
+//  Copyright © 2017 Facebook. All rights reserved.
+//
+
+#import <AsyncDisplayKit/ASControlNode.h>
+#import <AsyncDisplayKit/ASBaseDefines.h>
+
+#if AS_ENABLE_TIPS
+
+@class ASTip;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * ASTipNode will send these up the responder chain.
+ */
+@protocol ASTipNodeActions <NSObject>
+- (void)didTapTipNode:(id)sender;
+@end
+
+AS_SUBCLASSING_RESTRICTED
+@interface ASTipNode : ASControlNode
+
+- (instancetype)initWithTip:(ASTip *)tip NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)init NS_UNAVAILABLE;
+
+@property (nonatomic, strong, readonly) ASTip *tip;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif // AS_ENABLE_TIPS

--- a/Source/Private/ASTipNode.m
+++ b/Source/Private/ASTipNode.m
@@ -1,0 +1,27 @@
+//
+//  ASTipNode.m
+//  AsyncDisplayKit
+//
+//  Created by Adlai Holler on 4/12/17.
+//  Copyright © 2017 Facebook. All rights reserved.
+//
+
+#import "ASTipNode.h"
+
+#if AS_ENABLE_TIPS
+
+@implementation ASTipNode
+
+- (instancetype)initWithTip:(ASTip *)tip
+{
+  if (self = [super init]) {
+    self.backgroundColor = [UIColor colorWithRed:0 green:0.7 blue:0.2 alpha:0.3];
+    _tip = tip;
+    [self addTarget:nil action:@selector(didTapTipNode:) forControlEvents:ASControlNodeEventTouchUpInside];
+  }
+  return self;
+}
+
+@end
+
+#endif // AS_ENABLE_TIPS

--- a/Source/Private/ASTipProvider.h
+++ b/Source/Private/ASTipProvider.h
@@ -1,0 +1,41 @@
+//
+//  ASTipProvider.h
+//  AsyncDisplayKit
+//
+//  Created by Adlai Holler on 4/12/17.
+//  Copyright © 2017 Facebook. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <AsyncDisplayKit/ASBaseDefines.h>
+
+#if AS_ENABLE_TIPS
+
+@class ASDisplayNode, ASTip;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * An abstract superclass for all tip providers.
+ */
+@interface ASTipProvider : NSObject
+
+/**
+ * The provider looks at the node's current situation and
+ * generates a tip, if any, to add to the node.
+ *
+ * Subclasses must override this.
+ */
+- (nullable ASTip *)tipForNode:(ASDisplayNode *)node;
+
+@end
+
+@interface ASTipProvider (Lookup)
+
+@property (class, nonatomic, copy, readonly) NSArray<__kindof ASTipProvider *> *all;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif // AS_ENABLE_TIPS

--- a/Source/Private/ASTipProvider.m
+++ b/Source/Private/ASTipProvider.m
@@ -1,0 +1,42 @@
+//
+//  ASTipProvider.m
+//  AsyncDisplayKit
+//
+//  Created by Adlai Holler on 4/12/17.
+//  Copyright © 2017 Facebook. All rights reserved.
+//
+
+#import "ASTipProvider.h"
+
+#if AS_ENABLE_TIPS
+
+#import <AsyncDisplayKit/ASAssert.h>
+
+// Concrete classes
+#import <AsyncDisplayKit/ASLayerBackingTipProvider.h>
+
+@implementation ASTipProvider
+
+- (ASTip *)tipForNode:(ASDisplayNode *)node
+{
+  ASDisplayNodeFailAssert(@"Subclasses must override %@", NSStringFromSelector(_cmd));
+  return nil;
+}
+
+@end
+
+@implementation ASTipProvider (Lookup)
+
++ (NSArray<ASTipProvider *> *)all
+{
+  static NSArray<ASTipProvider *> *providers;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    providers = @[ [ASLayerBackingTipProvider new] ];
+  });
+  return providers;
+}
+
+@end
+
+#endif // AS_ENABLE_TIPS

--- a/Source/Private/ASTipsController.h
+++ b/Source/Private/ASTipsController.h
@@ -1,0 +1,39 @@
+//
+//  ASTipsController.h
+//  AsyncDisplayKit
+//
+//  Created by Adlai Holler on 4/12/17.
+//  Copyright © 2017 Facebook. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <AsyncDisplayKit/ASBaseDefines.h>
+
+#if AS_ENABLE_TIPS
+
+@class ASDisplayNode;
+
+NS_ASSUME_NONNULL_BEGIN
+
+AS_SUBCLASSING_RESTRICTED
+@interface ASTipsController : NSObject
+
+/**
+ * The shared tip controller instance.
+ */
+@property (class, strong, readonly) ASTipsController *shared;
+
+#pragma mark - Node Event Hooks
+
+/**
+ * Informs the controller that the sender did enter the visible range.
+ *
+ * The controller will run a pass with its tip providers, adding tips as needed.
+ */
+- (void)nodeDidAppear:(ASDisplayNode *)node;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif // AS_ENABLE_TIPS

--- a/Source/Private/ASTipsController.m
+++ b/Source/Private/ASTipsController.m
@@ -1,0 +1,184 @@
+//
+//  ASTipsController.m
+//  AsyncDisplayKit
+//
+//  Created by Adlai Holler on 4/12/17.
+//  Copyright © 2017 Facebook. All rights reserved.
+//
+
+#import "ASTipsController.h"
+
+#if AS_ENABLE_TIPS
+
+#import <AsyncDisplayKit/ASDisplayNodeTipState.h>
+#import <AsyncDisplayKit/AsyncDisplayKit+Tips.h>
+#import <AsyncDisplayKit/ASTipNode.h>
+#import <AsyncDisplayKit/ASTipProvider.h>
+#import <AsyncDisplayKit/ASTipsWindow.h>
+#import <AsyncDisplayKit/ASDisplayNodeExtras.h>
+
+@interface ASTipsController ()
+
+/// Nil on init, updates to most recent visible window.
+@property (nonatomic, strong) UIWindow *appVisibleWindow;
+
+/// Nil until an application window has become visible.
+@property (nonatomic, strong) ASTipsWindow *tipWindow;
+
+/// Main-thread-only.
+@property (nonatomic, strong, readonly) NSMapTable<ASDisplayNode *, ASDisplayNodeTipState *> *nodeToTipStates;
+
+@property (nonatomic, strong) NSMutableArray<ASDisplayNode *> *nodesThatAppearedDuringRunLoop;
+
+@end
+
+@implementation ASTipsController
+
+#pragma mark - Singleton
+
++ (void)load
+{
+  [NSNotificationCenter.defaultCenter addObserver:self.shared
+                                         selector:@selector(windowDidBecomeVisibleWithNotification:)
+                                             name:UIWindowDidBecomeVisibleNotification
+                                           object:nil];
+}
+
++ (ASTipsController *)shared
+{
+  static ASTipsController *ctrl;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    ctrl = [[ASTipsController alloc] init];
+  });
+  return ctrl;
+}
+
+#pragma mark - Lifecycle
+
+- (instancetype)init
+{
+  ASDisplayNodeAssertMainThread();
+  if (self = [super init]) {
+    _nodeToTipStates = [NSMapTable mapTableWithKeyOptions:(NSPointerFunctionsWeakMemory | NSPointerFunctionsObjectPointerPersonality) valueOptions:NSPointerFunctionsStrongMemory];
+    _nodesThatAppearedDuringRunLoop = [NSMutableArray array];
+  }
+  return self;
+}
+
+#pragma mark - Event Handling
+
+- (void)nodeDidAppear:(ASDisplayNode *)node
+{
+  ASDisplayNodeAssertMainThread();
+  // If they disabled tips on this class, bail.
+  if (![[node class] enableTips]) {
+    return;
+  }
+
+  // If this node appeared in some other window (like our tips window) ignore it.
+  if (ASFindWindowOfLayer(node.layer) != self.appVisibleWindow) {
+    return;
+  }
+
+  [_nodesThatAppearedDuringRunLoop addObject:node];
+}
+
+// If this is a main window, start watching it and clear out our tip window.
+- (void)windowDidBecomeVisibleWithNotification:(NSNotification *)notification
+{
+  ASDisplayNodeAssertMainThread();
+  UIWindow *window = notification.object;
+
+  // If this is the same window we're already watching, bail.
+  if (window == self.appVisibleWindow) {
+    return;
+  }
+
+  // Ignore windows that are not at the normal level or have empty bounds
+  if (window.windowLevel != UIWindowLevelNormal || CGRectIsEmpty(window.bounds)) {
+    return;
+  }
+
+  self.appVisibleWindow = window;
+
+  // Create the tip window if needed.
+  [self createTipWindowIfNeededWithFrame:window.bounds];
+
+  // Clear out our tip window and reset our states.
+  self.tipWindow.mainWindow = window;
+  [_nodeToTipStates removeAllObjects];
+}
+
+- (void)runLoopDidTick
+{
+  NSArray *nodes = [_nodesThatAppearedDuringRunLoop copy];
+  [_nodesThatAppearedDuringRunLoop removeAllObjects];
+
+  // Go through the old array, removing any that have tips but aren't still visible.
+  for (ASDisplayNode *node in [_nodeToTipStates copy]) {
+    if (!node.visible) {
+      [_nodeToTipStates removeObjectForKey:node];
+    }
+  }
+
+  for (ASDisplayNode *node in nodes) {
+    // Get the tip state for the node.
+    ASDisplayNodeTipState *tipState = [_nodeToTipStates objectForKey:node];
+
+    // If the node already has a tip, bail. This could change.
+    if (tipState.tipNode != nil) {
+      return;
+    }
+
+    for (ASTipProvider *provider in ASTipProvider.all) {
+      ASTip *tip = [provider tipForNode:node];
+      if (!tip) { continue; }
+
+      if (!tipState) {
+        tipState = [self createTipStateForNode:node];
+      }
+      tipState.tipNode = [[ASTipNode alloc] initWithTip:tip];
+    }
+  }
+  self.tipWindow.nodeToTipStates = _nodeToTipStates;
+  [self.tipWindow setNeedsLayout];
+}
+
+#pragma mark - Internal
+
+- (void)createTipWindowIfNeededWithFrame:(CGRect)tipWindowFrame
+{
+  // Lots of property accesses, but simple safe code, only run once.
+  if (self.tipWindow == nil) {
+    self.tipWindow = [[ASTipsWindow alloc] initWithFrame:tipWindowFrame];
+    self.tipWindow.hidden = NO;
+    [self setupRunLoopObserver];
+  }
+}
+
+/**
+ * In order to keep the UI updated, the tips controller registers a run loop observer.
+ * Before the transaction commit happens, the tips controller calls -setNeedsLayout
+ * on the view controller's view. It will then layout the main window, and then update the frames
+ * for tip nodes accordingly.
+ */
+- (void)setupRunLoopObserver
+{
+  CFRunLoopObserverRef o = CFRunLoopObserverCreateWithHandler(kCFAllocatorDefault, kCFRunLoopBeforeWaiting, true, 0, ^(CFRunLoopObserverRef observer, CFRunLoopActivity activity) {
+    [self runLoopDidTick];
+  });
+  CFRunLoopAddObserver(CFRunLoopGetMain(), o, kCFRunLoopCommonModes);
+}
+
+- (ASDisplayNodeTipState *)createTipStateForNode:(ASDisplayNode *)node
+{
+  ASDisplayNodeAssertMainThread();
+  ASDisplayNodeTipState *tipState = [[ASDisplayNodeTipState alloc] initWithNode:node];
+  [_nodeToTipStates setObject:tipState forKey:node];
+  return tipState;
+}
+
+@end
+
+#endif // AS_ENABLE_TIPS

--- a/Source/Private/ASTipsWindow.h
+++ b/Source/Private/ASTipsWindow.h
@@ -1,0 +1,35 @@
+//
+//  ASTipsWindow.h
+//  AsyncDisplayKit
+//
+//  Created by Adlai Holler on 4/12/17.
+//  Copyright © 2017 Facebook. All rights reserved.
+//
+
+#import <AsyncDisplayKit/ASViewController.h>
+#import <AsyncDisplayKit/ASBaseDefines.h>
+
+#if AS_ENABLE_TIPS
+
+@class ASDisplayNode, ASDisplayNodeTipState;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * A window that shows tips. This was originally meant to be a view controller
+ * but UIKit will not manage view controllers in non-key windows correctly AT ALL
+ * as of the time of this writing.
+ */
+AS_SUBCLASSING_RESTRICTED
+@interface ASTipsWindow : UIWindow
+
+/// The main application window that the tips are tracking.
+@property (nonatomic, weak) UIWindow *mainWindow;
+
+@property (nonatomic, copy, nullable) NSMapTable<ASDisplayNode *, ASDisplayNodeTipState *> *nodeToTipStates;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif

--- a/Source/Private/ASTipsWindow.m
+++ b/Source/Private/ASTipsWindow.m
@@ -1,0 +1,97 @@
+//
+//  ASTipsWindow.m
+//  AsyncDisplayKit
+//
+//  Created by Adlai Holler on 4/12/17.
+//  Copyright © 2017 Facebook. All rights reserved.
+//
+
+#import "ASTipsWindow.h"
+#if AS_ENABLE_TIPS
+
+#import <AsyncDisplayKit/ASDisplayNodeTipState.h>
+#import <AsyncDisplayKit/ASTipNode.h>
+#import <AsyncDisplayKit/ASTip.h>
+#import <AsyncDisplayKit/AsyncDisplayKit+Tips.h>
+
+@interface ASTipsWindow ()
+@property (nonatomic, strong, readonly) ASDisplayNode *node;
+@end
+
+@implementation ASTipsWindow
+
+- (instancetype)initWithFrame:(CGRect)frame
+{
+  if (self = [super initWithFrame:frame]) {
+    /**
+     * UIKit throws an exception if you don't add a root view controller to a window,
+     * but if the window isn't key, then it doesn't manage the root view controller correctly!
+     *
+     * So we set a dummy root view controller and hide it.
+     */
+    self.rootViewController = [UIViewController new];
+    self.rootViewController.view.hidden = YES;
+
+    _node = [[ASDisplayNode alloc] init];
+    [self addSubnode:_node];
+
+    self.windowLevel = UIWindowLevelNormal + 1;
+    self.opaque = NO;
+  }
+  return self;
+}
+
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
+{
+  UIView *result = [super hitTest:point withEvent:event];
+  // Ignore touches unless they hit one of my node's subnodes
+  if (result == _node.view) {
+    return nil;
+  }
+  return result;
+}
+
+- (void)setMainWindow:(UIWindow *)mainWindow
+{
+  _mainWindow = mainWindow;
+  for (ASDisplayNode *node in _node.subnodes) {
+    [node removeFromSupernode];
+  }
+}
+
+- (void)didTapTipNode:(ASTipNode *)tipNode
+{
+  ASDisplayNode.tipDisplayBlock(tipNode.tip.node, tipNode.tip.text);
+}
+
+- (void)layoutSubviews
+{
+  [super layoutSubviews];
+  _node.frame = self.bounds;
+  
+  // Ensure the main window is laid out first.
+  [self.mainWindow layoutIfNeeded];
+  
+  NSMutableSet *tipNodesToRemove = [NSMutableSet setWithArray:_node.subnodes];
+  for (ASDisplayNodeTipState *tipState in [_nodeToTipStates objectEnumerator]) {
+    ASDisplayNode *node = tipState.node;
+    ASTipNode *tipNode = tipState.tipNode;
+    [tipNodesToRemove removeObject:tipNode];
+    CGRect rect = node.bounds;
+    rect = [node.view convertRect:rect toView:nil];
+    rect = [self convertRect:rect fromView:nil];
+    tipNode.frame = rect;
+    if (tipNode.supernode != _node) {
+      [_node addSubnode:tipNode];
+    }
+  }
+  
+  // Clean up any tip nodes whose target nodes have disappeared.
+  for (ASTipNode *tipNode in tipNodesToRemove) {
+    [tipNode removeFromSupernode];
+  }
+}
+
+@end
+
+#endif // AS_ENABLE_TIPS

--- a/Tests/ASDisplayNodeTests.mm
+++ b/Tests/ASDisplayNodeTests.mm
@@ -225,13 +225,6 @@ for (ASDisplayNode *n in @[ nodes ]) {\
   XCTAssertFalse([node becomeFirstResponder]);
 }
 
-- (void)testLayerBackedFirstResponderBehavior {
-  ASTestDisplayNode *node = [[ASTestResponderNode alloc] init];
-  node.layerBacked = YES;
-  XCTAssertTrue([node canBecomeFirstResponder]);
-  XCTAssertFalse([node becomeFirstResponder]);
-}
-
 - (void)setUp
 {
   [super setUp];


### PR DESCRIPTION
- To activate: `#define AS_ENABLE_TIPS=1`
- ASDK will create a new window on top of the application window.
- At the end of each run loop, tips controller goes through all nodes that appeared during the turn.
- Runs all `ASTipProvider` subclasses against them. Currently we have `ASLayerBackingTipProvider`.
- If the provider generates a tip for that node, a node is added to the overlay window.
- If the user taps on a tip, we call a custom `tipDisplayBlock` with a message. Default is to log a message using NSLog.
- You can disable tips on a per-class level. `MYDisplayNode.enableTips = NO`.
- Only requires one hook from ASDisplayNode right now – `nodeDidAppear:`.

Example Screenshot:
<img width="487" alt="screen shot 2017-04-13 at 10 36 34 am" src="https://cloud.githubusercontent.com/assets/2466893/25016535/41b37bb0-2035-11e7-813c-dc52fba21cc2.png">

Tapping on one of the big images causes this message to get logged (or shown, if the app sets a custom `tipDisplayBlock`):

```
Enable layer backing to improve performance. Node ancestry: (
    "<PIRoundedImageNode: 0x7ff89a031c00>",
    "<PIFlexibleArticleNode: 0x7ff8984a4430>",
    "<PIWrapperCellNode: 0x7ff8985ace40>"
)
```

Caveats:
- As before, you can't have view-backed nodes inside layer-backed nodes, so you need to set `layerBacked=YES` on the leaf nodes first and work your way up.
- When tips are enabled, touches on green areas are not passed to the application window. This is annoying but not too annoying.

Results:
- No false positives in Pinterest yet, and all the green is gone in one diff!