### PR TITLE
Automatically resume ASVideoNode after returning from background

### DIFF
--- a/Source/ASVideoNode.mm
+++ b/Source/ASVideoNode.mm
@@ -711,10 +711,8 @@ static NSString * const kRate = @"rate";
 #pragma mark - Playback observers
 
 - (void)applicationDidBecomeActive:(NSNotification *)notification
-{
-  ASDN::MutexLocker l(__instanceLock__);
-  
-  if (_shouldBePlaying && ASInterfaceStateIncludesVisible(self.interfaceState)) {
+{  
+  if (self.shouldBePlaying && self.isVisible) {
     [self play];
   }
 }

--- a/Source/ASVideoNode.mm
+++ b/Source/ASVideoNode.mm
@@ -830,6 +830,9 @@ static NSString * const kRate = @"rate";
   _timeObserver = nil;
   [self removePlayerItemObservers:_currentPlayerItem];
   [self removePlayerObservers:_player];
+
+  NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
+  [notificationCenter removeObserver:self name:UIApplicationDidBecomeActiveNotification object:nil];
 }
 
 @end

--- a/Source/ASVideoNode.mm
+++ b/Source/ASVideoNode.mm
@@ -101,6 +101,9 @@ static NSString * const kRate = @"rate";
   [self addTarget:self action:@selector(tapped) forControlEvents:ASControlNodeEventTouchUpInside];
   _lastPlaybackTime = kCMTimeZero;
   
+  NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
+  [notificationCenter addObserver:self selector:@selector(applicationDidBecomeActive:) name:UIApplicationDidBecomeActiveNotification object:nil];
+
   return self;
 }
 
@@ -706,6 +709,15 @@ static NSString * const kRate = @"rate";
 
 
 #pragma mark - Playback observers
+
+- (void)applicationDidBecomeActive:(NSNotification *)notification
+{
+  ASDN::MutexLocker l(__instanceLock__);
+  
+  if (_shouldBePlaying && ASInterfaceStateIncludesVisible(self.interfaceState)) {
+    [self play];
+  }
+}
 
 - (void)didPlayToEnd:(NSNotification *)notification
 {


### PR DESCRIPTION
AVPlayerLayer pauses video when the application goes into the background. This change resumes the video playing when the app returns.

I'm not sure if there is a way to write tests for application state changes?